### PR TITLE
Pin axios to <1.14.1 to guard against supply chain attack

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
       "tsx": "$tsx",
       "turbo": "$turbo",
       "typescript": "$typescript",
+      "axios": "<1.14.1",
       "undici": "5.27.1",
       "use-error-boundary": "$use-error-boundary",
       "zustand": "$zustand"


### PR DESCRIPTION
Axes 1.14.1 introduced a malicious transitive dependency (plain-crypto-js).
This override ensures no transitive dep can pull in the compromised version.

https://claude.ai/code/session_01JcUDEXguBZA82FRfewQCnk