### PR TITLE
[Design System] `Toggle` supports small size

### DIFF
--- a/packages/ui/src/components/ToggleButton.tsx
+++ b/packages/ui/src/components/ToggleButton.tsx
@@ -11,8 +11,12 @@ import { focusRing } from '../utils';
 
 const styles = tv({
   extend: focusRing,
-  base: 'flex h-10 min-w-18 cursor-pointer items-center rounded-full p-1 outline-offset-0 outline-transparent transition-colors duration-300 focus-visible:ring-transparent',
+  base: 'flex cursor-pointer items-center rounded-full p-1 outline-offset-0 outline-transparent transition-colors duration-300 focus-visible:ring-transparent',
   variants: {
+    size: {
+      default: 'h-10 min-w-18',
+      small: 'h-5 min-w-8',
+    },
     isSelected: {
       false: 'bg-lightGray',
       true: 'bg-green',
@@ -21,21 +25,33 @@ const styles = tv({
       true: 'border-white/5 bg-neutral-200 text-neutral-400',
     },
   },
+  defaultVariants: {
+    size: 'default',
+  },
 });
 
-export const ToggleButton = (props: ToggleButtonProps) => {
+export const ToggleButton = (
+  props: ToggleButtonProps & { size?: 'default' | 'small' },
+) => {
   return (
     <RACToggleButton
       {...props}
       className={composeRenderProps(props.className, (className, renderProps) =>
-        styles({ ...renderProps, className }),
+        styles({ ...renderProps, size: props.size, className }),
       )}
     >
       {({ isSelected }) => (
         <div
           className={cn(
-            'size-8 rounded-full bg-white shadow-md transition-transform duration-300',
-            isSelected ? 'translate-x-8' : 'translate-x-0',
+            'rounded-full bg-white shadow-md transition-transform duration-300',
+            props.size === 'small' ? 'size-4' : 'size-8',
+            isSelected
+              ? props.size === 'small'
+                ? 'translate-x-2.5'
+                : 'translate-x-8'
+              : props.size === 'small'
+                ? '-translate-x-px'
+                : 'translate-x-0',
           )}
         />
       )}

--- a/packages/ui/stories/ToggleButton.stories.tsx
+++ b/packages/ui/stories/ToggleButton.stories.tsx
@@ -15,3 +15,9 @@ export default meta;
 export const Example = (args: any) => (
   <ToggleButton {...args}>Pin</ToggleButton>
 );
+
+export const Small = (args: any) => (
+  <ToggleButton {...args} size="small">
+    Pin
+  </ToggleButton>
+);


### PR DESCRIPTION
Adds the small size based on the Figma (32px by 20px).

---

<img width="312" height="74" alt="Screenshot 2025-08-24 at 9 14 29 PM" src="https://github.com/user-attachments/assets/dd87cbf1-7ffc-4d8c-89b5-1b3f69f94046" />
