### PR TITLE
[Design System] `Toast` supports `actions`

### DIFF
--- a/packages/ui/stories/Toast.stories.tsx
+++ b/packages/ui/stories/Toast.stories.tsx
@@ -294,3 +294,103 @@ export const MultipleToasts = () => (
     </div>
   </div>
 );
+
+export const ToastWithActions = () => (
+  <div className="space-y-4">
+    <Toast />
+    <div className="flex flex-wrap gap-4">
+      <Button
+        onPress={() =>
+          toast.success({
+            title: 'File Upload Complete',
+            message: 'Your document has been successfully uploaded.',
+            actions: [<Button color="primary">View File</Button>],
+          })
+        }
+      >
+        Toast with One Action
+      </Button>
+
+      <Button
+        onPress={() =>
+          toast.success({
+            title: 'Connection Restored',
+            message: 'Your internet connection has been restored.',
+            dismissable: true,
+            actions: [
+              <Button color="primary">Retry</Button>,
+              <Button color="secondary">Dismiss</Button>,
+            ],
+          })
+        }
+      >
+        Toast with Two Actions
+      </Button>
+    </div>
+  </div>
+);
+
+export const SingleLineToasts = () => (
+  <div className="space-y-4">
+    <Toast />
+    <div className="flex flex-wrap gap-4">
+      <Button
+        onPress={() =>
+          toast.success({
+            message:
+              'Cooperativum mutualitas communis, equitatis prosperum. Societas nostra fundata est super principia cooperationis et mutuae auxilii.',
+            actions: [
+              <Button color="primary" size="small">
+                View profile
+              </Button>,
+            ],
+          })
+        }
+      >
+        Single Line Success with Action
+      </Button>
+
+      <Button
+        onPress={() =>
+          toast.success({
+            message:
+              'Cooperativum mutualitas communis, equitatis prosperum. Societas nostra fundata est super principia cooperationis et mutuae auxilii.',
+            actions: [
+              <Button color="primary" size="small">
+                View profile
+              </Button>,
+              <Button color="secondary" size="small">
+                Undo
+              </Button>,
+            ],
+          })
+        }
+      >
+        Single Line Success with Two Actions
+      </Button>
+
+      <Button
+        color="destructive"
+        onPress={() =>
+          toast.error({
+            message:
+              'Cooperativum mutualitas communis, equitatis prosperum. Societas nostra fundata est super principia cooperationis et mutuae auxilii.',
+            dismissable: true,
+          })
+        }
+      >
+        Single Line Error with Dismiss
+      </Button>
+
+      <Button
+        onPress={() =>
+          toast.success({
+            message: 'Message without actions. '.repeat(4),
+          })
+        }
+      >
+        Single Line No Actions
+      </Button>
+    </div>
+  </div>
+);


### PR DESCRIPTION
Stacked on #62, but can be merged directly to `dev`.

Addresses https://app.asana.com/1/1108348036672214/project/1210891919698604/task/1210891919700765

Figma reference: https://www.figma.com/design/lrko7TMR4xy6Xb0w5GwzCQ/Common-Sense?node-id=214-1962&m=dev



Introduces an optional actions prop to the Toast component, allowing one or two action buttons to be rendered within toasts. Updates the storybook to demonstrate toasts with action buttons.

## Component API Design

- Add an optional prop to the existing `toast` object
- `actions` is typed as a one-tuple or two-tuple (accepting either one CTA or two). Each item must be a React node, allowing composition
- If `title` is not specified, the single-line design is used. The `message` is truncated, while actions and icon remain full-width.

---

<img width="575" height="205" alt="Screenshot 2025-07-26 at 1 21 30 PM" src="https://github.com/user-attachments/assets/22b52775-039a-49a4-a1a3-647ae8a06e79" />

<img width="593" height="192" alt="Screenshot 2025-07-26 at 1 29 42 PM" src="https://github.com/user-attachments/assets/e2a2d424-748b-4cdf-aebe-1852d307a293" />

<img width="608" height="111" alt="Screenshot 2025-07-26 at 3 06 36 PM" src="https://github.com/user-attachments/assets/cca8931f-9655-4803-a24d-644f9a9e175a" />

