### PR TITLE
[App] Contact link is inline

### DIFF
--- a/apps/app/src/components/ContactLink/index.tsx
+++ b/apps/app/src/components/ContactLink/index.tsx
@@ -11,9 +11,7 @@ export const ContactLink = ({
 }) => {
   return (
     <div className={cn('flex h-8 items-center gap-2', className)}>
-      <div className="flex w-full items-center gap-1 overflow-hidden">
-        {children}
-      </div>
+      <div className="flex items-center gap-1 overflow-hidden">{children}</div>
       {button}
     </div>
   );


### PR DESCRIPTION
Inline the contact link so that the copy button sits next to the link.

---

<img width="468" height="170" alt="Screenshot 2025-08-02 at 5 28 38 PM" src="https://github.com/user-attachments/assets/27d3d987-d627-4f52-8056-f7b85ec17f10" />
