### PR TITLE
[Design System] Rework `DatePicker` as Calendar select component

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -87,6 +87,7 @@
   },
   "devDependencies": {
     "@iconify/json": "2.2.311",
+    "@internationalized/date": "^3.8.2",
     "@op/typescript-config": "workspace:*",
     "@storybook/addon-essentials": "^8.6.2",
     "@storybook/addon-interactions": "^8.6.2",

--- a/packages/ui/src/components/DatePicker.tsx
+++ b/packages/ui/src/components/DatePicker.tsx
@@ -1,32 +1,41 @@
 'use client';
 
 import { CalendarIcon } from 'lucide-react';
-import { DatePicker as AriaDatePicker } from 'react-aria-components';
+import { DatePicker as AriaDatePicker, Button } from 'react-aria-components';
 import type {
   DatePickerProps as AriaDatePickerProps,
   DateValue,
   ValidationResult,
 } from 'react-aria-components';
 
+import { cn } from '../lib/utils';
 import { composeTailwindRenderProps } from '../utils';
-import { Button } from './Button';
 import { Calendar } from './Calendar';
-import { DateInput } from './DateField';
 import { Dialog } from './Dialog';
 import { Description, FieldError, FieldGroup, Label } from './Field';
 import { Popover } from './Popover';
 
-export interface DatePickerProps<T extends DateValue>
-  extends AriaDatePickerProps<T> {
+export type DatePickerProps<T extends DateValue> = AriaDatePickerProps<T> & {
   label?: string;
   description?: string;
   errorMessage?: string | ((validation: ValidationResult) => string);
-}
+  placeholder?: string;
+  fieldClassName?: string;
+  descriptionClassName?: string;
+  labelClassName?: string;
+  buttonClassName?: string;
+};
 
 export const DatePicker = <T extends DateValue>({
   label,
   description,
   errorMessage,
+  placeholder = 'Select date',
+  fieldClassName,
+  descriptionClassName,
+  labelClassName,
+  isRequired,
+  buttonClassName,
   ...props
 }: DatePickerProps<T>) => {
   return (
@@ -37,22 +46,80 @@ export const DatePicker = <T extends DateValue>({
         'group flex flex-col gap-1',
       )}
     >
-      {label && <Label>{label}</Label>}
-      <FieldGroup className="w-auto min-w-[208px]">
-        <DateInput className="min-w-[150px] flex-1 px-2 py-1.5 text-sm" />
-        <Button
-          variant="icon"
-          padding="none"
-          className="mr-1 aspect-square w-6 rounded outline-offset-0"
+      {label && (
+        <Label
+          className={cn(
+            labelClassName,
+            'group-data-[invalid=true]:text-functional-red',
+          )}
         >
-          <CalendarIcon aria-hidden className="size-4" />
+          {label}
+          {isRequired && <span className="text-functional-red"> *</span>}
+        </Label>
+      )}
+      <FieldGroup className={fieldClassName}>
+        <Button
+          isDisabled={props.isDisabled}
+          className={cn(
+            'flex h-10 min-w-0 flex-1 items-center gap-2',
+            'rounded-md border border-neutral-gray1',
+            'px-3',
+            'text-base leading-[0.5rem] text-neutral-black outline outline-0',
+            'active:border-neutral-gray4 active:outline',
+            'hover:border-neutral-gray2',
+            'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue',
+            'disabled:border-neutral-gray2 disabled:bg-neutral-gray1 disabled:text-lightGray',
+            buttonClassName,
+          )}
+        >
+          <CalendarIcon
+            className={cn(
+              'size-4 text-neutral-black',
+              props.isDisabled && 'text-lightGray',
+            )}
+          />
+          <span
+            className={cn(
+              'flex-1 text-left text-neutral-black',
+              props.isDisabled && 'text-lightGray',
+            )}
+          >
+            {props.value
+              ? new Date(
+                  props.value.year,
+                  props.value.month - 1,
+                  props.value.day,
+                ).toLocaleDateString('en-US', {
+                  month: '2-digit',
+                  day: '2-digit',
+                  year: 'numeric',
+                })
+              : placeholder}
+          </span>
         </Button>
       </FieldGroup>
-      {description && <Description>{description}</Description>}
+      {description && (
+        <Description className={descriptionClassName}>
+          {description}
+        </Description>
+      )}
       <FieldError>{errorMessage}</FieldError>
-      <Popover>
+      <Popover placement="bottom start">
         <Dialog>
-          <Calendar />
+          <Calendar
+            value={props.value}
+            onChange={props.onChange}
+            minValue={props.minValue}
+            maxValue={props.maxValue}
+            isDisabled={props.isDisabled}
+            isReadOnly={props.isReadOnly}
+            autoFocus={props.autoFocus}
+            onFocusChange={undefined}
+            errorMessage={
+              typeof errorMessage === 'string' ? errorMessage : undefined
+            }
+            className="overflow-y-clip"
+          />
         </Dialog>
       </Popover>
     </AriaDatePicker>

--- a/packages/ui/stories/DatePicker.stories.tsx
+++ b/packages/ui/stories/DatePicker.stories.tsx
@@ -1,14 +1,12 @@
+import { parseDate } from '@internationalized/date';
 import type { Meta } from '@storybook/react';
-import { Form } from 'react-aria-components';
+import { useState } from 'react';
+import type { DateValue } from 'react-aria-components';
 
-import { Button } from '../src/components/Button';
 import { DatePicker } from '../src/components/DatePicker';
 
 const meta: Meta<typeof DatePicker> = {
   component: DatePicker,
-  parameters: {
-    layout: 'centered',
-  },
   tags: ['autodocs'],
   args: {
     label: 'Event date',
@@ -17,15 +15,40 @@ const meta: Meta<typeof DatePicker> = {
 
 export default meta;
 
-export const Example = (args: any) => <DatePicker {...args} />;
+export const Example = () => {
+  const [value, setValue] = useState<DateValue | null>(null);
 
-export const Validation = (args: any) => (
-  <Form className="flex flex-col items-start gap-2">
-    <DatePicker {...args} />
-    <Button type="submit">Submit</Button>
-  </Form>
-);
+  return (
+    <div className="flex w-96 flex-col gap-2">
+      <DatePicker label="Event date" value={value} onChange={setValue} />
+      <div className="text-sm text-neutral-gray4">
+        Selected date:{' '}
+        {value ? `${value.year}-${value.month}-${value.day}` : 'None'}
+      </div>
+    </div>
+  );
+};
 
-Validation.args = {
-  isRequired: true,
+export const InitialValue = () => {
+  const [value, setValue] = useState<DateValue | null>(
+    () => parseDate('2020-02-03') as unknown as DateValue,
+  );
+
+  return (
+    <div className="flex w-96 flex-col gap-2">
+      <DatePicker label="Event date" value={value} onChange={setValue} />
+      <div className="text-sm text-neutral-gray4">
+        Selected date:{' '}
+        {value ? `${value.year}-${value.month}-${value.day}` : 'None'}
+      </div>
+    </div>
+  );
+};
+
+export const Disabled = () => {
+  return (
+    <div className="flex w-96 flex-col gap-2">
+      <DatePicker label="Event date" isDisabled />
+    </div>
+  );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,6 +709,9 @@ importers:
       '@iconify/json':
         specifier: 2.2.311
         version: 2.2.311
+      '@internationalized/date':
+        specifier: ^3.8.2
+        version: 3.8.2
       '@op/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config
@@ -1902,8 +1905,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@internationalized/date@3.7.0':
-    resolution: {integrity: sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==}
+  '@internationalized/date@3.8.2':
+    resolution: {integrity: sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==}
 
   '@internationalized/message@3.1.6':
     resolution: {integrity: sha512-JxbK3iAcTIeNr1p0WIFg/wQJjIzJt9l/2KNY/48vXV7GRGZSv3zMxJsce008fZclk2cDC8y0Ig3odceHO7EfNQ==}
@@ -8748,7 +8751,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.1':
     optional: true
 
-  '@internationalized/date@3.7.0':
+  '@internationalized/date@3.8.2':
     dependencies:
       '@swc/helpers': 0.5.15
 
@@ -9268,7 +9271,7 @@ snapshots:
 
   '@react-aria/calendar@3.7.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@react-aria/i18n': 3.12.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@react-aria/interactions': 3.23.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@react-aria/live-announcer': 3.4.1
@@ -9347,7 +9350,7 @@ snapshots:
 
   '@react-aria/datepicker@3.13.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@internationalized/number': 3.6.0
       '@internationalized/string': 3.2.5
       '@react-aria/focus': 3.19.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -9460,7 +9463,7 @@ snapshots:
 
   '@react-aria/i18n@3.12.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@internationalized/message': 3.1.6
       '@internationalized/number': 3.6.0
       '@internationalized/string': 3.2.5
@@ -9956,7 +9959,7 @@ snapshots:
 
   '@react-stately/calendar@3.7.0(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@react-stately/utils': 3.10.5(react@19.0.0)
       '@react-types/calendar': 3.6.0(react@19.0.0)
       '@react-types/shared': 3.27.0(react@19.0.0)
@@ -10012,7 +10015,7 @@ snapshots:
 
   '@react-stately/datepicker@3.12.0(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@internationalized/string': 3.2.5
       '@react-stately/form': 3.1.1(react@19.0.0)
       '@react-stately/overlays': 3.6.13(react@19.0.0)
@@ -10276,7 +10279,7 @@ snapshots:
 
   '@react-types/calendar@3.6.0(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@react-types/shared': 3.27.0(react@19.0.0)
       react: 19.0.0
 
@@ -10298,7 +10301,7 @@ snapshots:
 
   '@react-types/datepicker@3.10.0(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@react-types/calendar': 3.6.0(react@19.0.0)
       '@react-types/overlays': 3.8.12(react@19.0.0)
       '@react-types/shared': 3.27.0(react@19.0.0)
@@ -12487,7 +12490,7 @@ snapshots:
   gel@2.0.0:
     dependencies:
       '@petamoriken/float16': 3.9.1
-      debug: 4.4.0
+      debug: 4.4.1
       env-paths: 3.0.0
       semver: 7.7.1
       shell-quote: 1.8.2
@@ -13552,7 +13555,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.0
+      debug: 4.4.1
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -14261,7 +14264,7 @@ snapshots:
 
   react-aria-components@1.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@internationalized/string': 3.2.5
       '@react-aria/autocomplete': 3.0.0-alpha.37(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@react-aria/collections': 3.0.0-alpha.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
Review by commit.

This PR addresses the needs for a single, calendar select component.

On the surface, the component resembles a text field but is clickable. Clicking it will display the calendar. [The design of the calendar is TBD.](https://www.figma.com/design/u4YWqQeNlAosEjs1lrsGqf?node-id=2-2843#1356723319)

**Component API**

- Controlled component that provides the selected calendar value back to the consumer
- Supports initial value
- Supports disabled state

This also adds `@internationalized/date` as a development dependency to illustrate how an initial value can be passed to the component. This is taken from the React Aria docs: https://react-spectrum.adobe.com/react-aria/Calendar.html#value

---

## Initial state
<img width="500" height="538" alt="Screenshot 2025-08-03 at 2 24 36 PM" src="https://github.com/user-attachments/assets/e70668c6-c388-4a6e-a129-cf159e92ce66" />

## Initial value
<img width="500" height="351" alt="Screenshot 2025-08-03 at 2 24 40 PM" src="https://github.com/user-attachments/assets/299e9d0c-43e1-4906-bd37-2aca95e785c6" />

## Disabled state
<img width="500" height="328" alt="Screenshot 2025-08-03 at 2 24 43 PM" src="https://github.com/user-attachments/assets/cb119a7f-a454-4e04-9be9-9a49d2b238ce" />