### PR TITLE
feat: Commas in the Invite Modal for typed lists

### DIFF
--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -384,11 +384,24 @@ function ProfileInviteModalContent({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key !== ',' || !selectedRoleId || !canAddEmail) {
+    if (e.key !== ',' || !selectedRoleId) {
+      return;
+    }
+    const email = searchQuery.trim();
+    if (!isValidEmail(email)) {
+      return;
+    }
+    const lowerEmail = email.toLowerCase();
+    const takenEmails = new Set([
+      ...allSelectedItems.map((item) => item.email.toLowerCase()),
+      ...optimisticUsers.map((u) => u.email.toLowerCase()),
+      ...optimisticInvites.map((i) => i.email.toLowerCase()),
+    ]);
+    if (takenEmails.has(lowerEmail)) {
       return;
     }
     e.preventDefault();
-    handleAddEmail(debouncedQuery);
+    handleAddEmail(email);
   };
 
   const handlePaste = (e: React.ClipboardEvent) => {

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -384,24 +384,11 @@ function ProfileInviteModalContent({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key !== ',') {
-      return;
-    }
-    const email = searchQuery.trim().replace(/,$/, '').trim();
-    if (!isValidEmail(email)) {
-      return;
-    }
-    const lowerEmail = email.toLowerCase();
-    const takenEmails = new Set([
-      ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.map((u) => u.email.toLowerCase()),
-      ...optimisticInvites.map((i) => i.email.toLowerCase()),
-    ]);
-    if (takenEmails.has(lowerEmail)) {
+    if (e.key !== ',' || !selectedRoleId || !canAddEmail) {
       return;
     }
     e.preventDefault();
-    handleAddEmail(email);
+    handleAddEmail(debouncedQuery);
   };
 
   const handlePaste = (e: React.ClipboardEvent) => {

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -471,7 +471,11 @@ function ProfileInviteModalContent({
         )}
 
         {/* Search Input */}
-        <div ref={searchContainerRef} onPaste={handlePaste} onKeyDown={handleKeyDown}>
+        <div
+          ref={searchContainerRef}
+          onPaste={handlePaste}
+          onKeyDown={handleKeyDown}
+        >
           <SearchField
             placeholder={t('Search by name or email...')}
             value={searchQuery}

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -238,19 +238,22 @@ function ProfileInviteModalContent({
     );
   }, [flattenedResults, allSelectedItems, optimisticUsers, optimisticInvites]);
 
-  // Check if query is a valid email that hasn't been selected yet (across all roles)
+  const takenEmails = useMemo(
+    () =>
+      new Set([
+        ...allSelectedItems.map((item) => item.email.toLowerCase()),
+        ...optimisticUsers.map((u) => u.email.toLowerCase()),
+        ...optimisticInvites.map((i) => i.email.toLowerCase()),
+      ]),
+    [allSelectedItems, optimisticUsers, optimisticInvites],
+  );
+
   const canAddEmail = useMemo(() => {
     if (!isValidEmail(debouncedQuery)) {
       return false;
     }
-    const lowerQuery = debouncedQuery.toLowerCase();
-    const takenEmails = new Set([
-      ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.map((u) => u.email.toLowerCase()),
-      ...optimisticInvites.map((i) => i.email.toLowerCase()),
-    ]);
-    return !takenEmails.has(lowerQuery);
-  }, [debouncedQuery, allSelectedItems, optimisticUsers, optimisticInvites]);
+    return !takenEmails.has(debouncedQuery.toLowerCase());
+  }, [debouncedQuery, takenEmails]);
 
   // Mutations
   const inviteMutation = trpc.profile.invite.useMutation();
@@ -388,16 +391,7 @@ function ProfileInviteModalContent({
       return;
     }
     const email = searchQuery.trim();
-    if (!isValidEmail(email)) {
-      return;
-    }
-    const lowerEmail = email.toLowerCase();
-    const takenEmails = new Set([
-      ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.map((u) => u.email.toLowerCase()),
-      ...optimisticInvites.map((i) => i.email.toLowerCase()),
-    ]);
-    if (takenEmails.has(lowerEmail)) {
+    if (!isValidEmail(email) || takenEmails.has(email.toLowerCase())) {
       return;
     }
     e.preventDefault();
@@ -410,12 +404,7 @@ function ProfileInviteModalContent({
       return;
     }
 
-    const existingEmails = new Set([
-      ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.map((u) => u.email.toLowerCase()),
-      ...optimisticInvites.map((i) => i.email.toLowerCase()),
-    ]);
-    const emails = parseEmailPaste(pastedText, existingEmails);
+    const emails = parseEmailPaste(pastedText, takenEmails);
     if (!emails) {
       return;
     }

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -383,6 +383,27 @@ function ProfileInviteModalContent({
     });
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== ',') {
+      return;
+    }
+    const email = searchQuery.trim().replace(/,$/, '').trim();
+    if (!isValidEmail(email)) {
+      return;
+    }
+    const lowerEmail = email.toLowerCase();
+    const takenEmails = new Set([
+      ...allSelectedItems.map((item) => item.email.toLowerCase()),
+      ...optimisticUsers.map((u) => u.email.toLowerCase()),
+      ...optimisticInvites.map((i) => i.email.toLowerCase()),
+    ]);
+    if (takenEmails.has(lowerEmail)) {
+      return;
+    }
+    e.preventDefault();
+    handleAddEmail(email);
+  };
+
   const handlePaste = (e: React.ClipboardEvent) => {
     const pastedText = e.clipboardData.getData('text');
     if (!pastedText || !selectedRoleId) {
@@ -450,7 +471,7 @@ function ProfileInviteModalContent({
         )}
 
         {/* Search Input */}
-        <div ref={searchContainerRef} onPaste={handlePaste}>
+        <div ref={searchContainerRef} onPaste={handlePaste} onKeyDown={handleKeyDown}>
           <SearchField
             placeholder={t('Search by name or email...')}
             value={searchQuery}

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -471,15 +471,12 @@ function ProfileInviteModalContent({
         )}
 
         {/* Search Input */}
-        <div
-          ref={searchContainerRef}
-          onPaste={handlePaste}
-          onKeyDown={handleKeyDown}
-        >
+        <div ref={searchContainerRef} onPaste={handlePaste}>
           <SearchField
             placeholder={t('Search by name or email...')}
             value={searchQuery}
             onChange={setSearchQuery}
+            onKeyDown={handleKeyDown}
             className="w-full"
           />
         </div>


### PR DESCRIPTION
Allows manual typing of lists using the comma separator (more can be added later as we think through it). When an email is typed out followed by a comma the email is validated and added into the list of users.