### PR TITLE
Expose phaseId param on listProposals for historical phase-scoped access

### DIFF
--- a/apps/app/src/components/decisions/MyBallot.tsx
+++ b/apps/app/src/components/decisions/MyBallot.tsx
@@ -49,7 +49,6 @@ export const MyBallot = ({
 
   const [proposalsData] = trpc.decision.listProposals.useSuspenseQuery({
     processInstanceId: instanceId,
-    proposalIds: voteStatus.selectedProposals?.map((p) => p.id) || [],
   });
 
   if (!voteStatus.hasVoted || !voteStatus.selectedProposals) {

--- a/apps/app/src/components/decisions/MyBallot.tsx
+++ b/apps/app/src/components/decisions/MyBallot.tsx
@@ -36,7 +36,6 @@ export const MyBallot = ({
   slug: string;
   instanceId: string;
 }) => {
-  const t = useTranslations();
   const user = useUser();
 
   if (!user.user.id) {
@@ -47,20 +46,34 @@ export const MyBallot = ({
     processInstanceId: instanceId,
   });
 
-  const [proposalsData] = trpc.decision.listProposals.useSuspenseQuery({
-    processInstanceId: instanceId,
-  });
-
-  if (!voteStatus.hasVoted || !voteStatus.selectedProposals) {
+  if (!voteStatus.hasVoted || !voteStatus.voteSubmission) {
     return <NoVoteFound />;
   }
 
-  const selectedProposalIds = new Set(
-    voteStatus.selectedProposals.map((p) => p.id),
+  return (
+    <MyBallotProposals
+      slug={slug}
+      instanceId={instanceId}
+      votedByProfileId={voteStatus.voteSubmission.userId}
+    />
   );
-  const proposals = proposalsData.proposals.filter((proposal) =>
-    selectedProposalIds.has(proposal.id),
-  );
+};
+
+const MyBallotProposals = ({
+  slug,
+  instanceId,
+  votedByProfileId,
+}: {
+  slug: string;
+  instanceId: string;
+  votedByProfileId: string;
+}) => {
+  const t = useTranslations();
+
+  const [proposalsData] = trpc.decision.listProposals.useSuspenseQuery({
+    processInstanceId: instanceId,
+    votedByProfileId,
+  });
 
   return (
     <div className="flex flex-col gap-4 pb-12">
@@ -69,7 +82,7 @@ export const MyBallot = ({
       </Header3>
 
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {proposals.map((proposal) => (
+        {proposalsData.proposals.map((proposal) => (
           <VotingProposalCard
             isSelected={true}
             proposalId={proposal.id}

--- a/apps/app/src/components/decisions/MyBallot.tsx
+++ b/apps/app/src/components/decisions/MyBallot.tsx
@@ -54,7 +54,7 @@ export const MyBallot = ({
     <MyBallotProposals
       slug={slug}
       instanceId={instanceId}
-      votedByProfileId={voteStatus.voteSubmission.userId}
+      votedByProfileId={voteStatus.voteSubmission.submittedByProfileId}
     />
   );
 };

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -101,6 +101,15 @@ export const listProposals = async ({
 }) => {
   const { processInstanceId, skipAccessCheck = false } = input;
 
+  // Skip authentication check if this is a trusted context (e.g., background job)
+  if (!skipAccessCheck && !user) {
+    throw new UnauthorizedError('User must be authenticated');
+  }
+
+  // Resolve the caller's profile once; it's reused for ballot auth, the
+  // HIDDEN visibility filter, and owner/editable checks further down.
+  const currentProfileId = await getCurrentProfileId(input.authUserId);
+
   // Resolve a caller-provided "explicit scope" before falling back to phase
   // resolution. Explicit scope means: the caller knows the exact set of
   // proposals they want, so we bypass phase scoping entirely. This applies
@@ -112,11 +121,8 @@ export const listProposals = async ({
   } else if (input.votedByProfileId) {
     // Ballots are private: a caller can only request their own ballot.
     // Skip this check for trusted contexts (background jobs).
-    if (!skipAccessCheck) {
-      const callerProfileId = await getCurrentProfileId(input.authUserId);
-      if (callerProfileId !== input.votedByProfileId) {
-        throw new UnauthorizedError('You can only view your own ballot');
-      }
+    if (!skipAccessCheck && currentProfileId !== input.votedByProfileId) {
+      throw new UnauthorizedError('You can only view your own ballot');
     }
 
     const votedRows = await db
@@ -147,11 +153,6 @@ export const listProposals = async ({
       instanceId: processInstanceId,
       phaseId: input.phaseId,
     }));
-
-  // Skip authentication check if this is a trusted context (e.g., background job)
-  if (!skipAccessCheck && !user) {
-    throw new UnauthorizedError('User must be authenticated');
-  }
 
   // For trusted contexts (skipAccessCheck), drafts are never returned and phase
   // scoping is the only proposal-id filter — so an empty phase set means no results.
@@ -212,9 +213,6 @@ export const listProposals = async ({
       profileUser?.roles ?? [],
     );
   }
-
-  // Get current user's profile ID early for hidden filter and later for editable checks
-  const currentProfileId = await getCurrentProfileId(input.authUserId);
 
   const { limit = 20, offset = 0, orderBy = 'createdAt', dir = 'desc' } = input;
 

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -83,12 +83,7 @@ const buildWhereConditions = (
     conditions.push(ilike(sql`${proposals.proposalData}::text`, `%${search}%`));
   }
 
-  if (phaseProposalIds.length > 0) {
-    conditions.push(inArray(proposals.id, phaseProposalIds));
-  } else {
-    // No proposals in this phase — return empty result set
-    conditions.push(sql`false`);
-  }
+  conditions.push(inArray(proposals.id, phaseProposalIds));
 
   return conditions.length > 0 ? and(...conditions) : undefined;
 };
@@ -108,6 +103,15 @@ export const listProposals = async ({
       instanceId: processInstanceId,
       phaseId: input.phaseId,
     }));
+
+  if (phaseProposalIds.length === 0) {
+    return {
+      proposals: [],
+      total: 0,
+      hasMore: false,
+      canManageProposals: false,
+    };
+  }
 
   // Skip authentication check if this is a trusted context (e.g., background job)
   if (!skipAccessCheck && !user) {

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -33,6 +33,7 @@ import {
   getProfileAccessUser,
 } from '../access';
 import { getProposalDocumentsContent } from './getProposalDocumentsContent';
+import { getProposalIdsForPhase } from './getProposalsForPhase';
 import { parseProposalData } from './proposalDataSchema';
 import { resolveProposalTemplate } from './resolveProposalTemplate';
 
@@ -42,6 +43,12 @@ export interface ListProposalsInput {
   status?: ProposalStatus;
   search?: string;
   categoryId?: string;
+  /** Scope results to a specific phase. Defaults to the current phase when omitted. */
+  phaseId?: string;
+  /**
+   * Internal override: skip phase resolution and use this exact set of IDs.
+   * Not exposed on the tRPC schema — use phaseId for public phase filtering.
+   */
   proposalIds?: string[];
   phase?: 'results';
   limit?: number;
@@ -53,14 +60,11 @@ export interface ListProposalsInput {
 }
 
 // Shared function to build WHERE conditions for both count and data queries
-const buildWhereConditions = (input: ListProposalsInput) => {
-  const {
-    processInstanceId,
-    submittedByProfileId,
-    status,
-    search,
-    proposalIds,
-  } = input;
+const buildWhereConditions = (
+  input: ListProposalsInput,
+  phaseProposalIds: string[],
+) => {
+  const { processInstanceId, submittedByProfileId, status, search } = input;
 
   const conditions = [];
 
@@ -79,8 +83,11 @@ const buildWhereConditions = (input: ListProposalsInput) => {
     conditions.push(ilike(sql`${proposals.proposalData}::text`, `%${search}%`));
   }
 
-  if (proposalIds && proposalIds.length > 0) {
-    conditions.push(inArray(proposals.id, proposalIds));
+  if (phaseProposalIds.length > 0) {
+    conditions.push(inArray(proposals.id, phaseProposalIds));
+  } else {
+    // No proposals in this phase — return empty result set
+    conditions.push(sql`false`);
   }
 
   return conditions.length > 0 ? and(...conditions) : undefined;
@@ -94,6 +101,13 @@ export const listProposals = async ({
   user: User;
 }) => {
   const { processInstanceId, skipAccessCheck = false } = input;
+
+  const phaseProposalIds =
+    input.proposalIds ??
+    (await getProposalIdsForPhase({
+      instanceId: processInstanceId,
+      phaseId: input.phaseId,
+    }));
 
   // Skip authentication check if this is a trusted context (e.g., background job)
   if (!skipAccessCheck && !user) {
@@ -153,7 +167,7 @@ export const listProposals = async ({
   const { limit = 20, offset = 0, orderBy = 'createdAt', dir = 'desc' } = input;
 
   // Build shared WHERE clause using the extracted function
-  const baseWhereClause = buildWhereConditions(input);
+  const baseWhereClause = buildWhereConditions(input, phaseProposalIds);
 
   // Handle category filtering separately to avoid table reference issues
   const { categoryId } = input;

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -110,6 +110,15 @@ export const listProposals = async ({
   if (input.proposalIds !== undefined) {
     explicitScopeIds = input.proposalIds;
   } else if (input.votedByProfileId) {
+    // Ballots are private: a caller can only request their own ballot.
+    // Skip this check for trusted contexts (background jobs).
+    if (!skipAccessCheck) {
+      const callerProfileId = await getCurrentProfileId(input.authUserId);
+      if (callerProfileId !== input.votedByProfileId) {
+        throw new UnauthorizedError('You can only view your own ballot');
+      }
+    }
+
     const votedRows = await db
       .select({ proposalId: decisionsVoteProposals.proposalId })
       .from(decisionsVoteSubmissions)

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -68,6 +68,64 @@ export interface ListProposalsInput {
   skipAccessCheck?: boolean; // For trusted contexts like background jobs
 }
 
+/**
+ * Resolves a caller-provided "explicit scope" for the listProposals query.
+ *
+ * Explicit scope means the caller knows the exact set of proposal IDs they
+ * want, so we bypass phase resolution entirely. There are two ways to trigger
+ * it:
+ *
+ * 1. `proposalIds` (internal-only) — used by trusted callers that already
+ *    have the IDs in hand.
+ * 2. `votedByProfileId` (public) — surfaces a user's ballot regardless of
+ *    the current phase. Subject to a self-only auth check: a caller can only
+ *    request their own ballot. The check is skipped for trusted contexts.
+ *
+ * Returns `undefined` when no explicit scope was requested (caller will fall
+ * back to phase scoping).
+ */
+const resolveExplicitScope = async ({
+  input,
+  currentProfileId,
+  skipAccessCheck,
+}: {
+  input: ListProposalsInput;
+  currentProfileId: string | undefined;
+  skipAccessCheck: boolean;
+}): Promise<string[] | undefined> => {
+  if (input.proposalIds !== undefined) {
+    return input.proposalIds;
+  }
+
+  if (!input.votedByProfileId) {
+    return undefined;
+  }
+
+  // Ballots are private: a caller can only request their own ballot.
+  if (!skipAccessCheck && currentProfileId !== input.votedByProfileId) {
+    throw new UnauthorizedError('You can only view your own ballot');
+  }
+
+  const votedRows = await db
+    .select({ proposalId: decisionsVoteProposals.proposalId })
+    .from(decisionsVoteSubmissions)
+    .innerJoin(
+      decisionsVoteProposals,
+      eq(decisionsVoteSubmissions.id, decisionsVoteProposals.voteSubmissionId),
+    )
+    .where(
+      and(
+        eq(decisionsVoteSubmissions.processInstanceId, input.processInstanceId),
+        eq(
+          decisionsVoteSubmissions.submittedByProfileId,
+          input.votedByProfileId,
+        ),
+      ),
+    );
+
+  return votedRows.map((r) => r.proposalId);
+};
+
 // Shared function to build WHERE conditions for both count and data queries
 const buildWhereConditions = (input: ListProposalsInput) => {
   const { processInstanceId, submittedByProfileId, status, search } = input;
@@ -110,42 +168,11 @@ export const listProposals = async ({
   // HIDDEN visibility filter, and owner/editable checks further down.
   const currentProfileId = await getCurrentProfileId(input.authUserId);
 
-  // Resolve a caller-provided "explicit scope" before falling back to phase
-  // resolution. Explicit scope means: the caller knows the exact set of
-  // proposals they want, so we bypass phase scoping entirely. This applies
-  // both to internal `proposalIds` overrides and to the public `votedByProfileId`
-  // filter (which surfaces a user's ballot regardless of current phase).
-  let explicitScopeIds: string[] | undefined;
-  if (input.proposalIds !== undefined) {
-    explicitScopeIds = input.proposalIds;
-  } else if (input.votedByProfileId) {
-    // Ballots are private: a caller can only request their own ballot.
-    // Skip this check for trusted contexts (background jobs).
-    if (!skipAccessCheck && currentProfileId !== input.votedByProfileId) {
-      throw new UnauthorizedError('You can only view your own ballot');
-    }
-
-    const votedRows = await db
-      .select({ proposalId: decisionsVoteProposals.proposalId })
-      .from(decisionsVoteSubmissions)
-      .innerJoin(
-        decisionsVoteProposals,
-        eq(
-          decisionsVoteSubmissions.id,
-          decisionsVoteProposals.voteSubmissionId,
-        ),
-      )
-      .where(
-        and(
-          eq(decisionsVoteSubmissions.processInstanceId, processInstanceId),
-          eq(
-            decisionsVoteSubmissions.submittedByProfileId,
-            input.votedByProfileId,
-          ),
-        ),
-      );
-    explicitScopeIds = votedRows.map((r) => r.proposalId);
-  }
+  const explicitScopeIds = await resolveExplicitScope({
+    input,
+    currentProfileId,
+    skipAccessCheck,
+  });
 
   const phaseProposalIds =
     explicitScopeIds ??

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -14,6 +14,8 @@ import {
   ProfileRelationshipType,
   ProposalStatus,
   Visibility,
+  decisionsVoteProposals,
+  decisionsVoteSubmissions,
   posts,
   postsToProfiles,
   processInstances,
@@ -46,8 +48,15 @@ export interface ListProposalsInput {
   /** Scope results to a specific phase. Defaults to the current phase when omitted. */
   phaseId?: string;
   /**
+   * Restrict results to proposals voted on by this profile. Bypasses phase
+   * resolution so a ballot remains accessible after the process advances past
+   * the voting phase.
+   */
+  votedByProfileId?: string;
+  /**
    * Internal override: skip phase resolution and use this exact set of IDs.
-   * Not exposed on the tRPC schema — use phaseId for public phase filtering.
+   * Not exposed on the tRPC schema — public callers should use phaseId or
+   * votedByProfileId.
    */
   proposalIds?: string[];
   phase?: 'results';
@@ -60,10 +69,7 @@ export interface ListProposalsInput {
 }
 
 // Shared function to build WHERE conditions for both count and data queries
-const buildWhereConditions = (
-  input: ListProposalsInput,
-  phaseProposalIds: string[],
-) => {
+const buildWhereConditions = (input: ListProposalsInput) => {
   const { processInstanceId, submittedByProfileId, status, search } = input;
 
   const conditions = [];
@@ -83,8 +89,6 @@ const buildWhereConditions = (
     conditions.push(ilike(sql`${proposals.proposalData}::text`, `%${search}%`));
   }
 
-  conditions.push(inArray(proposals.id, phaseProposalIds));
-
   return conditions.length > 0 ? and(...conditions) : undefined;
 };
 
@@ -97,25 +101,60 @@ export const listProposals = async ({
 }) => {
   const { processInstanceId, skipAccessCheck = false } = input;
 
+  // Resolve a caller-provided "explicit scope" before falling back to phase
+  // resolution. Explicit scope means: the caller knows the exact set of
+  // proposals they want, so we bypass phase scoping entirely. This applies
+  // both to internal `proposalIds` overrides and to the public `votedByProfileId`
+  // filter (which surfaces a user's ballot regardless of current phase).
+  let explicitScopeIds: string[] | undefined;
+  if (input.proposalIds !== undefined) {
+    explicitScopeIds = input.proposalIds;
+  } else if (input.votedByProfileId) {
+    const votedRows = await db
+      .select({ proposalId: decisionsVoteProposals.proposalId })
+      .from(decisionsVoteSubmissions)
+      .innerJoin(
+        decisionsVoteProposals,
+        eq(
+          decisionsVoteSubmissions.id,
+          decisionsVoteProposals.voteSubmissionId,
+        ),
+      )
+      .where(
+        and(
+          eq(decisionsVoteSubmissions.processInstanceId, processInstanceId),
+          eq(
+            decisionsVoteSubmissions.submittedByProfileId,
+            input.votedByProfileId,
+          ),
+        ),
+      );
+    explicitScopeIds = votedRows.map((r) => r.proposalId);
+  }
+
   const phaseProposalIds =
-    input.proposalIds ??
+    explicitScopeIds ??
     (await getProposalIdsForPhase({
       instanceId: processInstanceId,
       phaseId: input.phaseId,
     }));
 
-  if (phaseProposalIds.length === 0) {
+  // Skip authentication check if this is a trusted context (e.g., background job)
+  if (!skipAccessCheck && !user) {
+    throw new UnauthorizedError('User must be authenticated');
+  }
+
+  // For trusted contexts (skipAccessCheck), drafts are never returned and phase
+  // scoping is the only proposal-id filter — so an empty phase set means no results.
+  // For authenticated callers we still need to consider drafts the user owns/collaborates
+  // on, which are not part of phaseProposalIds, so we cannot early-return here.
+  if (skipAccessCheck && phaseProposalIds.length === 0) {
     return {
       proposals: [],
       total: 0,
       hasMore: false,
       canManageProposals: false,
     };
-  }
-
-  // Skip authentication check if this is a trusted context (e.g., background job)
-  if (!skipAccessCheck && !user) {
-    throw new UnauthorizedError('User must be authenticated');
   }
 
   // Get the instance's profile for access checks + template resolution
@@ -171,11 +210,24 @@ export const listProposals = async ({
   const { limit = 20, offset = 0, orderBy = 'createdAt', dir = 'desc' } = input;
 
   // Build shared WHERE clause using the extracted function
-  const baseWhereClause = buildWhereConditions(input, phaseProposalIds);
+  const baseWhereClause = buildWhereConditions(input);
+
+  // When the caller provided an explicit scope (proposalIds or votedByProfileId),
+  // constrain the entire query to that ID set. This prevents the draft branch
+  // (below) from independently surfacing drafts the user owns but didn't ask for.
+  let whereClause = baseWhereClause;
+  if (explicitScopeIds !== undefined) {
+    const explicitScopeFilter =
+      explicitScopeIds.length > 0
+        ? inArray(proposals.id, explicitScopeIds)
+        : sql`false`;
+    whereClause = whereClause
+      ? and(whereClause, explicitScopeFilter)
+      : explicitScopeFilter;
+  }
 
   // Handle category filtering separately to avoid table reference issues
   const { categoryId } = input;
-  let whereClause = baseWhereClause;
   let categoryProposalIds: string[] = [];
 
   if (categoryId) {
@@ -197,21 +249,35 @@ export const listProposals = async ({
       };
     }
 
-    // Add category filter to WHERE clause
+    // Add category filter to WHERE clause (composed with any earlier filters)
     const categoryFilter = inArray(proposals.id, categoryProposalIds);
-    whereClause = baseWhereClause
-      ? and(baseWhereClause, categoryFilter)
+    whereClause = whereClause
+      ? and(whereClause, categoryFilter)
       : categoryFilter;
   }
 
-  // Draft proposals: only visible to users with proposal-level access
-  // (the creator and invited collaborators who have a profileUsers record on the proposal's profile).
-  // Non-draft proposals: visible to all users with instance-level access,
-  // but still respect the HIDDEN visibility filter (only admins and owners see hidden proposals).
-  if (!skipAccessCheck) {
-    // A proposal is visible if:
-    // 1. It's a DRAFT and the user has proposal-level access (via profileUsers), OR
-    // 2. It's not a DRAFT and passes the visibility filter
+  // Phase scoping applies to non-draft proposals only. Drafts are user-private
+  // and not part of any phase transition snapshot, so they bypass phaseProposalIds.
+  // When phaseProposalIds is empty (e.g. instance has no submitted proposals yet),
+  // the non-draft branch must short-circuit to false rather than emit an empty IN ().
+  const phaseScopedNonDraftIdFilter =
+    phaseProposalIds.length > 0
+      ? and(
+          ne(proposals.status, ProposalStatus.DRAFT),
+          inArray(proposals.id, phaseProposalIds),
+        )
+      : sql`false`;
+
+  if (skipAccessCheck) {
+    // Trusted contexts get all phase-scoped non-draft proposals.
+    whereClause = whereClause
+      ? and(whereClause, phaseScopedNonDraftIdFilter)
+      : phaseScopedNonDraftIdFilter;
+  } else {
+    // Draft proposals: only visible to users with proposal-level access
+    // (the creator and invited collaborators with a profileUsers record on the proposal's profile).
+    // Drafts are not phase-scoped and remain visible regardless of phaseId so that
+    // creators continue to see their own in-progress work alongside the current phase.
     const draftFilter = and(
       eq(proposals.status, ProposalStatus.DRAFT),
       inArray(
@@ -223,14 +289,12 @@ export const listProposals = async ({
       ),
     );
 
-    const nonDraftFilter = ne(proposals.status, ProposalStatus.DRAFT);
-
-    // For non-draft proposals, apply the existing HIDDEN visibility filter
-    // unless the user is an admin (canManageProposals)
+    // Non-draft proposals: phase-scoped, plus the HIDDEN visibility filter for
+    // non-admins (admins and the owning profile still see hidden proposals).
     const nonDraftVisibilityFilter = canManageProposals
-      ? nonDraftFilter
+      ? phaseScopedNonDraftIdFilter
       : and(
-          nonDraftFilter,
+          phaseScopedNonDraftIdFilter,
           or(
             eq(proposals.visibility, Visibility.VISIBLE),
             eq(proposals.submittedByProfileId, currentProfileId),

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -97,7 +97,7 @@ export interface ValidateVoteSelectionInput {
 export interface VoteSubmissionResult {
   id: string;
   processInstanceId: string;
-  userId: string;
+  submittedByProfileId: string;
   selectedProposalIds: string[];
   createdAt: Date;
   signature: string | null;
@@ -328,7 +328,7 @@ export const submitVote = async ({
     return {
       id: result.voteSubmission.id,
       processInstanceId: result.voteSubmission.processInstanceId,
-      userId: result.voteSubmission.submittedByProfileId,
+      submittedByProfileId: result.voteSubmission.submittedByProfileId,
       selectedProposalIds: result.selectedProposalIds,
       createdAt: new Date(result.voteSubmission.createdAt!),
       signature: result.voteSubmission.signature || null,
@@ -455,7 +455,7 @@ export const getVotingStatus = async ({
         ? {
             id: voteSubmission.id,
             processInstanceId: voteSubmission.processInstanceId,
-            userId: voteSubmission.submittedByProfileId,
+            submittedByProfileId: voteSubmission.submittedByProfileId,
             selectedProposalIds,
             createdAt: new Date(voteSubmission.createdAt!),
             signature: voteSubmission.signature,

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -668,6 +668,12 @@ export const proposalFilterSchema = z
     dir: z.enum(['asc', 'desc']).optional(),
     /** Phase ID to scope proposals to. Defaults to the current phase when omitted. */
     phaseId: z.string().optional(),
+    /**
+     * Restrict results to proposals voted on by this profile. Bypasses phase
+     * scoping so a user's ballot remains accessible after the process moves
+     * past the voting phase.
+     */
+    votedByProfileId: z.uuid().optional(),
     /** When set to 'results', all proposals are returned as non-editable */
     phase: z.enum(['results']).optional(),
   })

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -666,7 +666,8 @@ export const proposalFilterSchema = z
     status: z.enum(ProposalStatus).optional(),
     categoryId: z.string().optional(),
     dir: z.enum(['asc', 'desc']).optional(),
-    proposalIds: z.array(z.uuid()).optional(),
+    /** Phase ID to scope proposals to. Defaults to the current phase when omitted. */
+    phaseId: z.string().optional(),
     /** When set to 'results', all proposals are returned as non-editable */
     phase: z.enum(['results']).optional(),
   })

--- a/services/api/src/routers/decision/proposals/listProposalsBallot.test.ts
+++ b/services/api/src/routers/decision/proposals/listProposalsBallot.test.ts
@@ -1,0 +1,221 @@
+import { db } from '@op/db/client';
+import {
+  decisionsVoteProposals,
+  decisionsVoteSubmissions,
+} from '@op/db/schema';
+import { TRPCError } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import { createAuthenticatedCaller } from '../../../test/helpers/pipelineTestFixtures';
+
+/**
+ * Directly inserts a vote submission + vote proposals join rows for a given
+ * voter. Bypasses the voting business logic so these tests stay focused on
+ * the ballot-visibility filter in listProposals.
+ */
+async function seedBallot({
+  processInstanceId,
+  voterProfileId,
+  proposalIds,
+}: {
+  processInstanceId: string;
+  voterProfileId: string;
+  proposalIds: string[];
+}) {
+  const [submission] = await db
+    .insert(decisionsVoteSubmissions)
+    .values({
+      processInstanceId,
+      submittedByProfileId: voterProfileId,
+      voteData: {
+        schemaVersion: '1.0.0',
+        schemaType: 'simple',
+        submissionMetadata: { timestamp: new Date().toISOString() },
+        validationSignature: 'test-signature',
+      },
+    })
+    .returning({ id: decisionsVoteSubmissions.id });
+
+  if (!submission) {
+    throw new Error('Failed to seed vote submission');
+  }
+
+  if (proposalIds.length > 0) {
+    await db.insert(decisionsVoteProposals).values(
+      proposalIds.map((proposalId) => ({
+        voteSubmissionId: submission.id,
+        proposalId,
+      })),
+    );
+  }
+
+  return submission;
+}
+
+describe.concurrent('listProposals: votedByProfileId (ballot filter)', () => {
+  it('returns only the proposals a voter voted on when they query their own ballot', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Create a voter and a submitter; the submitter contributes 3 proposals,
+    // the voter votes on 2 of them.
+    const [voter, submitter] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+    ]);
+
+    const submitterCaller = await createAuthenticatedCaller(submitter.email);
+
+    const proposalA = await testData.createProposal({
+      userEmail: submitter.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: `Proposal A ${task.id}` },
+    });
+    const proposalB = await testData.createProposal({
+      userEmail: submitter.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: `Proposal B ${task.id}` },
+    });
+    const proposalC = await testData.createProposal({
+      userEmail: submitter.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: `Proposal C ${task.id}` },
+    });
+
+    await Promise.all([
+      submitterCaller.decision.submitProposal({ proposalId: proposalA.id }),
+      submitterCaller.decision.submitProposal({ proposalId: proposalB.id }),
+      submitterCaller.decision.submitProposal({ proposalId: proposalC.id }),
+    ]);
+
+    await seedBallot({
+      processInstanceId: instance.instance.id,
+      voterProfileId: voter.profileId,
+      proposalIds: [proposalA.id, proposalC.id],
+    });
+
+    const voterCaller = await createAuthenticatedCaller(voter.email);
+    const result = await voterCaller.decision.listProposals({
+      processInstanceId: instance.instance.id,
+      votedByProfileId: voter.profileId,
+    });
+
+    const returnedIds = result.proposals.map((p) => p.id).sort();
+    expect(returnedIds).toEqual([proposalA.id, proposalC.id].sort());
+    expect(result.total).toBe(2);
+  });
+
+  it('rejects another member trying to view a voter’s ballot', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const [voter, snoop] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+    ]);
+
+    const voterCaller = await createAuthenticatedCaller(voter.email);
+    const proposal = await testData.createProposal({
+      userEmail: voter.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: `Ballot Target ${task.id}` },
+    });
+    await voterCaller.decision.submitProposal({ proposalId: proposal.id });
+
+    await seedBallot({
+      processInstanceId: instance.instance.id,
+      voterProfileId: voter.profileId,
+      proposalIds: [proposal.id],
+    });
+
+    const snoopCaller = await createAuthenticatedCaller(snoop.email);
+    await expect(
+      snoopCaller.decision.listProposals({
+        processInstanceId: instance.instance.id,
+        votedByProfileId: voter.profileId,
+      }),
+    ).rejects.toThrowError(TRPCError);
+  });
+
+  it('rejects a decision admin trying to view another user’s ballot', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const voter = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+
+    const voterCaller = await createAuthenticatedCaller(voter.email);
+    const proposal = await testData.createProposal({
+      userEmail: voter.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: `Admin Peek ${task.id}` },
+    });
+    await voterCaller.decision.submitProposal({ proposalId: proposal.id });
+
+    await seedBallot({
+      processInstanceId: instance.instance.id,
+      voterProfileId: voter.profileId,
+      proposalIds: [proposal.id],
+    });
+
+    // setup.userEmail is a decision admin on the instance's profile.
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    await expect(
+      adminCaller.decision.listProposals({
+        processInstanceId: instance.instance.id,
+        votedByProfileId: voter.profileId,
+      }),
+    ).rejects.toThrowError(TRPCError);
+  });
+});

--- a/services/api/src/routers/decision/proposals/listProposalsPhaseScoped.test.ts
+++ b/services/api/src/routers/decision/proposals/listProposalsPhaseScoped.test.ts
@@ -1,0 +1,157 @@
+import { TransitionEngine } from '@op/common';
+import { db } from '@op/db/client';
+import { proposals } from '@op/db/schema';
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createAndSubmitProposal,
+  createInstanceWithSchema,
+  schemaWithPipeline,
+  schemaWithoutPipeline,
+} from '../../../test/helpers/pipelineTestFixtures';
+
+describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
+  it('returns only surviving proposals after a transition with a limiting pipeline', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithPipeline);
+
+    // Create and submit 3 proposals; the pipeline limits to 2
+    for (let i = 1; i <= 3; i++) {
+      await createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal ${i} ${task.id}` },
+      });
+    }
+
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    const result = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+    });
+
+    expect(result.proposals).toHaveLength(2);
+    expect(result.total).toBe(2);
+  });
+
+  it('returns all proposals after a transition without a pipeline', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithoutPipeline);
+
+    for (let i = 1; i <= 3; i++) {
+      await createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal ${i} ${task.id}` },
+      });
+    }
+
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    const result = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+    });
+
+    expect(result.proposals).toHaveLength(3);
+    expect(result.total).toBe(3);
+  });
+
+  it('excludes soft-deleted proposals from the phase-scoped list', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithoutPipeline);
+
+    const [p1, p2] = await Promise.all([
+      createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Active proposal ${task.id}` },
+      }),
+      createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `To-be-deleted proposal ${task.id}` },
+      }),
+    ]);
+
+    // Soft-delete the second proposal before transition
+    await db
+      .update(proposals)
+      .set({ deletedAt: new Date().toISOString() })
+      .where(eq(proposals.id, p2.id));
+
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    const result = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+    });
+
+    // Only the non-deleted proposal should appear
+    expect(result.proposals).toHaveLength(1);
+    expect(result.proposals[0]?.id).toBe(p1.id);
+  });
+
+  it('excludes proposals soft-deleted after transition from the phase-scoped list', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instanceId, user, userEmail, caller } =
+      await createInstanceWithSchema(testData, task.id, schemaWithoutPipeline);
+
+    const [p1, p2] = await Promise.all([
+      createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Active proposal ${task.id}` },
+      }),
+      createAndSubmitProposal(testData, caller, {
+        callerEmail: userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `To-be-deleted after transition ${task.id}` },
+      }),
+    ]);
+
+    // Transition first (both proposals make it into the join table)
+    await TransitionEngine.executeTransition({
+      data: { instanceId, toStateId: 'review' },
+      user,
+    });
+
+    // Soft-delete after transition
+    await db
+      .update(proposals)
+      .set({ deletedAt: new Date().toISOString() })
+      .where(eq(proposals.id, p2.id));
+
+    const result = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+    });
+
+    // Soft-deleted proposal must be excluded even though it's in the join table
+    expect(result.proposals).toHaveLength(1);
+    expect(result.proposals[0]?.id).toBe(p1.id);
+  });
+});

--- a/services/api/src/routers/decision/proposals/listProposalsPhaseScoped.test.ts
+++ b/services/api/src/routers/decision/proposals/listProposalsPhaseScoped.test.ts
@@ -24,7 +24,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
     // Create and submit 3 proposals; the pipeline limits to 2
     for (let i = 1; i <= 3; i++) {
       await createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal ${i} ${task.id}` },
       });
@@ -53,7 +53,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
 
     for (let i = 1; i <= 3; i++) {
       await createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Proposal ${i} ${task.id}` },
       });
@@ -82,12 +82,12 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
 
     const [p1, p2] = await Promise.all([
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Active proposal ${task.id}` },
       }),
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `To-be-deleted proposal ${task.id}` },
       }),
@@ -123,12 +123,12 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
 
     const [p1, p2] = await Promise.all([
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `Active proposal ${task.id}` },
       }),
       createAndSubmitProposal(testData, caller, {
-        callerEmail: userEmail,
+        userEmail,
         processInstanceId: instanceId,
         proposalData: { title: `To-be-deleted after transition ${task.id}` },
       }),

--- a/services/api/src/test/helpers/pipelineTestFixtures.ts
+++ b/services/api/src/test/helpers/pipelineTestFixtures.ts
@@ -37,11 +37,7 @@ export async function createAndSubmitProposal(
     proposalData: { title: string };
   },
 ) {
-  const { callerEmail, ...rest } = options;
-  const proposal = await testData.createProposal({
-    userEmail: callerEmail,
-    ...rest,
-  });
+  const proposal = await testData.createProposal(options);
   await caller.decision.submitProposal({ proposalId: proposal.id });
   return proposal;
 }

--- a/services/api/src/test/helpers/pipelineTestFixtures.ts
+++ b/services/api/src/test/helpers/pipelineTestFixtures.ts
@@ -37,7 +37,11 @@ export async function createAndSubmitProposal(
     proposalData: { title: string };
   },
 ) {
-  const proposal = await testData.createProposal(options);
+  const { callerEmail, ...rest } = options;
+  const proposal = await testData.createProposal({
+    userEmail: callerEmail,
+    ...rest,
+  });
   await caller.decision.submitProposal({ proposalId: proposal.id });
   return proposal;
 }


### PR DESCRIPTION
## Summary

- Adds optional `phaseId` parameter to `listProposals` tRPC endpoint for historical phase-scoped access
- Internal: passes `proposalIds` from `getProposalsForPhase` into the query rather than exposing raw IDs on the API surface
- Updates encoder to reflect the `phaseId` param in the schema
- Removes unused `proposalIds` tRPC param from `MyBallot` component
