### PR TITLE
Make PostHog optional so the app doesn't crash without the key

### DIFF
--- a/apps/app/src/components/PostHogProvider.tsx
+++ b/apps/app/src/components/PostHogProvider.tsx
@@ -6,9 +6,15 @@ import posthog from 'posthog-js';
 import { PostHogProvider as PHProvider, usePostHog } from 'posthog-js/react';
 import { Suspense, useEffect } from 'react';
 
+const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    if (!posthogKey) {
+      return;
+    }
+
+    posthog.init(posthogKey, {
       api_host: '/stats',
       ui_host: posthogUIHost,
       capture_pageview: false, // We capture pageviews manually
@@ -17,6 +23,10 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       // debug: process.env.NODE_ENV === 'development',
     });
   }, []);
+
+  if (!posthogKey) {
+    return <>{children}</>;
+  }
 
   return (
     <PHProvider client={posthog}>

--- a/apps/app/src/posthog.ts
+++ b/apps/app/src/posthog.ts
@@ -1,7 +1,13 @@
 import { PostHog } from 'posthog-node';
 
-export default function PostHogClient() {
-  const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+export default function PostHogClient(): PostHog | null {
+  const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+  if (!posthogKey) {
+    return null;
+  }
+
+  const posthogClient = new PostHog(posthogKey, {
     host: 'https://eu.i.posthog.com',
     flushAt: 1,
     flushInterval: 0,

--- a/packages/analytics/src/client.ts
+++ b/packages/analytics/src/client.ts
@@ -1,7 +1,13 @@
 import { PostHog } from 'posthog-node';
 
-export default function PostHogClient() {
-  const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+export default function PostHogClient(): PostHog | null {
+  const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+  if (!posthogKey) {
+    return null;
+  }
+
+  const posthogClient = new PostHog(posthogKey, {
     host: 'https://eu.i.posthog.com',
     flushAt: 1,
     flushInterval: 0,

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -2,6 +2,10 @@ import PostHogClient from './client';
 
 const posthog = PostHogClient();
 
+function isPostHogEnabled(): boolean {
+  return posthog !== null;
+}
+
 /**
  * Analytics utility functions for tracking user events
  */
@@ -25,12 +29,16 @@ export async function trackEvent({
   event,
   properties,
 }: AnalyticsEvent): Promise<void> {
-  posthog.capture({
+  if (!isPostHogEnabled()) {
+    return;
+  }
+
+  posthog!.capture({
     distinctId,
     event,
     properties,
   });
-  await posthog.shutdown();
+  await posthog!.shutdown();
 }
 
 /**
@@ -56,27 +64,33 @@ export async function identifyUser({
   distinctId,
   properties,
 }: AnalyticsIdentify): Promise<void> {
-  posthog.identify({
+  if (!isPostHogEnabled()) {
+    return;
+  }
+
+  posthog!.identify({
     distinctId,
     properties,
   });
-  await posthog.shutdown();
+  await posthog!.shutdown();
 }
 
 /**
  * Track multiple events in sequence
  */
 export async function trackEvents(events: AnalyticsEvent[]): Promise<void> {
-  if (events.length === 0) return;
+  if (events.length === 0 || !isPostHogEnabled()) {
+    return;
+  }
 
   events.forEach(({ distinctId, event, properties }) => {
-    posthog.capture({
+    posthog!.capture({
       distinctId,
       event,
       properties,
     });
   });
-  await posthog.shutdown();
+  await posthog!.shutdown();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Guard PostHog initialization so the app gracefully degrades when `NEXT_PUBLIC_POSTHOG_KEY` is missing
- Server-side analytics calls no-op instead of crashing