### PR TITLE
[Design System] `NumberField` supports prefix text

### DIFF
--- a/packages/ui/stories/NumberField.stories.tsx
+++ b/packages/ui/stories/NumberField.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from '@storybook/react';
+import { useState } from 'react';
 import { Form } from 'react-aria-components';
 
 import { Button } from '../src/components/Button';
@@ -56,4 +57,31 @@ export const Validation = (args: any) => (
 Validation.args = {
   isRequired: true,
   inputProps: { placeholder: 'Enter your age' },
+};
+
+export const WithPrefix = () => (
+  <NumberField
+    inputProps={{ placeholder: 'Enter your budget' }}
+    label="Budget"
+    prefixText="$"
+  />
+);
+
+export const DynamicPrefix = () => {
+  const [value, setValue] = useState(0);
+  const [prefix, setPrefix] = useState('$');
+
+  return (
+    <NumberField
+      inputProps={{ placeholder: 'Enter your budget' }}
+      label="Budget"
+      prefixText={prefix}
+      value={value}
+      onChange={(value) => {
+        setValue(value ?? 0);
+        const valueStr = value?.toString() || '0';
+        setPrefix('$'.repeat(valueStr.length));
+      }}
+    />
+  );
 };


### PR DESCRIPTION
Adds `prefixText` to `NumberField`. This is a common pattern when needing a prefix-able text that isn't directly tied to the controlled value. A use case is to prefix a dollar sign for currency.

The `prefixText` width calculation is dynamic and performant (resize observer).

---

## Design

<img width="633" height="240" alt="Screenshot 2025-08-23 at 9 06 00 AM" src="https://github.com/user-attachments/assets/3c6dd30d-9138-4680-9cd8-16180e4a5463" />

## Dynamic Width

https://github.com/user-attachments/assets/92c1d670-de5b-4030-b90d-32ad461fe433

