### PR TITLE
Add JWT authentication for Tiptap collaboration on proposals

### DIFF
--- a/apps/app/src/components/collaboration/CollaborativeDocContext.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeDocContext.tsx
@@ -32,6 +32,8 @@ const CollaborativeDocContext =
 interface CollaborativeDocProviderProps {
   /** Unique document identifier for collaboration */
   docId: string;
+  /** JWT token for Tiptap Cloud authentication */
+  token: string | null;
   /** User's display name for collaboration cursors */
   userName?: string;
   /** Loading state to show while the collaboration provider initializes */
@@ -46,7 +48,7 @@ interface CollaborativeDocProviderProps {
  *
  * @example
  * ```tsx
- * <CollaborativeDocProvider docId="proposal-123" userName="Alice" fallback={<Skeleton />}>
+ * <CollaborativeDocProvider docId="proposal-123" token={collabToken} userName="Alice" fallback={<Skeleton />}>
  *   <CollaborativeTitleField />
  *   <CollaborativeEditor />
  * </CollaborativeDocProvider>
@@ -54,6 +56,7 @@ interface CollaborativeDocProviderProps {
  */
 export function CollaborativeDocProvider({
   docId,
+  token,
   userName = 'Anonymous',
   fallback = null,
   children,
@@ -61,6 +64,7 @@ export function CollaborativeDocProvider({
   const { ydoc, provider, status, isSynced, user } = useTiptapCollab({
     docId,
     enabled: true,
+    token,
     userName,
   });
 

--- a/apps/app/src/components/collaboration/CollaborativeDocContext.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeDocContext.tsx
@@ -34,6 +34,8 @@ interface CollaborativeDocProviderProps {
   docId: string;
   /** JWT token for Tiptap Cloud authentication */
   token: string | null;
+  /** Called when Tiptap Cloud rejects the JWT (expired or invalid) */
+  onAuthenticationFailed?: () => void;
   /** User's display name for collaboration cursors */
   userName?: string;
   /** Loading state to show while the collaboration provider initializes */
@@ -57,6 +59,7 @@ interface CollaborativeDocProviderProps {
 export function CollaborativeDocProvider({
   docId,
   token,
+  onAuthenticationFailed,
   userName = 'Anonymous',
   fallback = null,
   children,
@@ -65,6 +68,7 @@ export function CollaborativeDocProvider({
     docId,
     enabled: true,
     token,
+    onAuthenticationFailed,
     userName,
   });
 

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -247,6 +247,12 @@ export function ProposalEditor({
     { staleTime: 1000 * 60 * 60 },
   );
 
+  const handleAuthenticationFailed = useCallback(() => {
+    void utils.decision.getCollabToken.invalidate({
+      proposalProfileId: proposal.profileId,
+    });
+  }, [utils, proposal.profileId]);
+
   // -- Render ----------------------------------------------------------------
 
   const userName = user.profile?.name ?? t('Anonymous');
@@ -255,6 +261,7 @@ export function ProposalEditor({
     <CollaborativeDocProvider
       docId={collaborationDocId}
       token={collabTokenData?.token ?? null}
+      onAuthenticationFailed={handleAuthenticationFailed}
       userName={userName}
       fallback={<ProposalEditorSkeleton />}
     >

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -240,6 +240,13 @@ export function ProposalEditor({
     draftRef,
   ]);
 
+  // -- Collaboration token ---------------------------------------------------
+
+  const { data: collabTokenData } = trpc.decision.getCollabToken.useQuery(
+    { proposalProfileId: proposal.profileId },
+    { staleTime: 1000 * 60 * 60 },
+  );
+
   // -- Render ----------------------------------------------------------------
 
   const userName = user.profile?.name ?? t('Anonymous');
@@ -247,6 +254,7 @@ export function ProposalEditor({
   return (
     <CollaborativeDocProvider
       docId={collaborationDocId}
+      token={collabTokenData?.token ?? null}
       userName={userName}
       fallback={<ProposalEditorSkeleton />}
     >

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -244,10 +244,7 @@ export function ProposalEditor({
 
   const { data: collabTokenData } = trpc.decision.getCollabToken.useQuery(
     { proposalProfileId: proposal.profileId },
-    {
-      staleTime: 1000 * 60 * 60, // 1 hour
-      refetchInterval: 1000 * 60 * 60 * 12, // 12 hours — refresh well before 24h JWT expiry
-    },
+    { staleTime: 1000 * 60 * 60 }, // 1 hour — refetched on demand via onAuthenticationFailed
   );
 
   const handleAuthenticationFailed = useCallback(() => {

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -244,7 +244,10 @@ export function ProposalEditor({
 
   const { data: collabTokenData } = trpc.decision.getCollabToken.useQuery(
     { proposalProfileId: proposal.profileId },
-    { staleTime: 1000 * 60 * 60 },
+    {
+      staleTime: 1000 * 60 * 60, // 1 hour
+      refetchInterval: 1000 * 60 * 60 * 12, // 12 hours — refresh well before 24h JWT expiry
+    },
   );
 
   const handleAuthenticationFailed = useCallback(() => {

--- a/apps/app/src/hooks/useTiptapCollab.ts
+++ b/apps/app/src/hooks/useTiptapCollab.ts
@@ -47,6 +47,13 @@ export function useTiptapCollab({
 
   const ydoc = useMemo(() => new Y.Doc(), []);
 
+  // Clean up Y.Doc on unmount
+  useEffect(() => {
+    return () => {
+      ydoc.destroy();
+    };
+  }, [ydoc]);
+
   // Derive color from username - matches Avatar gradient
   const user = useMemo<CollabUser>(() => {
     const { hex } = getAvatarColorForString(userName);

--- a/apps/app/src/hooks/useTiptapCollab.ts
+++ b/apps/app/src/hooks/useTiptapCollab.ts
@@ -17,6 +17,8 @@ export interface UseTiptapCollabOptions {
   enabled?: boolean;
   /** JWT token for Tiptap Cloud authentication */
   token: string | null;
+  /** Called when Tiptap Cloud rejects the JWT (expired or invalid) */
+  onAuthenticationFailed?: () => void;
   /** User's display name for the collaboration cursor */
   userName?: string;
 }
@@ -36,6 +38,7 @@ export function useTiptapCollab({
   docId,
   enabled = true,
   token,
+  onAuthenticationFailed,
   userName = 'Anonymous',
 }: UseTiptapCollabOptions): UseTiptapCollabReturn {
   const [status, setStatus] = useState<CollabStatus>('connecting');
@@ -78,6 +81,10 @@ export function useTiptapCollab({
       onSynced: () => {
         setIsSynced(true);
       },
+      onAuthenticationFailed: () => {
+        setStatus('disconnected');
+        onAuthenticationFailed?.();
+      },
     });
 
     setProvider(newProvider);
@@ -85,7 +92,7 @@ export function useTiptapCollab({
       newProvider.destroy();
       setProvider(null);
     };
-  }, [docId, enabled, token, ydoc]);
+  }, [docId, enabled, onAuthenticationFailed, token, ydoc]);
 
   // Update awareness when user info changes
   useEffect(() => {

--- a/apps/app/src/hooks/useTiptapCollab.ts
+++ b/apps/app/src/hooks/useTiptapCollab.ts
@@ -15,6 +15,8 @@ export interface CollabUser {
 export interface UseTiptapCollabOptions {
   docId: string | null;
   enabled?: boolean;
+  /** JWT token for Tiptap Cloud authentication */
+  token: string | null;
   /** User's display name for the collaboration cursor */
   userName?: string;
 }
@@ -33,6 +35,7 @@ export interface UseTiptapCollabReturn {
 export function useTiptapCollab({
   docId,
   enabled = true,
+  token,
   userName = 'Anonymous',
 }: UseTiptapCollabOptions): UseTiptapCollabReturn {
   const [status, setStatus] = useState<CollabStatus>('connecting');
@@ -48,7 +51,7 @@ export function useTiptapCollab({
   }, [userName]);
 
   useEffect(() => {
-    if (!enabled || !docId) {
+    if (!enabled || !docId || !token) {
       setStatus('disconnected');
       return;
     }
@@ -63,7 +66,7 @@ export function useTiptapCollab({
     const newProvider = new TiptapCollabProvider({
       name: docId,
       appId,
-      token: 'notoken', // TODO: proper JWT auth
+      token,
       document: ydoc,
       onConnect: () => {
         setStatus('connected');
@@ -82,7 +85,7 @@ export function useTiptapCollab({
       newProvider.destroy();
       setProvider(null);
     };
-  }, [docId, enabled, ydoc]);
+  }, [docId, enabled, token, ydoc]);
 
   // Update awareness when user info changes
   useEffect(() => {

--- a/packages/common/src/services/decision/getCollabToken.ts
+++ b/packages/common/src/services/decision/getCollabToken.ts
@@ -1,0 +1,62 @@
+import { generateCollabToken } from '@op/collab/server';
+import { db } from '@op/db/client';
+import type { User } from '@op/supabase/lib';
+import { permission } from 'access-zones';
+
+import { NotFoundError, ValidationError } from '../../utils';
+import { assertInstanceProfileAccess } from '../access';
+import { parseProposalData } from './proposalDataSchema';
+
+/**
+ * Generate a scoped Tiptap Cloud collaboration JWT for a proposal.
+ *
+ * Verifies the user has UPDATE access on the proposal's profile (with
+ * org-level fallback) before issuing the token. The JWT is scoped to the
+ * proposal's `collaborationDocId` so users can only access that document.
+ *
+ * @param proposalProfileId - The proposal's profile ID
+ * @param user - The authenticated user
+ * @returns An object containing the signed JWT token
+ */
+export const getCollabToken = async ({
+  proposalProfileId,
+  user,
+}: {
+  proposalProfileId: string;
+  user: User;
+}): Promise<{ token: string }> => {
+  const proposal = await db.query.proposals.findFirst({
+    where: { profileId: proposalProfileId },
+    columns: {
+      id: true,
+      proposalData: true,
+      profileId: true,
+    },
+    with: {
+      processInstance: true,
+    },
+  });
+
+  if (!proposal) {
+    throw new NotFoundError('Proposal not found');
+  }
+
+  await assertInstanceProfileAccess({
+    user: { id: user.id },
+    instance: proposal.processInstance,
+    profilePermissions: { profile: permission.UPDATE },
+    orgFallbackPermissions: { decisions: permission.UPDATE },
+  });
+
+  const { collaborationDocId } = parseProposalData(proposal.proposalData);
+
+  if (!collaborationDocId) {
+    throw new ValidationError(
+      'Proposal does not have a collaboration document',
+    );
+  }
+
+  const token = generateCollabToken(user.id, [collaborationDocId]);
+
+  return { token };
+};

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -39,6 +39,7 @@ export * from './createProposal';
 export * from './submitProposal';
 export * from './updateProposal';
 export * from './getProposal';
+export * from './getCollabToken';
 export * from './listProposals';
 export * from './deleteProposal';
 export * from './getProcessCategories';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1319,6 +1319,9 @@ importers:
 
   services/collab:
     dependencies:
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.2
       ky:
         specifier: ^1.8.1
         version: 1.14.2
@@ -1326,6 +1329,9 @@ importers:
       '@op/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config
+      '@types/jsonwebtoken':
+        specifier: ^9.0.10
+        version: 9.0.10
 
   services/db:
     dependencies:

--- a/services/api/src/routers/decision/proposals/getCollabToken.ts
+++ b/services/api/src/routers/decision/proposals/getCollabToken.ts
@@ -45,7 +45,7 @@ export const getCollabTokenRouter = router({
       });
 
       const hasAccess = checkPermission(
-        { profile: permission.READ },
+        { profile: permission.UPDATE },
         profileAccessUser?.roles ?? [],
       );
 

--- a/services/api/src/routers/decision/proposals/getCollabToken.ts
+++ b/services/api/src/routers/decision/proposals/getCollabToken.ts
@@ -1,8 +1,10 @@
-import { generateCollabToken } from '@op/collab/server';
-import { getProfileAccessUser, parseProposalData } from '@op/common';
-import { db } from '@op/db/client';
+import {
+  NotFoundError,
+  UnauthorizedError,
+  ValidationError,
+  getCollabToken,
+} from '@op/common';
 import { TRPCError } from '@trpc/server';
-import { checkPermission, permission } from 'access-zones';
 import { z } from 'zod';
 
 import { commonAuthedProcedure, router } from '../../../trpcFactory';
@@ -19,55 +21,32 @@ export const getCollabTokenRouter = router({
     .output(z.object({ token: z.string() }))
     .query(async ({ ctx, input }) => {
       const { user } = ctx;
-      const { proposalProfileId } = input;
 
-      // Look up the proposal by its profile ID
-      const proposal = await db.query.proposals.findFirst({
-        where: { profileId: proposalProfileId },
-        columns: {
-          id: true,
-          proposalData: true,
-          profileId: true,
-        },
-      });
-
-      if (!proposal) {
-        throw new TRPCError({
-          code: 'NOT_FOUND',
-          message: 'Proposal not found',
+      try {
+        return await getCollabToken({
+          proposalProfileId: input.proposalProfileId,
+          user,
         });
+      } catch (error: unknown) {
+        if (error instanceof NotFoundError) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: error.message,
+          });
+        }
+        if (error instanceof UnauthorizedError) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: error.message,
+          });
+        }
+        if (error instanceof ValidationError) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: error.message,
+          });
+        }
+        throw error;
       }
-
-      // Verify user has access to the proposal's profile
-      const profileAccessUser = await getProfileAccessUser({
-        user,
-        profileId: proposalProfileId,
-      });
-
-      const hasAccess = checkPermission(
-        { profile: permission.UPDATE },
-        profileAccessUser?.roles ?? [],
-      );
-
-      if (!hasAccess) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'You do not have access to this proposal',
-        });
-      }
-
-      // Extract the collaboration doc ID from the proposal data
-      const { collaborationDocId } = parseProposalData(proposal.proposalData);
-
-      if (!collaborationDocId) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Proposal does not have a collaboration document',
-        });
-      }
-
-      const token = generateCollabToken(user.id, [collaborationDocId]);
-
-      return { token };
     }),
 });

--- a/services/api/src/routers/decision/proposals/getCollabToken.ts
+++ b/services/api/src/routers/decision/proposals/getCollabToken.ts
@@ -1,0 +1,73 @@
+import { generateCollabToken } from '@op/collab/server';
+import { getProfileAccessUser, parseProposalData } from '@op/common';
+import { db } from '@op/db/client';
+import { TRPCError } from '@trpc/server';
+import { checkPermission, permission } from 'access-zones';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const getCollabTokenRouter = router({
+  getCollabToken: commonAuthedProcedure({
+    rateLimit: { windowSize: 60, maxRequests: 30 },
+  })
+    .input(
+      z.object({
+        proposalProfileId: z.uuid(),
+      }),
+    )
+    .output(z.object({ token: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const { user } = ctx;
+      const { proposalProfileId } = input;
+
+      // Look up the proposal by its profile ID
+      const proposal = await db._query.proposals.findFirst({
+        where: { profileId: proposalProfileId },
+        columns: {
+          id: true,
+          proposalData: true,
+          profileId: true,
+        },
+      });
+
+      if (!proposal) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Proposal not found',
+        });
+      }
+
+      // Verify user has access to the proposal's profile
+      const profileAccessUser = await getProfileAccessUser({
+        user,
+        profileId: proposalProfileId,
+      });
+
+      const hasAccess = checkPermission(
+        { profile: permission.READ },
+        profileAccessUser?.roles ?? [],
+      );
+
+      if (!hasAccess) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You do not have access to this proposal',
+        });
+      }
+
+      // Extract the collaboration doc ID from the proposal data
+      const { collaborationDocId } = parseProposalData(proposal.proposalData);
+
+      if (!collaborationDocId) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Proposal does not have a collaboration document',
+        });
+      }
+
+      const token = generateCollabToken(user.id, [collaborationDocId]);
+
+      return { token };
+    }),
+});

--- a/services/api/src/routers/decision/proposals/getCollabToken.ts
+++ b/services/api/src/routers/decision/proposals/getCollabToken.ts
@@ -22,7 +22,7 @@ export const getCollabTokenRouter = router({
       const { proposalProfileId } = input;
 
       // Look up the proposal by its profile ID
-      const proposal = await db._query.proposals.findFirst({
+      const proposal = await db.query.proposals.findFirst({
         where: { profileId: proposalProfileId },
         columns: {
           id: true,

--- a/services/api/src/routers/decision/proposals/index.ts
+++ b/services/api/src/routers/decision/proposals/index.ts
@@ -4,6 +4,7 @@ import { createProposalRouter } from './create';
 import { deleteProposalRouter } from './delete';
 import { exportProposalsRouter } from './export';
 import { getProposalRouter } from './get';
+import { getCollabTokenRouter } from './getCollabToken';
 import { getExportStatusRouter } from './getExportStatus';
 import { listProposalsRouter } from './list';
 import { submitProposalRouter } from './submit';
@@ -13,6 +14,7 @@ export const proposalsRouter = mergeRouters(
   acceptProposalInviteRouter,
   createProposalRouter,
   getProposalRouter,
+  getCollabTokenRouter,
   listProposalsRouter,
   submitProposalRouter,
   updateProposalRouter,

--- a/services/collab/package.json
+++ b/services/collab/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
     "./testing": "./__mocks__/index.ts"
   },
   "main": "./src/index.ts",
@@ -14,9 +15,11 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
+    "jsonwebtoken": "^9.0.2",
     "ky": "^1.8.1"
   },
   "devDependencies": {
-    "@op/typescript-config": "workspace:*"
+    "@op/typescript-config": "workspace:*",
+    "@types/jsonwebtoken": "^9.0.10"
   }
 }

--- a/services/collab/src/server/index.ts
+++ b/services/collab/src/server/index.ts
@@ -1,0 +1,1 @@
+export { generateCollabToken } from './token';

--- a/services/collab/src/server/token.ts
+++ b/services/collab/src/server/token.ts
@@ -1,0 +1,41 @@
+import jwt from 'jsonwebtoken';
+
+function getTiptapSecret(): string {
+  const secret = process.env.TIPTAP_SECRET;
+
+  if (!secret) {
+    throw new Error('Missing required environment variable: TIPTAP_SECRET');
+  }
+
+  return secret;
+}
+
+/**
+ * Generate a Tiptap Cloud collaboration JWT for a user.
+ *
+ * The token restricts the user to only the specified document names.
+ *
+ * @see https://tiptap.dev/docs/collaboration/getting-started/authenticate
+ *
+ * @param userId - The authenticated user's identifier
+ * @param allowedDocumentNames - Document names the user may access (supports trailing wildcards)
+ * @returns Signed JWT string
+ */
+export function generateCollabToken(
+  userId: string,
+  allowedDocumentNames: string[],
+): string {
+  const secret = getTiptapSecret();
+
+  return jwt.sign(
+    {
+      sub: userId,
+      allowedDocumentNames,
+    },
+    secret,
+    {
+      algorithm: 'HS256',
+      expiresIn: 60 * 60 * 24, // 24 hours
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded `notoken` placeholder in the Tiptap collaboration provider with proper JWT authentication, so collaborative editing is actually secured per-user and per-document.

- Users must have UPDATE permission on a proposal to receive a collaboration token, preventing unauthorized document edits through the Tiptap WebSocket connection
- Tokens are scoped to a single document ID so a compromised or leaked token cannot access other proposals
- Tokens refresh proactively and recover from expiry so long editing sessions do not silently lose sync