### PR TITLE
[Design System] Fix `Select` text alignment

### DIFF
--- a/packages/ui/src/components/ListBox.tsx
+++ b/packages/ui/src/components/ListBox.tsx
@@ -135,7 +135,7 @@ export const DropdownItem = (
     >
       {composeRenderProps(props.children, (children, { isSelected }) => (
         <>
-          <span className="group-hover:bgt-neutral-gray1 flex flex-1 items-center gap-2 truncate font-normal text-neutral-black">
+          <span className="group-hover:bgt-neutral-gray1 flex h-full flex-1 items-center gap-2 truncate font-normal text-neutral-black">
             {children}
           </span>
           <span className="flex w-5 items-center">

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -104,8 +104,15 @@ export const Select = <T extends object>({
             props.buttonClassName,
           )}
         >
-          <SelectValue className={cn(props.selectValueClassName)} />
-          <ChevronDown aria-hidden className={chevronStyles({ variant })} />
+          <span className="flex h-full w-full flex-1 items-center gap-1">
+            <SelectValue
+              className={cn(
+                props.selectValueClassName,
+                'flex h-full items-center',
+              )}
+            />
+            <ChevronDown aria-hidden className={chevronStyles({ variant })} />
+          </span>
         </Button>
       )}
       {description && <Description>{description}</Description>}

--- a/packages/ui/stories/Select.stories.tsx
+++ b/packages/ui/stories/Select.stories.tsx
@@ -18,21 +18,30 @@ const meta: Meta<typeof Select> = {
 export default meta;
 
 export const Example = () => (
-  <>
-    <Select className="w-full">
-      <SelectItem>Chocolate</SelectItem>
-      <SelectItem id="mint">Mint</SelectItem>
-      <SelectItem>Strawberry</SelectItem>
-      <SelectItem>Vanilla</SelectItem>
-    </Select>
-    Disabled
-    <Select className="w-full" isDisabled>
-      <SelectItem>Chocolate</SelectItem>
-      <SelectItem id="mint">Mint</SelectItem>
-      <SelectItem>Strawberry</SelectItem>
-      <SelectItem>Vanilla</SelectItem>
-    </Select>
-  </>
+  <Select className="w-full">
+    <SelectItem id="chocolate">All proposals</SelectItem>
+    <SelectItem id="mint">Mint</SelectItem>
+    <SelectItem id="strawberry">Strawberry</SelectItem>
+    <SelectItem id="vanilla">Vanilla</SelectItem>
+  </Select>
+);
+
+export const InitialSelectedItem = () => (
+  <Select className="w-full" defaultSelectedKey="chocolate">
+    <SelectItem id="chocolate">All proposals</SelectItem>
+    <SelectItem id="mint">Mint</SelectItem>
+    <SelectItem id="strawberry">Strawberry</SelectItem>
+    <SelectItem id="vanilla">Vanilla</SelectItem>
+  </Select>
+);
+
+export const Disabled = () => (
+  <Select className="w-full" isDisabled>
+    <SelectItem>Chocolate</SelectItem>
+    <SelectItem id="mint">Mint</SelectItem>
+    <SelectItem>Strawberry</SelectItem>
+    <SelectItem>Vanilla</SelectItem>
+  </Select>
 );
 
 export const DisabledItems = (args: any) => <Example {...args} />;
@@ -89,7 +98,7 @@ export const PillVariant = (args: any) => (
       <SelectItem>Testing</SelectItem>
       <SelectItem>Deployment</SelectItem>
     </Select>
-    
+
     <Select {...args} variant="pill" placeholder="Select category" isDisabled>
       <SelectItem>Planning</SelectItem>
       <SelectItem>Design</SelectItem>


### PR DESCRIPTION
The descenders are cut-off.

This fixes text vertical alignment in `Select` and `SelectItem`. This also isolates stories for easier development:

- Default (no selection)
- With initial selection
- Disabled

---

<img width="427" height="127" alt="Screenshot 2025-08-23 at 9 48 19 AM" src="https://github.com/user-attachments/assets/fa1c097a-b841-4d41-85f0-39f85f55c1d8" />
<img width="385" height="145" alt="Screenshot 2025-08-23 at 9 48 15 AM" src="https://github.com/user-attachments/assets/176dc5c6-3d4d-4233-9265-2005969bf858" />

## Before / After

<img width="527" height="77" alt="Screenshot 2025-08-23 at 9 57 59 AM" src="https://github.com/user-attachments/assets/ed25b7ae-f76a-4d34-9fdb-13e7943ab969" />
<img width="527" height="82" alt="Screenshot 2025-08-23 at 9 48 44 AM" src="https://github.com/user-attachments/assets/d994341f-2033-4f85-8e13-bb6e2429fef8" />

