### PR TITLE
fix: Ensure taxonomy terms are created when saving categories

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/useNavigationConfig.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/useNavigationConfig.ts
@@ -24,17 +24,27 @@ export function useNavigationConfig(
     (p) => p.rules?.proposals?.review === true,
   );
 
+  const organizeByCategories =
+    instance?.instanceData?.config?.organizeByCategories ?? true;
+
+  const generalSections = organizeByCategories
+    ? DEFAULT_NAVIGATION_CONFIG.sections?.general
+    : DEFAULT_NAVIGATION_CONFIG.sections?.general?.filter(
+        (s) => s !== 'proposalCategories',
+      );
+
   return useMemo(
     () => ({
       ...DEFAULT_NAVIGATION_CONFIG,
       steps: { ...DEFAULT_NAVIGATION_CONFIG.steps, reviews: hasReviewPhase },
       sections: {
         ...DEFAULT_NAVIGATION_CONFIG.sections,
+        general: generalSections,
         reviews: reviewFlowEnabled
           ? ['reviewSettings', 'reviewRubric']
           : ['criteria'],
       },
     }),
-    [hasReviewPhase, reviewFlowEnabled],
+    [hasReviewPhase, reviewFlowEnabled, generalSections],
   );
 }

--- a/packages/common/src/services/decision/createProcess.ts
+++ b/packages/common/src/services/decision/createProcess.ts
@@ -1,84 +1,11 @@
-import { db, eq } from '@op/db/client';
-import { decisionProcesses, taxonomies, taxonomyTerms } from '@op/db/schema';
+import { db } from '@op/db/client';
+import { decisionProcesses } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 
 import { CommonError, UnauthorizedError } from '../../utils';
 import { assertUserByAuthId } from '../assert';
+import { ensureProposalTaxonomy } from './ensureProposalTaxonomy';
 import type { ProcessSchema } from './types';
-
-/**
- * Ensures the "proposal" taxonomy exists and creates/updates taxonomy terms for the given categories
- */
-async function ensureProposalTaxonomy(categories: string[]): Promise<string[]> {
-  if (!categories || categories.length === 0) {
-    return [];
-  }
-
-  // Ensure "proposal" taxonomy exists
-  let proposalTaxonomy = await db._query.taxonomies.findFirst({
-    where: eq(taxonomies.name, 'proposal'),
-  });
-
-  if (!proposalTaxonomy) {
-    const [newTaxonomy] = await db
-      .insert(taxonomies)
-      .values({
-        name: 'proposal',
-        description:
-          'Categories for organizing proposals in decision-making processes',
-      })
-      .returning();
-
-    if (!newTaxonomy) {
-      throw new CommonError('Failed to create proposal taxonomy');
-    }
-    proposalTaxonomy = newTaxonomy;
-  }
-
-  // Process each category
-  const taxonomyTermIds: string[] = [];
-
-  for (const categoryName of categories) {
-    if (!categoryName.trim()) continue;
-
-    const categoryLabel = categoryName.trim();
-    const termUri = categoryLabel
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(/[^a-z0-9-]/g, '');
-
-    // Check if taxonomy term already exists
-    let existingTerm = await db._query.taxonomyTerms.findFirst({
-      where: eq(taxonomyTerms.termUri, termUri),
-    });
-
-    if (!existingTerm) {
-      // Create new taxonomy term
-      const [newTerm] = await db
-        .insert(taxonomyTerms)
-        .values({
-          taxonomyId: proposalTaxonomy.id,
-          termUri,
-          label: categoryLabel,
-          definition: `Category for ${categoryLabel} proposals`,
-        })
-        .returning();
-
-      if (!newTerm) {
-        throw new CommonError(
-          `Failed to create taxonomy term for category: ${categoryLabel}`,
-        );
-      }
-      existingTerm = newTerm;
-    }
-
-    if (existingTerm) {
-      taxonomyTermIds.push(existingTerm.id);
-    }
-  }
-
-  return taxonomyTermIds;
-}
 
 export interface CreateProcessInput {
   name: string;

--- a/packages/common/src/services/decision/ensureProposalTaxonomy.ts
+++ b/packages/common/src/services/decision/ensureProposalTaxonomy.ts
@@ -1,0 +1,80 @@
+import { db, eq } from '@op/db/client';
+import { taxonomies, taxonomyTerms } from '@op/db/schema';
+
+import { CommonError } from '../../utils';
+
+/**
+ * Ensures the "proposal" taxonomy exists and creates/updates taxonomy terms for the given categories
+ */
+export async function ensureProposalTaxonomy(
+  categories: string[],
+): Promise<string[]> {
+  if (!categories || categories.length === 0) {
+    return [];
+  }
+
+  // Ensure "proposal" taxonomy exists
+  let proposalTaxonomy = await db._query.taxonomies.findFirst({
+    where: eq(taxonomies.name, 'proposal'),
+  });
+
+  if (!proposalTaxonomy) {
+    const [newTaxonomy] = await db
+      .insert(taxonomies)
+      .values({
+        name: 'proposal',
+        description:
+          'Categories for organizing proposals in decision-making processes',
+      })
+      .returning();
+
+    if (!newTaxonomy) {
+      throw new CommonError('Failed to create proposal taxonomy');
+    }
+    proposalTaxonomy = newTaxonomy;
+  }
+
+  // Process each category
+  const taxonomyTermIds: string[] = [];
+
+  for (const categoryName of categories) {
+    if (!categoryName.trim()) continue;
+
+    const categoryLabel = categoryName.trim();
+    const termUri = categoryLabel
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9-]/g, '');
+
+    // Check if taxonomy term already exists
+    let existingTerm = await db._query.taxonomyTerms.findFirst({
+      where: eq(taxonomyTerms.termUri, termUri),
+    });
+
+    if (!existingTerm) {
+      // Create new taxonomy term
+      const [newTerm] = await db
+        .insert(taxonomyTerms)
+        .values({
+          taxonomyId: proposalTaxonomy.id,
+          termUri,
+          label: categoryLabel,
+          definition: `Category for ${categoryLabel} proposals`,
+        })
+        .returning();
+
+      if (!newTerm) {
+        throw new CommonError(
+          `Failed to create taxonomy term for category: ${categoryLabel}`,
+        );
+      }
+      existingTerm = newTerm;
+    }
+
+    if (existingTerm) {
+      taxonomyTermIds.push(existingTerm.id);
+    }
+  }
+
+  return taxonomyTermIds;
+}

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -5,6 +5,9 @@ export * from './getProcess';
 export * from './getTemplate';
 export * from './listProcesses';
 
+// Taxonomy utilities
+export * from './ensureProposalTaxonomy';
+
 // Instance management
 export * from './createInstanceFromTemplate';
 export * from './duplicateInstance';

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -15,6 +15,7 @@ import { getProfileAccessUser } from '../access';
 import { assertProfileAdmin } from '../assert';
 import { generateUniqueProfileSlug } from '../profile/utils';
 import { createTransitionsForProcess } from './createTransitionsForProcess';
+import { ensureProposalTaxonomy } from './ensureProposalTaxonomy';
 import { schemaValidator } from './schemaValidator';
 import type {
   DecisionInstanceData,
@@ -140,6 +141,11 @@ export const updateDecisionInstance = async ({
         ...existingInstanceData.config,
         ...config,
       };
+
+      // Ensure taxonomy terms exist for categories
+      if (config.categories && config.categories.length > 0) {
+        await ensureProposalTaxonomy(config.categories.map((c) => c.label));
+      }
     }
 
     // Apply phase updates — replaces the full phases array to accommodate

--- a/packages/common/src/services/decision/updateInstance.ts
+++ b/packages/common/src/services/decision/updateInstance.ts
@@ -3,89 +3,14 @@ import {
   ProcessStatus,
   decisionProcesses,
   processInstances,
-  taxonomies,
-  taxonomyTerms,
 } from '@op/db/schema';
 import { z } from 'zod';
 
 import { CommonError, NotFoundError, UnauthorizedError } from '../../utils';
 import { getCurrentProfileId } from '../access';
+import { ensureProposalTaxonomy } from './ensureProposalTaxonomy';
 import type { InstanceData } from './types';
 import { updateTransitionsForProcess } from './updateTransitionsForProcess';
-
-/**
- * Ensures the "proposal" taxonomy exists and creates/updates taxonomy terms for the given categories
- */
-async function ensureProposalTaxonomy(categories: string[]): Promise<string[]> {
-  if (!categories || categories.length === 0) {
-    return [];
-  }
-
-  // Ensure "proposal" taxonomy exists
-  let proposalTaxonomy = await db._query.taxonomies.findFirst({
-    where: eq(taxonomies.name, 'proposal'),
-  });
-
-  if (!proposalTaxonomy) {
-    const [newTaxonomy] = await db
-      .insert(taxonomies)
-      .values({
-        name: 'proposal',
-        description:
-          'Categories for organizing proposals in decision-making processes',
-      })
-      .returning();
-
-    if (!newTaxonomy) {
-      throw new CommonError('Failed to create proposal taxonomy');
-    }
-    proposalTaxonomy = newTaxonomy;
-  }
-
-  // Process each category
-  const taxonomyTermIds: string[] = [];
-
-  for (const categoryName of categories) {
-    if (!categoryName.trim()) continue;
-
-    const categoryLabel = categoryName.trim();
-    const termUri = categoryLabel
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(/[^a-z0-9-]/g, '');
-
-    // Check if taxonomy term already exists
-    let existingTerm = await db._query.taxonomyTerms.findFirst({
-      where: eq(taxonomyTerms.termUri, termUri),
-    });
-
-    if (!existingTerm) {
-      // Create new taxonomy term
-      const [newTerm] = await db
-        .insert(taxonomyTerms)
-        .values({
-          taxonomyId: proposalTaxonomy.id,
-          termUri,
-          label: categoryLabel,
-          definition: `Category for ${categoryLabel} proposals`,
-        })
-        .returning();
-
-      if (!newTerm) {
-        throw new CommonError(
-          `Failed to create taxonomy term for category: ${categoryLabel}`,
-        );
-      }
-      existingTerm = newTerm;
-    }
-
-    if (existingTerm) {
-      taxonomyTermIds.push(existingTerm.id);
-    }
-  }
-
-  return taxonomyTermIds;
-}
 
 export interface UpdateInstanceInput {
   instanceId: string;

--- a/packages/common/src/services/decision/updateProcess.ts
+++ b/packages/common/src/services/decision/updateProcess.ts
@@ -1,84 +1,11 @@
 import { db, eq } from '@op/db/client';
-import { decisionProcesses, taxonomies, taxonomyTerms } from '@op/db/schema';
+import { decisionProcesses } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 
 import { CommonError, NotFoundError, UnauthorizedError } from '../../utils';
 import { assertUserByAuthId } from '../assert';
+import { ensureProposalTaxonomy } from './ensureProposalTaxonomy';
 import type { ProcessSchema } from './types';
-
-/**
- * Ensures the "proposal" taxonomy exists and creates/updates taxonomy terms for the given categories
- */
-async function ensureProposalTaxonomy(categories: string[]): Promise<string[]> {
-  if (!categories || categories.length === 0) {
-    return [];
-  }
-
-  // Ensure "proposal" taxonomy exists
-  let proposalTaxonomy = await db._query.taxonomies.findFirst({
-    where: eq(taxonomies.name, 'proposal'),
-  });
-
-  if (!proposalTaxonomy) {
-    const [newTaxonomy] = await db
-      .insert(taxonomies)
-      .values({
-        name: 'proposal',
-        description:
-          'Categories for organizing proposals in decision-making processes',
-      })
-      .returning();
-
-    if (!newTaxonomy) {
-      throw new CommonError('Failed to create proposal taxonomy');
-    }
-    proposalTaxonomy = newTaxonomy;
-  }
-
-  // Process each category
-  const taxonomyTermIds: string[] = [];
-
-  for (const categoryName of categories) {
-    if (!categoryName.trim()) continue;
-
-    const categoryLabel = categoryName.trim();
-    const termUri = categoryLabel
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(/[^a-z0-9-]/g, '');
-
-    // Check if taxonomy term already exists
-    let existingTerm = await db._query.taxonomyTerms.findFirst({
-      where: eq(taxonomyTerms.termUri, termUri),
-    });
-
-    if (!existingTerm) {
-      // Create new taxonomy term
-      const [newTerm] = await db
-        .insert(taxonomyTerms)
-        .values({
-          taxonomyId: proposalTaxonomy.id,
-          termUri,
-          label: categoryLabel,
-          definition: `Category for ${categoryLabel} proposals`,
-        })
-        .returning();
-
-      if (!newTerm) {
-        throw new CommonError(
-          `Failed to create taxonomy term for category: ${categoryLabel}`,
-        );
-      }
-      existingTerm = newTerm;
-    }
-
-    if (existingTerm) {
-      taxonomyTermIds.push(existingTerm.id);
-    }
-  }
-
-  return taxonomyTermIds;
-}
 
 export interface UpdateProcessInput {
   name?: string;


### PR DESCRIPTION
## Summary

- Extracted `ensureProposalTaxonomy` from `updateInstance.ts` into a shared utility module so both save flows can reuse it.
- Called `ensureProposalTaxonomy` from `updateDecisionInstance` when `config.categories` changes, fixing the bug where taxonomy terms were never created via the new save path.
- This resolves empty category results from `getProcessCategories` and prevents category duplication on the proposals list.
