### PR TITLE
[Design System] Add `ModalStepper`

### DIFF
--- a/packages/ui/src/components/Modal.tsx
+++ b/packages/ui/src/components/Modal.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { ReactNode, memo, useCallback, useState } from 'react';
 import { ModalOverlay, Modal as RACModal } from 'react-aria-components';
 import type { ModalOverlayProps } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 
 import { cn } from '../lib/utils';
+import { Button } from './Button';
 import { Confetti } from './Confetti';
 import { Header1 } from './Header';
 
@@ -70,6 +71,73 @@ export const ModalFooter = ({
     </div>
   );
 };
+
+export const ModalStepper = memo(
+  ({
+    initialStep = 1,
+    totalSteps,
+    onNext,
+    onPrevious,
+    onFinish,
+  }: {
+    initialStep?: number;
+    totalSteps: number;
+    onNext: (currentStep: number) => void;
+    onPrevious: (currentStep: number) => void;
+    onFinish?: () => void;
+  }) => {
+    const [currentStep, setCurrentStep] = useState(initialStep);
+    const isFirstStep = currentStep === 1;
+    const isLastStep = currentStep === totalSteps;
+
+    const handleNext = useCallback(() => {
+      if (currentStep < totalSteps) {
+        const nextStep = currentStep + 1;
+        setCurrentStep(nextStep);
+        onNext(nextStep);
+      } else if (currentStep === totalSteps && onFinish) {
+        onFinish();
+      }
+    }, [currentStep, totalSteps, onNext, onFinish]);
+
+    const handlePrevious = useCallback(() => {
+      if (currentStep > 1) {
+        const previousStep = currentStep - 1;
+        setCurrentStep(previousStep);
+        onPrevious(previousStep);
+      }
+    }, [currentStep, onPrevious]);
+
+    return (
+      <footer
+        className={cn(
+          'sticky bottom-0',
+          'flex w-full items-center justify-between',
+          'px-6 py-3',
+          'border-t border-neutral-gray1 bg-white',
+        )}
+      >
+        <span className="flex-1">
+          {!isFirstStep && (
+            <Button color="secondary" onPress={handlePrevious}>
+              Back
+            </Button>
+          )}
+        </span>
+        <span className="flex-1 text-center text-sm text-neutral-gray4">
+          Step {currentStep} of {totalSteps}
+        </span>
+        <div className="flex flex-1 justify-end">
+          <Button type={isLastStep ? 'submit' : 'button'} onPress={handleNext}>
+            {isLastStep ? 'Finish' : 'Next'}
+          </Button>
+        </div>
+      </footer>
+    );
+  },
+);
+
+ModalStepper.displayName = 'ModalStepper';
 
 export const ModalInContext = ({
   className,

--- a/packages/ui/stories/Modal.stories.tsx
+++ b/packages/ui/stories/Modal.stories.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { Button } from '../src/components/Button';
 import { DialogTrigger } from '../src/components/Dialog';
 import {
@@ -5,6 +7,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  ModalStepper,
 } from '../src/components/Modal';
 
 export default {
@@ -206,5 +209,84 @@ export const LargeModal = () => (
         <Button>Save All</Button>
       </ModalFooter>
     </Modal>
+  </DialogTrigger>
+);
+
+const ModalStepperExample = () => {
+  const [currentStep, setCurrentStep] = useState(1);
+  const totalSteps = 3;
+
+  const handleNext = (step: number) => {
+    setCurrentStep(step);
+    console.log(`Next step ${step}`);
+  };
+
+  const handlePrevious = (step: number) => {
+    setCurrentStep(step);
+    console.log(`Previous step ${step}`);
+  };
+
+  const handleFinish = () => {
+    console.log('Finished');
+  };
+
+  const getStepContent = (step: number) => {
+    const stepData = {
+      1: {
+        title: 'Welcome',
+        description: 'This is the first step. Click Next to continue.',
+      },
+      2: {
+        title: 'Step 2',
+        description:
+          'You can now go back to the previous step or continue forward.',
+      },
+      3: {
+        title: 'Final Step',
+        description: "You've reached the final step. Click Finish to complete.",
+      },
+    };
+
+    const currentStep = stepData[step as keyof typeof stepData];
+
+    if (!currentStep) {
+      return { header: null, content: null };
+    }
+
+    return {
+      header: (
+        <h3 className="text-title-sm text-neutral-black">
+          {currentStep.title}
+        </h3>
+      ),
+      content: (
+        <p className="text-base text-neutral-charcoal">
+          {currentStep.description}
+        </p>
+      ),
+    };
+  };
+
+  const { header, content } = getStepContent(currentStep);
+
+  return (
+    <Modal className="min-w-[500px]">
+      <ModalHeader>{header}</ModalHeader>
+      <ModalBody className="min-w-[400px]">{content}</ModalBody>
+      <ModalStepper
+        totalSteps={totalSteps}
+        onNext={handleNext}
+        onPrevious={handlePrevious}
+        onFinish={handleFinish}
+        initialStep={1}
+      />
+    </Modal>
+  );
+};
+
+export const WithStepper = () => (
+  <DialogTrigger>
+    <Button>Open Modal with Stepper</Button>
+    <ModalStepperExample />
   </DialogTrigger>
 );


### PR DESCRIPTION
Adds a `ModalStepper` component based on these [Figma designs.](https://www.figma.com/design/u4YWqQeNlAosEjs1lrsGqf/%F0%9F%99%8B-Decision-Making-MVP?node-id=6-2155&m=dev)




**Component Design**

- `ModalStepper` is modeled after `ModalFooter`.
- `ModalStepper` manages current step state, but the consumer can/should also retain state to control the content that is rendered. Consumer can manage state via the callbacks (onNext, on Previous) etc..
  - Secondary variants is used for the "back" button while the primary variant is used for next/finish.

**Sample Usage**

```tsx
<ModalStepper
  initialStep={1}
  totalSteps={totalSteps}
  onNext={handleNext}
  onPrevious={handlePrevious}
  onFinish={handleFinish}
/>
```

**Other thoughts**

- If necessary, future work may be to add optional props to customize the back/next/finish button text.
- Separate, but I notice that the current Modal implementation doesn't quite match the designs (e.g., no close button, no Escape support, header text not centered). Scope-wise, will tackle as part of the audit.

---

<img width="988" height="369" alt="Screenshot 2025-07-27 at 8 31 25 PM" src="https://github.com/user-attachments/assets/09fb1c4b-1c78-4342-aa38-9eb08fbffc36" />

<img width="972" height="363" alt="Screenshot 2025-07-27 at 8 31 50 PM" src="https://github.com/user-attachments/assets/53e6ea4a-36a0-4413-9ce5-bcc1c67b24f3" />
<img width="985" height="358" alt="Screenshot 2025-07-27 at 8 31 54 PM" src="https://github.com/user-attachments/assets/b3707d42-e27d-4f58-bdc8-4bfdc3b95f5a" />