### PR TITLE
[Design System] Fixes for `DatePicker`

### DIFF
--- a/packages/ui/src/components/DatePicker.tsx
+++ b/packages/ui/src/components/DatePicker.tsx
@@ -162,60 +162,58 @@ export const DatePicker = <T extends DateValue>({
 
   return (
     <div className="relative">
-      <div className="relative">
-        <TextField
-          ref={inputRef}
-          label={label}
-          description={description}
-          errorMessage={errorMessage}
-          fieldClassName={fieldClassName}
-          descriptionClassName={descriptionClassName}
-          labelClassName={labelClassName}
-          isRequired={isRequired}
-          value={inputValue}
-          onChange={handleInputChange}
-          isDisabled={props.isDisabled}
-          inputProps={{
-            ...inputProps,
-            className: cn('pr-10', inputProps?.className),
-            placeholder: placeholder,
-            onFocus: handleInputFocus,
-            onBlur: handleInputBlur,
-          }}
-        />
+      <TextField
+        ref={inputRef}
+        label={label}
+        description={description}
+        errorMessage={errorMessage}
+        fieldClassName="relative"
+        descriptionClassName={descriptionClassName}
+        labelClassName={labelClassName}
+        isRequired={isRequired}
+        value={inputValue}
+        onChange={handleInputChange}
+        isDisabled={props.isDisabled}
+        inputProps={{
+          ...inputProps,
+          className: cn('pr-10', inputProps?.className),
+          placeholder: placeholder,
+          onFocus: handleInputFocus,
+          onBlur: handleInputBlur,
+        }}
+      >
         <button
           type="button"
           onClick={handleCalendarIconClick}
           disabled={props.isDisabled}
           className={cn(
-            'absolute bottom-0 right-3 m-auto',
-            'h-10',
+            'absolute right-0 top-1/2 -translate-y-1/2',
+            'h-10 w-10',
             'flex items-center justify-center',
-            'text-black',
+            'text-neutral-black',
             props.isDisabled && 'cursor-not-allowed text-lightGray',
           )}
-          style={{ marginTop: label ? '12px' : '0' }}
         >
           <CalendarIcon className="size-4" />
         </button>
-      </div>
-      {isCalendarOpen && (
-        <div
-          className="absolute top-full z-50 mt-1 w-full max-w-[15.5rem]"
-          role="dialog"
-          aria-modal="true"
-        >
-          <Calendar
-            value={props.value}
-            onChange={handleCalendarChange}
-            minValue={props.minValue}
-            maxValue={props.maxValue}
-            isDisabled={props.isDisabled}
-            isReadOnly={props.isReadOnly}
-            errorMessage={errorMessage}
-          />
-        </div>
-      )}
+        {isCalendarOpen && (
+          <div
+            className="absolute top-full z-50 mt-1 w-[15.5rem]"
+            role="dialog"
+            aria-modal="true"
+          >
+            <Calendar
+              value={props.value}
+              onChange={handleCalendarChange}
+              minValue={props.minValue}
+              maxValue={props.maxValue}
+              isDisabled={props.isDisabled}
+              isReadOnly={props.isReadOnly}
+              errorMessage={errorMessage}
+            />
+          </div>
+        )}
+      </TextField>
     </div>
   );
 };

--- a/packages/ui/stories/DatePicker.stories.tsx
+++ b/packages/ui/stories/DatePicker.stories.tsx
@@ -62,3 +62,15 @@ export const Disabled = () => {
     </div>
   );
 };
+
+export const ErrorState = () => {
+  return (
+    <div className="flex w-96 flex-col gap-2">
+      <DatePicker
+        label="Event date"
+        placeholder="08/06/2025"
+        errorMessage="This is an error message"
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
Review with [whitespace-hidden.](https://github.com/oneprojectorg/common/pull/100/files?w=1)

Addresses several UI issues:

- Vertically center calendar button if error displayed (added a Story to illustrate this)
- Fix calendar being offset by error message. This requires moving the calendar "inside" `TextField`
- Enforce fixed width for calendar
- Fix calendar icon button color

---

<img width="577" height="305" alt="Screenshot 2025-08-17 at 8 36 47 PM" src="https://github.com/user-attachments/assets/9cb8cbb6-a505-4d9e-b950-bc2f2ecfd484" />
