### PR TITLE
Keep proposal response limits in the template schema

### DIFF
--- a/apps/app/src/components/decisions/proposalTemplate.ts
+++ b/apps/app/src/components/decisions/proposalTemplate.ts
@@ -15,6 +15,7 @@
 import {
   type ProposalTemplateSchema,
   SYSTEM_FIELD_KEYS,
+  type XFormatPropertySchema,
   buildCategorySchema,
   parseSchemaOptions,
   schemaHasOptions,
@@ -37,6 +38,12 @@ import {
 export type { ProposalTemplateSchema };
 
 export type FieldType = 'short_text' | 'long_text' | 'dropdown';
+type TextLengthSchema = ProposalTemplateSchema | XFormatPropertySchema;
+
+const TEXT_FIELD_MAX_LENGTHS = {
+  short_text: 280,
+  long_text: 5000,
+} as const;
 
 /**
  * Flat read-only view of a single field, derived from a proposal template.
@@ -65,6 +72,82 @@ const X_FORMAT_TO_FIELD_TYPE: Record<string, FieldType> = {
   dropdown: 'dropdown',
 };
 
+function getDefaultTextFieldMaxLength(
+  xFormat: string | undefined,
+): number | undefined {
+  switch (xFormat) {
+    case 'short-text':
+      return TEXT_FIELD_MAX_LENGTHS.short_text;
+    case 'long-text':
+      return TEXT_FIELD_MAX_LENGTHS.long_text;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Applies the default text max length for short/long text fields when one is
+ * not already present in the schema.
+ */
+function withDefaultTextFieldMaxLength<T extends ProposalTemplateSchema>(
+  schema: T,
+): T;
+function withDefaultTextFieldMaxLength<T extends TextLengthSchema>(
+  schema: T,
+): T;
+function withDefaultTextFieldMaxLength<
+  T extends ProposalTemplateSchema | TextLengthSchema,
+>(schema: T): T {
+  if (schema.type !== 'string' || schema.maxLength != null) {
+    return schema;
+  }
+
+  const maxLength = getDefaultTextFieldMaxLength(
+    typeof schema['x-format'] === 'string' ? schema['x-format'] : undefined,
+  );
+  if (maxLength == null) {
+    return schema;
+  }
+
+  return {
+    ...schema,
+    maxLength,
+  };
+}
+
+/**
+ * Ensures all short/long text properties in a template carry their default
+ * character limit so the saved schema is ready for backend validation.
+ */
+function normalizeTextFieldMaxLengths(
+  template: ProposalTemplateSchema,
+): ProposalTemplateSchema {
+  const properties = template.properties;
+  if (!properties) {
+    return template;
+  }
+
+  let hasChanges = false;
+  const normalizedProperties = Object.fromEntries(
+    Object.entries(properties).map(([fieldId, fieldSchema]) => {
+      const normalizedFieldSchema = withDefaultTextFieldMaxLength(fieldSchema);
+      if (normalizedFieldSchema !== fieldSchema) {
+        hasChanges = true;
+      }
+      return [fieldId, normalizedFieldSchema];
+    }),
+  );
+
+  if (!hasChanges) {
+    return template;
+  }
+
+  return {
+    ...template,
+    properties: normalizedProperties,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Field type → JSON Schema creator
 // ---------------------------------------------------------------------------
@@ -73,7 +156,7 @@ function withXFormat(
   schema: ProposalTemplateSchema,
   xFormat: string,
 ): ProposalTemplateSchema {
-  return { ...schema, 'x-format': xFormat };
+  return withDefaultTextFieldMaxLength({ ...schema, 'x-format': xFormat });
 }
 
 export function createFieldJsonSchema(type: FieldType): ProposalTemplateSchema {
@@ -399,7 +482,7 @@ export function ensureLockedFields(
     requireCategorySelection?: boolean;
   },
 ): ProposalTemplateSchema {
-  let result = template;
+  let result = normalizeTextFieldMaxLengths(template);
 
   // Ensure title exists
   if (!getFieldSchema(result, 'title')) {

--- a/apps/app/src/components/decisions/proposalTemplate.ts
+++ b/apps/app/src/components/decisions/proposalTemplate.ts
@@ -38,11 +38,11 @@ import {
 export type { ProposalTemplateSchema };
 
 export type FieldType = 'short_text' | 'long_text' | 'dropdown';
-type TextLengthSchema = ProposalTemplateSchema | XFormatPropertySchema;
+type TextFieldFormat = 'short-text' | 'long-text';
 
-const TEXT_FIELD_MAX_LENGTHS = {
-  short_text: 280,
-  long_text: 5000,
+const TEXT_FIELD_MAX_LENGTHS_BY_FORMAT: Record<TextFieldFormat, number> = {
+  'short-text': 280,
+  'long-text': 5000,
 } as const;
 
 /**
@@ -72,46 +72,29 @@ const X_FORMAT_TO_FIELD_TYPE: Record<string, FieldType> = {
   dropdown: 'dropdown',
 };
 
-function getDefaultTextFieldMaxLength(
-  xFormat: string | undefined,
-): number | undefined {
-  switch (xFormat) {
-    case 'short-text':
-      return TEXT_FIELD_MAX_LENGTHS.short_text;
-    case 'long-text':
-      return TEXT_FIELD_MAX_LENGTHS.long_text;
-    default:
-      return undefined;
-  }
+function isTextFieldFormat(xFormat: unknown): xFormat is TextFieldFormat {
+  return xFormat === 'short-text' || xFormat === 'long-text';
 }
 
 /**
  * Applies the default text max length for short/long text fields when one is
  * not already present in the schema.
  */
-function withDefaultTextFieldMaxLength<T extends ProposalTemplateSchema>(
-  schema: T,
-): T;
-function withDefaultTextFieldMaxLength<T extends TextLengthSchema>(
-  schema: T,
-): T;
-function withDefaultTextFieldMaxLength<
-  T extends ProposalTemplateSchema | TextLengthSchema,
->(schema: T): T {
+function withDefaultTextFieldMaxLength(
+  schema: XFormatPropertySchema,
+): XFormatPropertySchema {
   if (schema.type !== 'string' || schema.maxLength != null) {
     return schema;
   }
 
-  const maxLength = getDefaultTextFieldMaxLength(
-    typeof schema['x-format'] === 'string' ? schema['x-format'] : undefined,
-  );
-  if (maxLength == null) {
+  const xFormat = schema['x-format'];
+  if (!isTextFieldFormat(xFormat)) {
     return schema;
   }
 
   return {
     ...schema,
-    maxLength,
+    maxLength: TEXT_FIELD_MAX_LENGTHS_BY_FORMAT[xFormat],
   };
 }
 
@@ -128,15 +111,16 @@ function normalizeTextFieldMaxLengths(
   }
 
   let hasChanges = false;
-  const normalizedProperties = Object.fromEntries(
-    Object.entries(properties).map(([fieldId, fieldSchema]) => {
-      const normalizedFieldSchema = withDefaultTextFieldMaxLength(fieldSchema);
-      if (normalizedFieldSchema !== fieldSchema) {
-        hasChanges = true;
-      }
-      return [fieldId, normalizedFieldSchema];
-    }),
-  );
+  const normalizedProperties: Record<string, XFormatPropertySchema> = {};
+
+  for (const [fieldId, fieldSchema] of Object.entries(properties)) {
+    const normalizedFieldSchema = withDefaultTextFieldMaxLength(fieldSchema);
+    normalizedProperties[fieldId] = normalizedFieldSchema;
+
+    if (normalizedFieldSchema !== fieldSchema) {
+      hasChanges = true;
+    }
+  }
 
   if (!hasChanges) {
     return template;
@@ -153,13 +137,13 @@ function normalizeTextFieldMaxLengths(
 // ---------------------------------------------------------------------------
 
 function withXFormat(
-  schema: ProposalTemplateSchema,
-  xFormat: string,
-): ProposalTemplateSchema {
+  schema: XFormatPropertySchema,
+  xFormat: XFormatPropertySchema['x-format'],
+): XFormatPropertySchema {
   return withDefaultTextFieldMaxLength({ ...schema, 'x-format': xFormat });
 }
 
-export function createFieldJsonSchema(type: FieldType): ProposalTemplateSchema {
+export function createFieldJsonSchema(type: FieldType): XFormatPropertySchema {
   switch (type) {
     case 'short_text':
       return withXFormat({ type: 'string' }, 'short-text');
@@ -429,9 +413,9 @@ export function setFieldRequired(
 // ---------------------------------------------------------------------------
 
 function createLockedFieldSchema(
-  xFormat: string,
+  xFormat: XFormatPropertySchema['x-format'],
   title: string,
-): ProposalTemplateSchema {
+): XFormatPropertySchema {
   return withXFormat({ type: 'string', title }, xFormat);
 }
 

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -317,6 +317,73 @@ describe.concurrent('submitProposal', () => {
     });
   });
 
+  it('should reject submission when a text field exceeds the template maxLength', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+      proposalTemplate: {
+        type: 'object',
+        required: ['title', 'summary'],
+        'x-field-order': ['title', 'summary'],
+        properties: {
+          title: {
+            type: 'string',
+            title: 'Title',
+            'x-format': 'short-text',
+            maxLength: 280,
+          },
+          summary: {
+            type: 'string',
+            title: 'Summary',
+            'x-format': 'long-text',
+            maxLength: 10,
+          },
+        },
+      },
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      callerEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: {
+        title: 'Character limit test',
+      },
+    });
+
+    await db
+      .update(proposals)
+      .set({
+        proposalData: {
+          title: 'Character limit test',
+          summary: 'This is definitely too long',
+        },
+      })
+      .where(eq(proposals.id, proposal.id));
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.submitProposal({
+        proposalId: proposal.id,
+      }),
+    ).rejects.toMatchObject({
+      cause: {
+        name: 'ValidationError',
+        message: expect.stringContaining('Summary cannot exceed 10 characters'),
+      },
+    });
+  });
+
   it('should use schema title in validation errors for UUID-keyed custom fields', async ({
     task,
     onTestFinished,


### PR DESCRIPTION
This keeps proposal length guardrails in the template schema so we can ship a minimal backend-first version now. It lets text responses be constrained without taking on the fuller UI work yet.