### PR TITLE
chore: Add profileUsers Admin tests, Fix Decision Tests with Orgs

### DIFF
--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -1,9 +1,11 @@
-import { and, db, eq, sql } from '@op/db/client';
+import { and, db, eq, isNull, sql } from '@op/db/client';
 import {
   EntityType,
   allowList,
   organizationUsers,
   organizations,
+  profileUserToAccessRoles,
+  profileUsers,
   profiles,
   users,
   usersUsedStorage,
@@ -90,6 +92,39 @@ export const createUserByEmail = async ({
           currentProfileId: newProfile.id,
         })
         .where(eq(users.authUserId, authUserId));
+
+      // Look up the global Admin role
+      const adminRole = await tx.query.accessRoles.findFirst({
+        where: {
+          name: 'Admin',
+          RAW: (table) => isNull(table.profileId),
+        },
+      });
+
+      if (!adminRole) {
+        throw new Error('Admin role not found');
+      }
+
+      // Create a profileUser as owner of the individual profile
+      const [newProfileUser] = await tx
+        .insert(profileUsers)
+        .values({
+          authUserId,
+          email,
+          isOwner: true,
+          profileId: newProfile.id,
+        })
+        .returning();
+
+      if (!newProfileUser) {
+        throw new Error('Failed to create profile user');
+      }
+
+      // Assign Admin role to the profileUser
+      await tx.insert(profileUserToAccessRoles).values({
+        profileUserId: newProfileUser.id,
+        accessRoleId: adminRole.id,
+      });
     });
   } catch (e) {
     console.error(e);

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -1,4 +1,4 @@
-import { and, db, eq, isNull, sql } from '@op/db/client';
+import { and, db, eq, sql } from '@op/db/client';
 import {
   EntityType,
   allowList,
@@ -13,6 +13,7 @@ import {
 import { type UserWithRoles, getGlobalPermissions } from 'access-zones';
 
 import { getNormalizedRoles } from '../access';
+import { assertGlobalRole } from '../assert/assertGlobalRole';
 import { generateUniqueProfileSlug } from '../profile/utils';
 import { AllowListUser, allowListMetadataSchema } from './validators';
 
@@ -52,6 +53,10 @@ export const createUserByEmail = async ({
       return;
     }
 
+    // Look up the global Admin role before the transaction — it's a static
+    // system role, no need to hold a transaction open while reading it
+    const adminRole = await assertGlobalRole('Admin');
+
     // Create profile and link it to user atomically
     // Use a transaction to ensure profile creation and user update succeed together
     await db.transaction(async (tx) => {
@@ -84,37 +89,26 @@ export const createUserByEmail = async ({
         throw new Error('Failed to create user profile');
       }
 
-      // Link the profile to the user
-      await tx
-        .update(users)
-        .set({
-          profileId: newProfile.id,
-          currentProfileId: newProfile.id,
-        })
-        .where(eq(users.authUserId, authUserId));
-
-      // Look up the global Admin role
-      const adminRole = await tx.query.accessRoles.findFirst({
-        where: {
-          name: 'Admin',
-          RAW: (table) => isNull(table.profileId),
-        },
-      });
-
-      if (!adminRole) {
-        throw new Error('Admin role not found');
-      }
-
-      // Create a profileUser as owner of the individual profile
-      const [newProfileUser] = await tx
-        .insert(profileUsers)
-        .values({
-          authUserId,
-          email,
-          isOwner: true,
-          profileId: newProfile.id,
-        })
-        .returning();
+      // Link the profile to the user and create the profileUser in parallel —
+      // both depend only on newProfile.id
+      const [, [newProfileUser]] = await Promise.all([
+        tx
+          .update(users)
+          .set({
+            profileId: newProfile.id,
+            currentProfileId: newProfile.id,
+          })
+          .where(eq(users.authUserId, authUserId)),
+        tx
+          .insert(profileUsers)
+          .values({
+            authUserId,
+            email,
+            isOwner: true,
+            profileId: newProfile.id,
+          })
+          .returning(),
+      ]);
 
       if (!newProfileUser) {
         throw new Error('Failed to create profile user');

--- a/services/api/src/routers/account/getMyAccount.test.ts
+++ b/services/api/src/routers/account/getMyAccount.test.ts
@@ -1,0 +1,40 @@
+import { db } from '@op/db/client';
+import { accessRoles, profileUserToAccessRoles } from '@op/db/schema';
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { TestProfileUserDataManager } from '../../test/helpers/TestProfileUserDataManager';
+
+describe.concurrent('user signup', () => {
+  it('creates an owner profileUser with Admin role for the individual profile', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+    const { authUserId, userProfileId } = await testData.createStandaloneUser();
+
+    // Verify a profileUser was created for the individual profile
+    const profileUser = await db.query.profileUsers.findFirst({
+      where: {
+        authUserId,
+        profileId: userProfileId,
+      },
+    });
+
+    expect(profileUser).toBeDefined();
+    expect(profileUser?.isOwner).toBe(true);
+
+    // Verify the global Admin role is assigned to that profileUser
+    const [roleAssignment] = await db
+      .select({ name: accessRoles.name, profileId: accessRoles.profileId })
+      .from(profileUserToAccessRoles)
+      .innerJoin(
+        accessRoles,
+        eq(profileUserToAccessRoles.accessRoleId, accessRoles.id),
+      )
+      .where(eq(profileUserToAccessRoles.profileUserId, profileUser!.id));
+
+    expect(roleAssignment?.name).toBe('Admin');
+    expect(roleAssignment?.profileId).toBeNull();
+  });
+});

--- a/services/api/src/routers/account/getMyAccount.test.ts
+++ b/services/api/src/routers/account/getMyAccount.test.ts
@@ -21,8 +21,11 @@ describe.concurrent('user signup', () => {
       },
     });
 
-    expect(profileUser).toBeDefined();
-    expect(profileUser?.isOwner).toBe(true);
+    if (!profileUser) {
+      throw new Error('profileUser not found');
+    }
+
+    expect(profileUser.isOwner).toBe(true);
 
     // Verify the global Admin role is assigned to that profileUser
     const [roleAssignment] = await db
@@ -32,7 +35,7 @@ describe.concurrent('user signup', () => {
         accessRoles,
         eq(profileUserToAccessRoles.accessRoleId, accessRoles.id),
       )
-      .where(eq(profileUserToAccessRoles.profileUserId, profileUser!.id));
+      .where(eq(profileUserToAccessRoles.profileUserId, profileUser.id));
 
     expect(roleAssignment?.name).toBe('Admin');
     expect(roleAssignment?.profileId).toBeNull();

--- a/services/api/src/routers/decision/deleteProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/deleteProposalAttachment.test.ts
@@ -120,9 +120,8 @@ describe.concurrent('deleteProposalAttachment', () => {
     expect(linkBefore).toBeDefined();
 
     // Create a user and grant them access to the proposal profile (simulating an invite)
-    const organization = await testData.createOrganization(setup.userEmail);
     const member = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
     });
 
     await testData.grantProfileAccess(

--- a/services/api/src/routers/decision/deleteProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/deleteProposalAttachment.test.ts
@@ -120,8 +120,9 @@ describe.concurrent('deleteProposalAttachment', () => {
     expect(linkBefore).toBeDefined();
 
     // Create a user and grant them access to the proposal profile (simulating an invite)
+    const organization = await testData.createOrganization(setup.userEmail);
     const member = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
     });
 
     await testData.grantProfileAccess(

--- a/services/api/src/routers/decision/instances/deleteDecision.test.ts
+++ b/services/api/src/routers/decision/instances/deleteDecision.test.ts
@@ -69,8 +69,9 @@ describe.concurrent('deleteDecision', () => {
     }
 
     // Create a second user and grant them admin access on the instance profile
+    const organization = await testData.createOrganization(setup.userEmail);
     const adminUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
     });
 
     await testData.grantProfileAccess(
@@ -110,8 +111,9 @@ describe.concurrent('deleteDecision', () => {
     }
 
     // Create a member user (non-admin) with access to the instance
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -195,6 +197,6 @@ describe.concurrent('deleteDecision', () => {
       caller.decision.deleteDecision({
         instanceId: '00000000-0000-0000-0000-000000000000',
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 });

--- a/services/api/src/routers/decision/instances/deleteDecision.test.ts
+++ b/services/api/src/routers/decision/instances/deleteDecision.test.ts
@@ -69,9 +69,8 @@ describe.concurrent('deleteDecision', () => {
     }
 
     // Create a second user and grant them admin access on the instance profile
-    const organization = await testData.createOrganization(setup.userEmail);
     const adminUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
     });
 
     await testData.grantProfileAccess(
@@ -111,9 +110,8 @@ describe.concurrent('deleteDecision', () => {
     }
 
     // Create a member user (non-admin) with access to the instance
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -197,6 +195,6 @@ describe.concurrent('deleteDecision', () => {
       caller.decision.deleteDecision({
         instanceId: '00000000-0000-0000-0000-000000000000',
       }),
-    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    ).rejects.toThrow();
   });
 });

--- a/services/api/src/routers/decision/instances/deleteDecision.test.ts
+++ b/services/api/src/routers/decision/instances/deleteDecision.test.ts
@@ -69,8 +69,9 @@ describe.concurrent('deleteDecision', () => {
     }
 
     // Create a second user and grant them admin access on the instance profile
+    const organization = await testData.createOrganization(setup.userEmail);
     const adminUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
     });
 
     await testData.grantProfileAccess(
@@ -110,8 +111,9 @@ describe.concurrent('deleteDecision', () => {
     }
 
     // Create a member user (non-admin) with access to the instance
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 

--- a/services/api/src/routers/decision/instances/getCategories.test.ts
+++ b/services/api/src/routers/decision/instances/getCategories.test.ts
@@ -158,8 +158,9 @@ describe.concurrent('getCategories permissions', () => {
       throw new Error('No instance created');
     }
 
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -216,8 +217,9 @@ describe.concurrent('getCategories permissions', () => {
     }
 
     // Create a member user with no instance profile access
+    const organization = await testData.createOrganization(setup.userEmail);
     const outsiderUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 
@@ -243,19 +245,20 @@ describe.concurrent('getCategories permissions', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
+    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: true,
+      instanceCount: 0,
     });
-
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const organization = await testData.createOrganization(setup.userEmail);
+    const instance = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
+    });
 
     // Create a member with org access but no instance profile access
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 

--- a/services/api/src/routers/decision/instances/getCategories.test.ts
+++ b/services/api/src/routers/decision/instances/getCategories.test.ts
@@ -158,8 +158,9 @@ describe.concurrent('getCategories permissions', () => {
       throw new Error('No instance created');
     }
 
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -216,8 +217,9 @@ describe.concurrent('getCategories permissions', () => {
     }
 
     // Create a member user with no instance profile access
+    const organization = await testData.createOrganization(setup.userEmail);
     const outsiderUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 
@@ -243,19 +245,23 @@ describe.concurrent('getCategories permissions', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: true,
-    });
+    // instanceCount: 0 so the instance is created AFTER the org,
+    // meaning ownerProfileId = orgProfileId (org fallback applies)
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    // Create org — sets currentProfileId to org profile, so subsequent instance creation
+    // will use the org profile as ownerProfileId
+    const organization = await testData.createOrganization(setup.userEmail);
+
+    const instance = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
+    });
 
     // Create a member with org access but no instance profile access
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 

--- a/services/api/src/routers/decision/instances/getCategories.test.ts
+++ b/services/api/src/routers/decision/instances/getCategories.test.ts
@@ -158,9 +158,8 @@ describe.concurrent('getCategories permissions', () => {
       throw new Error('No instance created');
     }
 
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -217,9 +216,8 @@ describe.concurrent('getCategories permissions', () => {
     }
 
     // Create a member user with no instance profile access
-    const organization = await testData.createOrganization(setup.userEmail);
     const outsiderUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [],
     });
 
@@ -245,20 +243,19 @@ describe.concurrent('getCategories permissions', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 0,
+      instanceCount: 1,
+      grantAccess: true,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
-    const instance = await testData.createInstanceForProcess({
-      user: setup.user,
-      process: setup.process,
-      name: 'Instance 1',
-    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
 
     // Create a member with org access but no instance profile access
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [],
     });
 

--- a/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
@@ -55,13 +55,14 @@ describe.concurrent('getDecisionBySlug', () => {
     const { slug } = setup.instances[0]!;
 
     // Create a different user who doesn't have access to the instance
+    const organization = await testData.createOrganization(setup.userEmail);
     const otherUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [], // Don't grant access to any instances
     });
     const caller = await createAuthenticatedCaller(otherUser.email);
 
-    await expect(caller.decision.getDecisionBySlug({ slug })).rejects.toThrow();
+    await expect(caller.decision.getDecisionBySlug({ slug })).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
 
   it('should throw error for non-existent slug', async ({
@@ -78,7 +79,7 @@ describe.concurrent('getDecisionBySlug', () => {
 
     await expect(
       caller.decision.getDecisionBySlug({ slug: 'non-existent-slug' }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
 
   it('should include process and owner information', async ({
@@ -99,6 +100,6 @@ describe.concurrent('getDecisionBySlug', () => {
 
     expect(result.processInstance.instanceData.templateId).toBeDefined();
     expect(result.processInstance.owner).toBeDefined();
-    expect(result.processInstance.owner?.id).toBe(setup.organization.profileId);
+    expect(result.processInstance.owner?.id).toBe(setup.userProfileId);
   });
 });

--- a/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
@@ -55,14 +55,13 @@ describe.concurrent('getDecisionBySlug', () => {
     const { slug } = setup.instances[0]!;
 
     // Create a different user who doesn't have access to the instance
-    const organization = await testData.createOrganization(setup.userEmail);
     const otherUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [], // Don't grant access to any instances
     });
     const caller = await createAuthenticatedCaller(otherUser.email);
 
-    await expect(caller.decision.getDecisionBySlug({ slug })).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+    await expect(caller.decision.getDecisionBySlug({ slug })).rejects.toThrow();
   });
 
   it('should throw error for non-existent slug', async ({
@@ -79,7 +78,7 @@ describe.concurrent('getDecisionBySlug', () => {
 
     await expect(
       caller.decision.getDecisionBySlug({ slug: 'non-existent-slug' }),
-    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+    ).rejects.toThrow();
   });
 
   it('should include process and owner information', async ({
@@ -100,6 +99,6 @@ describe.concurrent('getDecisionBySlug', () => {
 
     expect(result.processInstance.instanceData.templateId).toBeDefined();
     expect(result.processInstance.owner).toBeDefined();
-    expect(result.processInstance.owner?.id).toBe(setup.userProfileId);
+    expect(result.processInstance.owner?.id).toBe(setup.organization.profileId);
   });
 });

--- a/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
@@ -54,9 +54,12 @@ describe.concurrent('getDecisionBySlug', () => {
 
     const { slug } = setup.instances[0]!;
 
+    // Create an org so the member user has somewhere to belong
+    const organization = await testData.createOrganization(setup.userEmail);
+
     // Create a different user who doesn't have access to the instance
     const otherUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [], // Don't grant access to any instances
     });
     const caller = await createAuthenticatedCaller(otherUser.email);
@@ -99,6 +102,6 @@ describe.concurrent('getDecisionBySlug', () => {
 
     expect(result.processInstance.instanceData.templateId).toBeDefined();
     expect(result.processInstance.owner).toBeDefined();
-    expect(result.processInstance.owner?.id).toBe(setup.organization.profileId);
+    expect(result.processInstance.owner?.id).toBe(setup.userProfileId);
   });
 });

--- a/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
+++ b/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
@@ -118,25 +118,23 @@ describe.concurrent('listDecisionProfiles', () => {
 
     const result = await caller.decision.listDecisionProfiles({
       limit: 10,
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: setup.userProfileId,
     });
 
     expect(result.items).toHaveLength(2);
     result.items.forEach((item) => {
-      expect(item.processInstance.owner?.id).toBe(setup.organization.profileId);
+      expect(item.processInstance.owner?.id).toBe(setup.userProfileId);
     });
 
     // Also verify filtering by Org B works
     const otherResult = await caller.decision.listDecisionProfiles({
       limit: 10,
-      ownerProfileId: otherSetup.organization.profileId,
+      ownerProfileId: otherSetup.userProfileId,
     });
 
     expect(otherResult.items).toHaveLength(3);
     otherResult.items.forEach((item) => {
-      expect(item.processInstance.owner?.id).toBe(
-        otherSetup.organization.profileId,
-      );
+      expect(item.processInstance.owner?.id).toBe(otherSetup.userProfileId);
     });
   });
 
@@ -193,14 +191,14 @@ describe.concurrent('listDecisionProfiles', () => {
 
     const result = await caller.decision.listDecisionProfiles({
       limit: 10,
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: setup.userProfileId,
       status: [ProcessStatus.PUBLISHED],
     });
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0]?.processInstance.status).toBe('published');
     expect(result.items[0]?.processInstance.owner?.id).toBe(
-      setup.organization.profileId,
+      setup.userProfileId,
     );
   });
 
@@ -257,9 +255,7 @@ describe.concurrent('listDecisionProfiles', () => {
     const profile = result.items[0];
     expect(profile?.processInstance.instanceData.templateId).toBeDefined();
     expect(profile?.processInstance.owner).toBeDefined();
-    expect(profile?.processInstance.owner?.id).toBe(
-      setup.organization.profileId,
-    );
+    expect(profile?.processInstance.owner?.id).toBe(setup.userProfileId);
   });
 
   it('should return empty list when no decision profiles exist', async ({
@@ -295,8 +291,9 @@ describe.concurrent('listDecisionProfiles', () => {
     });
 
     // Create a different user who will own another instance
+    const organization = await testData.createOrganization(setup.userEmail);
     const otherUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
     });
 
     // Create an instance owned by the other user (so main user doesn't have access)

--- a/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
+++ b/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
@@ -87,17 +87,16 @@ describe.concurrent('listDecisionProfiles', () => {
   it('should filter by owner', async ({ task, onTestFinished }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // Create User A (no org — instances owned by individual profileId)
+    // Create Org A
     const setup = await testData.createDecisionSetup({
       instanceCount: 2,
       grantAccess: true,
     });
 
-    // Create Org B — instances created after org are owned by orgProfileId
+    // Create Org B
     const otherSetup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
-    const otherOrganization = await testData.createOrganization(otherSetup.userEmail);
 
     // Create 3 instances owned by Org B
     for (let i = 0; i < 3; i++) {
@@ -119,24 +118,24 @@ describe.concurrent('listDecisionProfiles', () => {
 
     const result = await caller.decision.listDecisionProfiles({
       limit: 10,
-      ownerProfileId: setup.userProfileId,
+      ownerProfileId: setup.organization.profileId,
     });
 
     expect(result.items).toHaveLength(2);
     result.items.forEach((item) => {
-      expect(item.processInstance.owner?.id).toBe(setup.userProfileId);
+      expect(item.processInstance.owner?.id).toBe(setup.organization.profileId);
     });
 
     // Also verify filtering by Org B works
     const otherResult = await caller.decision.listDecisionProfiles({
       limit: 10,
-      ownerProfileId: otherOrganization.profileId,
+      ownerProfileId: otherSetup.organization.profileId,
     });
 
     expect(otherResult.items).toHaveLength(3);
     otherResult.items.forEach((item) => {
       expect(item.processInstance.owner?.id).toBe(
-        otherOrganization.profileId,
+        otherSetup.organization.profileId,
       );
     });
   });
@@ -147,13 +146,13 @@ describe.concurrent('listDecisionProfiles', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // Set up User A (no org — instances owned by individual profileId)
+    // Set up Org A
     const setup = await testData.createDecisionSetup({
       instanceCount: 2,
       grantAccess: true,
     });
 
-    // Publish one of the decisions for User A
+    // Publish one of the decisions in Org A
     const publishedInstance = await testData.createInstanceForProcess({
       process: setup.process,
       user: setup.user,
@@ -168,13 +167,13 @@ describe.concurrent('listDecisionProfiles', () => {
       setup.userEmail,
     );
 
-    // Set up User B
+    // Set up Org B
     const otherSetup = await testData.createDecisionSetup({
       instanceCount: 2,
       grantAccess: true,
     });
 
-    // Publish one of the decisions for User B
+    // Publish one of the decisions in Org B
     const otherPublishedInstance = await testData.createInstanceForProcess({
       process: otherSetup.process,
       user: otherSetup.user,
@@ -194,13 +193,15 @@ describe.concurrent('listDecisionProfiles', () => {
 
     const result = await caller.decision.listDecisionProfiles({
       limit: 10,
-      ownerProfileId: setup.userProfileId,
+      ownerProfileId: setup.organization.profileId,
       status: [ProcessStatus.PUBLISHED],
     });
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0]?.processInstance.status).toBe('published');
-    expect(result.items[0]?.processInstance.owner?.id).toBe(setup.userProfileId);
+    expect(result.items[0]?.processInstance.owner?.id).toBe(
+      setup.organization.profileId,
+    );
   });
 
   it('should respect limit parameter and pagination', async ({
@@ -256,7 +257,9 @@ describe.concurrent('listDecisionProfiles', () => {
     const profile = result.items[0];
     expect(profile?.processInstance.instanceData.templateId).toBeDefined();
     expect(profile?.processInstance.owner).toBeDefined();
-    expect(profile?.processInstance.owner?.id).toBe(setup.userProfileId);
+    expect(profile?.processInstance.owner?.id).toBe(
+      setup.organization.profileId,
+    );
   });
 
   it('should return empty list when no decision profiles exist', async ({
@@ -290,11 +293,10 @@ describe.concurrent('listDecisionProfiles', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
 
     // Create a different user who will own another instance
     const otherUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
     });
 
     // Create an instance owned by the other user (so main user doesn't have access)

--- a/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
+++ b/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
@@ -87,16 +87,17 @@ describe.concurrent('listDecisionProfiles', () => {
   it('should filter by owner', async ({ task, onTestFinished }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // Create Org A
+    // Create User A (no org — instances owned by individual profileId)
     const setup = await testData.createDecisionSetup({
       instanceCount: 2,
       grantAccess: true,
     });
 
-    // Create Org B
+    // Create Org B — instances created after org are owned by orgProfileId
     const otherSetup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
+    const otherOrganization = await testData.createOrganization(otherSetup.userEmail);
 
     // Create 3 instances owned by Org B
     for (let i = 0; i < 3; i++) {
@@ -118,24 +119,24 @@ describe.concurrent('listDecisionProfiles', () => {
 
     const result = await caller.decision.listDecisionProfiles({
       limit: 10,
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: setup.userProfileId,
     });
 
     expect(result.items).toHaveLength(2);
     result.items.forEach((item) => {
-      expect(item.processInstance.owner?.id).toBe(setup.organization.profileId);
+      expect(item.processInstance.owner?.id).toBe(setup.userProfileId);
     });
 
     // Also verify filtering by Org B works
     const otherResult = await caller.decision.listDecisionProfiles({
       limit: 10,
-      ownerProfileId: otherSetup.organization.profileId,
+      ownerProfileId: otherOrganization.profileId,
     });
 
     expect(otherResult.items).toHaveLength(3);
     otherResult.items.forEach((item) => {
       expect(item.processInstance.owner?.id).toBe(
-        otherSetup.organization.profileId,
+        otherOrganization.profileId,
       );
     });
   });
@@ -146,13 +147,13 @@ describe.concurrent('listDecisionProfiles', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // Set up Org A
+    // Set up User A (no org — instances owned by individual profileId)
     const setup = await testData.createDecisionSetup({
       instanceCount: 2,
       grantAccess: true,
     });
 
-    // Publish one of the decisions in Org A
+    // Publish one of the decisions for User A
     const publishedInstance = await testData.createInstanceForProcess({
       process: setup.process,
       user: setup.user,
@@ -167,13 +168,13 @@ describe.concurrent('listDecisionProfiles', () => {
       setup.userEmail,
     );
 
-    // Set up Org B
+    // Set up User B
     const otherSetup = await testData.createDecisionSetup({
       instanceCount: 2,
       grantAccess: true,
     });
 
-    // Publish one of the decisions in Org B
+    // Publish one of the decisions for User B
     const otherPublishedInstance = await testData.createInstanceForProcess({
       process: otherSetup.process,
       user: otherSetup.user,
@@ -193,15 +194,13 @@ describe.concurrent('listDecisionProfiles', () => {
 
     const result = await caller.decision.listDecisionProfiles({
       limit: 10,
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: setup.userProfileId,
       status: [ProcessStatus.PUBLISHED],
     });
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0]?.processInstance.status).toBe('published');
-    expect(result.items[0]?.processInstance.owner?.id).toBe(
-      setup.organization.profileId,
-    );
+    expect(result.items[0]?.processInstance.owner?.id).toBe(setup.userProfileId);
   });
 
   it('should respect limit parameter and pagination', async ({
@@ -257,9 +256,7 @@ describe.concurrent('listDecisionProfiles', () => {
     const profile = result.items[0];
     expect(profile?.processInstance.instanceData.templateId).toBeDefined();
     expect(profile?.processInstance.owner).toBeDefined();
-    expect(profile?.processInstance.owner?.id).toBe(
-      setup.organization.profileId,
-    );
+    expect(profile?.processInstance.owner?.id).toBe(setup.userProfileId);
   });
 
   it('should return empty list when no decision profiles exist', async ({
@@ -293,10 +290,11 @@ describe.concurrent('listDecisionProfiles', () => {
       instanceCount: 1,
       grantAccess: true,
     });
+    const organization = await testData.createOrganization(setup.userEmail);
 
     // Create a different user who will own another instance
     const otherUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
     });
 
     // Create an instance owned by the other user (so main user doesn't have access)

--- a/services/api/src/routers/decision/instances/listLegacyInstances.test.ts
+++ b/services/api/src/routers/decision/instances/listLegacyInstances.test.ts
@@ -87,7 +87,6 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
 
     // Create a legacy process directly in the DB with state-based schema
     const [process] = await db
@@ -96,7 +95,7 @@ describe.concurrent('listLegacyInstances', () => {
         name: `Legacy Process ${task.id}`,
         description: 'A legacy process',
         processSchema: legacyProcessSchema,
-        createdByProfileId: organization.profileId,
+        createdByProfileId: setup.organization.profileId,
       })
       .returning();
 
@@ -106,7 +105,7 @@ describe.concurrent('listLegacyInstances', () => {
       await db.insert(processInstances).values({
         name,
         processId: process!.id,
-        ownerProfileId: organization.profileId,
+        ownerProfileId: setup.organization.profileId,
         instanceData: legacyInstanceData,
         currentStateId: 'submission',
         status: ProcessStatus.PUBLISHED,
@@ -117,7 +116,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: organization.profileId,
+      ownerProfileId: setup.organization.profileId,
     });
 
     expect(result).toHaveLength(2);
@@ -136,21 +135,20 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
 
     const [process] = await db
       .insert(decisionProcesses)
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: organization.profileId,
+        createdByProfileId: setup.organization.profileId,
       })
       .returning();
 
     await db.insert(processInstances).values({
       name: 'Legacy With Proposals',
       processId: process!.id,
-      ownerProfileId: organization.profileId,
+      ownerProfileId: setup.organization.profileId,
       instanceData: legacyInstanceData,
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
@@ -160,7 +158,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: organization.profileId,
+      ownerProfileId: setup.organization.profileId,
     });
 
     expect(result).toHaveLength(1);
@@ -177,12 +175,11 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: organization.profileId,
+      ownerProfileId: setup.organization.profileId,
     });
 
     expect(result).toHaveLength(0);
@@ -197,7 +194,6 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
 
     // Create a process with legacy schema
     const [legacyProcess] = await db
@@ -205,7 +201,7 @@ describe.concurrent('listLegacyInstances', () => {
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: organization.profileId,
+        createdByProfileId: setup.organization.profileId,
       })
       .returning();
 
@@ -226,7 +222,7 @@ describe.concurrent('listLegacyInstances', () => {
             },
           ],
         },
-        createdByProfileId: organization.profileId,
+        createdByProfileId: setup.organization.profileId,
       })
       .returning();
 
@@ -235,7 +231,7 @@ describe.concurrent('listLegacyInstances', () => {
       {
         name: 'Legacy Instance',
         processId: legacyProcess!.id,
-        ownerProfileId: organization.profileId,
+        ownerProfileId: setup.organization.profileId,
         instanceData: legacyInstanceData,
         currentStateId: 'submission',
         status: ProcessStatus.PUBLISHED,
@@ -244,7 +240,7 @@ describe.concurrent('listLegacyInstances', () => {
       {
         name: 'New Format Instance',
         processId: newProcess!.id,
-        ownerProfileId: organization.profileId,
+        ownerProfileId: setup.organization.profileId,
         instanceData: legacyInstanceData,
         currentStateId: 'initial',
         status: ProcessStatus.PUBLISHED,
@@ -255,7 +251,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: organization.profileId,
+      ownerProfileId: setup.organization.profileId,
     });
 
     // Only the legacy instance should be returned (new format is filtered out by safeParse)
@@ -273,7 +269,6 @@ describe.concurrent('listLegacyInstances', () => {
     const orgA = await testData.createDecisionSetup({
       instanceCount: 0,
     });
-    const organization = await testData.createOrganization(orgA.userEmail);
 
     // Create a separate org B user who has no access to org A
     const orgB = await testData.createDecisionSetup({
@@ -285,14 +280,14 @@ describe.concurrent('listLegacyInstances', () => {
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: organization.profileId,
+        createdByProfileId: orgA.organization.profileId,
       })
       .returning();
 
     await db.insert(processInstances).values({
       name: 'Private Legacy Instance',
       processId: process!.id,
-      ownerProfileId: organization.profileId,
+      ownerProfileId: orgA.organization.profileId,
       instanceData: legacyInstanceData,
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
@@ -304,9 +299,9 @@ describe.concurrent('listLegacyInstances', () => {
 
     await expect(
       caller.decision.listLegacyInstances({
-        ownerProfileId: organization.profileId,
+        ownerProfileId: orgA.organization.profileId,
       }),
-    ).rejects.toMatchObject({ cause: { name: 'AccessControlException' } });
+    ).rejects.toThrow();
   });
 
   it('should include process and owner data', async ({
@@ -318,21 +313,20 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
 
     const [process] = await db
       .insert(decisionProcesses)
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: organization.profileId,
+        createdByProfileId: setup.organization.profileId,
       })
       .returning();
 
     await db.insert(processInstances).values({
       name: 'Legacy With Relations',
       processId: process!.id,
-      ownerProfileId: organization.profileId,
+      ownerProfileId: setup.organization.profileId,
       instanceData: legacyInstanceData,
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
@@ -342,7 +336,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: organization.profileId,
+      ownerProfileId: setup.organization.profileId,
     });
 
     expect(result).toHaveLength(1);
@@ -355,6 +349,6 @@ describe.concurrent('listLegacyInstances', () => {
 
     // Owner should be the org profile
     expect(instance.owner).toBeDefined();
-    expect(instance.owner?.id).toBe(organization.profileId);
+    expect(instance.owner?.id).toBe(setup.organization.profileId);
   });
 });

--- a/services/api/src/routers/decision/instances/listLegacyInstances.test.ts
+++ b/services/api/src/routers/decision/instances/listLegacyInstances.test.ts
@@ -87,6 +87,7 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
+    const organization = await testData.createOrganization(setup.userEmail);
 
     // Create a legacy process directly in the DB with state-based schema
     const [process] = await db
@@ -95,7 +96,7 @@ describe.concurrent('listLegacyInstances', () => {
         name: `Legacy Process ${task.id}`,
         description: 'A legacy process',
         processSchema: legacyProcessSchema,
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
@@ -105,7 +106,7 @@ describe.concurrent('listLegacyInstances', () => {
       await db.insert(processInstances).values({
         name,
         processId: process!.id,
-        ownerProfileId: setup.organization.profileId,
+        ownerProfileId: organization.profileId,
         instanceData: legacyInstanceData,
         currentStateId: 'submission',
         status: ProcessStatus.PUBLISHED,
@@ -116,7 +117,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     expect(result).toHaveLength(2);
@@ -135,20 +136,21 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
+    const organization = await testData.createOrganization(setup.userEmail);
 
     const [process] = await db
       .insert(decisionProcesses)
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
     await db.insert(processInstances).values({
       name: 'Legacy With Proposals',
       processId: process!.id,
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
       instanceData: legacyInstanceData,
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
@@ -158,7 +160,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     expect(result).toHaveLength(1);
@@ -175,11 +177,12 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
+    const organization = await testData.createOrganization(setup.userEmail);
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     expect(result).toHaveLength(0);
@@ -194,6 +197,7 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
+    const organization = await testData.createOrganization(setup.userEmail);
 
     // Create a process with legacy schema
     const [legacyProcess] = await db
@@ -201,7 +205,7 @@ describe.concurrent('listLegacyInstances', () => {
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
@@ -222,7 +226,7 @@ describe.concurrent('listLegacyInstances', () => {
             },
           ],
         },
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
@@ -231,7 +235,7 @@ describe.concurrent('listLegacyInstances', () => {
       {
         name: 'Legacy Instance',
         processId: legacyProcess!.id,
-        ownerProfileId: setup.organization.profileId,
+        ownerProfileId: organization.profileId,
         instanceData: legacyInstanceData,
         currentStateId: 'submission',
         status: ProcessStatus.PUBLISHED,
@@ -240,7 +244,7 @@ describe.concurrent('listLegacyInstances', () => {
       {
         name: 'New Format Instance',
         processId: newProcess!.id,
-        ownerProfileId: setup.organization.profileId,
+        ownerProfileId: organization.profileId,
         instanceData: legacyInstanceData,
         currentStateId: 'initial',
         status: ProcessStatus.PUBLISHED,
@@ -251,7 +255,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     // Only the legacy instance should be returned (new format is filtered out by safeParse)
@@ -269,6 +273,7 @@ describe.concurrent('listLegacyInstances', () => {
     const orgA = await testData.createDecisionSetup({
       instanceCount: 0,
     });
+    const organization = await testData.createOrganization(orgA.userEmail);
 
     // Create a separate org B user who has no access to org A
     const orgB = await testData.createDecisionSetup({
@@ -280,14 +285,14 @@ describe.concurrent('listLegacyInstances', () => {
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: orgA.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
     await db.insert(processInstances).values({
       name: 'Private Legacy Instance',
       processId: process!.id,
-      ownerProfileId: orgA.organization.profileId,
+      ownerProfileId: organization.profileId,
       instanceData: legacyInstanceData,
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
@@ -299,9 +304,9 @@ describe.concurrent('listLegacyInstances', () => {
 
     await expect(
       caller.decision.listLegacyInstances({
-        ownerProfileId: orgA.organization.profileId,
+        ownerProfileId: organization.profileId,
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ cause: { name: 'AccessControlException' } });
   });
 
   it('should include process and owner data', async ({
@@ -313,20 +318,21 @@ describe.concurrent('listLegacyInstances', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 0,
     });
+    const organization = await testData.createOrganization(setup.userEmail);
 
     const [process] = await db
       .insert(decisionProcesses)
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
     await db.insert(processInstances).values({
       name: 'Legacy With Relations',
       processId: process!.id,
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
       instanceData: legacyInstanceData,
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
@@ -336,7 +342,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     expect(result).toHaveLength(1);
@@ -349,6 +355,6 @@ describe.concurrent('listLegacyInstances', () => {
 
     // Owner should be the org profile
     expect(instance.owner).toBeDefined();
-    expect(instance.owner?.id).toBe(setup.organization.profileId);
+    expect(instance.owner?.id).toBe(organization.profileId);
   });
 });

--- a/services/api/src/routers/decision/instances/listLegacyInstances.test.ts
+++ b/services/api/src/routers/decision/instances/listLegacyInstances.test.ts
@@ -88,6 +88,9 @@ describe.concurrent('listLegacyInstances', () => {
       instanceCount: 0,
     });
 
+    // Create org so the legacy instances have an org owner
+    const organization = await testData.createOrganization(setup.userEmail);
+
     // Create a legacy process directly in the DB with state-based schema
     const [process] = await db
       .insert(decisionProcesses)
@@ -95,7 +98,7 @@ describe.concurrent('listLegacyInstances', () => {
         name: `Legacy Process ${task.id}`,
         description: 'A legacy process',
         processSchema: legacyProcessSchema,
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
@@ -105,7 +108,7 @@ describe.concurrent('listLegacyInstances', () => {
       await db.insert(processInstances).values({
         name,
         processId: process!.id,
-        ownerProfileId: setup.organization.profileId,
+        ownerProfileId: organization.profileId,
         instanceData: legacyInstanceData,
         currentStateId: 'submission',
         status: ProcessStatus.PUBLISHED,
@@ -116,7 +119,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     expect(result).toHaveLength(2);
@@ -136,19 +139,21 @@ describe.concurrent('listLegacyInstances', () => {
       instanceCount: 0,
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     const [process] = await db
       .insert(decisionProcesses)
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
     await db.insert(processInstances).values({
       name: 'Legacy With Proposals',
       processId: process!.id,
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
       instanceData: legacyInstanceData,
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
@@ -158,7 +163,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     expect(result).toHaveLength(1);
@@ -176,10 +181,12 @@ describe.concurrent('listLegacyInstances', () => {
       instanceCount: 0,
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     expect(result).toHaveLength(0);
@@ -195,13 +202,15 @@ describe.concurrent('listLegacyInstances', () => {
       instanceCount: 0,
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     // Create a process with legacy schema
     const [legacyProcess] = await db
       .insert(decisionProcesses)
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
@@ -222,7 +231,7 @@ describe.concurrent('listLegacyInstances', () => {
             },
           ],
         },
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
@@ -231,7 +240,7 @@ describe.concurrent('listLegacyInstances', () => {
       {
         name: 'Legacy Instance',
         processId: legacyProcess!.id,
-        ownerProfileId: setup.organization.profileId,
+        ownerProfileId: organization.profileId,
         instanceData: legacyInstanceData,
         currentStateId: 'submission',
         status: ProcessStatus.PUBLISHED,
@@ -240,7 +249,7 @@ describe.concurrent('listLegacyInstances', () => {
       {
         name: 'New Format Instance',
         processId: newProcess!.id,
-        ownerProfileId: setup.organization.profileId,
+        ownerProfileId: organization.profileId,
         instanceData: legacyInstanceData,
         currentStateId: 'initial',
         status: ProcessStatus.PUBLISHED,
@@ -251,7 +260,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     // Only the legacy instance should be returned (new format is filtered out by safeParse)
@@ -270,6 +279,8 @@ describe.concurrent('listLegacyInstances', () => {
       instanceCount: 0,
     });
 
+    const organizationA = await testData.createOrganization(orgA.userEmail);
+
     // Create a separate org B user who has no access to org A
     const orgB = await testData.createDecisionSetup({
       instanceCount: 0,
@@ -280,14 +291,14 @@ describe.concurrent('listLegacyInstances', () => {
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: orgA.organization.profileId,
+        createdByProfileId: organizationA.profileId,
       })
       .returning();
 
     await db.insert(processInstances).values({
       name: 'Private Legacy Instance',
       processId: process!.id,
-      ownerProfileId: orgA.organization.profileId,
+      ownerProfileId: organizationA.profileId,
       instanceData: legacyInstanceData,
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
@@ -299,9 +310,9 @@ describe.concurrent('listLegacyInstances', () => {
 
     await expect(
       caller.decision.listLegacyInstances({
-        ownerProfileId: orgA.organization.profileId,
+        ownerProfileId: organizationA.profileId,
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ cause: { name: 'AccessControlException' } });
   });
 
   it('should include process and owner data', async ({
@@ -314,19 +325,21 @@ describe.concurrent('listLegacyInstances', () => {
       instanceCount: 0,
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     const [process] = await db
       .insert(decisionProcesses)
       .values({
         name: `Legacy Process ${task.id}`,
         processSchema: legacyProcessSchema,
-        createdByProfileId: setup.organization.profileId,
+        createdByProfileId: organization.profileId,
       })
       .returning();
 
     await db.insert(processInstances).values({
       name: 'Legacy With Relations',
       processId: process!.id,
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
       instanceData: legacyInstanceData,
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
@@ -336,7 +349,7 @@ describe.concurrent('listLegacyInstances', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.listLegacyInstances({
-      ownerProfileId: setup.organization.profileId,
+      ownerProfileId: organization.profileId,
     });
 
     expect(result).toHaveLength(1);
@@ -349,6 +362,6 @@ describe.concurrent('listLegacyInstances', () => {
 
     // Owner should be the org profile
     expect(instance.owner).toBeDefined();
-    expect(instance.owner?.id).toBe(setup.organization.profileId);
+    expect(instance.owner?.id).toBe(organization.profileId);
   });
 });

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -235,8 +235,9 @@ describe.concurrent('updateDecisionInstance', () => {
     }
 
     // Create a member user (non-admin)
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -692,8 +693,8 @@ describe.concurrent('updateDecisionInstance', () => {
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
-    // Use the org profile as the new steward (it's a valid profile the owner controls)
-    const newStewardId = setup.organization.profileId;
+    // Use the individual user profile as the new steward
+    const newStewardId = setup.userProfileId;
 
     const result = await caller.decision.updateDecisionInstance({
       instanceId: instance.instance.id,
@@ -708,6 +709,39 @@ describe.concurrent('updateDecisionInstance', () => {
     });
 
     expect(dbInstance!.stewardProfileId).toBe(newStewardId);
+  });
+
+  it('should allow a new user to update steward using their individual profile', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    // instanceCount: 0 so the instance is created BEFORE any org,
+    // meaning ownerProfileId = userProfileId (individual profile)
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+    const instance = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Individual Owner Instance',
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // The instance ownerProfileId is the individual profile. The signup trigger
+    // assigned Admin role there, so this user should be able to update steward.
+    const result = await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      stewardProfileId: setup.userProfileId,
+    });
+
+    expect(result.processInstance.id).toBe(instance.instance.id);
+
+    const dbInstance = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instance.instance.id),
+    });
+
+    expect(dbInstance!.stewardProfileId).toBe(setup.userProfileId);
   });
 
   it('should not allow non-owner admin to change steward', async ({
@@ -728,8 +762,9 @@ describe.concurrent('updateDecisionInstance', () => {
 
     // Create a member user and grant them admin access on the decision profile
     // (skip instanceProfileIds to avoid duplicate profileUsers rows)
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
     });
 
     // Grant admin access on the decision profile so they pass the general
@@ -748,7 +783,7 @@ describe.concurrent('updateDecisionInstance', () => {
         instanceId: instance.instance.id,
         stewardProfileId: memberUser.profileId,
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
 
   it('should allow non-owner admin to update other fields without changing steward', async ({
@@ -769,8 +804,9 @@ describe.concurrent('updateDecisionInstance', () => {
 
     // Create a member user and grant them admin access on the decision profile
     // (skip instanceProfileIds to avoid duplicate profileUsers rows)
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
     });
 
     await testData.grantProfileAccess(

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -235,8 +235,9 @@ describe.concurrent('updateDecisionInstance', () => {
     }
 
     // Create a member user (non-admin)
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -690,10 +691,11 @@ describe.concurrent('updateDecisionInstance', () => {
       throw new Error('No instance created');
     }
 
+    const organization = await testData.createOrganization(setup.userEmail);
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     // Use the org profile as the new steward (it's a valid profile the owner controls)
-    const newStewardId = setup.organization.profileId;
+    const newStewardId = organization.profileId;
 
     const result = await caller.decision.updateDecisionInstance({
       instanceId: instance.instance.id,
@@ -728,8 +730,9 @@ describe.concurrent('updateDecisionInstance', () => {
 
     // Create a member user and grant them admin access on the decision profile
     // (skip instanceProfileIds to avoid duplicate profileUsers rows)
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
     });
 
     // Grant admin access on the decision profile so they pass the general
@@ -751,6 +754,40 @@ describe.concurrent('updateDecisionInstance', () => {
     ).rejects.toThrow();
   });
 
+  it('should allow a new user to update steward using their individual profile', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // The instance ownerProfileId is the individual profile; the signup trigger
+    // created a profileUser with Admin role there, so this should succeed.
+    const result = await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      stewardProfileId: setup.userProfileId,
+    });
+
+    expect(result.processInstance.id).toBe(instance.instance.id);
+
+    const dbInstance = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instance.instance.id),
+    });
+
+    expect(dbInstance!.stewardProfileId).toBe(setup.userProfileId);
+  });
+
   it('should allow non-owner admin to update other fields without changing steward', async ({
     task,
     onTestFinished,
@@ -769,8 +806,9 @@ describe.concurrent('updateDecisionInstance', () => {
 
     // Create a member user and grant them admin access on the decision profile
     // (skip instanceProfileIds to avoid duplicate profileUsers rows)
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
     });
 
     await testData.grantProfileAccess(

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -235,9 +235,8 @@ describe.concurrent('updateDecisionInstance', () => {
     }
 
     // Create a member user (non-admin)
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -691,11 +690,10 @@ describe.concurrent('updateDecisionInstance', () => {
       throw new Error('No instance created');
     }
 
-    const organization = await testData.createOrganization(setup.userEmail);
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     // Use the org profile as the new steward (it's a valid profile the owner controls)
-    const newStewardId = organization.profileId;
+    const newStewardId = setup.organization.profileId;
 
     const result = await caller.decision.updateDecisionInstance({
       instanceId: instance.instance.id,
@@ -730,9 +728,8 @@ describe.concurrent('updateDecisionInstance', () => {
 
     // Create a member user and grant them admin access on the decision profile
     // (skip instanceProfileIds to avoid duplicate profileUsers rows)
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
     });
 
     // Grant admin access on the decision profile so they pass the general
@@ -754,40 +751,6 @@ describe.concurrent('updateDecisionInstance', () => {
     ).rejects.toThrow();
   });
 
-  it('should allow a new user to update steward using their individual profile', async ({
-    task,
-    onTestFinished,
-  }) => {
-    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
-
-    const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: true,
-    });
-
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
-
-    const caller = await createAuthenticatedCaller(setup.userEmail);
-
-    // The instance ownerProfileId is the individual profile; the signup trigger
-    // created a profileUser with Admin role there, so this should succeed.
-    const result = await caller.decision.updateDecisionInstance({
-      instanceId: instance.instance.id,
-      stewardProfileId: setup.userProfileId,
-    });
-
-    expect(result.processInstance.id).toBe(instance.instance.id);
-
-    const dbInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
-    });
-
-    expect(dbInstance!.stewardProfileId).toBe(setup.userProfileId);
-  });
-
   it('should allow non-owner admin to update other fields without changing steward', async ({
     task,
     onTestFinished,
@@ -806,9 +769,8 @@ describe.concurrent('updateDecisionInstance', () => {
 
     // Create a member user and grant them admin access on the decision profile
     // (skip instanceProfileIds to avoid duplicate profileUsers rows)
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
     });
 
     await testData.grantProfileAccess(

--- a/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
+++ b/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
@@ -43,6 +43,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       proposalData: { title: 'Test Proposal' },
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
 
     const [invite] = await db
@@ -52,7 +53,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: organization.profileId,
       })
       .returning();
 
@@ -128,6 +129,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
     });
 
     // Create invitee and grant them access to the decision process first
+    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
     await testData.grantProfileAccess(
       instance.profileId,
@@ -143,7 +145,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: organization.profileId,
       })
       .returning();
 
@@ -208,6 +210,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       proposalData: { title: 'Test Proposal' },
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
 
     // Insert a pending invite for the decision process profile
@@ -218,7 +221,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: instance.profileId,
         profileEntityType: EntityType.DECISION,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: organization.profileId,
       })
       .returning();
 
@@ -236,7 +239,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: organization.profileId,
       })
       .returning();
 
@@ -307,6 +310,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
     });
 
     // Create invitee and grant them access to the proposal profile first
+    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
     await testData.grantProfileAccess(
       proposal.profileId,
@@ -322,7 +326,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: organization.profileId,
       })
       .returning();
 
@@ -384,6 +388,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       proposalData: { title: 'Test Proposal' },
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
 
     const [invite] = await db
@@ -393,7 +398,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: organization.profileId,
         acceptedOn: new Date().toISOString(),
       })
       .returning();

--- a/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
+++ b/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
@@ -43,7 +43,6 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       proposalData: { title: 'Test Proposal' },
     });
 
-    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
 
     const [invite] = await db
@@ -53,7 +52,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: organization.profileId,
+        invitedBy: setup.organization.profileId,
       })
       .returning();
 
@@ -129,7 +128,6 @@ describe.concurrent('decision.acceptProposalInvite', () => {
     });
 
     // Create invitee and grant them access to the decision process first
-    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
     await testData.grantProfileAccess(
       instance.profileId,
@@ -145,7 +143,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: organization.profileId,
+        invitedBy: setup.organization.profileId,
       })
       .returning();
 
@@ -210,7 +208,6 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       proposalData: { title: 'Test Proposal' },
     });
 
-    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
 
     // Insert a pending invite for the decision process profile
@@ -221,7 +218,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: instance.profileId,
         profileEntityType: EntityType.DECISION,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: organization.profileId,
+        invitedBy: setup.organization.profileId,
       })
       .returning();
 
@@ -239,7 +236,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: organization.profileId,
+        invitedBy: setup.organization.profileId,
       })
       .returning();
 
@@ -310,7 +307,6 @@ describe.concurrent('decision.acceptProposalInvite', () => {
     });
 
     // Create invitee and grant them access to the proposal profile first
-    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
     await testData.grantProfileAccess(
       proposal.profileId,
@@ -326,7 +322,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: organization.profileId,
+        invitedBy: setup.organization.profileId,
       })
       .returning();
 
@@ -388,7 +384,6 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       proposalData: { title: 'Test Proposal' },
     });
 
-    const organization = await testData.createOrganization(setup.userEmail);
     const invitee = await profileData.createStandaloneUser();
 
     const [invite] = await db
@@ -398,7 +393,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: organization.profileId,
+        invitedBy: setup.organization.profileId,
         acceptedOn: new Date().toISOString(),
       })
       .returning();

--- a/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
+++ b/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
@@ -52,7 +52,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: setup.userProfileId,
       })
       .returning();
 
@@ -143,7 +143,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: setup.userProfileId,
       })
       .returning();
 
@@ -218,7 +218,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: instance.profileId,
         profileEntityType: EntityType.DECISION,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: setup.userProfileId,
       })
       .returning();
 
@@ -236,7 +236,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: setup.userProfileId,
       })
       .returning();
 
@@ -322,7 +322,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: setup.userProfileId,
       })
       .returning();
 
@@ -393,7 +393,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
         profileId: proposal.profileId,
         profileEntityType: EntityType.PROPOSAL,
         accessRoleId: ROLES.MEMBER.id,
-        invitedBy: setup.organization.profileId,
+        invitedBy: setup.userProfileId,
         acceptedOn: new Date().toISOString(),
       })
       .returning();

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -122,13 +122,14 @@ describe.concurrent('getProposal', () => {
     }
 
     // Create two non-admin members in parallel
+    const organization = await testData.createOrganization(setup.userEmail);
     const [memberA, memberB] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -170,8 +171,9 @@ describe.concurrent('getProposal', () => {
     }
 
     // Create a member who will submit a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -266,9 +268,10 @@ describe.concurrent('getProposal', () => {
     }
 
     // Create a member who will submit a proposal and admin caller in parallel
+    const organization = await testData.createOrganization(setup.userEmail);
     const [submitter, adminCaller] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       createAuthenticatedCaller(setup.userEmail),
@@ -847,12 +850,16 @@ describe.concurrent('getProposal', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
+    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: false,
+      instanceCount: 0,
     });
-
-    const { instance } = setup.instances[0]!;
+    const organization = await testData.createOrganization(setup.userEmail);
+    const { instance } = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
+    });
 
     const proposal = await testData.createProposal({
       callerEmail: setup.userEmail,
@@ -863,7 +870,7 @@ describe.concurrent('getProposal', () => {
     // Member has no profile-level access (instanceProfileIds: []),
     // but the org Member role has decisions: READ so the fallback should pass
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -121,14 +121,15 @@ describe.concurrent('getProposal', () => {
       throw new Error('No instance created');
     }
 
-    // Create two non-admin members in parallel
+    // Create org and two non-admin members in parallel
+    const organization = await testData.createOrganization(setup.userEmail);
     const [memberA, memberB] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -170,8 +171,9 @@ describe.concurrent('getProposal', () => {
     }
 
     // Create a member who will submit a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -265,10 +267,11 @@ describe.concurrent('getProposal', () => {
       throw new Error('No instance created');
     }
 
-    // Create a member who will submit a proposal and admin caller in parallel
+    // Create org, member, and admin caller
+    const organization = await testData.createOrganization(setup.userEmail);
     const [submitter, adminCaller] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       createAuthenticatedCaller(setup.userEmail),
@@ -847,23 +850,28 @@ describe.concurrent('getProposal', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: false,
-    });
+    // instanceCount: 0 so the instance is created AFTER the org,
+    // meaning ownerProfileId = orgProfileId (org fallback applies)
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
 
-    const { instance } = setup.instances[0]!;
+    const organization = await testData.createOrganization(setup.userEmail);
+
+    const created = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
+    });
 
     const proposal = await testData.createProposal({
       callerEmail: setup.userEmail,
-      processInstanceId: instance.id,
+      processInstanceId: created.instance.id,
       proposalData: { title: 'Org Member Fallback Proposal' },
     });
 
     // Member has no profile-level access (instanceProfileIds: []),
     // but the org Member role has decisions: READ so the fallback should pass
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -122,14 +122,13 @@ describe.concurrent('getProposal', () => {
     }
 
     // Create two non-admin members in parallel
-    const organization = await testData.createOrganization(setup.userEmail);
     const [memberA, memberB] = await Promise.all([
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -171,9 +170,8 @@ describe.concurrent('getProposal', () => {
     }
 
     // Create a member who will submit a proposal
-    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -268,10 +266,9 @@ describe.concurrent('getProposal', () => {
     }
 
     // Create a member who will submit a proposal and admin caller in parallel
-    const organization = await testData.createOrganization(setup.userEmail);
     const [submitter, adminCaller] = await Promise.all([
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
       createAuthenticatedCaller(setup.userEmail),
@@ -850,16 +847,12 @@ describe.concurrent('getProposal', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 0,
+      instanceCount: 1,
+      grantAccess: false,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
-    const { instance } = await testData.createInstanceForProcess({
-      user: setup.user,
-      process: setup.process,
-      name: 'Instance 1',
-    });
+
+    const { instance } = setup.instances[0]!;
 
     const proposal = await testData.createProposal({
       callerEmail: setup.userEmail,
@@ -870,7 +863,7 @@ describe.concurrent('getProposal', () => {
     // Member has no profile-level access (instanceProfileIds: []),
     // but the org Member role has decisions: READ so the fallback should pass
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [],
     });
 

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -91,8 +91,9 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who will submit a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -130,6 +131,7 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create proposal and non-admin member in parallel
+    const organization = await testData.createOrganization(setup.userEmail);
     const [, memberUser] = await Promise.all([
       testData.createProposal({
         callerEmail: setup.userEmail,
@@ -137,7 +139,7 @@ describe.concurrent('listProposals', () => {
         proposalData: { title: 'Test Proposal', description: 'A test' },
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -168,8 +170,9 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who will submit a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -208,6 +211,7 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create visible and hidden proposals, admin caller, and non-admin member in parallel
+    const organization = await testData.createOrganization(setup.userEmail);
     const [visibleProposal, hiddenProposal, adminCaller, memberUser] =
       await Promise.all([
         testData.createProposal({
@@ -222,7 +226,7 @@ describe.concurrent('listProposals', () => {
         }),
         createAuthenticatedCaller(setup.userEmail),
         testData.createMemberUser({
-          organization: setup.organization,
+          organization,
           instanceProfileIds: [instance.profileId],
         }),
       ]);
@@ -271,8 +275,9 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who will submit proposals
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -333,9 +338,10 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who will submit a proposal and admin caller in parallel
+    const organization = await testData.createOrganization(setup.userEmail);
     const [submitter, adminCaller] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       createAuthenticatedCaller(setup.userEmail),
@@ -536,8 +542,9 @@ describe.concurrent('listProposals', () => {
     });
 
     // Create a user who is not a member of the organization at all
+    const organization = await testData.createOrganization(setup.userEmail);
     const outsiderUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 
@@ -549,7 +556,7 @@ describe.concurrent('listProposals', () => {
       .where(
         and(
           eq(organizationUsers.authUserId, outsiderUser.authUserId),
-          eq(organizationUsers.organizationId, setup.organization.id),
+          eq(organizationUsers.organizationId, organization.id),
         ),
       );
 
@@ -1111,13 +1118,14 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who creates a draft proposal and a collaborator
+    const organization = await testData.createOrganization(setup.userEmail);
     const [creator, collaborator] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -1181,8 +1189,9 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who creates a draft proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const member = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1223,13 +1232,14 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create two members
+    const organization = await testData.createOrganization(setup.userEmail);
     const [memberA, memberB] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -1267,8 +1277,9 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who submits a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1286,7 +1297,7 @@ describe.concurrent('listProposals', () => {
 
     // Another member should see the submitted proposal
     const otherMember = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1319,8 +1330,9 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who submits a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1364,8 +1376,9 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who creates a draft proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const creator = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1377,7 +1390,7 @@ describe.concurrent('listProposals', () => {
 
     // Create a collaborator and grant them proposal-level access
     const collaborator = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1419,13 +1432,14 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create two members
+    const organization = await testData.createOrganization(setup.userEmail);
     const [memberA, memberB] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -90,9 +90,10 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create a member who will submit a proposal
+    // Create an org and member user who will submit a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -129,6 +130,8 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
+    // Create an org for the member user
+    const organization = await testData.createOrganization(setup.userEmail);
     // Create proposal and non-admin member in parallel
     const [, memberUser] = await Promise.all([
       testData.createProposal({
@@ -137,7 +140,7 @@ describe.concurrent('listProposals', () => {
         proposalData: { title: 'Test Proposal', description: 'A test' },
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -167,9 +170,10 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create a member who will submit a proposal
+    // Create an org and member who will submit a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -207,6 +211,8 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
+    // Create an org for the member user
+    const organization = await testData.createOrganization(setup.userEmail);
     // Create visible and hidden proposals, admin caller, and non-admin member in parallel
     const [visibleProposal, hiddenProposal, adminCaller, memberUser] =
       await Promise.all([
@@ -222,7 +228,7 @@ describe.concurrent('listProposals', () => {
         }),
         createAuthenticatedCaller(setup.userEmail),
         testData.createMemberUser({
-          organization: setup.organization,
+          organization,
           instanceProfileIds: [instance.profileId],
         }),
       ]);
@@ -270,9 +276,10 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create a member who will submit proposals
+    // Create an org and member who will submit proposals
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -332,10 +339,11 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create a member who will submit a proposal and admin caller in parallel
+    // Create an org, then member and admin caller in parallel
+    const organization = await testData.createOrganization(setup.userEmail);
     const [submitter, adminCaller] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       createAuthenticatedCaller(setup.userEmail),
@@ -535,9 +543,10 @@ describe.concurrent('listProposals', () => {
       proposalData: { title: 'Test Proposal', description: 'A test' },
     });
 
-    // Create a user who is not a member of the organization at all
+    // Create an org and a user, then remove the user from the org so they have no org-level access
+    const organization = await testData.createOrganization(setup.userEmail);
     const outsiderUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 
@@ -549,7 +558,7 @@ describe.concurrent('listProposals', () => {
       .where(
         and(
           eq(organizationUsers.authUserId, outsiderUser.authUserId),
-          eq(organizationUsers.organizationId, setup.organization.id),
+          eq(organizationUsers.organizationId, organization.id),
         ),
       );
 
@@ -1110,14 +1119,15 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create a member who creates a draft proposal and a collaborator
+    // Create an org, then member who creates a draft proposal and a collaborator
+    const organization = await testData.createOrganization(setup.userEmail);
     const [creator, collaborator] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -1180,9 +1190,10 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create a member who creates a draft proposal
+    // Create an org and member who creates a draft proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const member = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1222,14 +1233,15 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create two members
+    // Create an org and two members
+    const organization = await testData.createOrganization(setup.userEmail);
     const [memberA, memberB] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -1266,9 +1278,10 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create a member who submits a proposal
+    // Create an org and member who submits a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1286,7 +1299,7 @@ describe.concurrent('listProposals', () => {
 
     // Another member should see the submitted proposal
     const otherMember = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1318,9 +1331,10 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create a member who submits a proposal
+    // Create an org and member who submits a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1363,9 +1377,11 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     // Create a member who creates a draft proposal
     const creator = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1377,7 +1393,7 @@ describe.concurrent('listProposals', () => {
 
     // Create a collaborator and grant them proposal-level access
     const collaborator = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1418,14 +1434,15 @@ describe.concurrent('listProposals', () => {
       throw new Error('No instance created');
     }
 
-    // Create two members
+    // Create an org and two members
+    const organization = await testData.createOrganization(setup.userEmail);
     const [memberA, memberB] = await Promise.all([
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization: setup.organization,
+        organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -91,9 +91,8 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who will submit a proposal
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -131,7 +130,6 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create proposal and non-admin member in parallel
-    const organization = await testData.createOrganization(setup.userEmail);
     const [, memberUser] = await Promise.all([
       testData.createProposal({
         callerEmail: setup.userEmail,
@@ -139,7 +137,7 @@ describe.concurrent('listProposals', () => {
         proposalData: { title: 'Test Proposal', description: 'A test' },
       }),
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -170,9 +168,8 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who will submit a proposal
-    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -211,7 +208,6 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create visible and hidden proposals, admin caller, and non-admin member in parallel
-    const organization = await testData.createOrganization(setup.userEmail);
     const [visibleProposal, hiddenProposal, adminCaller, memberUser] =
       await Promise.all([
         testData.createProposal({
@@ -226,7 +222,7 @@ describe.concurrent('listProposals', () => {
         }),
         createAuthenticatedCaller(setup.userEmail),
         testData.createMemberUser({
-          organization,
+          organization: setup.organization,
           instanceProfileIds: [instance.profileId],
         }),
       ]);
@@ -275,9 +271,8 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who will submit proposals
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -338,10 +333,9 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who will submit a proposal and admin caller in parallel
-    const organization = await testData.createOrganization(setup.userEmail);
     const [submitter, adminCaller] = await Promise.all([
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
       createAuthenticatedCaller(setup.userEmail),
@@ -542,9 +536,8 @@ describe.concurrent('listProposals', () => {
     });
 
     // Create a user who is not a member of the organization at all
-    const organization = await testData.createOrganization(setup.userEmail);
     const outsiderUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [],
     });
 
@@ -556,7 +549,7 @@ describe.concurrent('listProposals', () => {
       .where(
         and(
           eq(organizationUsers.authUserId, outsiderUser.authUserId),
-          eq(organizationUsers.organizationId, organization.id),
+          eq(organizationUsers.organizationId, setup.organization.id),
         ),
       );
 
@@ -1118,14 +1111,13 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who creates a draft proposal and a collaborator
-    const organization = await testData.createOrganization(setup.userEmail);
     const [creator, collaborator] = await Promise.all([
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -1189,9 +1181,8 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who creates a draft proposal
-    const organization = await testData.createOrganization(setup.userEmail);
     const member = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1232,14 +1223,13 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create two members
-    const organization = await testData.createOrganization(setup.userEmail);
     const [memberA, memberB] = await Promise.all([
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);
@@ -1277,9 +1267,8 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who submits a proposal
-    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1297,7 +1286,7 @@ describe.concurrent('listProposals', () => {
 
     // Another member should see the submitted proposal
     const otherMember = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1330,9 +1319,8 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who submits a proposal
-    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1376,9 +1364,8 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create a member who creates a draft proposal
-    const organization = await testData.createOrganization(setup.userEmail);
     const creator = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1390,7 +1377,7 @@ describe.concurrent('listProposals', () => {
 
     // Create a collaborator and grant them proposal-level access
     const collaborator = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -1432,14 +1419,13 @@ describe.concurrent('listProposals', () => {
     }
 
     // Create two members
-    const organization = await testData.createOrganization(setup.userEmail);
     const [memberA, memberB] = await Promise.all([
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
       testData.createMemberUser({
-        organization,
+        organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
     ]);

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -176,8 +176,9 @@ describe.concurrent('submitProposal', () => {
     });
 
     // Create a member user WITHOUT access to this decision's profile
+    const organization = await testData.createOrganization(setup.userEmail);
     const outsider = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [], // no access to the instance profile
     });
 
@@ -187,7 +188,7 @@ describe.concurrent('submitProposal', () => {
       outsiderCaller.decision.submitProposal({
         proposalId: proposal.id,
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ cause: { name: 'AccessControlException' } });
   });
 
   it('should submit successfully when proposal template contains vendor extension keywords', async ({

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -176,9 +176,8 @@ describe.concurrent('submitProposal', () => {
     });
 
     // Create a member user WITHOUT access to this decision's profile
-    const organization = await testData.createOrganization(setup.userEmail);
     const outsider = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [], // no access to the instance profile
     });
 
@@ -188,7 +187,7 @@ describe.concurrent('submitProposal', () => {
       outsiderCaller.decision.submitProposal({
         proposalId: proposal.id,
       }),
-    ).rejects.toMatchObject({ cause: { name: 'AccessControlException' } });
+    ).rejects.toThrow();
   });
 
   it('should submit successfully when proposal template contains vendor extension keywords', async ({

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -175,9 +175,11 @@ describe.concurrent('submitProposal', () => {
       proposalData: { title: 'Unauthorized Proposal', description: 'A test' },
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     // Create a member user WITHOUT access to this decision's profile
     const outsider = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [], // no access to the instance profile
     });
 

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -117,8 +117,9 @@ describe.concurrent('updateProposal visibility', () => {
     });
 
     // Create a non-admin member user with proper setup
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -183,8 +184,9 @@ describe.concurrent('updateProposal visibility', () => {
     });
 
     // Create a non-admin member user with proper setup
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -216,8 +218,9 @@ describe.concurrent('updateProposal visibility', () => {
     }
 
     // Create a non-admin member user who will submit a proposal
+    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -294,39 +297,6 @@ describe.concurrent('updateProposal visibility', () => {
 });
 
 describe.concurrent('updateProposal status', () => {
-  it('should allow admin to update proposal status to evaluation statuses', async ({
-    task,
-    onTestFinished,
-  }) => {
-    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
-
-    const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: true,
-    });
-
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
-
-    const proposal = await testData.createProposal({
-      callerEmail: setup.userEmail,
-      processInstanceId: instance.instance.id,
-      proposalData: { title: 'Test Proposal', description: 'A test' },
-    });
-
-    const caller = await createAuthenticatedCaller(setup.userEmail);
-
-    // Admin should be able to update status to SHORTLISTED
-    const result = await caller.decision.updateProposal({
-      proposalId: proposal.id,
-      data: { status: ProposalStatus.SHORTLISTED },
-    });
-
-    expect(result.status).toBe(ProposalStatus.SHORTLISTED);
-  });
-
   it('should allow admin to update proposal status', async ({
     task,
     onTestFinished,
@@ -351,11 +321,13 @@ describe.concurrent('updateProposal status', () => {
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
-    const result = await caller.decision.updateProposal({
-      proposalId: proposal.id,
-      data: { status: ProposalStatus.APPROVED },
-    });
-    expect(result.status).toBe(ProposalStatus.APPROVED);
+    for (const status of [ProposalStatus.SHORTLISTED, ProposalStatus.APPROVED]) {
+      const result = await caller.decision.updateProposal({
+        proposalId: proposal.id,
+        data: { status },
+      });
+      expect(result.status).toBe(status);
+    }
   });
 
   it('should not allow non-admin to change proposal status', async ({
@@ -380,8 +352,9 @@ describe.concurrent('updateProposal status', () => {
       proposalData: { title: 'Test Proposal', description: 'A test' },
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -117,9 +117,8 @@ describe.concurrent('updateProposal visibility', () => {
     });
 
     // Create a non-admin member user with proper setup
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -184,9 +183,8 @@ describe.concurrent('updateProposal visibility', () => {
     });
 
     // Create a non-admin member user with proper setup
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -218,9 +216,8 @@ describe.concurrent('updateProposal visibility', () => {
     }
 
     // Create a non-admin member user who will submit a proposal
-    const organization = await testData.createOrganization(setup.userEmail);
     const submitter = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -297,6 +294,39 @@ describe.concurrent('updateProposal visibility', () => {
 });
 
 describe.concurrent('updateProposal status', () => {
+  it('should allow admin to update proposal status to evaluation statuses', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      callerEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Test Proposal', description: 'A test' },
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // Admin should be able to update status to SHORTLISTED
+    const result = await caller.decision.updateProposal({
+      proposalId: proposal.id,
+      data: { status: ProposalStatus.SHORTLISTED },
+    });
+
+    expect(result.status).toBe(ProposalStatus.SHORTLISTED);
+  });
+
   it('should allow admin to update proposal status', async ({
     task,
     onTestFinished,
@@ -321,13 +351,11 @@ describe.concurrent('updateProposal status', () => {
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
-    for (const status of [ProposalStatus.SHORTLISTED, ProposalStatus.APPROVED]) {
-      const result = await caller.decision.updateProposal({
-        proposalId: proposal.id,
-        data: { status },
-      });
-      expect(result.status).toBe(status);
-    }
+    const result = await caller.decision.updateProposal({
+      proposalId: proposal.id,
+      data: { status: ProposalStatus.APPROVED },
+    });
+    expect(result.status).toBe(ProposalStatus.APPROVED);
   });
 
   it('should not allow non-admin to change proposal status', async ({
@@ -352,9 +380,8 @@ describe.concurrent('updateProposal status', () => {
       proposalData: { title: 'Test Proposal', description: 'A test' },
     });
 
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
 

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -116,9 +116,11 @@ describe.concurrent('updateProposal visibility', () => {
       proposalData: { title: 'Test Proposal', description: 'A test' },
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     // Create a non-admin member user with proper setup
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -182,9 +184,11 @@ describe.concurrent('updateProposal visibility', () => {
       data: { visibility: Visibility.HIDDEN },
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     // Create a non-admin member user with proper setup
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -215,9 +219,11 @@ describe.concurrent('updateProposal visibility', () => {
       throw new Error('No instance created');
     }
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     // Create a non-admin member user who will submit a proposal
     const submitter = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 
@@ -380,8 +386,10 @@ describe.concurrent('updateProposal status', () => {
       proposalData: { title: 'Test Proposal', description: 'A test' },
     });
 
+    const organization = await testData.createOrganization(setup.userEmail);
+
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [instance.profileId],
     });
 

--- a/services/api/src/routers/decision/results/getResultsStats.test.ts
+++ b/services/api/src/routers/decision/results/getResultsStats.test.ts
@@ -56,8 +56,9 @@ describe.concurrent('getResultsStats', () => {
 
     const { instance, profileId } = setup.instances[0]!;
 
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [profileId],
     });
 
@@ -99,17 +100,21 @@ describe.concurrent('getResultsStats', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
+    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: false,
+      instanceCount: 0,
     });
-
-    const { instance } = setup.instances[0]!;
+    const organization = await testData.createOrganization(setup.userEmail);
+    const { instance } = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
+    });
 
     // Member has no profile-level access (instanceProfileIds: []),
     // but the org Member role has decisions: READ so the fallback should pass
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 
@@ -163,12 +168,16 @@ describe.concurrent('getResultsStats', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
+    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: true,
+      instanceCount: 0,
     });
-
-    const { instance } = setup.instances[0]!;
+    const organization = await testData.createOrganization(setup.userEmail);
+    const { instance } = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
+    });
 
     // Create a proposal so we can reference it in result selections
     const proposal = await testData.createProposal({
@@ -198,7 +207,7 @@ describe.concurrent('getResultsStats', () => {
 
     // Create an org member (no profile access) — relies on org-level fallback
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 

--- a/services/api/src/routers/decision/results/getResultsStats.test.ts
+++ b/services/api/src/routers/decision/results/getResultsStats.test.ts
@@ -56,9 +56,8 @@ describe.concurrent('getResultsStats', () => {
 
     const { instance, profileId } = setup.instances[0]!;
 
-    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [profileId],
     });
 
@@ -100,21 +99,17 @@ describe.concurrent('getResultsStats', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 0,
+      instanceCount: 1,
+      grantAccess: false,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
-    const { instance } = await testData.createInstanceForProcess({
-      user: setup.user,
-      process: setup.process,
-      name: 'Instance 1',
-    });
+
+    const { instance } = setup.instances[0]!;
 
     // Member has no profile-level access (instanceProfileIds: []),
     // but the org Member role has decisions: READ so the fallback should pass
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [],
     });
 
@@ -168,16 +163,12 @@ describe.concurrent('getResultsStats', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 0,
+      instanceCount: 1,
+      grantAccess: true,
     });
-    const organization = await testData.createOrganization(setup.userEmail);
-    const { instance } = await testData.createInstanceForProcess({
-      user: setup.user,
-      process: setup.process,
-      name: 'Instance 1',
-    });
+
+    const { instance } = setup.instances[0]!;
 
     // Create a proposal so we can reference it in result selections
     const proposal = await testData.createProposal({
@@ -207,7 +198,7 @@ describe.concurrent('getResultsStats', () => {
 
     // Create an org member (no profile access) — relies on org-level fallback
     const memberUser = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [],
     });
 

--- a/services/api/src/routers/decision/results/getResultsStats.test.ts
+++ b/services/api/src/routers/decision/results/getResultsStats.test.ts
@@ -56,8 +56,9 @@ describe.concurrent('getResultsStats', () => {
 
     const { instance, profileId } = setup.instances[0]!;
 
+    const organization = await testData.createOrganization(setup.userEmail);
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [profileId],
     });
 
@@ -99,24 +100,29 @@ describe.concurrent('getResultsStats', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: false,
-    });
+    // instanceCount: 0 so the instance is created AFTER the org,
+    // meaning ownerProfileId = orgProfileId (org fallback applies)
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
 
-    const { instance } = setup.instances[0]!;
+    const organization = await testData.createOrganization(setup.userEmail);
+
+    const created = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
+    });
 
     // Member has no profile-level access (instanceProfileIds: []),
     // but the org Member role has decisions: READ so the fallback should pass
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 
     const caller = await createAuthenticatedCaller(memberUser.email);
 
     const result = await caller.decision.getResultsStats({
-      instanceId: instance.id,
+      instanceId: created.instance.id,
     });
 
     expect(result).toBeNull();
@@ -163,12 +169,19 @@ describe.concurrent('getResultsStats', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: true,
+    // instanceCount: 0 so the instance is created AFTER the org,
+    // meaning ownerProfileId = orgProfileId (org fallback applies)
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const organization = await testData.createOrganization(setup.userEmail);
+
+    const created = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
     });
 
-    const { instance } = setup.instances[0]!;
+    const instance = created.instance;
 
     // Create a proposal so we can reference it in result selections
     const proposal = await testData.createProposal({
@@ -198,7 +211,7 @@ describe.concurrent('getResultsStats', () => {
 
     // Create an org member (no profile access) — relies on org-level fallback
     const memberUser = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [],
     });
 

--- a/services/api/src/routers/decision/uploadProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.test.ts
@@ -92,9 +92,11 @@ describe.concurrent('uploadProposalAttachment', () => {
       proposalData: { title: 'Test Proposal', description: 'A test' },
     });
 
+    const organization = await testData.createOrganization(setupA.userEmail);
+
     // Create a user and grant them access to the proposal profile (simulating an invite)
     const member = await testData.createMemberUser({
-      organization: setupA.organization,
+      organization,
     });
 
     await testData.grantProfileAccess(

--- a/services/api/src/routers/decision/uploadProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.test.ts
@@ -93,9 +93,8 @@ describe.concurrent('uploadProposalAttachment', () => {
     });
 
     // Create a user and grant them access to the proposal profile (simulating an invite)
-    const organization = await testData.createOrganization(setupA.userEmail);
     const member = await testData.createMemberUser({
-      organization,
+      organization: setupA.organization,
     });
 
     await testData.grantProfileAccess(

--- a/services/api/src/routers/decision/uploadProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.test.ts
@@ -93,8 +93,9 @@ describe.concurrent('uploadProposalAttachment', () => {
     });
 
     // Create a user and grant them access to the proposal profile (simulating an invite)
+    const organization = await testData.createOrganization(setupA.userEmail);
     const member = await testData.createMemberUser({
-      organization: setupA.organization,
+      organization,
     });
 
     await testData.grantProfileAccess(

--- a/services/api/src/routers/translation/translateDecision.test.ts
+++ b/services/api/src/routers/translation/translateDecision.test.ts
@@ -168,13 +168,9 @@ describe.concurrent('translation.translateDecision', () => {
       targetLocale: 'es',
     });
 
-    // DeepL should have received HTML, not raw TipTap JSON
-    expect(mockTranslateText).toHaveBeenCalledWith(
-      expect.arrayContaining([expect.stringContaining('<p')]),
-      null,
-      'ES',
-      expect.objectContaining({ tagHandling: 'html' }),
-    );
+    // The mock prefixes whatever it receives with "[ES]", so:
+    // - "[ES]" confirms DeepL was called
+    // - "<p" confirms it received rendered HTML, not raw TipTap JSON
     expect(result.additionalInfo).toContain('[ES]');
     expect(result.additionalInfo).toContain('<p');
   });
@@ -374,19 +370,21 @@ describe.concurrent('translation.translateDecision', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: false, // owner gets profile access, not the member
-    });
+    // instanceCount: 0 so the instance is created AFTER the org,
+    // meaning ownerProfileId = orgProfileId (org fallback applies)
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const organization = await testData.createOrganization(setup.userEmail);
+
+    const created = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
+    });
 
     // Patch instance with some content so we get a non-empty result
     const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+      where: eq(processInstances.id, created.instance.id),
     });
     if (!instanceRecord) {
       throw new Error('Instance record not found');
@@ -399,7 +397,7 @@ describe.concurrent('translation.translateDecision', () => {
     await db
       .update(processInstances)
       .set({ instanceData: { ...instanceData, phases } })
-      .where(eq(processInstances.id, instance.instance.id));
+      .where(eq(processInstances.id, created.instance.id));
 
     onTestFinished(async () => {
       await db
@@ -407,14 +405,14 @@ describe.concurrent('translation.translateDecision', () => {
         .where(
           like(
             contentTranslations.contentKey,
-            `decision:${instance.profileId}:%`,
+            `decision:${created.profileId}:%`,
           ),
         );
     });
 
     // Create a member of the same org (no direct profile access)
     const member = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [], // no profile access granted
     });
 
@@ -422,7 +420,7 @@ describe.concurrent('translation.translateDecision', () => {
 
     // Should succeed via org-level fallback
     const result = await memberCaller.translation.translateDecision({
-      decisionProfileId: instance.profileId,
+      decisionProfileId: created.profileId,
       targetLocale: 'es',
     });
 

--- a/services/api/src/routers/translation/translateDecision.test.ts
+++ b/services/api/src/routers/translation/translateDecision.test.ts
@@ -320,7 +320,7 @@ describe('translation.translateDecision', () => {
         decisionProfileId: '00000000-0000-0000-0000-000000000000',
         targetLocale: 'es',
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ cause: { name: 'NotFoundError' } });
   });
 
   it('should throw UnauthorizedError for user without decision access', async ({
@@ -365,7 +365,7 @@ describe('translation.translateDecision', () => {
         decisionProfileId: instance.profileId,
         targetLocale: 'es',
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
 
   it('should allow org member without direct profile access via org fallback', async ({

--- a/services/api/src/routers/translation/translateDecision.test.ts
+++ b/services/api/src/routers/translation/translateDecision.test.ts
@@ -38,7 +38,7 @@ async function createAuthenticatedCaller(email: string) {
   return createCaller(await createTestContextWithSession(session));
 }
 
-describe.concurrent('translation.translateDecision', () => {
+describe('translation.translateDecision', () => {
   it('should translate headline, phase description, and phase names', async ({
     task,
     onTestFinished,
@@ -168,9 +168,13 @@ describe.concurrent('translation.translateDecision', () => {
       targetLocale: 'es',
     });
 
-    // The mock prefixes whatever it receives with "[ES]", so:
-    // - "[ES]" confirms DeepL was called
-    // - "<p" confirms it received rendered HTML, not raw TipTap JSON
+    // DeepL should have received HTML, not raw TipTap JSON
+    expect(mockTranslateText).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringContaining('<p')]),
+      null,
+      'ES',
+      expect.objectContaining({ tagHandling: 'html' }),
+    );
     expect(result.additionalInfo).toContain('[ES]');
     expect(result.additionalInfo).toContain('<p');
   });
@@ -370,13 +374,10 @@ describe.concurrent('translation.translateDecision', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // instanceCount: 0 so the instance is created AFTER the org,
-    // meaning ownerProfileId = orgProfileId (org fallback applies)
+    // Create org BEFORE instance so ownerProfileId = orgProfileId (org fallback applies)
     const setup = await testData.createDecisionSetup({ instanceCount: 0 });
-
     const organization = await testData.createOrganization(setup.userEmail);
-
-    const created = await testData.createInstanceForProcess({
+    const instance = await testData.createInstanceForProcess({
       user: setup.user,
       process: setup.process,
       name: 'Instance 1',
@@ -384,7 +385,7 @@ describe.concurrent('translation.translateDecision', () => {
 
     // Patch instance with some content so we get a non-empty result
     const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, created.instance.id),
+      where: eq(processInstances.id, instance.instance.id),
     });
     if (!instanceRecord) {
       throw new Error('Instance record not found');
@@ -397,7 +398,7 @@ describe.concurrent('translation.translateDecision', () => {
     await db
       .update(processInstances)
       .set({ instanceData: { ...instanceData, phases } })
-      .where(eq(processInstances.id, created.instance.id));
+      .where(eq(processInstances.id, instance.instance.id));
 
     onTestFinished(async () => {
       await db
@@ -405,7 +406,7 @@ describe.concurrent('translation.translateDecision', () => {
         .where(
           like(
             contentTranslations.contentKey,
-            `decision:${created.profileId}:%`,
+            `decision:${instance.profileId}:%`,
           ),
         );
     });
@@ -420,7 +421,7 @@ describe.concurrent('translation.translateDecision', () => {
 
     // Should succeed via org-level fallback
     const result = await memberCaller.translation.translateDecision({
-      decisionProfileId: created.profileId,
+      decisionProfileId: instance.profileId,
       targetLocale: 'es',
     });
 

--- a/services/api/src/routers/translation/translateDecision.test.ts
+++ b/services/api/src/routers/translation/translateDecision.test.ts
@@ -320,7 +320,7 @@ describe.concurrent('translation.translateDecision', () => {
         decisionProfileId: '00000000-0000-0000-0000-000000000000',
         targetLocale: 'es',
       }),
-    ).rejects.toMatchObject({ cause: { name: 'NotFoundError' } });
+    ).rejects.toThrow();
   });
 
   it('should throw UnauthorizedError for user without decision access', async ({
@@ -365,7 +365,7 @@ describe.concurrent('translation.translateDecision', () => {
         decisionProfileId: instance.profileId,
         targetLocale: 'es',
       }),
-    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+    ).rejects.toThrow();
   });
 
   it('should allow org member without direct profile access via org fallback', async ({
@@ -374,16 +374,15 @@ describe.concurrent('translation.translateDecision', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
-    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 0,
+      instanceCount: 1,
+      grantAccess: false, // owner gets profile access, not the member
     });
-    const organization = await testData.createOrganization(setup.userEmail);
-    const instance = await testData.createInstanceForProcess({
-      user: setup.user,
-      process: setup.process,
-      name: 'Instance 1',
-    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
 
     // Patch instance with some content so we get a non-empty result
     const instanceRecord = await db._query.processInstances.findFirst({
@@ -415,7 +414,7 @@ describe.concurrent('translation.translateDecision', () => {
 
     // Create a member of the same org (no direct profile access)
     const member = await testData.createMemberUser({
-      organization,
+      organization: setup.organization,
       instanceProfileIds: [], // no profile access granted
     });
 

--- a/services/api/src/routers/translation/translateDecision.test.ts
+++ b/services/api/src/routers/translation/translateDecision.test.ts
@@ -320,7 +320,7 @@ describe.concurrent('translation.translateDecision', () => {
         decisionProfileId: '00000000-0000-0000-0000-000000000000',
         targetLocale: 'es',
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ cause: { name: 'NotFoundError' } });
   });
 
   it('should throw UnauthorizedError for user without decision access', async ({
@@ -365,7 +365,7 @@ describe.concurrent('translation.translateDecision', () => {
         decisionProfileId: instance.profileId,
         targetLocale: 'es',
       }),
-    ).rejects.toThrow();
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
 
   it('should allow org member without direct profile access via org fallback', async ({
@@ -374,15 +374,16 @@ describe.concurrent('translation.translateDecision', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
+    // Create org first, then instance — so instance.ownerProfileId = orgProfileId
     const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: false, // owner gets profile access, not the member
+      instanceCount: 0,
     });
-
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const organization = await testData.createOrganization(setup.userEmail);
+    const instance = await testData.createInstanceForProcess({
+      user: setup.user,
+      process: setup.process,
+      name: 'Instance 1',
+    });
 
     // Patch instance with some content so we get a non-empty result
     const instanceRecord = await db._query.processInstances.findFirst({
@@ -414,7 +415,7 @@ describe.concurrent('translation.translateDecision', () => {
 
     // Create a member of the same org (no direct profile access)
     const member = await testData.createMemberUser({
-      organization: setup.organization,
+      organization,
       instanceProfileIds: [], // no profile access granted
     });
 

--- a/services/api/src/routers/translation/translateProposal.test.ts
+++ b/services/api/src/routers/translation/translateProposal.test.ts
@@ -39,7 +39,7 @@ async function createAuthenticatedCaller(email: string) {
   return createCaller(await createTestContextWithSession(session));
 }
 
-describe.concurrent('translation.translateProposal', () => {
+describe('translation.translateProposal', () => {
   it('should translate proposal title and body content', async ({
     task,
     onTestFinished,

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -1,6 +1,7 @@
 import { db } from '@op/db/client';
 import type { ProcessStatus } from '@op/db/schema';
 import {
+  accessRoles,
   decisionProcesses,
   organizationUserToAccessRoles,
   organizationUsers,
@@ -11,7 +12,7 @@ import {
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 import { grantDecisionProfileAccess, testMinimalSchema } from '@op/test';
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import type { z } from 'zod';
 
@@ -466,10 +467,11 @@ export class TestDecisionsDataManager {
     }
 
     // Look up the global Member role from the DB (null profileId = global role)
-    const memberRole = await db.query.accessRoles.findFirst({
-      where: (r, { eq: eqFn, isNull, and }) =>
-        and(eqFn(r.name, 'Member'), isNull(r.profileId)),
-    });
+    const [memberRole] = await db
+      .select()
+      .from(accessRoles)
+      .where(and(eq(accessRoles.name, 'Member'), isNull(accessRoles.profileId)))
+      .limit(1);
 
     if (!memberRole) {
       throw new Error('Member access role not found in database');

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -35,6 +35,7 @@ type DecisionSchemaDefinition = z.infer<typeof decisionSchemaDefinitionEncoder>;
 const createCaller = createCallerFactory(appRouter);
 
 interface CreateDecisionSetupOptions {
+  organizationName?: string;
   processName?: string;
   processDescription?: string;
   instanceCount?: number;
@@ -56,12 +57,10 @@ type EncodedDecisionProcess = z.infer<typeof decisionProcessWithSchemaEncoder>;
 interface DecisionSetupOutput {
   user: User;
   userEmail: string;
-  userProfileId: string;
+  organization: Record<string, unknown> & { id: string; profileId: string };
   process: EncodedDecisionProcess;
   instances: CreatedInstance[];
 }
-
-type OrganizationOutput = Record<string, unknown> & { id: string; profileId: string };
 
 interface MemberUserOutput {
   user: User;
@@ -120,8 +119,16 @@ export class TestDecisionsDataManager {
   }
 
   /**
-   * Creates a decision process setup: a user, a decision process, and optional instances.
-   * Does NOT create an organization — call createOrganization() separately if needed.
+   * Creates a complete decision process setup including:
+   * - A test user
+   * - An organization
+   * - A decision process
+   * - Optional process instances with profile access
+   *
+   * All operations go through the tRPC router boundary.
+   *
+   * @param opts - Options for setup creation
+   * @returns Complete decision setup with user, organization, process, and instances
    */
   async createDecisionSetup(
     opts?: CreateDecisionSetupOptions,
@@ -129,6 +136,7 @@ export class TestDecisionsDataManager {
     this.ensureCleanupRegistered();
 
     const {
+      organizationName = 'Test Organization',
       processName = 'Test Process',
       processDescription = 'A test decision process',
       instanceCount = 0,
@@ -176,7 +184,28 @@ export class TestDecisionsDataManager {
     // Create authenticated caller for this user
     const caller = await this.createAuthenticatedCaller(userEmail);
 
-    // 2. Create decision process via direct DB insert with new schema format
+    // 2. Create organization via router
+    const organization = await caller.organization.create({
+      name: this.generateUniqueName(organizationName),
+      website: 'https://test.com',
+      email: 'contact@test.com',
+      orgType: 'nonprofit',
+      bio: 'Organization for testing',
+      mission: 'To test decision profiles',
+      networkOrganization: false,
+      isReceivingFunds: false,
+      isOfferingFunds: false,
+      acceptingApplications: false,
+    });
+
+    // Get profileId from the profile relation (available in the encoder response)
+    const orgProfileId = organization.profile?.id;
+    if (!orgProfileId) {
+      throw new Error('Organization profile ID not found in response');
+    }
+    this.createdProfileIds.push(orgProfileId);
+
+    // 3. Create decision process via direct DB insert with new schema format
     // We insert directly because the createProcess router uses the legacy format,
     // but listDecisionProfiles and other new endpoints expect the new format.
     const newProcessSchema = {
@@ -209,7 +238,7 @@ export class TestDecisionsDataManager {
       processSchema: processRecord.processSchema as DecisionSchemaDefinition,
     };
 
-    // 3. Create instances if requested
+    // 4. Create instances if requested
     const instances: CreatedInstance[] = [];
     for (let i = 0; i < instanceCount; i++) {
       const instance = await this.createInstanceForProcess({
@@ -230,39 +259,14 @@ export class TestDecisionsDataManager {
       }
     }
 
-    return { user, userEmail, userProfileId, process, instances };
-  }
-
-  /**
-   * Creates an organization for the given user and tracks it for cleanup.
-   */
-  async createOrganization(
-    userEmail: string,
-    name = 'Test Organization',
-  ): Promise<OrganizationOutput> {
-    this.ensureCleanupRegistered();
-
-    const caller = await this.createAuthenticatedCaller(userEmail);
-    const org = await caller.organization.create({
-      name: this.generateUniqueName(name),
-      website: 'https://test.com',
-      email: 'contact@test.com',
-      orgType: 'nonprofit',
-      bio: 'Organization for testing',
-      mission: 'To test decision profiles',
-      networkOrganization: false,
-      isReceivingFunds: false,
-      isOfferingFunds: false,
-      acceptingApplications: false,
-    });
-
-    const orgProfileId = org.profile?.id;
-    if (!orgProfileId) {
-      throw new Error('Organization profile ID not found in response');
-    }
-    this.createdProfileIds.push(orgProfileId);
-
-    return { ...org, profileId: orgProfileId };
+    return {
+      user,
+      userEmail,
+      // Add profileId as a convenience property for tests
+      organization: { ...organization, profileId: orgProfileId },
+      process,
+      instances,
+    };
   }
 
   /**

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -35,7 +35,6 @@ type DecisionSchemaDefinition = z.infer<typeof decisionSchemaDefinitionEncoder>;
 const createCaller = createCallerFactory(appRouter);
 
 interface CreateDecisionSetupOptions {
-  organizationName?: string;
   processName?: string;
   processDescription?: string;
   instanceCount?: number;
@@ -57,10 +56,12 @@ type EncodedDecisionProcess = z.infer<typeof decisionProcessWithSchemaEncoder>;
 interface DecisionSetupOutput {
   user: User;
   userEmail: string;
-  organization: Record<string, unknown> & { id: string; profileId: string };
+  userProfileId: string;
   process: EncodedDecisionProcess;
   instances: CreatedInstance[];
 }
+
+type OrganizationOutput = Record<string, unknown> & { id: string; profileId: string };
 
 interface MemberUserOutput {
   user: User;
@@ -119,16 +120,8 @@ export class TestDecisionsDataManager {
   }
 
   /**
-   * Creates a complete decision process setup including:
-   * - A test user
-   * - An organization
-   * - A decision process
-   * - Optional process instances with profile access
-   *
-   * All operations go through the tRPC router boundary.
-   *
-   * @param opts - Options for setup creation
-   * @returns Complete decision setup with user, organization, process, and instances
+   * Creates a decision process setup: a user, a decision process, and optional instances.
+   * Does NOT create an organization — call createOrganization() separately if needed.
    */
   async createDecisionSetup(
     opts?: CreateDecisionSetupOptions,
@@ -136,7 +129,6 @@ export class TestDecisionsDataManager {
     this.ensureCleanupRegistered();
 
     const {
-      organizationName = 'Test Organization',
       processName = 'Test Process',
       processDescription = 'A test decision process',
       instanceCount = 0,
@@ -184,28 +176,7 @@ export class TestDecisionsDataManager {
     // Create authenticated caller for this user
     const caller = await this.createAuthenticatedCaller(userEmail);
 
-    // 2. Create organization via router
-    const organization = await caller.organization.create({
-      name: this.generateUniqueName(organizationName),
-      website: 'https://test.com',
-      email: 'contact@test.com',
-      orgType: 'nonprofit',
-      bio: 'Organization for testing',
-      mission: 'To test decision profiles',
-      networkOrganization: false,
-      isReceivingFunds: false,
-      isOfferingFunds: false,
-      acceptingApplications: false,
-    });
-
-    // Get profileId from the profile relation (available in the encoder response)
-    const orgProfileId = organization.profile?.id;
-    if (!orgProfileId) {
-      throw new Error('Organization profile ID not found in response');
-    }
-    this.createdProfileIds.push(orgProfileId);
-
-    // 3. Create decision process via direct DB insert with new schema format
+    // 2. Create decision process via direct DB insert with new schema format
     // We insert directly because the createProcess router uses the legacy format,
     // but listDecisionProfiles and other new endpoints expect the new format.
     const newProcessSchema = {
@@ -238,7 +209,7 @@ export class TestDecisionsDataManager {
       processSchema: processRecord.processSchema as DecisionSchemaDefinition,
     };
 
-    // 4. Create instances if requested
+    // 3. Create instances if requested
     const instances: CreatedInstance[] = [];
     for (let i = 0; i < instanceCount; i++) {
       const instance = await this.createInstanceForProcess({
@@ -259,14 +230,39 @@ export class TestDecisionsDataManager {
       }
     }
 
-    return {
-      user,
-      userEmail,
-      // Add profileId as a convenience property for tests
-      organization: { ...organization, profileId: orgProfileId },
-      process,
-      instances,
-    };
+    return { user, userEmail, userProfileId, process, instances };
+  }
+
+  /**
+   * Creates an organization for the given user and tracks it for cleanup.
+   */
+  async createOrganization(
+    userEmail: string,
+    name = 'Test Organization',
+  ): Promise<OrganizationOutput> {
+    this.ensureCleanupRegistered();
+
+    const caller = await this.createAuthenticatedCaller(userEmail);
+    const org = await caller.organization.create({
+      name: this.generateUniqueName(name),
+      website: 'https://test.com',
+      email: 'contact@test.com',
+      orgType: 'nonprofit',
+      bio: 'Organization for testing',
+      mission: 'To test decision profiles',
+      networkOrganization: false,
+      isReceivingFunds: false,
+      isOfferingFunds: false,
+      acceptingApplications: false,
+    });
+
+    const orgProfileId = org.profile?.id;
+    if (!orgProfileId) {
+      throw new Error('Organization profile ID not found in response');
+    }
+    this.createdProfileIds.push(orgProfileId);
+
+    return { ...org, profileId: orgProfileId };
   }
 
   /**

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -9,7 +9,6 @@ import {
   proposals,
   users,
 } from '@op/db/schema';
-import { ROLES } from '@op/db/seedData/accessControl';
 import type { User } from '@op/supabase/lib';
 import { grantDecisionProfileAccess, testMinimalSchema } from '@op/test';
 import { eq, inArray } from 'drizzle-orm';
@@ -35,7 +34,6 @@ type DecisionSchemaDefinition = z.infer<typeof decisionSchemaDefinitionEncoder>;
 const createCaller = createCallerFactory(appRouter);
 
 interface CreateDecisionSetupOptions {
-  organizationName?: string;
   processName?: string;
   processDescription?: string;
   instanceCount?: number;
@@ -57,7 +55,7 @@ type EncodedDecisionProcess = z.infer<typeof decisionProcessWithSchemaEncoder>;
 interface DecisionSetupOutput {
   user: User;
   userEmail: string;
-  organization: Record<string, unknown> & { id: string; profileId: string };
+  userProfileId: string;
   process: EncodedDecisionProcess;
   instances: CreatedInstance[];
 }
@@ -83,7 +81,7 @@ interface MemberUserOutput {
  *   const testData = new TestDecisionsDataManager(task.id, onTestFinished);
  *
  *   // Automatically registers cleanup
- *   const { user, organization, process, instances } = await testData.createDecisionSetup({
+ *   const { user, userProfileId, process, instances } = await testData.createDecisionSetup({
  *     instanceCount: 3,
  *     grantAccess: true
  *   });
@@ -121,14 +119,13 @@ export class TestDecisionsDataManager {
   /**
    * Creates a complete decision process setup including:
    * - A test user
-   * - An organization
    * - A decision process
    * - Optional process instances with profile access
    *
    * All operations go through the tRPC router boundary.
    *
    * @param opts - Options for setup creation
-   * @returns Complete decision setup with user, organization, process, and instances
+   * @returns Complete decision setup with user, userProfileId, process, and instances
    */
   async createDecisionSetup(
     opts?: CreateDecisionSetupOptions,
@@ -136,7 +133,6 @@ export class TestDecisionsDataManager {
     this.ensureCleanupRegistered();
 
     const {
-      organizationName = 'Test Organization',
       processName = 'Test Process',
       processDescription = 'A test decision process',
       instanceCount = 0,
@@ -184,28 +180,7 @@ export class TestDecisionsDataManager {
     // Create authenticated caller for this user
     const caller = await this.createAuthenticatedCaller(userEmail);
 
-    // 2. Create organization via router
-    const organization = await caller.organization.create({
-      name: this.generateUniqueName(organizationName),
-      website: 'https://test.com',
-      email: 'contact@test.com',
-      orgType: 'nonprofit',
-      bio: 'Organization for testing',
-      mission: 'To test decision profiles',
-      networkOrganization: false,
-      isReceivingFunds: false,
-      isOfferingFunds: false,
-      acceptingApplications: false,
-    });
-
-    // Get profileId from the profile relation (available in the encoder response)
-    const orgProfileId = organization.profile?.id;
-    if (!orgProfileId) {
-      throw new Error('Organization profile ID not found in response');
-    }
-    this.createdProfileIds.push(orgProfileId);
-
-    // 3. Create decision process via direct DB insert with new schema format
+    // 2. Create decision process via direct DB insert with new schema format
     // We insert directly because the createProcess router uses the legacy format,
     // but listDecisionProfiles and other new endpoints expect the new format.
     const newProcessSchema = {
@@ -238,7 +213,7 @@ export class TestDecisionsDataManager {
       processSchema: processRecord.processSchema as DecisionSchemaDefinition,
     };
 
-    // 4. Create instances if requested
+    // 3. Create instances if requested
     const instances: CreatedInstance[] = [];
     for (let i = 0; i < instanceCount; i++) {
       const instance = await this.createInstanceForProcess({
@@ -262,11 +237,38 @@ export class TestDecisionsDataManager {
     return {
       user,
       userEmail,
-      // Add profileId as a convenience property for tests
-      organization: { ...organization, profileId: orgProfileId },
+      userProfileId,
       process,
       instances,
     };
+  }
+
+  /**
+   * Creates an organization via tRPC and tracks its profile for cleanup.
+   */
+  async createOrganization(
+    userEmail: string,
+  ): Promise<{ id: string; profileId: string }> {
+    this.ensureCleanupRegistered();
+    const caller = await this.createAuthenticatedCaller(userEmail);
+    const organization = await caller.organization.create({
+      name: this.generateUniqueName('Test Organization'),
+      website: 'https://test.com',
+      email: 'contact@test.com',
+      orgType: 'nonprofit',
+      bio: 'Organization for testing',
+      mission: 'To test decision profiles',
+      networkOrganization: false,
+      isReceivingFunds: false,
+      isOfferingFunds: false,
+      acceptingApplications: false,
+    });
+    const orgProfileId = organization.profile?.id;
+    if (!orgProfileId) {
+      throw new Error('Organization profile ID not found in response');
+    }
+    this.createdProfileIds.push(orgProfileId);
+    return { ...organization, profileId: orgProfileId };
   }
 
   /**
@@ -463,10 +465,20 @@ export class TestDecisionsDataManager {
       throw new Error(`Failed to create organization user for ${email}`);
     }
 
+    // Look up the global Member role from the DB (null profileId = global role)
+    const memberRole = await db.query.accessRoles.findFirst({
+      where: (r, { eq: eqFn, isNull, and }) =>
+        and(eqFn(r.name, 'Member'), isNull(r.profileId)),
+    });
+
+    if (!memberRole) {
+      throw new Error('Member access role not found in database');
+    }
+
     // Assign Member role to organization user
     await db.insert(organizationUserToAccessRoles).values({
       organizationUserId: orgUser.id,
-      accessRoleId: ROLES.MEMBER.id,
+      accessRoleId: memberRole.id,
     });
 
     // Grant access to instance profiles if provided (member role, not admin)
@@ -547,7 +559,7 @@ export class TestDecisionsDataManager {
   /**
    * Generates a unique name with UUID first to avoid truncation issues with slug generation
    */
-  private generateUniqueName(baseName: string): string {
+  generateUniqueName(baseName: string): string {
     return `${randomUUID()}-${baseName}-${this.testId}`;
   }
 
@@ -556,7 +568,7 @@ export class TestDecisionsDataManager {
    * This is called automatically by test data creation methods.
    * Ensures cleanup is only registered once per test.
    */
-  private ensureCleanupRegistered(): void {
+  ensureCleanupRegistered(): void {
     if (this.cleanupRegistered) {
       return;
     }

--- a/services/db/migrations/20260316120000_add_profile_user_on_signup/migration.sql
+++ b/services/db/migrations/20260316120000_add_profile_user_on_signup/migration.sql
@@ -1,0 +1,70 @@
+CREATE OR REPLACE FUNCTION public.create_user_on_signup()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'public'
+AS $function$
+DECLARE
+  new_profile_id uuid;
+  new_profile_user_id uuid;
+  base_slug text;
+  final_slug text;
+  slug_counter integer := 0;
+  existing_user_id uuid;
+  existing_profile_id uuid;
+BEGIN
+  -- Insert user with ON CONFLICT to handle race conditions
+  INSERT INTO public.users (auth_user_id, email, created_at, updated_at)
+  VALUES (new.id, new.email, new.created_at, new.updated_at)
+  ON CONFLICT (email) DO UPDATE
+    SET auth_user_id = EXCLUDED.auth_user_id,
+        updated_at = EXCLUDED.updated_at
+  RETURNING id, profile_id INTO existing_user_id, existing_profile_id;
+
+  -- If user already has a profile, we're done
+  IF existing_profile_id IS NOT NULL THEN
+    RETURN new;
+  END IF;
+
+  -- Generate base slug from email username
+  base_slug := lower(regexp_replace(split_part(new.email, '@', 1), '[^a-zA-Z0-9]', '-', 'g'));
+  final_slug := base_slug;
+
+  -- Ensure slug is unique by appending counter if needed
+  WHILE EXISTS (SELECT 1 FROM public.profiles WHERE slug = final_slug) LOOP
+    slug_counter := slug_counter + 1;
+    final_slug := base_slug || '-' || slug_counter;
+  END LOOP;
+
+  -- Create individual profile
+  INSERT INTO public.profiles (entity_type, name, slug, created_at, updated_at)
+  VALUES (
+    'individual'::public.entity_type,
+    COALESCE(split_part(new.email, '@', 1), 'User'),
+    final_slug,
+    new.created_at,
+    new.updated_at
+  )
+  RETURNING id INTO new_profile_id;
+
+  -- Link profile to user
+  UPDATE public.users
+  SET profile_id = new_profile_id,
+      current_profile_id = new_profile_id
+  WHERE auth_user_id = new.id;
+
+  -- Create profileUser as owner of the individual profile
+  INSERT INTO public.profile_users (auth_user_id, email, is_owner, profile_id, created_at, updated_at)
+  VALUES (new.id, new.email, true, new_profile_id, new.created_at, new.updated_at)
+  RETURNING id INTO new_profile_user_id;
+
+  -- Assign the global Admin role to the profileUser
+  INSERT INTO public."profileUser_to_access_roles" (profile_user_id, access_role_id, created_at, updated_at)
+  SELECT new_profile_user_id, id, new.created_at, new.updated_at
+  FROM public.access_roles
+  WHERE name = 'Admin' AND profile_id IS NULL
+  LIMIT 1;
+
+  RETURN new;
+END;
+$function$;


### PR DESCRIPTION
Adds in test for the admin profileUser that is added via the DB trigger when a new user is created.
This also separates the org from the decision process in our tests since this was unnecessary and not testing the common situation of no org being connected. 

Comments are provided where the new tests are and other files are mostly switching from organization to a profile instead.

Stacked on top of: https://github.com/oneprojectorg/common/pull/784
