### PR TITLE
[Design System] Rework `NumberField`

### DIFF
--- a/packages/ui/src/components/NumberField.tsx
+++ b/packages/ui/src/components/NumberField.tsx
@@ -1,99 +1,145 @@
 'use client';
 
-import { ChevronDown, ChevronUp } from 'lucide-react';
-import { NumberField as AriaNumberField, Button } from 'react-aria-components';
+import { useEffect, useState } from 'react';
+import { TextField as AriaTextField } from 'react-aria-components';
 import type {
-  NumberFieldProps as AriaNumberFieldProps,
-  ButtonProps as RACButtonProps,
+  TextFieldProps as AriaTextFieldProps,
   ValidationResult,
 } from 'react-aria-components';
 
 import { cn } from '../lib/utils';
 import { composeTailwindRenderProps } from '../utils';
-import {
-  Description,
-  FieldError,
-  FieldGroup,
-  Input,
-  Label,
-  fieldBorderStyles,
-} from './Field';
+import { Description, FieldError, FieldGroup, Input, Label } from './Field';
+import type { InputWithVariantsProps } from './Field';
 
-const StepperButton = (props: RACButtonProps) => {
-  return (
-    <Button
-      {...props}
-      className="cursor-default px-0.5 text-neutral-600 pressed:bg-neutral-200 group-disabled:text-neutral-400"
-    />
-  );
-};
-
-export interface NumberFieldProps extends AriaNumberFieldProps {
+export interface NumberFieldProps
+  extends Omit<
+    AriaTextFieldProps,
+    'type' | 'value' | 'defaultValue' | 'onChange' | 'onInput'
+  > {
   label?: string;
   description?: string;
   errorMessage?: string | ((validation: ValidationResult) => string);
-  onDoubleClick?: (e: React.MouseEvent<HTMLInputElement>) => void;
-  inputClassName?: string;
+  inputProps?: InputWithVariantsProps & { className?: string };
   fieldClassName?: string;
-  showStepper?: boolean;
-  placeholder?: string;
+  descriptionClassName?: string;
+  labelClassName?: string;
+  value?: number | null;
+  defaultValue?: number | null;
+  onChange?: (value: number | null) => void;
+  onInput?: (value: number | null) => void;
 }
 
+const filterNumericInput = (value: string) => {
+  return value
+    .replace(/[^0-9.-]/g, '') // Keep only digits, minus, and decimal
+    .replace(/(?!^)-/g, '') // Remove minus signs that aren't at the beginning
+    .replace(/\.(?=.*\.)/g, ''); // Remove decimal points except the last one
+};
+
+const parseNumericValue = (value: string) => {
+  const filtered = filterNumericInput(value);
+  if (filtered === '' || filtered === '-') return null;
+  const parsed = parseFloat(filtered);
+  return isNaN(parsed) ? null : parsed;
+};
+
 export const NumberField = ({
+  ref,
   label,
   description,
   errorMessage,
-  showStepper = true,
+  inputProps,
   fieldClassName,
-  placeholder,
+  descriptionClassName,
+  labelClassName,
+  value,
+  defaultValue,
+  onChange,
+  onInput,
+  children,
+  isRequired,
   ...props
-}: NumberFieldProps) => {
+}: NumberFieldProps & {
+  ref?: React.RefObject<HTMLInputElement | null>;
+  children?: React.ReactNode;
+}) => {
+  const [displayValue, setDisplayValue] = useState('');
+
+  useEffect(() => {
+    if (value !== undefined) {
+      setDisplayValue(value?.toString() || '');
+    }
+  }, [value]);
+
+  useEffect(() => {
+    if (value === undefined && defaultValue !== undefined) {
+      setDisplayValue(defaultValue?.toString() || '');
+    }
+  }, [defaultValue, value]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = e.target.value;
+    const filteredValue = filterNumericInput(inputValue);
+    const numericValue = parseNumericValue(filteredValue);
+
+    setDisplayValue(filteredValue);
+    onChange?.(numericValue);
+  };
+
+  const handleInput = (e: React.FormEvent<HTMLInputElement>) => {
+    const target = e.target as HTMLInputElement;
+    const inputValue = target.value;
+    const filteredValue = filterNumericInput(inputValue);
+    const numericValue = parseNumericValue(filteredValue);
+
+    setDisplayValue(filteredValue);
+    onInput?.(numericValue);
+  };
+
   return (
-    <AriaNumberField
+    <AriaTextField
       {...props}
+      type="text"
+      isInvalid={!!errorMessage && errorMessage.length > 0}
       className={composeTailwindRenderProps(
         props.className,
         'group flex flex-col gap-1',
       )}
-      formatOptions={{
-        useGrouping: false,
-      }}
     >
-      <Label hidden>{label}</Label>
+      {label && (
+        <Label
+          className={cn(
+            labelClassName,
+            'group-data-[invalid=true]:text-functional-red',
+          )}
+        >
+          {label}
+          {isRequired && <span className="text-functional-red"> *</span>}
+        </Label>
+      )}
       <FieldGroup className={fieldClassName}>
-        {(renderProps) => (
-          <>
-            <Input
-              className={cn('', props.inputClassName)}
-              onDoubleClick={props.onDoubleClick}
-              placeholder={placeholder}
-            />
-            {showStepper && (
-              <div
-                className={fieldBorderStyles({
-                  ...renderProps,
-                  class: 'flex flex-col border-s-2',
-                })}
-              >
-                <StepperButton slot="increment">
-                  <ChevronUp aria-hidden className="size-4" />
-                </StepperButton>
-                <div
-                  className={fieldBorderStyles({
-                    ...renderProps,
-                    class: 'border-b-2',
-                  })}
-                />
-                <StepperButton slot="decrement">
-                  <ChevronDown aria-hidden className="size-4" />
-                </StepperButton>
-              </div>
-            )}
-          </>
-        )}
+        <Input
+          {...inputProps}
+          type="text"
+          value={displayValue}
+          onChange={handleInputChange}
+          onInput={handleInput}
+          className={cn(
+            inputProps?.className,
+            'group-data-[invalid=true]:outline-1 group-data-[invalid=true]:outline-functional-red',
+          )}
+          ref={ref as React.RefObject<HTMLInputElement>}
+        />
+        {children}
       </FieldGroup>
-      {description && <Description>{description}</Description>}
+
+      {description && (
+        <Description className={descriptionClassName}>
+          {description}
+        </Description>
+      )}
       <FieldError>{errorMessage}</FieldError>
-    </AriaNumberField>
+    </AriaTextField>
   );
 };

--- a/packages/ui/stories/NumberField.stories.tsx
+++ b/packages/ui/stories/NumberField.stories.tsx
@@ -11,13 +11,40 @@ const meta: Meta<typeof NumberField> = {
   },
   tags: ['autodocs'],
   args: {
-    label: 'Cookies',
+    label: 'Age',
   },
 };
 
 export default meta;
 
-export const Example = (args: any) => <NumberField {...args} />;
+export const Example = () => (
+  <div className="flex w-96 flex-col gap-8">
+    <NumberField
+      inputProps={{ placeholder: 'Enter your age' }}
+      description="Helper text"
+      label="Normal state"
+    />
+    <NumberField
+      isDisabled
+      label="Disabled state"
+      isRequired
+      inputProps={{ placeholder: 'Enter your age' }}
+    />
+
+    <NumberField
+      label="With value"
+      value={25}
+      inputProps={{ placeholder: 'Enter your age' }}
+    />
+
+    <NumberField
+      isDisabled
+      label="Disabled with value"
+      value={30}
+      inputProps={{ placeholder: 'Enter your age' }}
+    />
+  </div>
+);
 
 export const Validation = (args: any) => (
   <Form className="flex flex-col items-start gap-2">
@@ -28,4 +55,5 @@ export const Validation = (args: any) => (
 
 Validation.args = {
   isRequired: true,
+  inputProps: { placeholder: 'Enter your age' },
 };


### PR DESCRIPTION
This PR reworks the `NumberField` component.

Although this component already exists in the Design System, it's not currently used in the main codebase.

Going off of the design, it closely resembles the `TextField`. I intentionally opted to use the `type="text"` approach (avoiding the native number input steppers) and patterned the component API off `TextField` for consistency.

Number validation is handled by the component; this component converts the value to number for the onChange/onInput callbacks. `null` signifies "no value."



```ts
"" --> null
-1 // negative numbers
12 // whole numbers
0.05 // floating numbers
```

<img width="519" height="447" alt="Screenshot 2025-08-02 at 3 43 50 PM" src="https://github.com/user-attachments/assets/4a360909-c60c-4ed9-a2a1-a5715fe4a26d" />
