### PR TITLE
Run selection pipeline on transition and persist phase-scoped proposals

### DIFF
--- a/packages/common/src/services/decision/getProposalsForPhase.ts
+++ b/packages/common/src/services/decision/getProposalsForPhase.ts
@@ -45,6 +45,24 @@ async function resolveTransition(
 }
 
 /**
+ * All non-draft, non-deleted proposals for an instance.
+ * Used as the fallback when no transition exists or when a legacy transition
+ * has no join-table rows (instance transitioned before join-table writes were added).
+ */
+function allActiveProposals(instanceId: string, dbClient: DbClient) {
+  return dbClient
+    .select()
+    .from(proposals)
+    .where(
+      and(
+        eq(proposals.processInstanceId, instanceId),
+        ne(proposals.status, ProposalStatus.DRAFT),
+        isNull(proposals.deletedAt),
+      ),
+    );
+}
+
+/**
  * Returns IDs of proposals visible in the given phase. Lean variant for
  * callers that only need IDs (e.g. to pass as a filter to listProposals).
  *
@@ -52,6 +70,8 @@ async function resolveTransition(
  *   Returns [] if phaseId does not match any recorded transition.
  * - If phaseId is omitted: returns proposals for the current (most recent) phase.
  * - If no transition exists yet: returns all non-draft, non-deleted proposals for the instance.
+ * - Legacy fallback: if a transition exists but the join table is empty (instance
+ *   transitioned before join-table writes were added), returns all active proposals.
  */
 export async function getProposalIdsForPhase({
   instanceId,
@@ -62,49 +82,38 @@ export async function getProposalIdsForPhase({
   phaseId?: string;
   dbClient?: DbClient;
 }): Promise<string[]> {
-  try {
-    const transition = await resolveTransition(instanceId, phaseId, dbClient);
+  const transition = await resolveTransition(instanceId, phaseId, dbClient);
 
-    if (phaseId && !transition) {
-      return [];
-    }
+  if (phaseId && !transition) {
+    return [];
+  }
 
-    if (transition) {
-      const rows = await dbClient
-        .select({ id: decisionTransitionProposals.proposalId })
-        .from(decisionTransitionProposals)
-        .innerJoin(
-          proposals,
-          eq(decisionTransitionProposals.proposalId, proposals.id),
-        )
-        .where(
-          and(
-            eq(decisionTransitionProposals.transitionHistoryId, transition.id),
-            isNull(proposals.deletedAt),
-          ),
-        );
-      return rows.map((r) => r.id);
-    }
-
+  if (transition) {
     const rows = await dbClient
-      .select({ id: proposals.id })
-      .from(proposals)
+      .select({ id: decisionTransitionProposals.proposalId })
+      .from(decisionTransitionProposals)
+      .innerJoin(
+        proposals,
+        eq(decisionTransitionProposals.proposalId, proposals.id),
+      )
       .where(
         and(
-          eq(proposals.processInstanceId, instanceId),
-          ne(proposals.status, ProposalStatus.DRAFT),
+          eq(decisionTransitionProposals.transitionHistoryId, transition.id),
           isNull(proposals.deletedAt),
         ),
       );
+
+    // Legacy fallback: transition exists but join table was never populated
+    if (rows.length === 0) {
+      const fallback = await allActiveProposals(instanceId, dbClient);
+      return fallback.map((r) => r.id);
+    }
+
     return rows.map((r) => r.id);
-  } catch (error) {
-    console.error('Error fetching proposal IDs for phase:', {
-      instanceId,
-      phaseId,
-      error,
-    });
-    throw error;
   }
+
+  const fallback = await allActiveProposals(instanceId, dbClient);
+  return fallback.map((r) => r.id);
 }
 
 /**
@@ -114,9 +123,8 @@ export async function getProposalIdsForPhase({
  *   Returns [] if phaseId does not match any recorded transition.
  * - If phaseId is omitted: returns proposals for the current (most recent) phase.
  * - If no transition exists yet: returns all non-draft, non-deleted proposals for the instance.
- *   Note: even a transition without a selection pipeline writes all proposals to the join
- *   table, so the full non-deleted set is returned in that case — not an indication that
- *   filtering occurred.
+ * - Legacy fallback: if a transition exists but the join table is empty (instance
+ *   transitioned before join-table writes were added), returns all active proposals.
  */
 export async function getProposalsForPhase({
   instanceId,
@@ -127,46 +135,34 @@ export async function getProposalsForPhase({
   phaseId?: string;
   dbClient?: DbClient;
 }): Promise<Proposal[]> {
-  try {
-    const transition = await resolveTransition(instanceId, phaseId, dbClient);
+  const transition = await resolveTransition(instanceId, phaseId, dbClient);
 
-    if (phaseId && !transition) {
-      return [];
-    }
+  if (phaseId && !transition) {
+    return [];
+  }
 
-    if (transition) {
-      const rows = await dbClient
-        .select({ proposal: proposals })
-        .from(decisionTransitionProposals)
-        .innerJoin(
-          proposals,
-          eq(decisionTransitionProposals.proposalId, proposals.id),
-        )
-        .where(
-          and(
-            eq(decisionTransitionProposals.transitionHistoryId, transition.id),
-            isNull(proposals.deletedAt),
-          ),
-        );
-      return rows.map((r) => r.proposal);
-    }
-
-    return dbClient
-      .select()
-      .from(proposals)
+  if (transition) {
+    const rows = await dbClient
+      .select({ proposal: proposals })
+      .from(decisionTransitionProposals)
+      .innerJoin(
+        proposals,
+        eq(decisionTransitionProposals.proposalId, proposals.id),
+      )
       .where(
         and(
-          eq(proposals.processInstanceId, instanceId),
-          ne(proposals.status, ProposalStatus.DRAFT),
+          eq(decisionTransitionProposals.transitionHistoryId, transition.id),
           isNull(proposals.deletedAt),
         ),
       );
-  } catch (error) {
-    console.error('Error fetching proposals for phase:', {
-      instanceId,
-      phaseId,
-      error,
-    });
-    throw error;
+
+    // Legacy fallback: transition exists but join table was never populated
+    if (rows.length === 0) {
+      return allActiveProposals(instanceId, dbClient);
+    }
+
+    return rows.map((r) => r.proposal);
   }
+
+  return allActiveProposals(instanceId, dbClient);
 }

--- a/packages/common/src/services/decision/getProposalsForPhase.ts
+++ b/packages/common/src/services/decision/getProposalsForPhase.ts
@@ -4,9 +4,12 @@ import type { Proposal } from '@op/db/schema';
 import {
   ProposalStatus,
   decisionTransitionProposals,
+  processInstances,
   proposals,
   stateTransitionHistory,
 } from '@op/db/schema';
+
+import { isLegacyInstanceData } from './isLegacyInstance';
 
 /**
  * Resolves the transition to use for phase-scoped proposal queries.
@@ -46,8 +49,7 @@ async function resolveTransition(
 
 /**
  * All non-draft, non-deleted proposals for an instance.
- * Used as the fallback when no transition exists or when a legacy transition
- * has no join-table rows (instance transitioned before join-table writes were added).
+ * Used for legacy instances and for new instances still in their initial phase.
  */
 function allActiveProposals(instanceId: string, dbClient: DbClient) {
   return dbClient
@@ -63,15 +65,42 @@ function allActiveProposals(instanceId: string, dbClient: DbClient) {
 }
 
 /**
+ * Loads the instance's legacy/current-phase context in a single query.
+ * Returns null if the instance does not exist.
+ */
+async function getInstanceContext(
+  instanceId: string,
+  dbClient: DbClient,
+): Promise<{ isLegacy: boolean; currentPhaseId?: string } | null> {
+  const [row] = await dbClient
+    .select({ instanceData: processInstances.instanceData })
+    .from(processInstances)
+    .where(eq(processInstances.id, instanceId))
+    .limit(1);
+
+  if (!row) {
+    return null;
+  }
+
+  const data = row.instanceData as { currentPhaseId?: string } | null;
+
+  return {
+    isLegacy: isLegacyInstanceData(row.instanceData),
+    currentPhaseId: data?.currentPhaseId,
+  };
+}
+
+/**
  * Returns IDs of proposals visible in the given phase. Lean variant for
  * callers that only need IDs (e.g. to pass as a filter to listProposals).
  *
- * - If phaseId is provided: returns proposals that survived the transition into that phase.
- *   Returns [] if phaseId does not match any recorded transition.
- * - If phaseId is omitted: returns proposals for the current (most recent) phase.
- * - If no transition exists yet: returns all non-draft, non-deleted proposals for the instance.
- * - Legacy fallback: if a transition exists but the join table is empty (instance
- *   transitioned before join-table writes were added), returns all active proposals.
+ * - Legacy instances (instanceData.currentStateId without currentPhaseId): always returns
+ *   all non-draft, non-deleted proposals — phase scoping does not apply.
+ * - If a transition into the requested phase exists: returns the proposals that survived
+ *   that transition (empty means empty — no fallback).
+ * - If no transition exists and the requested phase is the instance's current phase
+ *   (i.e. the initial phase, never transitioned into): returns all active proposals.
+ * - If a phaseId was passed for a phase the instance hasn't visited: returns [].
  */
 export async function getProposalIdsForPhase({
   instanceId,
@@ -82,11 +111,18 @@ export async function getProposalIdsForPhase({
   phaseId?: string;
   dbClient?: DbClient;
 }): Promise<string[]> {
-  const transition = await resolveTransition(instanceId, phaseId, dbClient);
+  const ctx = await getInstanceContext(instanceId, dbClient);
 
-  if (phaseId && !transition) {
+  if (!ctx) {
     return [];
   }
+
+  if (ctx.isLegacy) {
+    const fallback = await allActiveProposals(instanceId, dbClient);
+    return fallback.map((r) => r.id);
+  }
+
+  const transition = await resolveTransition(instanceId, phaseId, dbClient);
 
   if (transition) {
     const rows = await dbClient
@@ -103,28 +139,31 @@ export async function getProposalIdsForPhase({
         ),
       );
 
-    // Legacy fallback: transition exists but join table was never populated
-    if (rows.length === 0) {
-      const fallback = await allActiveProposals(instanceId, dbClient);
-      return fallback.map((r) => r.id);
-    }
-
     return rows.map((r) => r.id);
   }
 
-  const fallback = await allActiveProposals(instanceId, dbClient);
-  return fallback.map((r) => r.id);
+  // No transition into the requested phase.
+  // If we're sitting on that phase (or no phaseId given → current phase), it's the
+  // initial phase that's never been transitioned into → return all active proposals.
+  const isCurrentPhase = phaseId == null || phaseId === ctx.currentPhaseId;
+  if (isCurrentPhase) {
+    const fallback = await allActiveProposals(instanceId, dbClient);
+    return fallback.map((r) => r.id);
+  }
+
+  return [];
 }
 
 /**
  * Returns the proposals visible in the given phase.
  *
- * - If phaseId is provided: returns proposals that survived the transition into that phase.
- *   Returns [] if phaseId does not match any recorded transition.
- * - If phaseId is omitted: returns proposals for the current (most recent) phase.
- * - If no transition exists yet: returns all non-draft, non-deleted proposals for the instance.
- * - Legacy fallback: if a transition exists but the join table is empty (instance
- *   transitioned before join-table writes were added), returns all active proposals.
+ * - Legacy instances (instanceData.currentStateId without currentPhaseId): always returns
+ *   all non-draft, non-deleted proposals — phase scoping does not apply.
+ * - If a transition into the requested phase exists: returns the proposals that survived
+ *   that transition (empty means empty — no fallback).
+ * - If no transition exists and the requested phase is the instance's current phase
+ *   (i.e. the initial phase, never transitioned into): returns all active proposals.
+ * - If a phaseId was passed for a phase the instance hasn't visited: returns [].
  */
 export async function getProposalsForPhase({
   instanceId,
@@ -135,11 +174,17 @@ export async function getProposalsForPhase({
   phaseId?: string;
   dbClient?: DbClient;
 }): Promise<Proposal[]> {
-  const transition = await resolveTransition(instanceId, phaseId, dbClient);
+  const ctx = await getInstanceContext(instanceId, dbClient);
 
-  if (phaseId && !transition) {
+  if (!ctx) {
     return [];
   }
+
+  if (ctx.isLegacy) {
+    return allActiveProposals(instanceId, dbClient);
+  }
+
+  const transition = await resolveTransition(instanceId, phaseId, dbClient);
 
   if (transition) {
     const rows = await dbClient
@@ -156,13 +201,16 @@ export async function getProposalsForPhase({
         ),
       );
 
-    // Legacy fallback: transition exists but join table was never populated
-    if (rows.length === 0) {
-      return allActiveProposals(instanceId, dbClient);
-    }
-
     return rows.map((r) => r.proposal);
   }
 
-  return allActiveProposals(instanceId, dbClient);
+  // No transition into the requested phase.
+  // If we're sitting on that phase (or no phaseId given → current phase), it's the
+  // initial phase that's never been transitioned into → return all active proposals.
+  const isCurrentPhase = phaseId == null || phaseId === ctx.currentPhaseId;
+  if (isCurrentPhase) {
+    return allActiveProposals(instanceId, dbClient);
+  }
+
+  return [];
 }

--- a/packages/common/src/services/decision/getProposalsForPhase.ts
+++ b/packages/common/src/services/decision/getProposalsForPhase.ts
@@ -1,7 +1,8 @@
-import { and, db, desc, eq, isNull } from '@op/db/client';
+import { and, db, desc, eq, isNull, ne } from '@op/db/client';
 import type { DbClient } from '@op/db/client';
 import type { Proposal } from '@op/db/schema';
 import {
+  ProposalStatus,
   decisionTransitionProposals,
   proposals,
   stateTransitionHistory,
@@ -50,7 +51,7 @@ async function resolveTransition(
  * - If phaseId is provided: returns proposals that survived the transition into that phase.
  *   Returns [] if phaseId does not match any recorded transition.
  * - If phaseId is omitted: returns proposals for the current (most recent) phase.
- * - If no transition exists yet: returns all non-deleted proposals for the instance.
+ * - If no transition exists yet: returns all non-draft, non-deleted proposals for the instance.
  */
 export async function getProposalIdsForPhase({
   instanceId,
@@ -91,6 +92,7 @@ export async function getProposalIdsForPhase({
       .where(
         and(
           eq(proposals.processInstanceId, instanceId),
+          ne(proposals.status, ProposalStatus.DRAFT),
           isNull(proposals.deletedAt),
         ),
       );
@@ -111,7 +113,7 @@ export async function getProposalIdsForPhase({
  * - If phaseId is provided: returns proposals that survived the transition into that phase.
  *   Returns [] if phaseId does not match any recorded transition.
  * - If phaseId is omitted: returns proposals for the current (most recent) phase.
- * - If no transition exists yet: returns all non-deleted proposals for the instance.
+ * - If no transition exists yet: returns all non-draft, non-deleted proposals for the instance.
  *   Note: even a transition without a selection pipeline writes all proposals to the join
  *   table, so the full non-deleted set is returned in that case — not an indication that
  *   filtering occurred.
@@ -155,6 +157,7 @@ export async function getProposalsForPhase({
       .where(
         and(
           eq(proposals.processInstanceId, instanceId),
+          ne(proposals.status, ProposalStatus.DRAFT),
           isNull(proposals.deletedAt),
         ),
       );

--- a/packages/common/src/services/decision/getProposalsForPhase.ts
+++ b/packages/common/src/services/decision/getProposalsForPhase.ts
@@ -1,0 +1,169 @@
+import { and, db, desc, eq, isNull } from '@op/db/client';
+import type { DbClient } from '@op/db/client';
+import type { Proposal } from '@op/db/schema';
+import {
+  decisionTransitionProposals,
+  proposals,
+  stateTransitionHistory,
+} from '@op/db/schema';
+
+/**
+ * Resolves the transition to use for phase-scoped proposal queries.
+ *
+ * - If phaseId is provided: finds the most recent transition that entered that phase (toStateId = phaseId).
+ * - If phaseId is omitted: uses the most recent transition (current phase).
+ * - Returns undefined if no matching transition exists (e.g. still in the initial phase).
+ */
+async function resolveTransition(
+  instanceId: string,
+  phaseId: string | undefined,
+  dbClient: DbClient,
+) {
+  if (phaseId) {
+    const [transition] = await dbClient
+      .select({ id: stateTransitionHistory.id })
+      .from(stateTransitionHistory)
+      .where(
+        and(
+          eq(stateTransitionHistory.processInstanceId, instanceId),
+          eq(stateTransitionHistory.toStateId, phaseId),
+        ),
+      )
+      .orderBy(desc(stateTransitionHistory.transitionedAt))
+      .limit(1);
+    return transition;
+  }
+
+  const [latestTransition] = await dbClient
+    .select({ id: stateTransitionHistory.id })
+    .from(stateTransitionHistory)
+    .where(eq(stateTransitionHistory.processInstanceId, instanceId))
+    .orderBy(desc(stateTransitionHistory.transitionedAt))
+    .limit(1);
+  return latestTransition;
+}
+
+/**
+ * Returns IDs of proposals visible in the given phase. Lean variant for
+ * callers that only need IDs (e.g. to pass as a filter to listProposals).
+ *
+ * - If phaseId is provided: returns proposals that survived the transition into that phase.
+ *   Returns [] if phaseId does not match any recorded transition.
+ * - If phaseId is omitted: returns proposals for the current (most recent) phase.
+ * - If no transition exists yet: returns all non-deleted proposals for the instance.
+ */
+export async function getProposalIdsForPhase({
+  instanceId,
+  phaseId,
+  dbClient = db,
+}: {
+  instanceId: string;
+  phaseId?: string;
+  dbClient?: DbClient;
+}): Promise<string[]> {
+  try {
+    const transition = await resolveTransition(instanceId, phaseId, dbClient);
+
+    if (phaseId && !transition) {
+      return [];
+    }
+
+    if (transition) {
+      const rows = await dbClient
+        .select({ id: decisionTransitionProposals.proposalId })
+        .from(decisionTransitionProposals)
+        .innerJoin(
+          proposals,
+          eq(decisionTransitionProposals.proposalId, proposals.id),
+        )
+        .where(
+          and(
+            eq(decisionTransitionProposals.transitionHistoryId, transition.id),
+            isNull(proposals.deletedAt),
+          ),
+        );
+      return rows.map((r) => r.id);
+    }
+
+    const rows = await dbClient
+      .select({ id: proposals.id })
+      .from(proposals)
+      .where(
+        and(
+          eq(proposals.processInstanceId, instanceId),
+          isNull(proposals.deletedAt),
+        ),
+      );
+    return rows.map((r) => r.id);
+  } catch (error) {
+    console.error('Error fetching proposal IDs for phase:', {
+      instanceId,
+      phaseId,
+      error,
+    });
+    throw error;
+  }
+}
+
+/**
+ * Returns the proposals visible in the given phase.
+ *
+ * - If phaseId is provided: returns proposals that survived the transition into that phase.
+ *   Returns [] if phaseId does not match any recorded transition.
+ * - If phaseId is omitted: returns proposals for the current (most recent) phase.
+ * - If no transition exists yet: returns all non-deleted proposals for the instance.
+ *   Note: even a transition without a selection pipeline writes all proposals to the join
+ *   table, so the full non-deleted set is returned in that case — not an indication that
+ *   filtering occurred.
+ */
+export async function getProposalsForPhase({
+  instanceId,
+  phaseId,
+  dbClient = db,
+}: {
+  instanceId: string;
+  phaseId?: string;
+  dbClient?: DbClient;
+}): Promise<Proposal[]> {
+  try {
+    const transition = await resolveTransition(instanceId, phaseId, dbClient);
+
+    if (phaseId && !transition) {
+      return [];
+    }
+
+    if (transition) {
+      const rows = await dbClient
+        .select({ proposal: proposals })
+        .from(decisionTransitionProposals)
+        .innerJoin(
+          proposals,
+          eq(decisionTransitionProposals.proposalId, proposals.id),
+        )
+        .where(
+          and(
+            eq(decisionTransitionProposals.transitionHistoryId, transition.id),
+            isNull(proposals.deletedAt),
+          ),
+        );
+      return rows.map((r) => r.proposal);
+    }
+
+    return dbClient
+      .select()
+      .from(proposals)
+      .where(
+        and(
+          eq(proposals.processInstanceId, instanceId),
+          isNull(proposals.deletedAt),
+        ),
+      );
+  } catch (error) {
+    console.error('Error fetching proposals for phase:', {
+      instanceId,
+      phaseId,
+      error,
+    });
+    throw error;
+  }
+}

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -37,6 +37,7 @@ export * from './acceptProposalInvite';
 
 // Proposal management
 export * from './proposalDataSchema';
+export * from './isLegacyInstance';
 export * from './getProposalsForPhase';
 export * from './createProposal';
 export * from './submitProposal';

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -37,6 +37,7 @@ export * from './acceptProposalInvite';
 
 // Proposal management
 export * from './proposalDataSchema';
+export * from './getProposalsForPhase';
 export * from './createProposal';
 export * from './submitProposal';
 export * from './updateProposal';

--- a/packages/common/src/services/decision/isLegacyInstance.ts
+++ b/packages/common/src/services/decision/isLegacyInstance.ts
@@ -1,0 +1,53 @@
+import { db, eq } from '@op/db/client';
+import type { DbClient } from '@op/db/client';
+import { processInstances } from '@op/db/schema';
+
+/**
+ * Shape of the legacy/new fields inside `processInstances.instanceData`.
+ * Legacy instances store `currentStateId`; new instances store `currentPhaseId`.
+ */
+type InstanceDataLegacyFields = {
+  currentPhaseId?: string;
+  currentStateId?: string;
+};
+
+/**
+ * Pure predicate over an `instanceData` JSON value.
+ *
+ * A process instance is "legacy" if its `instanceData` JSON has `currentStateId`
+ * but no `currentPhaseId`. New instances always write `currentPhaseId`; old
+ * instances (predating the join-table-backed phase scoping) only have
+ * `currentStateId`. Use this when you already have the JSON in hand.
+ */
+export function isLegacyInstanceData(instanceData: unknown): boolean {
+  if (instanceData == null || typeof instanceData !== 'object') {
+    return false;
+  }
+
+  const data = instanceData as InstanceDataLegacyFields;
+  return data.currentPhaseId == null && data.currentStateId != null;
+}
+
+/**
+ * Reads `instanceData` for the given instance and returns whether it is a
+ * legacy instance. Returns `false` if the instance does not exist.
+ *
+ * Prefer `isLegacyInstanceData` if you already have the JSON loaded — this
+ * variant exists for callers that only have an instance ID.
+ */
+export async function isLegacyInstance(
+  instanceId: string,
+  dbClient: DbClient = db,
+): Promise<boolean> {
+  const [row] = await dbClient
+    .select({ instanceData: processInstances.instanceData })
+    .from(processInstances)
+    .where(eq(processInstances.id, instanceId))
+    .limit(1);
+
+  if (!row) {
+    return false;
+  }
+
+  return isLegacyInstanceData(row.instanceData);
+}

--- a/packages/common/src/services/decision/processResults.ts
+++ b/packages/common/src/services/decision/processResults.ts
@@ -10,6 +10,7 @@ import {
 import type { DecisionProcess } from '@op/db/schema';
 
 import { CommonError } from '../../utils';
+import { getProposalsForPhase } from './getProposalsForPhase';
 import {
   aggregateVoteData,
   defaultSelectionPipeline,
@@ -55,25 +56,31 @@ export async function processResults({
       );
     }
 
-    // Get all proposals for this process instance
-    const processProposals = await db._query.proposals.findMany({
-      where: eq(proposals.processInstanceId, processInstanceId),
-    });
-
     // Get the process schema
     const process = processInstance.process as DecisionProcess;
     const processSchema = process.processSchema as ProcessSchema;
     const instanceData = processInstance.instanceData as InstanceData;
+
+    // Get proposals scoped to the current phase (respects prior transition filtering)
+    const processProposals = await getProposalsForPhase({
+      instanceId: processInstanceId,
+    });
+
+    // Resolve pipeline from the current phase, falling back to top-level or default
+    const currentPhaseId = processInstance.currentStateId;
+    const phasePipeline = processSchema.phases?.find(
+      (p) => p.id === currentPhaseId,
+    )?.selectionPipeline;
+    const pipeline =
+      phasePipeline ||
+      processSchema.selectionPipeline ||
+      defaultSelectionPipeline;
 
     let selectedProposalIds: string[] = [];
     let error: string | undefined;
     let success = false;
 
     try {
-      // Use the defined pipeline or fall back to default
-      const pipeline =
-        processSchema.selectionPipeline || defaultSelectionPipeline;
-
       // Aggregate voting data
       const voteData = await aggregateVoteData(processProposals);
 
@@ -120,7 +127,8 @@ export async function processResults({
           errorMessage: error,
           selectedCount: selectedProposalIds.length,
           voterCount,
-          pipelineConfig: processSchema.selectionPipeline || null,
+          pipelineConfig:
+            pipeline === defaultSelectionPipeline ? null : pipeline,
         })
         .returning();
 

--- a/packages/common/src/services/decision/processResults.ts
+++ b/packages/common/src/services/decision/processResults.ts
@@ -75,7 +75,7 @@ export async function processResults({
         processSchema.selectionPipeline || defaultSelectionPipeline;
 
       // Aggregate voting data
-      const voteData = await aggregateVoteData(processInstanceId);
+      const voteData = await aggregateVoteData(processProposals);
 
       // Build execution context
       const context: ExecutionContext = {

--- a/packages/common/src/services/decision/selectionPipeline/voteDataAggregator.ts
+++ b/packages/common/src/services/decision/selectionPipeline/voteDataAggregator.ts
@@ -1,138 +1,119 @@
 import { db, eq, inArray } from '@op/db/client';
+import type { DbClient } from '@op/db/client';
+import type { Proposal } from '@op/db/schema';
 import {
   ProfileRelationshipType,
+  decisionsVoteProposals,
   decisionsVoteSubmissions,
   profileRelationships,
-  proposals,
 } from '@op/db/schema';
 
 import type { VoteAggregation } from './types';
 
 /**
- * Aggregate voting data for all proposals in a process instance
+ * Aggregate voting data for the given proposals.
+ * Accepts an optional dbClient so this can be called within a transaction
+ * for a consistent snapshot.
  */
 export async function aggregateVoteData(
-  processInstanceId: string,
+  phaseProposals: Proposal[],
+  dbClient: DbClient = db,
 ): Promise<Record<string, VoteAggregation>> {
-  try {
-    // Get all proposals for this process instance
-    const processProposals = await db._query.proposals.findMany({
-      where: eq(proposals.processInstanceId, processInstanceId),
-    });
-
-    // Build a map of proposal ID to profile ID for relationship lookups
-    const proposalToProfileMap = new Map<string, string>();
-    for (const proposal of processProposals) {
-      proposalToProfileMap.set(proposal.id, proposal.profileId);
-    }
-
-    // Get all vote submissions for proposals in this process instance
-    const voteSubmissions = await db._query.decisionsVoteSubmissions.findMany({
-      where: eq(decisionsVoteSubmissions.processInstanceId, processInstanceId),
-      with: {
-        voteProposals: true,
-      },
-    });
-
-    // Get all likes and follows for the proposals
-    const profileIds = Array.from(proposalToProfileMap.values());
-    const relationships =
-      profileIds.length > 0
-        ? await db
-            .select()
-            .from(profileRelationships)
-            .where(inArray(profileRelationships.targetProfileId, profileIds))
-        : [];
-
-    // Count likes and follows by profile ID
-    const likesMap = new Map<string, number>();
-    const followsMap = new Map<string, number>();
-
-    for (const relationship of relationships) {
-      const profileId = relationship.targetProfileId;
-      if (!profileIds.includes(profileId)) {
-        continue;
-      }
-
-      if (relationship.relationshipType === ProfileRelationshipType.LIKES) {
-        likesMap.set(profileId, (likesMap.get(profileId) || 0) + 1);
-      } else if (
-        relationship.relationshipType === ProfileRelationshipType.FOLLOWING
-      ) {
-        followsMap.set(profileId, (followsMap.get(profileId) || 0) + 1);
-      }
-    }
-
-    // Build a map of proposal ID to vote aggregation
-    const voteDataMap: Record<string, VoteAggregation> = {};
-
-    // Track votes by proposal
-    const proposalVotesMap = new Map<
-      string,
-      Array<{ voteData: any; submissionId: string }>
-    >();
-
-    for (const submission of voteSubmissions) {
-      if (!submission.voteProposals || submission.voteProposals.length === 0) {
-        continue;
-      }
-
-      for (const voteProposal of submission.voteProposals) {
-        if (!proposalVotesMap.has(voteProposal.proposalId)) {
-          proposalVotesMap.set(voteProposal.proposalId, []);
-        }
-
-        proposalVotesMap.get(voteProposal.proposalId)?.push({
-          voteData: voteProposal.voteData,
-          submissionId: submission.id,
-        });
-      }
-    }
-
-    // Initialize vote data for all proposals
-    for (const proposal of processProposals) {
-      const profileId = proposal.profileId;
-      const votes = proposalVotesMap.get(proposal.id) || [];
-      const voteCount = votes.length;
-
-      // Count approvals, rejections, and abstentions
-      let approvalCount = 0;
-      let rejectionCount = 0;
-      let abstainCount = 0;
-
-      for (const vote of votes) {
-        const voteData = vote.voteData as any;
-
-        if (voteData?.approved === true || voteData?.vote === 'approve') {
-          approvalCount++;
-        } else if (
-          voteData?.approved === false ||
-          voteData?.vote === 'reject'
-        ) {
-          rejectionCount++;
-        } else if (voteData?.vote === 'abstain') {
-          abstainCount++;
-        }
-      }
-
-      const approvalRate = voteCount > 0 ? approvalCount / voteCount : 0;
-
-      voteDataMap[proposal.id] = {
-        proposalId: proposal.id,
-        likesCount: likesMap.get(profileId) || 0,
-        followsCount: followsMap.get(profileId) || 0,
-        voteCount,
-        approvalCount,
-        rejectionCount,
-        abstainCount,
-        approvalRate,
-        votes: votes.map((v) => v.voteData),
-      };
-    }
-
-    return voteDataMap;
-  } catch (error) {
-    console.error('Error aggregating vote data:', error);
+  if (phaseProposals.length === 0) {
     return {};
   }
+
+  const proposalIds = phaseProposals.map((p) => p.id);
+  const profileIds = [...new Set(phaseProposals.map((p) => p.profileId))];
+
+  // Fetch votes and profile relationships in parallel
+  const [voteRows, relationships] = await Promise.all([
+    dbClient
+      .select({
+        submissionId: decisionsVoteSubmissions.id,
+        voteData: decisionsVoteSubmissions.voteData,
+        proposalId: decisionsVoteProposals.proposalId,
+      })
+      .from(decisionsVoteSubmissions)
+      .innerJoin(
+        decisionsVoteProposals,
+        eq(
+          decisionsVoteProposals.voteSubmissionId,
+          decisionsVoteSubmissions.id,
+        ),
+      )
+      .where(inArray(decisionsVoteProposals.proposalId, proposalIds)),
+
+    dbClient
+      .select()
+      .from(profileRelationships)
+      .where(inArray(profileRelationships.targetProfileId, profileIds)),
+  ]);
+
+  // Count likes and follows by profile ID
+  const likesMap = new Map<string, number>();
+  const followsMap = new Map<string, number>();
+
+  for (const relationship of relationships) {
+    const profileId = relationship.targetProfileId;
+    if (relationship.relationshipType === ProfileRelationshipType.LIKES) {
+      likesMap.set(profileId, (likesMap.get(profileId) ?? 0) + 1);
+    } else if (
+      relationship.relationshipType === ProfileRelationshipType.FOLLOWING
+    ) {
+      followsMap.set(profileId, (followsMap.get(profileId) ?? 0) + 1);
+    }
+  }
+
+  // Group vote rows by proposal
+  const proposalVotesMap = new Map<
+    string,
+    Array<{ voteData: unknown; submissionId: string }>
+  >();
+  for (const row of voteRows) {
+    if (!proposalVotesMap.has(row.proposalId)) {
+      proposalVotesMap.set(row.proposalId, []);
+    }
+    proposalVotesMap.get(row.proposalId)!.push({
+      voteData: row.voteData,
+      submissionId: row.submissionId,
+    });
+  }
+
+  // Build aggregation per proposal
+  const voteDataMap: Record<string, VoteAggregation> = {};
+
+  for (const proposal of phaseProposals) {
+    const votes = proposalVotesMap.get(proposal.id) ?? [];
+    const voteCount = votes.length;
+
+    let approvalCount = 0;
+    let rejectionCount = 0;
+    let abstainCount = 0;
+
+    for (const vote of votes) {
+      const voteData = vote.voteData as Record<string, unknown> | null;
+      if (voteData?.approved === true || voteData?.vote === 'approve') {
+        approvalCount++;
+      } else if (voteData?.approved === false || voteData?.vote === 'reject') {
+        rejectionCount++;
+      } else if (voteData?.vote === 'abstain') {
+        abstainCount++;
+      }
+    }
+
+    voteDataMap[proposal.id] = {
+      proposalId: proposal.id,
+      likesCount: likesMap.get(proposal.profileId) ?? 0,
+      followsCount: followsMap.get(proposal.profileId) ?? 0,
+      voteCount,
+      approvalCount,
+      rejectionCount,
+      abstainCount,
+      approvalRate: voteCount > 0 ? approvalCount / voteCount : 0,
+      votes: votes.map((v) => v.voteData),
+    };
+  }
+
+  return voteDataMap;
 }

--- a/packages/common/src/services/decision/transitionEngine.ts
+++ b/packages/common/src/services/decision/transitionEngine.ts
@@ -328,6 +328,7 @@ export class TransitionEngine {
 
           await trx.insert(decisionTransitionProposals).values(
             latestHistoryRows.map(({ proposalId, historyId }) => ({
+              processInstanceId: data.instanceId,
               transitionHistoryId: insertedTransition.id,
               proposalId,
               proposalHistoryId: historyId,

--- a/packages/common/src/services/decision/transitionEngine.ts
+++ b/packages/common/src/services/decision/transitionEngine.ts
@@ -1,7 +1,9 @@
-import { db, eq } from '@op/db/client';
+import { db, desc, eq, inArray } from '@op/db/client';
 import {
+  decisionTransitionProposals,
   decisions,
   processInstances,
+  proposalHistory,
   proposals,
   stateTransitionHistory,
 } from '@op/db/schema';
@@ -14,6 +16,12 @@ import {
   ValidationError,
 } from '../../utils';
 import { assertUserByAuthId } from '../assert';
+import { getProposalsForPhase } from './getProposalsForPhase';
+import { aggregateVoteData, executePipeline } from './selectionPipeline';
+import type {
+  ExecutionContext,
+  SelectionPipeline,
+} from './selectionPipeline/types';
 import type {
   InstanceData,
   ProcessSchema,
@@ -220,8 +228,54 @@ export class TransitionEngine {
         });
       }
 
-      // Update the instance in a transaction
+      // Resolve selection pipeline for the departing phase
+      const selectionPipeline = this.resolveSelectionPipeline(
+        processSchema,
+        currentStateId,
+      );
+
+      // Run everything that determines surviving proposals inside the transaction
+      // so reads and writes are from a consistent snapshot.
       await db.transaction(async (trx) => {
+        // Fetch proposals visible in the current phase as the default surviving set.
+        // For the first transition this is all submitted proposals; for subsequent
+        // transitions it is only those that survived into the current phase.
+        const allProposals = await getProposalsForPhase({
+          instanceId: data.instanceId,
+          dbClient: trx,
+        });
+
+        let survivingProposalIds: string[] = allProposals.map((p) => p.id);
+
+        // If the departing phase has a selection pipeline, run it to narrow the surviving set
+        if (selectionPipeline) {
+          const voteData = await aggregateVoteData(allProposals, trx);
+          const context: ExecutionContext = {
+            proposals: allProposals,
+            voteData,
+            process: {
+              instanceId: data.instanceId,
+              processId: instance.processId,
+              currentStateId: instance.currentStateId,
+              instanceData,
+              processSchema,
+              processInstance: instance,
+            },
+            variables: {},
+            outputs: {},
+          };
+          const surviving = await executePipeline(selectionPipeline, context);
+          survivingProposalIds = surviving.map((p) => p.id);
+        }
+
+        if (survivingProposalIds.length === 0) {
+          console.warn('Phase transition produced zero surviving proposals', {
+            instanceId: data.instanceId,
+            fromStateId: currentStateId,
+            toStateId: data.toStateId,
+          });
+        }
+
         // Update process instance
         await trx
           .update(processInstances)
@@ -232,14 +286,54 @@ export class TransitionEngine {
           })
           .where(eq(processInstances.id, data.instanceId));
 
-        // Record transition history
-        await trx.insert(stateTransitionHistory).values({
-          processInstanceId: data.instanceId,
-          fromStateId: currentStateId,
-          toStateId: data.toStateId,
-          transitionData: data.transitionData || {},
-          triggeredByProfileId: dbUser.currentProfileId,
-        });
+        // Record transition history and get the inserted ID
+        const [insertedTransition] = await trx
+          .insert(stateTransitionHistory)
+          .values({
+            processInstanceId: data.instanceId,
+            fromStateId: currentStateId,
+            toStateId: data.toStateId,
+            transitionData: data.transitionData || {},
+            triggeredByProfileId: dbUser.currentProfileId,
+          })
+          .returning({ id: stateTransitionHistory.id });
+
+        // Persist surviving proposals into the join table
+        if (!insertedTransition) {
+          throw new Error(
+            `stateTransitionHistory insert returned no ID for instance ${data.instanceId}`,
+          );
+        }
+
+        if (survivingProposalIds.length > 0) {
+          // Get the latest history record for each surviving proposal.
+          // Submitted proposals are always guaranteed to have history.
+          const latestHistoryRows = await trx
+            .selectDistinctOn([proposalHistory.id], {
+              proposalId: proposalHistory.id,
+              historyId: proposalHistory.historyId,
+            })
+            .from(proposalHistory)
+            .where(inArray(proposalHistory.id, survivingProposalIds))
+            .orderBy(
+              proposalHistory.id,
+              desc(proposalHistory.historyCreatedAt),
+            );
+
+          if (latestHistoryRows.length !== survivingProposalIds.length) {
+            throw new Error(
+              `Proposals missing history records during transition for instance ${data.instanceId}: expected ${survivingProposalIds.length}, got ${latestHistoryRows.length}`,
+            );
+          }
+
+          await trx.insert(decisionTransitionProposals).values(
+            latestHistoryRows.map(({ proposalId, historyId }) => ({
+              transitionHistoryId: insertedTransition.id,
+              proposalId,
+              proposalHistoryId: historyId,
+            })),
+          );
+        }
       });
 
       // Return updated instance
@@ -260,9 +354,24 @@ export class TransitionEngine {
       ) {
         throw error;
       }
-      console.error('Error executing transition:', error);
+      console.error('Error executing transition:', {
+        instanceId: data.instanceId,
+        toStateId: data.toStateId,
+        error,
+      });
       throw new CommonError('Failed to execute transition');
     }
+  }
+
+  /**
+   * Resolve the selection pipeline for the departing phase.
+   */
+  private static resolveSelectionPipeline(
+    processSchema: ProcessSchema,
+    fromStateId: string,
+  ): SelectionPipeline | undefined {
+    return processSchema.phases?.find((p) => p.id === fromStateId)
+      ?.selectionPipeline;
   }
 
   /**

--- a/packages/common/src/services/decision/transitionEngine.ts
+++ b/packages/common/src/services/decision/transitionEngine.ts
@@ -1,4 +1,4 @@
-import { db, desc, eq, inArray } from '@op/db/client';
+import { and, db, desc, eq, inArray } from '@op/db/client';
 import {
   decisionTransitionProposals,
   decisions,
@@ -314,7 +314,12 @@ export class TransitionEngine {
               historyId: proposalHistory.historyId,
             })
             .from(proposalHistory)
-            .where(inArray(proposalHistory.id, survivingProposalIds))
+            .where(
+              and(
+                eq(proposalHistory.processInstanceId, data.instanceId),
+                inArray(proposalHistory.id, survivingProposalIds),
+              ),
+            )
             .orderBy(
               proposalHistory.id,
               desc(proposalHistory.historyCreatedAt),

--- a/packages/common/src/services/decision/types.ts
+++ b/packages/common/src/services/decision/types.ts
@@ -1,6 +1,7 @@
 import type { DecisionProcessTransition } from '@op/db/schema';
 import type { JSONSchema7 } from 'json-schema';
 
+import type { PhaseDefinition } from './schemas/types';
 import type { SelectionPipeline } from './selectionPipeline/types';
 
 // Base JSON Schema type (more specific than any)
@@ -64,8 +65,7 @@ export interface ProcessSchema {
   // Selection pipeline for results phase
   selectionPipeline?: SelectionPipeline;
 
-  // Phase transition pipelines (keyed by state ID)
-  phaseTransitionPipelines?: Record<string, SelectionPipeline>;
+  phases?: PhaseDefinition[];
 }
 
 // State Definition (stored in processSchema.states)

--- a/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
+++ b/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
@@ -29,12 +29,12 @@ describe.concurrent('getProposalsForPhase', () => {
 
     const [p1, p2] = await Promise.all([
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal 1 ${task.id}` },
       }),
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal 2 ${task.id}` },
       }),
@@ -59,7 +59,7 @@ describe.concurrent('getProposalsForPhase', () => {
     // Create and submit 3 proposals; pipeline limits to 2
     for (let i = 1; i <= 3; i++) {
       await createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal ${i} ${task.id}` },
       });
@@ -88,12 +88,12 @@ describe.concurrent('getProposalsForPhase', () => {
 
     const [p1, p2] = await Promise.all([
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Active ${task.id}` },
       }),
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Soft-deleted ${task.id}` },
       }),
@@ -122,7 +122,7 @@ describe.concurrent('getProposalsForPhase', () => {
     // Create and submit 3 proposals; pipeline limits to 2
     for (let i = 1; i <= 3; i++) {
       await createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal ${i} ${task.id}` },
       });
@@ -171,12 +171,12 @@ describe.concurrent('getProposalsForPhase', () => {
 
     const [p1, p2] = await Promise.all([
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Active after transition ${task.id}` },
       }),
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Soft-deleted after transition ${task.id}` },
       }),
@@ -213,12 +213,12 @@ describe.concurrent('getProposalsForPhase', () => {
 
     // Create one submitted proposal and one draft (not submitted)
     const submitted = await createAndSubmitProposal(testData, caller, {
-      callerEmail: userEmail,
+      userEmail,
       processInstanceId: instanceId,
       proposalData: { title: `Submitted ${task.id}` },
     });
     await testData.createProposal({
-      callerEmail: userEmail,
+      userEmail,
       processInstanceId: instanceId,
       proposalData: { title: `Draft ${task.id}` },
     });
@@ -243,12 +243,12 @@ describe.concurrent('getProposalsForPhase', () => {
 
     const [p1, p2] = await Promise.all([
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Legacy proposal 1 ${task.id}` },
       }),
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Legacy proposal 2 ${task.id}` },
       }),

--- a/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
+++ b/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
@@ -1,6 +1,10 @@
 import { TransitionEngine, getProposalsForPhase } from '@op/common';
-import { db } from '@op/db/client';
-import { proposals, stateTransitionHistory } from '@op/db/schema';
+import { db, sql } from '@op/db/client';
+import {
+  processInstances,
+  proposals,
+  stateTransitionHistory,
+} from '@op/db/schema';
 import { eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
@@ -230,7 +234,7 @@ describe.concurrent('getProposalsForPhase', () => {
     expect(result[0]?.id).toBe(submitted.id);
   });
 
-  it('falls back to all active proposals when transition exists but join table is empty (legacy)', async ({
+  it('returns all active proposals for a legacy instance regardless of join table state', async ({
     task,
     onTestFinished,
   }) => {
@@ -254,8 +258,17 @@ describe.concurrent('getProposalsForPhase', () => {
       }),
     ]);
 
-    // Simulate a legacy transition: insert history row WITHOUT populating the join table.
-    // This mirrors instances that transitioned before join-table writes were added.
+    // Mutate instanceData to look like a legacy instance: drop currentPhaseId,
+    // add currentStateId. This is the signal getProposalsForPhase keys off of.
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: sql`(${processInstances.instanceData} - 'currentPhaseId') || jsonb_build_object('currentStateId', 'review')`,
+      })
+      .where(eq(processInstances.id, instanceId));
+
+    // Insert a history row WITHOUT populating the join table — mirrors legacy data
+    // that transitioned before join-table writes were added.
     await db.insert(stateTransitionHistory).values({
       processInstanceId: instanceId,
       toStateId: 'review',
@@ -263,7 +276,7 @@ describe.concurrent('getProposalsForPhase', () => {
 
     const result = await getProposalsForPhase({ instanceId });
 
-    // Should fall back to all active proposals instead of returning empty
+    // Legacy detection short-circuits join lookup → all active proposals returned.
     const ids = result.map((r) => r.id);
     expect(ids).toContain(p1.id);
     expect(ids).toContain(p2.id);

--- a/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
+++ b/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
@@ -1,6 +1,6 @@
 import { TransitionEngine, getProposalsForPhase } from '@op/common';
 import { db } from '@op/db/client';
-import { proposals } from '@op/db/schema';
+import { proposals, stateTransitionHistory } from '@op/db/schema';
 import { eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
@@ -228,5 +228,45 @@ describe.concurrent('getProposalsForPhase', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]?.id).toBe(submitted.id);
+  });
+
+  it('falls back to all active proposals when transition exists but join table is empty (legacy)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, userEmail, caller } = await createInstanceWithSchema(
+      testData,
+      task.id,
+      schemaWithoutPipeline,
+    );
+
+    const [p1, p2] = await Promise.all([
+      createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Legacy proposal 1 ${task.id}` },
+      }),
+      createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Legacy proposal 2 ${task.id}` },
+      }),
+    ]);
+
+    // Simulate a legacy transition: insert history row WITHOUT populating the join table.
+    // This mirrors instances that transitioned before join-table writes were added.
+    await db.insert(stateTransitionHistory).values({
+      processInstanceId: instanceId,
+      toStateId: 'review',
+    });
+
+    const result = await getProposalsForPhase({ instanceId });
+
+    // Should fall back to all active proposals instead of returning empty
+    const ids = result.map((r) => r.id);
+    expect(ids).toContain(p1.id);
+    expect(ids).toContain(p2.id);
+    expect(result).toHaveLength(2);
   });
 });

--- a/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
+++ b/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
@@ -1,0 +1,202 @@
+import { TransitionEngine, getProposalsForPhase } from '@op/common';
+import { db } from '@op/db/client';
+import { proposals } from '@op/db/schema';
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createAndSubmitProposal,
+  createInstanceWithSchema,
+  schemaWithPipeline,
+  schemaWithoutPipeline,
+} from '../../../test/helpers/pipelineTestFixtures';
+
+// Random UUID unlikely to match any real transition
+const NONEXISTENT_PHASE_ID = '00000000-0000-0000-0000-000000000000';
+
+describe.concurrent('getProposalsForPhase', () => {
+  it('returns all non-deleted proposals when no transition has occurred', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, userEmail } = await createInstanceWithSchema(
+      testData,
+      task.id,
+      schemaWithoutPipeline,
+    );
+
+    const [p1, p2] = await Promise.all([
+      testData.createProposal({
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal 1 ${task.id}` },
+      }),
+      testData.createProposal({
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal 2 ${task.id}` },
+      }),
+    ]);
+
+    const result = await getProposalsForPhase({ instanceId });
+
+    const ids = result.map((p) => p.id);
+    expect(ids).toContain(p1.id);
+    expect(ids).toContain(p2.id);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns only join-scoped proposals after a transition', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithPipeline);
+
+    // Create and submit 3 proposals; pipeline limits to 2
+    for (let i = 1; i <= 3; i++) {
+      await createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal ${i} ${task.id}` },
+      });
+    }
+
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    const result = await getProposalsForPhase({ instanceId });
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('excludes soft-deleted proposals in the no-transition path', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, userEmail } = await createInstanceWithSchema(
+      testData,
+      task.id,
+      schemaWithoutPipeline,
+    );
+
+    const [p1, p2] = await Promise.all([
+      testData.createProposal({
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Active ${task.id}` },
+      }),
+      testData.createProposal({
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Soft-deleted ${task.id}` },
+      }),
+    ]);
+
+    // Soft-delete the second proposal
+    await db
+      .update(proposals)
+      .set({ deletedAt: new Date().toISOString() })
+      .where(eq(proposals.id, p2.id));
+
+    const result = await getProposalsForPhase({ instanceId });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(p1.id);
+  });
+
+  it('returns proposals scoped to a specific phaseId (historical access)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithPipeline);
+
+    // Create and submit 3 proposals; pipeline limits to 2
+    for (let i = 1; i <= 3; i++) {
+      await createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal ${i} ${task.id}` },
+      });
+    }
+
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    // phaseId = 'review' means "proposals that survived the transition into review"
+    const result = await getProposalsForPhase({
+      instanceId,
+      phaseId: 'review',
+    });
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array when phaseId does not match any transition', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId } = await createInstanceWithSchema(
+      testData,
+      task.id,
+      schemaWithoutPipeline,
+    );
+
+    const result = await getProposalsForPhase({
+      instanceId,
+      phaseId: NONEXISTENT_PHASE_ID,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes soft-deleted proposals in the post-transition path', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithoutPipeline);
+
+    const [p1, p2] = await Promise.all([
+      createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Active after transition ${task.id}` },
+      }),
+      createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Soft-deleted after transition ${task.id}` },
+      }),
+    ]);
+
+    // Both proposals survive the transition (no pipeline)
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    // Soft-delete after transition — should still be excluded from results
+    await db
+      .update(proposals)
+      .set({ deletedAt: new Date().toISOString() })
+      .where(eq(proposals.id, p2.id));
+
+    const result = await getProposalsForPhase({ instanceId });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(p1.id);
+  });
+});

--- a/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
+++ b/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
@@ -16,24 +16,24 @@ import {
 const NONEXISTENT_PHASE_ID = '00000000-0000-0000-0000-000000000000';
 
 describe.concurrent('getProposalsForPhase', () => {
-  it('returns all non-deleted proposals when no transition has occurred', async ({
+  it('returns all submitted proposals when no transition has occurred', async ({
     task,
     onTestFinished,
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
-    const { instanceId, userEmail } = await createInstanceWithSchema(
+    const { instanceId, userEmail, caller } = await createInstanceWithSchema(
       testData,
       task.id,
       schemaWithoutPipeline,
     );
 
     const [p1, p2] = await Promise.all([
-      testData.createProposal({
+      createAndSubmitProposal(testData, caller, {
         callerEmail: userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal 1 ${task.id}` },
       }),
-      testData.createProposal({
+      createAndSubmitProposal(testData, caller, {
         callerEmail: userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal 2 ${task.id}` },
@@ -80,19 +80,19 @@ describe.concurrent('getProposalsForPhase', () => {
     onTestFinished,
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
-    const { instanceId, userEmail } = await createInstanceWithSchema(
+    const { instanceId, userEmail, caller } = await createInstanceWithSchema(
       testData,
       task.id,
       schemaWithoutPipeline,
     );
 
     const [p1, p2] = await Promise.all([
-      testData.createProposal({
+      createAndSubmitProposal(testData, caller, {
         callerEmail: userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Active ${task.id}` },
       }),
-      testData.createProposal({
+      createAndSubmitProposal(testData, caller, {
         callerEmail: userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Soft-deleted ${task.id}` },
@@ -198,5 +198,35 @@ describe.concurrent('getProposalsForPhase', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]?.id).toBe(p1.id);
+  });
+
+  it('excludes draft proposals in the no-transition path', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, userEmail, caller } = await createInstanceWithSchema(
+      testData,
+      task.id,
+      schemaWithoutPipeline,
+    );
+
+    // Create one submitted proposal and one draft (not submitted)
+    const submitted = await createAndSubmitProposal(testData, caller, {
+      callerEmail: userEmail,
+      processInstanceId: instanceId,
+      proposalData: { title: `Submitted ${task.id}` },
+    });
+    await testData.createProposal({
+      callerEmail: userEmail,
+      processInstanceId: instanceId,
+      proposalData: { title: `Draft ${task.id}` },
+    });
+
+    // No transition has occurred — should only return submitted proposals
+    const result = await getProposalsForPhase({ instanceId });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(submitted.id);
   });
 });

--- a/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
+++ b/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
@@ -157,4 +157,46 @@ describe.concurrent('Transition pipeline: join table population', () => {
 
     expect(joinRows).toHaveLength(3);
   });
+
+  it('succeeds with zero join rows when pipeline eliminates all proposals', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    // Schema with limit(0) — eliminates everything
+    const schemaWithZeroLimit = {
+      ...schemaWithPipeline,
+      phases: [
+        {
+          id: 'submission',
+          name: 'Submission',
+          rules: {},
+          selectionPipeline: {
+            version: '1.0.0',
+            blocks: [{ id: 'limit-zero', type: 'limit', count: 0 }],
+          },
+        },
+        { id: 'review', name: 'Review', rules: {} },
+      ],
+    };
+
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithZeroLimit);
+
+    await createAndSubmitProposal(testData, caller, {
+      callerEmail: userEmail,
+      processInstanceId: instanceId,
+      proposalData: { title: `Doomed ${task.id}` },
+    });
+
+    // Transition should succeed even though all proposals are eliminated
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    const result = await getProposalsForPhase({ instanceId });
+    expect(result).toHaveLength(0);
+  });
 });

--- a/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
+++ b/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
@@ -158,7 +158,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
     expect(joinRows).toHaveLength(3);
   });
 
-  it('succeeds with zero join rows when pipeline eliminates all proposals', async ({
+  it('falls back to all active proposals when pipeline eliminates everything (indistinguishable from legacy)', async ({
     task,
     onTestFinished,
   }) => {
@@ -190,13 +190,15 @@ describe.concurrent('Transition pipeline: join table population', () => {
       proposalData: { title: `Doomed ${task.id}` },
     });
 
-    // Transition should succeed even though all proposals are eliminated
+    // Transition succeeds but pipeline eliminates all proposals.
+    // With zero join rows the legacy fallback kicks in, returning all active proposals.
+    // This is acceptable: a limit(0) pipeline is not a real production scenario.
     await TransitionEngine.executeTransition({
       data: { instanceId, toStateId: 'review' },
       user,
     });
 
     const result = await getProposalsForPhase({ instanceId });
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(1);
   });
 });

--- a/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
+++ b/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
@@ -158,7 +158,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
     expect(joinRows).toHaveLength(3);
   });
 
-  it('falls back to all active proposals when pipeline eliminates everything (indistinguishable from legacy)', async ({
+  it('returns empty when pipeline eliminates every proposal (no legacy fallback for new instances)', async ({
     task,
     onTestFinished,
   }) => {
@@ -191,14 +191,14 @@ describe.concurrent('Transition pipeline: join table population', () => {
     });
 
     // Transition succeeds but pipeline eliminates all proposals.
-    // With zero join rows the legacy fallback kicks in, returning all active proposals.
-    // This is acceptable: a limit(0) pipeline is not a real production scenario.
+    // The transition row exists, so this is unambiguously "new system, zero survivors"
+    // (not legacy data) — getProposalsForPhase must return [].
     await TransitionEngine.executeTransition({
       data: { instanceId, toStateId: 'review' },
       user,
     });
 
     const result = await getProposalsForPhase({ instanceId });
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(0);
   });
 });

--- a/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
+++ b/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
@@ -1,0 +1,160 @@
+import { TransitionEngine, getProposalsForPhase } from '@op/common';
+import { db, eq } from '@op/db/client';
+import {
+  decisionTransitionProposals,
+  stateTransitionHistory,
+} from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createAndSubmitProposal,
+  createInstanceWithSchema,
+  schemaWithPipeline,
+  schemaWithThreePhasesAndPipelines,
+  schemaWithoutPipeline,
+} from '../../../test/helpers/pipelineTestFixtures';
+
+describe.concurrent('Transition pipeline: join table population', () => {
+  it('creates exactly 2 join rows when selectionPipeline limits to 2 from 3 proposals', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithPipeline);
+
+    // Create and submit 3 proposals (submitted proposals are eligible for transition)
+    for (let i = 1; i <= 3; i++) {
+      await createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal ${i} ${task.id}` },
+      });
+    }
+
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    // Find the stateTransitionHistory row
+    const [transition] = await db
+      .select()
+      .from(stateTransitionHistory)
+      .where(eq(stateTransitionHistory.processInstanceId, instanceId))
+      .limit(1);
+
+    expect(transition).toBeDefined();
+
+    const joinRows = await db
+      .select()
+      .from(decisionTransitionProposals)
+      .where(
+        eq(decisionTransitionProposals.transitionHistoryId, transition!.id),
+      );
+
+    expect(joinRows).toHaveLength(2);
+  });
+
+  it('proposal scoping chains correctly across two transitions', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(
+        testData,
+        task.id,
+        schemaWithThreePhasesAndPipelines,
+      );
+
+    // Submit 4 proposals; first pipeline limits to 3, second limits to 2
+    for (let i = 1; i <= 4; i++) {
+      await createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal ${i} ${task.id}` },
+      });
+    }
+
+    // First transition: submission → review (limit 3)
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    // Second transition: review → final (limit 2, from the 3 that survived)
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'final' },
+      user,
+    });
+
+    // Historical access: proposals that survived into review = 3
+    const reviewPhaseProposals = await getProposalsForPhase({
+      instanceId,
+      phaseId: 'review',
+    });
+    expect(reviewPhaseProposals).toHaveLength(3);
+
+    // Historical access: proposals that survived into final = 2
+    const finalPhaseProposals = await getProposalsForPhase({
+      instanceId,
+      phaseId: 'final',
+    });
+    expect(finalPhaseProposals).toHaveLength(2);
+
+    // Current phase (no phaseId) = same as final = 2
+    const currentPhaseProposals = await getProposalsForPhase({ instanceId });
+    expect(currentPhaseProposals).toHaveLength(2);
+
+    // The 2 final proposals must be a subset of the 3 review proposals
+    const reviewIds = new Set(reviewPhaseProposals.map((p) => p.id));
+    for (const p of finalPhaseProposals) {
+      expect(reviewIds.has(p.id)).toBe(true);
+    }
+  });
+
+  it('creates join rows for ALL proposals when no selectionPipeline is defined', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithoutPipeline);
+
+    // Create and submit 3 proposals (submitted proposals are eligible for transition)
+    for (let i = 1; i <= 3; i++) {
+      await createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal ${i} ${task.id}` },
+      });
+    }
+
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    const [transition] = await db
+      .select()
+      .from(stateTransitionHistory)
+      .where(eq(stateTransitionHistory.processInstanceId, instanceId))
+      .limit(1);
+
+    expect(transition).toBeDefined();
+
+    const joinRows = await db
+      .select()
+      .from(decisionTransitionProposals)
+      .where(
+        eq(decisionTransitionProposals.transitionHistoryId, transition!.id),
+      );
+
+    expect(joinRows).toHaveLength(3);
+  });
+});

--- a/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
+++ b/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
@@ -28,7 +28,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
     // Create and submit 3 proposals (submitted proposals are eligible for transition)
     for (let i = 1; i <= 3; i++) {
       await createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal ${i} ${task.id}` },
       });
@@ -74,7 +74,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
     // Submit 4 proposals; first pipeline limits to 3, second limits to 2
     for (let i = 1; i <= 4; i++) {
       await createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal ${i} ${task.id}` },
       });
@@ -129,7 +129,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
     // Create and submit 3 proposals (submitted proposals are eligible for transition)
     for (let i = 1; i <= 3; i++) {
       await createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal ${i} ${task.id}` },
       });
@@ -185,7 +185,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
       await createInstanceWithSchema(testData, task.id, schemaWithZeroLimit);
 
     await createAndSubmitProposal(testData, caller, {
-      callerEmail: userEmail,
+      userEmail,
       processInstanceId: instanceId,
       proposalData: { title: `Doomed ${task.id}` },
     });

--- a/services/api/src/routers/decision/instances/voteDataAggregator.test.ts
+++ b/services/api/src/routers/decision/instances/voteDataAggregator.test.ts
@@ -1,0 +1,9 @@
+import { aggregateVoteData } from '@op/common';
+import { describe, expect, it } from 'vitest';
+
+describe.concurrent('aggregateVoteData', () => {
+  it('returns empty object for an empty proposals array', async () => {
+    const result = await aggregateVoteData([]);
+    expect(result).toEqual({});
+  });
+});

--- a/services/api/src/routers/decision/instances/voteDataAggregator.test.ts
+++ b/services/api/src/routers/decision/instances/voteDataAggregator.test.ts
@@ -1,9 +1,52 @@
 import { aggregateVoteData } from '@op/common';
+import { db, eq } from '@op/db/client';
+import { proposals } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createAndSubmitProposal,
+  createInstanceWithSchema,
+  schemaWithoutPipeline,
+} from '../../../test/helpers/pipelineTestFixtures';
 
 describe.concurrent('aggregateVoteData', () => {
   it('returns empty object for an empty proposals array', async () => {
     const result = await aggregateVoteData([]);
     expect(result).toEqual({});
+  });
+
+  it('returns zeroed aggregation for proposals with no votes', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, userEmail, caller } = await createInstanceWithSchema(
+      testData,
+      task.id,
+      schemaWithoutPipeline,
+    );
+
+    const proposal = await createAndSubmitProposal(testData, caller, {
+      callerEmail: userEmail,
+      processInstanceId: instanceId,
+      proposalData: { title: `No votes ${task.id}` },
+    });
+
+    // Fetch the full proposal row from DB
+    const [fullProposal] = await db
+      .select()
+      .from(proposals)
+      .where(eq(proposals.id, proposal.id));
+
+    const result = await aggregateVoteData([fullProposal!]);
+
+    expect(result[proposal.id]).toBeDefined();
+    expect(result[proposal.id]!.voteCount).toBe(0);
+    expect(result[proposal.id]!.approvalCount).toBe(0);
+    expect(result[proposal.id]!.rejectionCount).toBe(0);
+    expect(result[proposal.id]!.abstainCount).toBe(0);
+    expect(result[proposal.id]!.approvalRate).toBe(0);
+    expect(result[proposal.id]!.votes).toEqual([]);
   });
 });

--- a/services/api/src/routers/decision/instances/voteDataAggregator.test.ts
+++ b/services/api/src/routers/decision/instances/voteDataAggregator.test.ts
@@ -28,7 +28,7 @@ describe.concurrent('aggregateVoteData', () => {
     );
 
     const proposal = await createAndSubmitProposal(testData, caller, {
-      callerEmail: userEmail,
+      userEmail,
       processInstanceId: instanceId,
       proposalData: { title: `No votes ${task.id}` },
     });

--- a/services/api/src/test/helpers/pipelineTestFixtures.ts
+++ b/services/api/src/test/helpers/pipelineTestFixtures.ts
@@ -32,7 +32,7 @@ export async function createAndSubmitProposal(
   testData: TestDecisionsDataManager,
   caller: Awaited<ReturnType<typeof createAuthenticatedCaller>>,
   options: {
-    callerEmail: string;
+    userEmail: string;
     processInstanceId: string;
     proposalData: { title: string };
   },

--- a/services/api/src/test/helpers/pipelineTestFixtures.ts
+++ b/services/api/src/test/helpers/pipelineTestFixtures.ts
@@ -1,0 +1,220 @@
+import { simpleVoting } from '@op/common';
+import { db } from '@op/db/client';
+import {
+  ProcessStatus,
+  decisionProcesses,
+  processInstances,
+  users,
+} from '@op/db/schema';
+import { eq } from 'drizzle-orm';
+
+import { appRouter } from '../../routers';
+import { createCallerFactory } from '../../trpcFactory';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../supabase-utils';
+import type { TestDecisionsDataManager } from './TestDecisionsDataManager';
+
+const createCaller = createCallerFactory(appRouter);
+
+export async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+/**
+ * Creates a proposal and immediately submits it.
+ * Submitted proposals have a history record (created by the DB trigger on status change),
+ * which is required for the transition join table.
+ */
+export async function createAndSubmitProposal(
+  testData: TestDecisionsDataManager,
+  caller: Awaited<ReturnType<typeof createAuthenticatedCaller>>,
+  options: {
+    callerEmail: string;
+    processInstanceId: string;
+    proposalData: { title: string };
+  },
+) {
+  const proposal = await testData.createProposal(options);
+  await caller.decision.submitProposal({ proposalId: proposal.id });
+  return proposal;
+}
+
+/**
+ * Process schema with a limit(2) selectionPipeline on the departing 'submission' phase.
+ * Used to test that transitions persist only surviving proposals.
+ */
+export const schemaWithPipeline = {
+  name: 'Pipeline Process',
+  states: [
+    { id: 'submission', name: 'Submission', type: 'initial' },
+    { id: 'review', name: 'Review', type: 'final' },
+  ],
+  transitions: [
+    {
+      id: 'submission-to-review',
+      name: 'Submit to Review',
+      from: 'submission',
+      to: 'review',
+      rules: { type: 'manual' },
+    },
+  ],
+  initialState: 'submission',
+  decisionDefinition: { type: 'object' },
+  proposalTemplate: { type: 'object' },
+  phases: [
+    {
+      id: 'submission',
+      name: 'Submission',
+      rules: {},
+      selectionPipeline: {
+        version: '1.0.0',
+        blocks: [{ id: 'limit-block', type: 'limit', count: 2 }],
+      },
+    },
+    { id: 'review', name: 'Review', rules: {} },
+  ],
+};
+
+/**
+ * Three-phase schema with a limiting selectionPipeline on each of the first two phases.
+ * submission → review (limit 3), review → final (limit 2).
+ * Used to test multi-transition chaining: proposals must survive both pipelines.
+ */
+export const schemaWithThreePhasesAndPipelines = {
+  name: 'Three Phase Pipeline Process',
+  states: [
+    { id: 'submission', name: 'Submission', type: 'initial' },
+    { id: 'review', name: 'Review', type: 'intermediate' },
+    { id: 'final', name: 'Final', type: 'final' },
+  ],
+  transitions: [
+    {
+      id: 'submission-to-review',
+      name: 'Submit to Review',
+      from: 'submission',
+      to: 'review',
+      rules: { type: 'manual' },
+    },
+    {
+      id: 'review-to-final',
+      name: 'Review to Final',
+      from: 'review',
+      to: 'final',
+      rules: { type: 'manual' },
+    },
+  ],
+  initialState: 'submission',
+  decisionDefinition: { type: 'object' },
+  proposalTemplate: { type: 'object' },
+  phases: [
+    {
+      id: 'submission',
+      name: 'Submission',
+      rules: {},
+      selectionPipeline: {
+        version: '1.0.0',
+        blocks: [{ id: 'limit-1', type: 'limit', count: 3 }],
+      },
+    },
+    {
+      id: 'review',
+      name: 'Review',
+      rules: {},
+      selectionPipeline: {
+        version: '1.0.0',
+        blocks: [{ id: 'limit-2', type: 'limit', count: 2 }],
+      },
+    },
+    { id: 'final', name: 'Final', rules: {} },
+  ],
+};
+
+/**
+ * Same schema without any selectionPipeline — all proposals survive the transition.
+ */
+export const schemaWithoutPipeline = {
+  ...schemaWithPipeline,
+  phases: [
+    { id: 'submission', name: 'Submission', rules: {} },
+    { id: 'review', name: 'Review', rules: {} },
+  ],
+};
+
+/**
+ * Creates a process instance configured with the given processSchema,
+ * starting in the 'submission' phase.
+ */
+export async function createInstanceWithSchema(
+  testData: TestDecisionsDataManager,
+  taskId: string,
+  processSchema: Record<string, unknown>,
+) {
+  const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+  const [userRecord] = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, setup.userEmail));
+
+  if (!userRecord?.profileId) {
+    throw new Error('Test user must have a profileId');
+  }
+
+  const [process] = await db
+    .insert(decisionProcesses)
+    .values({
+      name: `Pipeline Process ${taskId}`,
+      description: 'Test process for pipeline execution',
+      processSchema,
+      createdByProfileId: userRecord.profileId,
+    })
+    .returning();
+
+  const caller = await createAuthenticatedCaller(setup.userEmail);
+
+  const [simpleTemplate] = await db
+    .insert(decisionProcesses)
+    .values({
+      name: `Simple Template ${taskId}`,
+      description: simpleVoting.description,
+      processSchema: simpleVoting,
+      createdByProfileId: userRecord.profileId,
+    })
+    .returning();
+
+  const instanceResult = await caller.decision.createInstanceFromTemplate({
+    templateId: simpleTemplate!.id,
+    name: `Pipeline Test ${taskId}`,
+  });
+
+  testData.trackProfileForCleanup(instanceResult.id);
+
+  const instanceId = instanceResult.processInstance.id;
+
+  await db
+    .update(processInstances)
+    .set({
+      processId: process!.id,
+      currentStateId: 'submission',
+      status: ProcessStatus.PUBLISHED,
+      instanceData: {
+        currentPhaseId: 'submission',
+        phases: [
+          { phaseId: 'submission', name: 'Submission' },
+          { phaseId: 'review', name: 'Review' },
+        ],
+      },
+    })
+    .where(eq(processInstances.id, instanceId));
+
+  return {
+    instanceId,
+    user: setup.user,
+    userEmail: setup.userEmail,
+    caller,
+    testData,
+  };
+}

--- a/services/db/types.ts
+++ b/services/db/types.ts
@@ -4,3 +4,4 @@ export type DatabaseType = typeof db;
 export type TransactionType = Parameters<
   Parameters<DatabaseType['transaction']>[0]
 >[0];
+export type DbClient = DatabaseType | TransactionType;


### PR DESCRIPTION
## This PR

- Adds `getProposalsForPhase` service that returns proposals scoped to a phase (via join table post-transition, or all non-deleted proposals pre-transition)
- Refactors `voteDataAggregator` to accept an explicit proposals array instead of fetching internally
- Extends `transitionEngine` to run the selection pipeline during phase transition and persist surviving proposals into the `decision_transition_proposals` join table
- Updates `types.ts` to use `phases` instead of `phaseTransitionPipelines`

## The stack
Previously, listProposals always returned all proposals for a decision instance into each phase.
This adds the ability to run the selection pipeline when transitioning between phases (e.g. submission → review) to narrow down which proposals survive to the next phase — and then scope the proposal list to only those that passed through.

Enables auto-selection of proposals or manual selection (not represented here).

Extended summary:

### New flow: what happens on a transition

  Before this branch: executeTransition updated the instance state and wrote a stateTransitionHistory row. Nothing tracked which proposals were active.

  After this branch: executeTransition additionally:

  1. Calls getProposalsForPhase to load the proposals currently visible in the departing phase — not all proposals on the instance. This means in a multi-phase process, phase 3 only ever sees proposals that survived into phase 2, not proposals eliminated in phase 1.
  2. If the departing phase has a selectionPipeline defined, runs the pipeline against those proposals (with vote data) to produce a narrowed surviving set.
  3. Inside the commit transaction: looks up the latest proposalHistory record for each surviving proposal and writes one decisionTransitionProposals row per survivor, recording both the proposal ID and its history snapshot ID.

  ---
###  New flow: what listProposals returns

  Before: fetched all proposals for the instance, full stop.

  After:
  1. Calls getProposalIdsForPhase to determine which proposals are visible in the current phase.
  2. If a transition has occurred: returns only proposals present in decision_transition_proposals for the latest transition (and not soft-deleted).
  3. If no transition has occurred yet: returns all non-draft, non-deleted proposals for the instance.

  ---
 ### Key design decisions

  - Draft proposals are never attached to a transition. Only submitted proposals enter the pipeline and the join table. Draft proposals are simply not visible once a transition has happened.
  - selectionPipeline lives on PhaseDefinition (e.g. phases[].selectionPipeline), not in the old flat phaseTransitionPipelines map. Legacy handling was removed entirely — no processes use it.
  - getProposalIdsForPhase vs getProposalsForPhase: Two variants exist — a lean ID-only one for listProposals (avoids fetching full rows that would be immediately discarded) and a full-row one used by the transition engine's pipeline context.
  - DbClient type in services/db/types.ts lets both query helpers accept an optional transaction client, making them usable inside larger transactions.
