### PR TITLE
Fix: exclude draft proposals from submitter count

### DIFF
--- a/apps/app/src/utils/proposalUtils.ts
+++ b/apps/app/src/utils/proposalUtils.ts
@@ -1,12 +1,14 @@
 /**
- * Extract unique submitters from proposals for display components like FacePile
+ * Extract unique submitters from non-draft proposals for display components like FacePile.
+ * Draft proposals are excluded so only users who have actually submitted appear in the count.
  */
 export function getUniqueSubmitters<
-  T extends { submittedBy?: { id: string } | null },
+  T extends { submittedBy?: { id: string } | null; status?: string | null },
 >(proposals: T[]): Array<NonNullable<T['submittedBy']>> {
   return proposals.reduce(
     (acc, proposal) => {
       if (
+        proposal.status !== 'draft' &&
         proposal.submittedBy &&
         !acc.some((s) => s.id === proposal.submittedBy?.id)
       ) {

--- a/apps/app/src/utils/proposalUtils.ts
+++ b/apps/app/src/utils/proposalUtils.ts
@@ -1,3 +1,5 @@
+import { ProposalStatus } from '@op/api/encoders';
+
 /**
  * Extract unique submitters from non-draft proposals for display components like FacePile.
  * Draft proposals are excluded so only users who have actually submitted appear in the count.
@@ -8,7 +10,7 @@ export function getUniqueSubmitters<
   return proposals.reduce(
     (acc, proposal) => {
       if (
-        proposal.status !== 'draft' &&
+        proposal.status !== ProposalStatus.DRAFT &&
         proposal.submittedBy &&
         !acc.some((s) => s.id === proposal.submittedBy?.id)
       ) {


### PR DESCRIPTION
Fixes bug where draft proposals were counted in the "X members have submitted proposals" FacePile display


Asana: https://app.asana.com/1/1108348036672214/project/1211387328265612/task/1213925645730161
