### PR TITLE
chore(styles): custom tailwind-merge config 

### DIFF
--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -409,7 +409,7 @@ export const PostItem = ({
       <FeedMain>
         <FeedHeader className="relative w-full justify-between">
           <div className="flex items-baseline gap-2">
-            <Header3 className="font-sans leading-3 font-semibold">
+            <Header3 className="font-sans text-base leading-3 font-semibold">
               <PostDisplayName
                 displayName={displayName}
                 displaySlug={displaySlug}
@@ -487,7 +487,7 @@ export const PostItemOnDetailPage = ({
       <FeedMain>
         <FeedHeader className="relative w-full justify-between">
           <div className="flex items-baseline gap-2">
-            <Header3 className="font-sans leading-3 font-semibold">
+            <Header3 className="font-sans text-base leading-3 font-semibold">
               <PostDisplayName
                 displayName={displayName}
                 displaySlug={displaySlug}

--- a/apps/app/src/components/Profile/ProfileContent/index.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/index.tsx
@@ -128,7 +128,7 @@ const ProfileAbout = ({
       <div className="flex flex-col gap-4 rounded border p-4 sm:rounded-none sm:border-none sm:p-0">
         {email || website ? (
           <section className="flex flex-col gap-2">
-            <Header3 className="font-sans">{t('Contact')}</Header3>
+            <Header3 className="font-sans text-base">{t('Contact')}</Header3>
             <div className="flex flex-col text-teal">
               {website ? (
                 <ContactLink>
@@ -177,7 +177,7 @@ const ProfileAbout = ({
 
         {orgType ? (
           <section className="flex flex-col gap-2 text-neutral-charcoal">
-            <Header3 className="font-sans">
+            <Header3 className="font-sans text-base">
               {t('Organizational Status')}
             </Header3>
             <TagGroup>

--- a/apps/app/src/components/decisions/DecisionHero.tsx
+++ b/apps/app/src/components/decisions/DecisionHero.tsx
@@ -19,7 +19,7 @@ export function DecisionHero({
   return (
     <div className="flex flex-col gap-2 text-center">
       {variant === 'results' ? (
-        <Header2 className="font-serif text-title-xxl font-light uppercase">
+        <Header2 className="font-serif text-title-xxl font-light text-neutral-offWhite uppercase">
           <bdi>{title}</bdi>
         </Header2>
       ) : (

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,9 +1,26 @@
 import { clsx } from 'clsx';
 import type { ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { extendTailwindMerge } from 'tailwind-merge';
+
+const customTwMerge = extendTailwindMerge({
+  extend: {
+    theme: {
+      text: [
+        'title-xxl',
+        'title-xl',
+        'title-lg',
+        'title-md',
+        'title-base',
+        'title-sm',
+        'title-xs',
+        'title-xxs',
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return customTwMerge(clsx(inputs));
 }
 
 export const GRADIENTS = [

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,9 +1,26 @@
 import { clsx } from 'clsx';
 import type { ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { extendTailwindMerge } from 'tailwind-merge';
+
+const customTwMerge = extendTailwindMerge({
+  extend: {
+    theme: {
+      text: [
+        'title-xxl',
+        'title-xl',
+        'title-lg',
+        'title-md',
+        'title-base',
+        'title-sm',
+        'title-xs',
+        'title-xxs',
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return customTwMerge(clsx(inputs));
 }
 
 export const GRADIENT_COLORS = [


### PR DESCRIPTION
Some classes defined in our tailwind config are being filtered out by `tailwind-merge` because we haven't [defined a custom config](https://github.com/dcastil/tailwind-merge/blob/v3.4.0/docs/configuration.md). This PR defines that config and updates our `cn` utility. 

I still need to go through and make sure this doesn't break anything. Also need to decide whether we want to consolidate with the `cx` utility from Intent UI. 