### PR TITLE
[Design System] Update `Calendar` styles

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -67,6 +67,7 @@
     "lint": "pnpm tsc --noEmit"
   },
   "dependencies": {
+    "@internationalized/date": "^3.8.2",
     "@op/core": "workspace:*",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/typography": "^0.5.16",

--- a/packages/ui/src/components/Calendar.tsx
+++ b/packages/ui/src/components/Calendar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getLocalTimeZone, isToday } from '@internationalized/date';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import {
   Calendar as AriaCalendar,
@@ -23,14 +24,17 @@ import { Button } from './Button';
 
 const cellStyles = tv({
   extend: focusRing,
-  base: 'flex size-9 cursor-default items-center justify-center rounded-full text-sm forced-color-adjust-none',
+  base: 'focus-within:outline-blueGreen flex size-8 cursor-default items-center justify-center text-base outline-offset-2 outline-transparent forced-color-adjust-none hover:bg-neutral-offWhite',
   variants: {
     isSelected: {
-      false: 'text-neutral-800 hover:bg-neutral-300 pressed:bg-neutral-400',
-      true: 'bg-neutral-400 text-white invalid:bg-red-600',
+      false: 'text-neutral-charcoal',
+      true: 'bg-primary-teal text-white hover:bg-primary-teal',
     },
     isDisabled: {
-      true: 'text-neutral-400',
+      true: 'text-neutral-gray3',
+    },
+    isOutsideMonth: {
+      true: 'text-neutral-gray4',
     },
   },
 });
@@ -45,19 +49,27 @@ export const CalendarHeader = () => {
 
   return (
     <header className="flex w-full items-center justify-between gap-2 px-1 pb-4">
-      <Button variant="icon" slot="previous">
+      <Button
+        variant="icon"
+        slot="previous"
+        className="h-8 w-8 rounded-none bg-white p-0 text-neutral-charcoal shadow-none hover:bg-neutral-offWhite pressed:bg-neutral-offWhite pressed:shadow-none"
+      >
         {direction === 'rtl' ? (
-          <ChevronRight aria-hidden />
+          <ChevronRight className="size-4" aria-hidden />
         ) : (
-          <ChevronLeft aria-hidden />
+          <ChevronLeft className="size-4" aria-hidden />
         )}
       </Button>
-      <Heading className="text-center text-xl font-semibold text-neutral-800" />
-      <Button variant="icon" slot="next">
+      <Heading className="text-center text-base text-neutral-charcoal" />
+      <Button
+        variant="icon"
+        slot="next"
+        className="h-8 w-8 rounded-none bg-white p-0 text-neutral-charcoal shadow-none hover:bg-neutral-offWhite pressed:bg-neutral-offWhite pressed:shadow-none"
+      >
         {direction === 'rtl' ? (
-          <ChevronLeft aria-hidden />
+          <ChevronLeft className="size-4" aria-hidden />
         ) : (
-          <ChevronRight aria-hidden />
+          <ChevronRight className="size-4" aria-hidden />
         )}
       </Button>
     </header>
@@ -68,7 +80,7 @@ export const CalendarGridHeader = () => {
   return (
     <AriaCalendarGridHeader>
       {(day) => (
-        <CalendarHeaderCell className="text-xs font-semibold text-neutral-500">
+        <CalendarHeaderCell className="text-base text-neutral-charcoal">
           {day}
         </CalendarHeaderCell>
       )}
@@ -81,12 +93,29 @@ export const Calendar = <T extends DateValue>({
   ...props
 }: CalendarProps<T>) => {
   return (
-    <AriaCalendar {...props}>
+    <AriaCalendar
+      {...props}
+      className="rounded-md border border-solid border-neutral-gray1 bg-white p-1"
+    >
       <CalendarHeader />
       <CalendarGrid>
         <CalendarGridHeader />
         <CalendarGridBody>
-          {(date) => <CalendarCell date={date} className={cellStyles} />}
+          {(date) => {
+            const isTodayCell = isToday(date, getLocalTimeZone());
+            const cell = <CalendarCell date={date} className={cellStyles} />;
+
+            if (isTodayCell) {
+              return (
+                <span className="relative flex flex-col">
+                  {cell}
+                  <span className="absolute bottom-1 left-0 right-0 m-auto size-1 rounded-full bg-primary-teal"></span>
+                </span>
+              );
+            }
+
+            return cell;
+          }}
         </CalendarGridBody>
       </CalendarGrid>
       {errorMessage && (

--- a/packages/ui/stories/Calendar.stories.tsx
+++ b/packages/ui/stories/Calendar.stories.tsx
@@ -13,5 +13,9 @@ const meta: Meta<typeof Calendar> = {
 export default meta;
 
 export const Example = (args: any) => (
-  <Calendar aria-label="Event date" {...args} />
+  <Calendar
+    aria-label="Event date"
+    {...args}
+    onChange={(date) => console.log(date)}
+  />
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,6 +648,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@internationalized/date':
+        specifier: ^3.8.2
+        version: 3.8.2
       '@op/core':
         specifier: workspace:*
         version: link:../core
@@ -1908,8 +1911,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@internationalized/date@3.7.0':
-    resolution: {integrity: sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==}
+  '@internationalized/date@3.8.2':
+    resolution: {integrity: sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==}
 
   '@internationalized/message@3.1.6':
     resolution: {integrity: sha512-JxbK3iAcTIeNr1p0WIFg/wQJjIzJt9l/2KNY/48vXV7GRGZSv3zMxJsce008fZclk2cDC8y0Ig3odceHO7EfNQ==}
@@ -8754,7 +8757,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.1':
     optional: true
 
-  '@internationalized/date@3.7.0':
+  '@internationalized/date@3.8.2':
     dependencies:
       '@swc/helpers': 0.5.15
 
@@ -9274,7 +9277,7 @@ snapshots:
 
   '@react-aria/calendar@3.7.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@react-aria/i18n': 3.12.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@react-aria/interactions': 3.23.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@react-aria/live-announcer': 3.4.1
@@ -9353,7 +9356,7 @@ snapshots:
 
   '@react-aria/datepicker@3.13.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@internationalized/number': 3.6.0
       '@internationalized/string': 3.2.5
       '@react-aria/focus': 3.19.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -9466,7 +9469,7 @@ snapshots:
 
   '@react-aria/i18n@3.12.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@internationalized/message': 3.1.6
       '@internationalized/number': 3.6.0
       '@internationalized/string': 3.2.5
@@ -9962,7 +9965,7 @@ snapshots:
 
   '@react-stately/calendar@3.7.0(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@react-stately/utils': 3.10.5(react@19.0.0)
       '@react-types/calendar': 3.6.0(react@19.0.0)
       '@react-types/shared': 3.27.0(react@19.0.0)
@@ -10018,7 +10021,7 @@ snapshots:
 
   '@react-stately/datepicker@3.12.0(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@internationalized/string': 3.2.5
       '@react-stately/form': 3.1.1(react@19.0.0)
       '@react-stately/overlays': 3.6.13(react@19.0.0)
@@ -10282,7 +10285,7 @@ snapshots:
 
   '@react-types/calendar@3.6.0(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@react-types/shared': 3.27.0(react@19.0.0)
       react: 19.0.0
 
@@ -10304,7 +10307,7 @@ snapshots:
 
   '@react-types/datepicker@3.10.0(react@19.0.0)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@react-types/calendar': 3.6.0(react@19.0.0)
       '@react-types/overlays': 3.8.12(react@19.0.0)
       '@react-types/shared': 3.27.0(react@19.0.0)
@@ -14267,7 +14270,7 @@ snapshots:
 
   react-aria-components@1.6.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.8.2
       '@internationalized/string': 3.2.5
       '@react-aria/autocomplete': 3.0.0-alpha.37(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@react-aria/collections': 3.0.0-alpha.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
- Update calendar styles (all cell types, factoring in different states)
- Stylize "current day"
- Add [@internationalized/date dependency](https://github.com/oneprojectorg/common/commit/60305ec7bcffa46926886b41e9d68404a84ef1c4), which is the recommended way to "obtain" the current date

---

<img width="526" height="346" alt="Screenshot 2025-08-09 at 1 31 58 PM" src="https://github.com/user-attachments/assets/3b693b16-f4ca-445f-925a-5da2400c99c4" />
