### PR TITLE
fix: centralize process builder autosave to prevent data loss

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
@@ -1,6 +1,8 @@
+import { ProcessStatus } from '@op/api/encoders';
 import { createClient } from '@op/api/serverClient';
 import { forbidden, notFound } from 'next/navigation';
 
+import { ProcessBuilderAutosaveProvider } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { ProcessBuilderContent } from '@/components/decisions/ProcessBuilder/ProcessBuilderContent';
 import { ProcessBuilderFooter } from '@/components/decisions/ProcessBuilder/ProcessBuilderFooter';
 import { ProcessBuilderHeader } from '@/components/decisions/ProcessBuilder/ProcessBuilderHeader';
@@ -45,34 +47,42 @@ const EditDecisionPage = async ({
     config: instanceData.config,
   };
 
+  const isDraft = processInstance.status === ProcessStatus.DRAFT;
+
   return (
     <ProcessBuilderShell>
-      <div className="bg-background relative flex h-dvh w-full flex-1 flex-col overflow-y-hidden">
-        <ProcessBuilderStoreInitializer
-          decisionProfileId={decisionProfile.id}
-          serverData={serverData}
-          isDraft={processInstance.status === 'draft'}
-        />
-        <ProcessBuilderHeader instanceId={instanceId} slug={slug} />
-        <div className="flex min-h-0 grow flex-col overflow-y-auto md:flex-row md:overflow-y-hidden">
-          <ProcessBuilderSidebar
+      <ProcessBuilderAutosaveProvider
+        decisionProfileId={decisionProfile.id}
+        instanceId={instanceId}
+        isDraft={isDraft}
+      >
+        <div className="bg-background relative flex h-dvh w-full flex-1 flex-col overflow-y-hidden">
+          <ProcessBuilderStoreInitializer
+            decisionProfileId={decisionProfile.id}
+            serverData={serverData}
+            isDraft={isDraft}
+          />
+          <ProcessBuilderHeader instanceId={instanceId} slug={slug} />
+          <div className="flex min-h-0 grow flex-col overflow-y-auto md:flex-row md:overflow-y-hidden">
+            <ProcessBuilderSidebar
+              instanceId={instanceId}
+              decisionProfileId={decisionProfile.id}
+            />
+            <main className="h-full grow overflow-y-auto">
+              <ProcessBuilderContent
+                decisionProfileId={decisionProfile.id}
+                instanceId={instanceId}
+                decisionName={decisionProfile.name}
+              />
+            </main>
+          </div>
+          <ProcessBuilderFooter
             instanceId={instanceId}
+            slug={slug}
             decisionProfileId={decisionProfile.id}
           />
-          <main className="h-full grow overflow-y-auto">
-            <ProcessBuilderContent
-              decisionProfileId={decisionProfile.id}
-              instanceId={instanceId}
-              decisionName={decisionProfile.name}
-            />
-          </main>
         </div>
-        <ProcessBuilderFooter
-          instanceId={instanceId}
-          slug={slug}
-          decisionProfileId={decisionProfile.id}
-        />
-      </div>
+      </ProcessBuilderAutosaveProvider>
     </ProcessBuilderShell>
   );
 };

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
@@ -34,7 +34,8 @@ const EditDecisionPage = async ({
 
   const { processInstance } = decisionProfile;
   const instanceId = processInstance.id;
-  const instanceData = processInstance.instanceData;
+  const instanceData =
+    processInstance.instanceData as ProcessBuilderInstanceData;
 
   // Seed the store with server data so validation works immediately.
   const serverData: ProcessBuilderInstanceData = {
@@ -42,10 +43,8 @@ const EditDecisionPage = async ({
     description: processInstance.description ?? undefined,
     stewardProfileId: processInstance.steward?.id,
     phases: instanceData.phases,
-    proposalTemplate:
-      instanceData.proposalTemplate as ProcessBuilderInstanceData['proposalTemplate'],
-    rubricTemplate:
-      instanceData.rubricTemplate as ProcessBuilderInstanceData['rubricTemplate'],
+    proposalTemplate: instanceData.proposalTemplate,
+    rubricTemplate: instanceData.rubricTemplate,
     config: instanceData.config,
   };
 

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
@@ -44,6 +44,8 @@ const EditDecisionPage = async ({
     phases: instanceData.phases,
     proposalTemplate:
       instanceData.proposalTemplate as ProcessBuilderInstanceData['proposalTemplate'],
+    rubricTemplate:
+      instanceData.rubricTemplate as ProcessBuilderInstanceData['rubricTemplate'],
     config: instanceData.config,
   };
 

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { trpc } from '@op/api/client';
+import { useDebouncedCallback } from '@op/hooks';
+import { toast } from '@op/ui/Toast';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
+
+import {
+  type ProcessBuilderInstanceData,
+  type SaveStatus,
+  useProcessBuilderStore,
+} from './stores/useProcessBuilderStore';
+
+const AUTOSAVE_DEBOUNCE_MS = 1000;
+
+interface AutosaveActions {
+  saveChanges: (data: Partial<ProcessBuilderInstanceData>) => void;
+  /** Flushes any pending debounced save. Returns a promise that resolves
+   *  when the in-flight mutation completes (or immediately if nothing pending). */
+  flushPendingChanges: () => Promise<void>;
+}
+
+interface AutosaveStatus {
+  status: SaveStatus;
+  savedAt?: Date;
+}
+
+const ActionsContext = createContext<AutosaveActions | null>(null);
+const StatusContext = createContext<AutosaveStatus>({ status: 'idle' });
+
+export function useProcessBuilderAutosave(): AutosaveActions & {
+  saveState: AutosaveStatus;
+} {
+  const actions = useContext(ActionsContext);
+  if (!actions) {
+    throw new Error(
+      'useProcessBuilderAutosave must be used within ProcessBuilderAutosaveProvider',
+    );
+  }
+  const saveState = useContext(StatusContext);
+  return { ...actions, saveState };
+}
+
+export function ProcessBuilderAutosaveProvider({
+  decisionProfileId,
+  instanceId,
+  isDraft,
+  children,
+}: {
+  decisionProfileId: string;
+  instanceId: string;
+  isDraft: boolean;
+  children: React.ReactNode;
+}) {
+  const utils = trpc.useUtils();
+  const setInstanceData = useProcessBuilderStore((s) => s.setInstanceData);
+  const setProposalTemplateSchema = useProcessBuilderStore(
+    (s) => s.setProposalTemplateSchema,
+  );
+  const setRubricTemplateSchema = useProcessBuilderStore(
+    (s) => s.setRubricTemplateSchema,
+  );
+  const setSaveStatus = useProcessBuilderStore((s) => s.setSaveStatus);
+  const markSaved = useProcessBuilderStore((s) => s.markSaved);
+  const saveState = useProcessBuilderStore((s) =>
+    s.getSaveState(decisionProfileId),
+  );
+
+  // Tracks the in-flight mutation promise so flushPendingChanges can await it.
+  const inflightRef = useRef<Promise<unknown> | null>(null);
+
+  // Accumulates only the fields that changed since the last debounce fired.
+  // This ensures saves are scoped — editing phases only sends phases, not
+  // the full snapshot — so concurrent editors on different sections don't
+  // overwrite each other.
+  const dirtyFieldsRef = useRef<Partial<ProcessBuilderInstanceData>>({});
+
+  const debouncedSaveRef = useRef<() => boolean>(null);
+  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
+    onSuccess: () => markSaved(decisionProfileId),
+    onError: (error) => {
+      setSaveStatus(decisionProfileId, 'error');
+      toast.error({
+        title: 'Failed to save changes',
+        message: error.message,
+      });
+    },
+    onSettled: () => {
+      inflightRef.current = null;
+      if (debouncedSaveRef.current?.()) {
+        return;
+      }
+      void utils.decision.getInstance.invalidate({ instanceId });
+    },
+  });
+
+  const debouncedSave = useDebouncedCallback(() => {
+    const payload = dirtyFieldsRef.current;
+    dirtyFieldsRef.current = {};
+
+    if (Object.keys(payload).length === 0) {
+      return;
+    }
+
+    if (isDraft) {
+      setSaveStatus(decisionProfileId, 'saving');
+
+      // Suppress unhandled rejection — errors are handled by the mutation's
+      // onError callback. The promise is stored so flushPendingChanges can await it.
+      inflightRef.current = updateInstance
+        .mutateAsync({
+          instanceId,
+          ...payload,
+        })
+        .catch(() => {});
+    } else {
+      // Published: data is already in the store (written immediately by
+      // saveChanges). Mark as saved for the UI indicator.
+      markSaved(decisionProfileId);
+    }
+  }, AUTOSAVE_DEBOUNCE_MS);
+  debouncedSaveRef.current = () => debouncedSave.isPending();
+
+  // Flush on provider unmount (page exit)
+  useEffect(() => {
+    return () => {
+      debouncedSave.flush();
+    };
+  }, [debouncedSave]);
+
+  const saveChanges = useCallback(
+    (data: Partial<ProcessBuilderInstanceData>) => {
+      // Write to the store immediately for responsive UI — survives
+      // navigation between sections even if the debounce hasn't fired.
+      const { proposalTemplate, rubricTemplate, ...rest } = data;
+
+      if (Object.keys(rest).length > 0) {
+        setInstanceData(decisionProfileId, rest);
+      }
+      if (proposalTemplate !== undefined) {
+        setProposalTemplateSchema(decisionProfileId, proposalTemplate);
+      }
+      if (rubricTemplate !== undefined) {
+        setRubricTemplateSchema(decisionProfileId, rubricTemplate);
+      }
+
+      // Accumulate dirty fields for the next debounced save
+      dirtyFieldsRef.current = { ...dirtyFieldsRef.current, ...data };
+
+      debouncedSave();
+    },
+    [
+      decisionProfileId,
+      setInstanceData,
+      setProposalTemplateSchema,
+      setRubricTemplateSchema,
+      debouncedSave,
+    ],
+  );
+
+  const flushPendingChanges = useCallback(async () => {
+    debouncedSave.flush();
+    if (inflightRef.current) {
+      try {
+        await inflightRef.current;
+      } catch {
+        // Error already handled by onError callback
+      }
+    }
+  }, [debouncedSave]);
+
+  const actions = useMemo<AutosaveActions>(
+    () => ({ saveChanges, flushPendingChanges }),
+    [saveChanges, flushPendingChanges],
+  );
+
+  return (
+    <ActionsContext.Provider value={actions}>
+      <StatusContext.Provider value={saveState}>
+        {children}
+      </StatusContext.Provider>
+    </ActionsContext.Provider>
+  );
+}

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
@@ -38,7 +38,7 @@ const ActionsContext = createContext<AutosaveActions | null>(null);
 const StatusContext = createContext<AutosaveStatus>({ status: 'idle' });
 
 export function useProcessBuilderAutosave(): AutosaveActions & {
-  saveState: AutosaveStatus;
+  autosaveStatus: AutosaveStatus;
 } {
   const actions = useContext(ActionsContext);
   if (!actions) {
@@ -46,8 +46,8 @@ export function useProcessBuilderAutosave(): AutosaveActions & {
       'useProcessBuilderAutosave must be used within ProcessBuilderAutosaveProvider',
     );
   }
-  const saveState = useContext(StatusContext);
-  return { ...actions, saveState };
+  const autosaveStatus = useContext(StatusContext);
+  return { ...actions, autosaveStatus };
 }
 
 export function ProcessBuilderAutosaveProvider({
@@ -72,7 +72,7 @@ export function ProcessBuilderAutosaveProvider({
   );
   const setSaveStatus = useProcessBuilderStore((s) => s.setSaveStatus);
   const markSaved = useProcessBuilderStore((s) => s.markSaved);
-  const saveState = useProcessBuilderStore((s) =>
+  const currentStatus = useProcessBuilderStore((s) =>
     s.getSaveState(decisionProfileId),
   );
 
@@ -125,7 +125,10 @@ export function ProcessBuilderAutosaveProvider({
         ...payload,
       });
       inflightRef.current = promise;
-      promise.catch(() => {});
+      promise.catch(() => {
+        // Handled by the mutation's onError callback (toast + status).
+        // This catch only prevents unhandled promise rejection warnings.
+      });
     } else {
       // Published: data is only in the store (localStorage) until the user
       // clicks "Update Process". Don't show a save indicator — it would be
@@ -199,7 +202,7 @@ export function ProcessBuilderAutosaveProvider({
 
   return (
     <ActionsContext.Provider value={actions}>
-      <StatusContext.Provider value={saveState}>
+      <StatusContext.Provider value={currentStatus}>
         {children}
       </StatusContext.Provider>
     </ActionsContext.Provider>

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
@@ -12,6 +12,8 @@ import {
   useRef,
 } from 'react';
 
+import { useTranslations } from '@/lib/i18n';
+
 import {
   type ProcessBuilderInstanceData,
   type SaveStatus,
@@ -22,9 +24,9 @@ const AUTOSAVE_DEBOUNCE_MS = 1000;
 
 interface AutosaveActions {
   saveChanges: (data: Partial<ProcessBuilderInstanceData>) => void;
-  /** Flushes any pending debounced save. Returns a promise that resolves
-   *  when the in-flight mutation completes (or immediately if nothing pending). */
-  flushPendingChanges: () => Promise<void>;
+  /** Flushes any pending debounced save. Returns true if all pending saves
+   *  completed successfully, false if a save failed (error already toasted). */
+  flushPendingChanges: () => Promise<boolean>;
 }
 
 interface AutosaveStatus {
@@ -59,6 +61,7 @@ export function ProcessBuilderAutosaveProvider({
   isDraft: boolean;
   children: React.ReactNode;
 }) {
+  const t = useTranslations();
   const utils = trpc.useUtils();
   const setInstanceData = useProcessBuilderStore((s) => s.setInstanceData);
   const setProposalTemplateSchema = useProcessBuilderStore(
@@ -88,7 +91,7 @@ export function ProcessBuilderAutosaveProvider({
     onError: (error) => {
       setSaveStatus(decisionProfileId, 'error');
       toast.error({
-        title: 'Failed to save changes',
+        title: t('Failed to save changes'),
         message: error.message,
       });
     },
@@ -112,18 +115,19 @@ export function ProcessBuilderAutosaveProvider({
     if (isDraft) {
       setSaveStatus(decisionProfileId, 'saving');
 
-      // Suppress unhandled rejection — errors are handled by the mutation's
-      // onError callback. The promise is stored so flushPendingChanges can await it.
-      inflightRef.current = updateInstance
-        .mutateAsync({
-          instanceId,
-          ...payload,
-        })
-        .catch(() => {});
+      // Store the raw promise so flushPendingChanges can detect failure.
+      // Suppress unhandled rejection separately — errors are surfaced by
+      // the mutation's onError callback (toast + status).
+      const promise = updateInstance.mutateAsync({
+        instanceId,
+        ...payload,
+      });
+      inflightRef.current = promise;
+      promise.catch(() => {});
     } else {
-      // Published: data is already in the store (written immediately by
-      // saveChanges). Mark as saved for the UI indicator.
-      markSaved(decisionProfileId);
+      // Published: data is only in the store (localStorage) until the user
+      // clicks "Update Process". Don't show a save indicator — it would be
+      // misleading since nothing has been persisted to the server yet.
     }
   }, AUTOSAVE_DEBOUNCE_MS);
   debouncedSaveRef.current = () => debouncedSave.isPending();
@@ -165,15 +169,17 @@ export function ProcessBuilderAutosaveProvider({
     ],
   );
 
-  const flushPendingChanges = useCallback(async () => {
+  const flushPendingChanges = useCallback(async (): Promise<boolean> => {
     debouncedSave.flush();
     if (inflightRef.current) {
       try {
         await inflightRef.current;
       } catch {
-        // Error already handled by onError callback
+        // Error already surfaced via onError toast — tell caller it failed
+        return false;
       }
     }
+    return true;
   }, [debouncedSave]);
 
   const actions = useMemo<AutosaveActions>(

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
@@ -81,8 +81,8 @@ export function ProcessBuilderAutosaveProvider({
 
   // Accumulates only the fields that changed since the last debounce fired.
   // This ensures saves are scoped — editing phases only sends phases, not
-  // the full snapshot — so concurrent editors on different sections don't
-  // overwrite each other.
+  // the full snapshot — so edits in one section don't overwrite changes
+  // the user made in another section.
   const dirtyFieldsRef = useRef<Partial<ProcessBuilderInstanceData>>({});
 
   const debouncedSaveRef = useRef<() => boolean>(null);
@@ -97,6 +97,8 @@ export function ProcessBuilderAutosaveProvider({
     },
     onSettled: () => {
       inflightRef.current = null;
+      // Another save is queued — let its onSettled invalidate instead,
+      // avoiding a stale refetch that could overwrite optimistic updates.
       if (debouncedSaveRef.current?.()) {
         return;
       }
@@ -155,8 +157,16 @@ export function ProcessBuilderAutosaveProvider({
         setRubricTemplateSchema(decisionProfileId, rubricTemplate);
       }
 
-      // Accumulate dirty fields for the next debounced save
-      dirtyFieldsRef.current = { ...dirtyFieldsRef.current, ...data };
+      // Accumulate dirty fields for the next debounced save.
+      // Deep-merge config so rapid cross-section edits don't overwrite
+      // each other's config sub-fields within the debounce window.
+      dirtyFieldsRef.current = {
+        ...dirtyFieldsRef.current,
+        ...data,
+        config: data.config
+          ? { ...dirtyFieldsRef.current.config, ...data.config }
+          : dirtyFieldsRef.current.config,
+      };
 
       debouncedSave();
     },

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -89,6 +89,10 @@ export const ProcessBuilderFooter = ({
     // before either launching or updating.
     const flushed = await flushPendingChanges();
     if (!flushed) {
+      toast.error({
+        title: t('Failed to save changes'),
+        message: t('Please try again in a moment'),
+      });
       return;
     }
 

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -12,6 +12,7 @@ import { LuLogOut } from 'react-icons/lu';
 import { Link, useTranslations } from '@/lib/i18n';
 
 import { LaunchProcessModal } from './LaunchProcessModal';
+import { useProcessBuilderAutosave } from './ProcessBuilderAutosaveContext';
 import { ProgressIndicator } from './components/ProgressIndicator';
 import { useProcessBuilderStore } from './stores/useProcessBuilderStore';
 import { useNavigationConfig } from './useNavigationConfig';
@@ -57,14 +58,18 @@ export const ProcessBuilderFooter = ({
   const storeData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
+  const clearInstance = useProcessBuilderStore((s) => s.clearInstance);
   const displayName =
     storeData?.name || decisionProfile?.name || t('New process');
 
+  const { flushPendingChanges } = useProcessBuilderAutosave();
   const utils = trpc.useUtils();
 
   const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
     onSuccess: async (data) => {
       toast.success({ message: t('Changes saved successfully') });
+      // Clear stale store data so the editor reseeds from fresh server data
+      clearInstance(decisionProfileId);
       await utils.decision.getDecisionBySlug.invalidate({ slug });
       if (data.slug !== slug) {
         await utils.decision.getDecisionBySlug.invalidate({ slug: data.slug });
@@ -79,10 +84,12 @@ export const ProcessBuilderFooter = ({
     },
   });
 
-  const handleLaunchOrSave = () => {
+  const handleLaunchOrSave = async () => {
     if (isDraft) {
       setIsLaunchModalOpen(true);
     } else {
+      // Flush any pending autosave before publishing
+      await flushPendingChanges();
       updateInstance.mutate({
         instanceId,
         name: storeData?.name || undefined,

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -85,11 +85,16 @@ export const ProcessBuilderFooter = ({
   });
 
   const handleLaunchOrSave = async () => {
+    // Flush any pending autosave so the latest edits are persisted
+    // before either launching or updating.
+    const flushed = await flushPendingChanges();
+    if (!flushed) {
+      return;
+    }
+
     if (isDraft) {
       setIsLaunchModalOpen(true);
     } else {
-      // Flush any pending autosave before publishing
-      await flushPendingChanges();
       updateInstance.mutate({
         instanceId,
         name: storeData?.name || undefined,

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -85,14 +85,12 @@ export const ProcessBuilderFooter = ({
   });
 
   const handleLaunchOrSave = async () => {
-    // Flush any pending autosave so the latest edits are persisted
-    // before either launching or updating.
+    // Flush any pending autosave so in-flight draft saves complete
+    // before launching or updating. For non-draft, this is a no-op
+    // but ensures a clean state.
     const flushed = await flushPendingChanges();
     if (!flushed) {
-      toast.error({
-        title: t('Failed to save changes'),
-        message: t('Please try again in a moment'),
-      });
+      // Error already toasted by the autosave context's onError callback.
       return;
     }
 

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
@@ -77,7 +77,7 @@ export function OverviewSectionForm({
   const instanceData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
-  const { saveChanges, saveState } = useProcessBuilderAutosave();
+  const { saveChanges, autosaveStatus } = useProcessBuilderAutosave();
 
   // Fetch the current user's profiles (individual + organizations)
   const { data: userProfiles } = trpc.account.getUserProfiles.useQuery();
@@ -168,8 +168,8 @@ export function OverviewSectionForm({
                   {t('Process Overview')}
                 </Header2>
                 <SaveStatusIndicator
-                  status={saveState.status}
-                  savedAt={saveState.savedAt}
+                  status={autosaveStatus.status}
+                  savedAt={autosaveStatus.savedAt}
                 />
               </div>
               <p className="mt-2 text-neutral-gray4">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
@@ -262,10 +262,10 @@ export function OverviewSectionForm({
                       isSelected={field.state.value}
                       onChange={(value) => {
                         field.handleChange(value);
-                        // Write to Zustand store immediately so the sidebar
+                        // Write to store immediately so the sidebar
                         // hides/shows "Proposal Categories" without waiting
                         // for the debounced save.
-                        setInstanceData(decisionProfileId, {
+                        saveChanges({
                           config: { organizeByCategories: value },
                         });
                       }}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { ProcessStatus } from '@op/api/encoders';
-import { useDebouncedCallback } from '@op/hooks';
 import { Header2 } from '@op/ui/Header';
 import { SelectItem } from '@op/ui/Select';
 import { useEffect, useRef } from 'react';
@@ -11,13 +9,12 @@ import { z } from 'zod';
 import { useTranslations } from '@/lib/i18n';
 import type { TranslateFn } from '@/lib/i18n';
 
+import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
 import { ToggleRow } from '@/components/decisions/ProcessBuilder/components/ToggleRow';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
 import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import { getFieldErrorMessage, useAppForm } from '@/components/form/utils';
-
-const AUTOSAVE_DEBOUNCE_MS = 1000;
 
 const createOverviewValidator = (t: TranslateFn) =>
   z.object({
@@ -74,42 +71,13 @@ export function OverviewSectionForm({
   decisionName,
 }: SectionProps) {
   const t = useTranslations();
-  const utils = trpc.useUtils();
 
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
-  const isDraft = instance.status === ProcessStatus.DRAFT;
 
-  // Store: used as a localStorage buffer for non-draft edits only
   const instanceData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
-  const setInstanceData = useProcessBuilderStore((s) => s.setInstanceData);
-  const saveState = useProcessBuilderStore((s) =>
-    s.getSaveState(decisionProfileId),
-  );
-  const setSaveStatus = useProcessBuilderStore((s) => s.setSaveStatus);
-  const markSaved = useProcessBuilderStore((s) => s.markSaved);
-
-  // Reset stale save status from previous sessions
-  useEffect(() => {
-    setSaveStatus(decisionProfileId, 'idle');
-  }, [decisionProfileId, setSaveStatus]);
-
-  // tRPC mutation with cache invalidation (matches phase editor pattern)
-  const debouncedSaveRef = useRef<() => boolean>(null);
-  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
-    onSuccess: () => markSaved(decisionProfileId),
-    onError: () => setSaveStatus(decisionProfileId, 'error'),
-    onSettled: () => {
-      // Skip invalidation if another debounced save is pending — that save's
-      // onSettled will reconcile. This prevents a stale refetch from overwriting
-      // optimistic cache updates made between the two saves.
-      if (debouncedSaveRef.current?.()) {
-        return;
-      }
-      void utils.decision.getInstance.invalidate({ instanceId });
-    },
-  });
+  const { saveChanges, saveState } = useProcessBuilderAutosave();
 
   // Fetch the current user's profiles (individual + organizations)
   const { data: userProfiles } = trpc.account.getUserProfiles.useQuery();
@@ -134,42 +102,20 @@ export function OverviewSectionForm({
   // Only the process owner can change the steward
   const isProcessOwner = userProfiles?.some((p) => p.id === instance.owner?.id);
 
-  // Debounced save: draft persists to API; non-draft only buffers locally.
-  const debouncedSave = useDebouncedCallback((values: OverviewFormData) => {
-    setSaveStatus(decisionProfileId, 'saving');
-
-    // Always buffer in the store so the UI reflects the latest values.
-    // For non-draft this also persists to localStorage as an offline buffer.
-    setInstanceData(decisionProfileId, {
+  const handleValuesChange = (values: OverviewFormData) => {
+    saveChanges({
       name: values.name,
       description: values.description,
-      stewardProfileId: values.stewardProfileId,
+      stewardProfileId: isProcessOwner
+        ? values.stewardProfileId || undefined
+        : undefined,
       config: {
         organizeByCategories: values.organizeByCategories,
         requireCollaborativeProposals: values.requireCollaborativeProposals,
         isPrivate: values.isPrivate,
       },
     });
-
-    if (isDraft) {
-      updateInstance.mutate({
-        instanceId,
-        name: values.name,
-        description: values.description,
-        stewardProfileId: isProcessOwner
-          ? values.stewardProfileId || undefined
-          : undefined,
-        config: {
-          organizeByCategories: values.organizeByCategories,
-          requireCollaborativeProposals: values.requireCollaborativeProposals,
-          isPrivate: values.isPrivate,
-        },
-      });
-    } else {
-      markSaved(decisionProfileId);
-    }
-  }, AUTOSAVE_DEBOUNCE_MS);
-  debouncedSaveRef.current = () => debouncedSave.isPending();
+  };
 
   // Prefer store (localStorage buffer) over API data — the store is written
   // synchronously on every save, so it's always the freshest source.
@@ -208,7 +154,7 @@ export function OverviewSectionForm({
           children={(values) => (
             <FormValueWatcher
               values={values as OverviewFormData}
-              onValuesChange={debouncedSave}
+              onValuesChange={handleValuesChange}
             />
           )}
         />

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -70,7 +70,8 @@ function PhaseDetailForm({
   const storePhases = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId]?.phases,
   );
-  const { saveChanges, saveState } = useProcessBuilderAutosave();
+  const { saveChanges, saveState, flushPendingChanges } =
+    useProcessBuilderAutosave();
 
   // Resolve the initial phase data (same priority as PhasesSectionContent)
   const allPhases: PhaseDefinition[] = (() => {
@@ -154,10 +155,13 @@ function PhaseDetailForm({
 
   // Delete phase
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const confirmDelete = () => {
+  const confirmDelete = async () => {
     const remainingPhases = allPhases.filter((p) => p.id !== phaseId);
     saveChanges({ phases: toPayload(remainingPhases) });
-    onDelete();
+    const flushed = await flushPendingChanges();
+    if (flushed) {
+      onDelete();
+    }
   };
 
   // Validation

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -3,7 +3,6 @@
 import { parseAbsoluteToLocal, toCalendarDate } from '@internationalized/date';
 import { trpc } from '@op/api/client';
 import type { PhaseDefinition, PhaseRules } from '@op/api/encoders';
-import { useDebouncedCallback } from '@op/hooks';
 import { Button } from '@op/ui/Button';
 import { DatePicker } from '@op/ui/DatePicker';
 import { Header2 } from '@op/ui/Header';
@@ -18,13 +17,12 @@ import { useTranslations } from '@/lib/i18n';
 
 import { RichTextEditorWithToolbar } from '@/components/RichTextEditor/RichTextEditorWithToolbar';
 
+import { useProcessBuilderAutosave } from '../../ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '../../components/SaveStatusIndicator';
 import { ToggleRow } from '../../components/ToggleRow';
 import type { SectionProps } from '../../contentRegistry';
 import { isPhaseSection, sectionIdToPhaseId } from '../../navigationConfig';
 import { useProcessBuilderStore } from '../../stores/useProcessBuilderStore';
-
-const AUTOSAVE_DEBOUNCE_MS = 1000;
 
 export function PhaseDetailPage({
   instanceId,
@@ -68,17 +66,11 @@ function PhaseDetailForm({
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   const instancePhases = instance.instanceData?.phases;
   const templatePhases = instance.process?.processSchema?.phases;
-  const isDraft = instance.status === 'draft';
 
   const storePhases = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId]?.phases,
   );
-  const setInstanceData = useProcessBuilderStore((s) => s.setInstanceData);
-  const setSaveStatus = useProcessBuilderStore((s) => s.setSaveStatus);
-  const markSaved = useProcessBuilderStore((s) => s.markSaved);
-  const saveState = useProcessBuilderStore((s) =>
-    s.getSaveState(decisionProfileId),
-  );
+  const { saveChanges, saveState } = useProcessBuilderAutosave();
 
   // Resolve the initial phase data (same priority as PhasesSectionContent)
   const allPhases: PhaseDefinition[] = (() => {
@@ -108,49 +100,17 @@ function PhaseDetailForm({
   const allPhasesRef = useRef(allPhases);
   allPhasesRef.current = allPhases;
 
-  const utils = trpc.useUtils();
-  const debouncedSaveRef = useRef<() => boolean>(null);
-  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
-    onSuccess: () => markSaved(decisionProfileId),
-    onError: () => setSaveStatus(decisionProfileId, 'error'),
-    onSettled: () => {
-      if (debouncedSaveRef.current?.()) {
-        return;
-      }
-      void utils.decision.getInstance.invalidate({ instanceId });
-    },
-  });
-
-  const debouncedSave = useDebouncedCallback(
-    (updatedPhase: PhaseDefinition) => {
-      setSaveStatus(decisionProfileId, 'saving');
-
-      // Build the full phases array with this phase updated
-      const phasesPayload = allPhasesRef.current.map((p) => {
-        const source = p.id === phaseId ? updatedPhase : p;
-        return {
-          phaseId: source.id,
-          name: source.name,
-          description: source.description,
-          headline: source.headline,
-          additionalInfo: source.additionalInfo,
-          startDate: source.startDate,
-          endDate: source.endDate,
-          rules: source.rules,
-        };
-      });
-
-      setInstanceData(decisionProfileId, { phases: phasesPayload });
-
-      if (isDraft) {
-        updateInstance.mutate({ instanceId, phases: phasesPayload });
-      } else {
-        markSaved(decisionProfileId);
-      }
-    },
-    AUTOSAVE_DEBOUNCE_MS,
-  );
-  debouncedSaveRef.current = () => debouncedSave.isPending();
+  const toPayload = (phases: PhaseDefinition[]) =>
+    phases.map((p) => ({
+      phaseId: p.id,
+      name: p.name,
+      description: p.description,
+      headline: p.headline,
+      additionalInfo: p.additionalInfo,
+      startDate: p.startDate,
+      endDate: p.endDate,
+      rules: p.rules,
+    }));
 
   const updatePhase = (updates: Partial<PhaseDefinition>) => {
     setPhase((prev) => {
@@ -158,7 +118,10 @@ function PhaseDetailForm({
         return prev;
       }
       const updated = { ...prev, ...updates };
-      debouncedSave(updated);
+      const phasesPayload = toPayload(
+        allPhasesRef.current.map((p) => (p.id === phaseId ? updated : p)),
+      );
+      saveChanges({ phases: phasesPayload });
       return updated;
     });
   };
@@ -169,56 +132,14 @@ function PhaseDetailForm({
     }
     const newRules = { ...phase.rules, ...updates };
     updatePhase({ rules: newRules });
-
-    // Optimistically update getInstance cache so useNavigationConfig reacts
-    utils.decision.getInstance.setData({ instanceId }, (old) => {
-      if (!old?.instanceData?.phases) {
-        return old;
-      }
-      return {
-        ...old,
-        instanceData: {
-          ...old.instanceData,
-          phases: old.instanceData.phases.map((p) =>
-            p.phaseId === phaseId ? { ...p, rules: newRules } : p,
-          ),
-        },
-      };
-    });
   };
 
   // Delete phase
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const confirmDelete = () => {
-    setSaveStatus(decisionProfileId, 'saving');
-    const remainingPhases = allPhases
-      .filter((p) => p.id !== phaseId)
-      .map((p) => ({
-        phaseId: p.id,
-        name: p.name,
-        description: p.description,
-        headline: p.headline,
-        additionalInfo: p.additionalInfo,
-        startDate: p.startDate,
-        endDate: p.endDate,
-        rules: p.rules,
-      }));
-
-    setInstanceData(decisionProfileId, { phases: remainingPhases });
-
-    if (isDraft) {
-      updateInstance.mutate(
-        { instanceId, phases: remainingPhases },
-        {
-          onSuccess: () => {
-            onDelete();
-          },
-        },
-      );
-    } else {
-      markSaved(decisionProfileId);
-      onDelete();
-    }
+    const remainingPhases = allPhases.filter((p) => p.id !== phaseId);
+    saveChanges({ phases: toPayload(remainingPhases) });
+    onDelete();
   };
 
   // Validation

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -126,12 +126,30 @@ function PhaseDetailForm({
     });
   };
 
+  const utils = trpc.useUtils();
   const updateRules = (updates: Partial<PhaseRules>) => {
     if (!phase) {
       return;
     }
     const newRules = { ...phase.rules, ...updates };
     updatePhase({ rules: newRules });
+
+    // Optimistically update getInstance cache so useNavigationConfig
+    // reacts immediately (e.g., showing/hiding the Reviews sidebar section).
+    utils.decision.getInstance.setData({ instanceId }, (old) => {
+      if (!old?.instanceData?.phases) {
+        return old;
+      }
+      return {
+        ...old,
+        instanceData: {
+          ...old.instanceData,
+          phases: old.instanceData.phases.map((p) =>
+            p.phaseId === phaseId ? { ...p, rules: newRules } : p,
+          ),
+        },
+      };
+    });
   };
 
   // Delete phase

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -51,6 +51,18 @@ export function PhaseDetailPage({
   );
 }
 
+const toPayload = (phases: PhaseDefinition[]) =>
+  phases.map((p) => ({
+    phaseId: p.id,
+    name: p.name,
+    description: p.description,
+    headline: p.headline,
+    additionalInfo: p.additionalInfo,
+    startDate: p.startDate,
+    endDate: p.endDate,
+    rules: p.rules,
+  }));
+
 function PhaseDetailForm({
   instanceId,
   decisionProfileId,
@@ -70,7 +82,7 @@ function PhaseDetailForm({
   const storePhases = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId]?.phases,
   );
-  const { saveChanges, saveState, flushPendingChanges } =
+  const { saveChanges, autosaveStatus, flushPendingChanges } =
     useProcessBuilderAutosave();
 
   // Resolve the initial phase data (same priority as PhasesSectionContent)
@@ -100,18 +112,6 @@ function PhaseDetailForm({
 
   const allPhasesRef = useRef(allPhases);
   allPhasesRef.current = allPhases;
-
-  const toPayload = (phases: PhaseDefinition[]) =>
-    phases.map((p) => ({
-      phaseId: p.id,
-      name: p.name,
-      description: p.description,
-      headline: p.headline,
-      additionalInfo: p.additionalInfo,
-      startDate: p.startDate,
-      endDate: p.endDate,
-      rules: p.rules,
-    }));
 
   const updatePhase = (updates: Partial<PhaseDefinition>) => {
     setPhase((prev) => {
@@ -243,8 +243,8 @@ function PhaseDetailForm({
           </Header2>
         </div>
         <SaveStatusIndicator
-          status={saveState.status}
-          savedAt={saveState.savedAt}
+          status={autosaveStatus.status}
+          savedAt={autosaveStatus.savedAt}
         />
       </div>
 

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -161,6 +161,10 @@ function PhaseDetailForm({
     const flushed = await flushPendingChanges();
     if (flushed) {
       onDelete();
+    } else {
+      // Revert the optimistic removal so store matches server
+      saveChanges({ phases: toPayload(allPhases) });
+      setShowDeleteModal(false);
     }
   };
 

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
@@ -31,7 +31,7 @@ export function PhasesSectionContent({
   const storePhases = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId]?.phases,
   );
-  const { saveChanges, saveState } = useProcessBuilderAutosave();
+  const { saveChanges, autosaveStatus } = useProcessBuilderAutosave();
 
   const initialPhases: PhaseDefinition[] = (() => {
     const source = storePhases?.length ? storePhases : instancePhases;
@@ -122,8 +122,8 @@ export function PhasesSectionContent({
       <div className="flex items-center justify-between">
         <Header2 className="font-serif text-title-sm">{t('Phases')}</Header2>
         <SaveStatusIndicator
-          status={saveState.status}
-          savedAt={saveState.savedAt}
+          status={autosaveStatus.status}
+          savedAt={autosaveStatus.savedAt}
         />
       </div>
       <p className="text-neutral-charcoal">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { type PhaseDefinition, ProcessStatus } from '@op/api/encoders';
-import { useDebouncedCallback } from '@op/hooks';
+import type { PhaseDefinition } from '@op/api/encoders';
 import { Button } from '@op/ui/Button';
 import { Header2 } from '@op/ui/Header';
 import { IconButton } from '@op/ui/IconButton';
@@ -10,17 +9,16 @@ import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
 import { DragHandle, Sortable } from '@op/ui/Sortable';
 import { cn } from '@op/ui/utils';
 import { useQueryState } from 'nuqs';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { LuCheck, LuPlus, LuTrash2 } from 'react-icons/lu';
 
 import { type TranslateFn, useTranslations } from '@/lib/i18n';
 
+import { useProcessBuilderAutosave } from '../../ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '../../components/SaveStatusIndicator';
 import type { SectionProps } from '../../contentRegistry';
 import { phaseToSectionId } from '../../navigationConfig';
 import { useProcessBuilderStore } from '../../stores/useProcessBuilderStore';
-
-const AUTOSAVE_DEBOUNCE_MS = 1000;
 
 export function PhasesSectionContent({
   instanceId,
@@ -29,21 +27,14 @@ export function PhasesSectionContent({
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   const instancePhases = instance.instanceData?.phases;
   const templatePhases = instance.process?.processSchema?.phases;
-  const isDraft = instance.status === ProcessStatus.DRAFT;
 
   const storePhases = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId]?.phases,
   );
-  const setInstanceData = useProcessBuilderStore((s) => s.setInstanceData);
-  const setSaveStatus = useProcessBuilderStore((s) => s.setSaveStatus);
-  const markSaved = useProcessBuilderStore((s) => s.markSaved);
-  const saveState = useProcessBuilderStore((s) =>
-    s.getSaveState(decisionProfileId),
-  );
+  const { saveChanges, saveState } = useProcessBuilderAutosave();
 
   const initialPhases: PhaseDefinition[] = (() => {
-    const source =
-      !isDraft && storePhases?.length ? storePhases : instancePhases;
+    const source = storePhases?.length ? storePhases : instancePhases;
     return (
       source?.map((p) => ({
         id: p.phaseId,
@@ -64,19 +55,6 @@ export function PhasesSectionContent({
   const [, setSectionParam] = useQueryState('section', { history: 'push' });
   const setSection = (sectionId: string) => setSectionParam(sectionId);
 
-  const utils = trpc.useUtils();
-  const debouncedSaveRef = useRef<() => boolean>(null);
-  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
-    onSuccess: () => markSaved(decisionProfileId),
-    onError: () => setSaveStatus(decisionProfileId, 'error'),
-    onSettled: () => {
-      if (debouncedSaveRef.current?.()) {
-        return;
-      }
-      void utils.decision.getInstance.invalidate({ instanceId });
-    },
-  });
-
   const toPayload = (data: PhaseDefinition[]) =>
     data.map((phase) => ({
       phaseId: phase.id,
@@ -89,19 +67,9 @@ export function PhasesSectionContent({
       rules: phase.rules,
     }));
 
-  const debouncedSave = useDebouncedCallback((data: PhaseDefinition[]) => {
-    setSaveStatus(decisionProfileId, 'saving');
-
-    const phasesPayload = toPayload(data);
-    setInstanceData(decisionProfileId, { phases: phasesPayload });
-
-    if (isDraft) {
-      updateInstance.mutate({ instanceId, phases: phasesPayload });
-    } else {
-      markSaved(decisionProfileId);
-    }
-  }, AUTOSAVE_DEBOUNCE_MS);
-  debouncedSaveRef.current = () => debouncedSave.isPending();
+  const savePhasesPayload = (data: PhaseDefinition[]) => {
+    saveChanges({ phases: toPayload(data) });
+  };
 
   const updatePhases = (
     updater:
@@ -110,7 +78,7 @@ export function PhasesSectionContent({
   ) => {
     setPhases((prev) => {
       const updated = typeof updater === 'function' ? updater(prev) : updater;
-      debouncedSave(updated);
+      savePhasesPayload(updated);
       return updated;
     });
   };
@@ -123,9 +91,7 @@ export function PhasesSectionContent({
     };
     const updated = [...phases, newPhase];
     setPhases(updated);
-    // Immediately update store so navigation sees the new phase
-    setInstanceData(decisionProfileId, { phases: toPayload(updated) });
-    debouncedSave(updated);
+    savePhasesPayload(updated);
     setSection(phaseToSectionId(newPhase.id));
   };
 
@@ -137,9 +103,7 @@ export function PhasesSectionContent({
     }
     const updated = phases.filter((p) => p.id !== phaseToDelete);
     setPhases(updated);
-    // Immediately update store so navigation reflects the removal
-    setInstanceData(decisionProfileId, { phases: toPayload(updated) });
-    debouncedSave(updated);
+    savePhasesPayload(updated);
     setPhaseToDelete(null);
   };
 

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
@@ -40,7 +40,7 @@ export function ProposalCategoriesSectionContent({
   const storeData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
-  const { saveChanges, saveState } = useProcessBuilderAutosave();
+  const { saveChanges, autosaveStatus } = useProcessBuilderAutosave();
 
   // Local state — immediate source of truth for UI
   // Seed from store (localStorage) first, then fall back to server data
@@ -162,8 +162,8 @@ export function ProposalCategoriesSectionContent({
             {t('Proposal Categories')}
           </Header2>
           <SaveStatusIndicator
-            status={saveState.status}
-            savedAt={saveState.savedAt}
+            status={autosaveStatus.status}
+            savedAt={autosaveStatus.savedAt}
           />
         </div>
         <p className="text-neutral-gray4">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from '@/lib/i18n';
 
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
+import type { ProcessBuilderInstanceData } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import { ensureLockedFields } from '@/components/decisions/proposalTemplate';
 
@@ -61,27 +62,25 @@ export function ProposalCategoriesSectionContent({
   // Also syncs the proposalTemplate so that the category field and required
   // array stay consistent with the config.
   const updateConfig = (update: Partial<CategoryConfig>) => {
-    setConfig((prev) => {
-      const updated = { ...prev, ...update };
+    const updated = { ...config, ...update };
+    setConfig(updated);
 
-      const existingTemplate =
-        storeData?.proposalTemplate ?? instance.instanceData.proposalTemplate;
+    const existingTemplate =
+      storeData?.proposalTemplate ?? instance.instanceData.proposalTemplate;
 
-      const payload: Record<string, unknown> = { config: updated };
+    const payload: Partial<ProcessBuilderInstanceData> = { config: updated };
 
-      if (existingTemplate) {
-        payload.proposalTemplate = ensureLockedFields(existingTemplate, {
-          titleLabel: t('Proposal title'),
-          categoryLabel: t('Category'),
-          categories: updated.categories,
-          allowMultipleCategories: updated.allowMultipleCategories,
-          requireCategorySelection: updated.requireCategorySelection,
-        });
-      }
+    if (existingTemplate) {
+      payload.proposalTemplate = ensureLockedFields(existingTemplate, {
+        titleLabel: t('Proposal title'),
+        categoryLabel: t('Category'),
+        categories: updated.categories,
+        allowMultipleCategories: updated.allowMultipleCategories,
+        requireCategorySelection: updated.requireCategorySelection,
+      });
+    }
 
-      saveChanges(payload);
-      return updated;
-    });
+    saveChanges(payload);
   };
 
   // Ephemeral form UI state

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
@@ -1,24 +1,22 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { ProcessStatus } from '@op/api/encoders';
 import type { ProposalCategory } from '@op/common';
-import { useDebouncedCallback } from '@op/hooks';
 import { Button } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header2, Header3 } from '@op/ui/Header';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { LuLeaf, LuPencil, LuPlus, LuTrash2 } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
+import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
 import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import { ensureLockedFields } from '@/components/decisions/proposalTemplate';
 
-const AUTOSAVE_DEBOUNCE_MS = 1000;
 const CATEGORY_TITLE_MAX_LENGTH = 50;
 
 interface CategoryConfig {
@@ -32,22 +30,15 @@ export function ProposalCategoriesSectionContent({
   instanceId,
 }: SectionProps) {
   const t = useTranslations();
-  const utils = trpc.useUtils();
 
   // Fetch server data for seeding
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
-  const isDraft = instance.status === ProcessStatus.DRAFT;
   const serverConfig = instance.instanceData?.config;
 
   const storeData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
-  const setInstanceData = useProcessBuilderStore((s) => s.setInstanceData);
-  const setProposalTemplateSchema = useProcessBuilderStore(
-    (s) => s.setProposalTemplateSchema,
-  );
-  const setSaveStatus = useProcessBuilderStore((s) => s.setSaveStatus);
-  const markSaved = useProcessBuilderStore((s) => s.markSaved);
+  const { saveChanges } = useProcessBuilderAutosave();
 
   // Local state — immediate source of truth for UI
   // Seed from store (localStorage) first, then fall back to server data
@@ -66,63 +57,29 @@ export function ProposalCategoriesSectionContent({
   const { categories, requireCategorySelection, allowMultipleCategories } =
     config;
 
-  // tRPC mutation with cache invalidation (matches phase editor pattern)
-  const debouncedSaveRef = useRef<() => boolean>(null);
-  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
-    onSuccess: () => markSaved(decisionProfileId),
-    onError: () => setSaveStatus(decisionProfileId, 'error'),
-    onSettled: () => {
-      // Skip invalidation if another debounced save is pending — that save's
-      // onSettled will reconcile. This prevents a stale refetch from overwriting
-      // optimistic cache updates made between the two saves.
-      if (debouncedSaveRef.current?.()) {
-        return;
-      }
-      void utils.decision.getInstance.invalidate({ instanceId });
-    },
-  });
-
-  // Debounced auto-save: draft persists to API, non-draft only buffers locally.
+  // Update local state and save via centralized autosave.
   // Also syncs the proposalTemplate so that the category field and required
-  // array stay consistent with the config — even if the template editor is
-  // not currently mounted.
-  const debouncedSave = useDebouncedCallback((data: CategoryConfig) => {
-    setSaveStatus(decisionProfileId, 'saving');
-    setInstanceData(decisionProfileId, { config: data });
-
-    const existingTemplate =
-      storeData?.proposalTemplate ?? instance.instanceData.proposalTemplate;
-
-    const mutation: Parameters<typeof updateInstance.mutate>[0] = {
-      instanceId,
-      config: data,
-    };
-
-    if (existingTemplate) {
-      const syncedTemplate = ensureLockedFields(existingTemplate, {
-        titleLabel: t('Proposal title'),
-        categoryLabel: t('Category'),
-        categories: data.categories,
-        allowMultipleCategories: data.allowMultipleCategories,
-        requireCategorySelection: data.requireCategorySelection,
-      });
-      mutation.proposalTemplate = syncedTemplate;
-      setProposalTemplateSchema(decisionProfileId, syncedTemplate);
-    }
-
-    if (isDraft) {
-      updateInstance.mutate(mutation);
-    } else {
-      markSaved(decisionProfileId);
-    }
-  }, AUTOSAVE_DEBOUNCE_MS);
-  debouncedSaveRef.current = () => debouncedSave.isPending();
-
-  // Update local state and trigger debounced save
+  // array stay consistent with the config.
   const updateConfig = (update: Partial<CategoryConfig>) => {
     setConfig((prev) => {
       const updated = { ...prev, ...update };
-      debouncedSave(updated);
+
+      const existingTemplate =
+        storeData?.proposalTemplate ?? instance.instanceData.proposalTemplate;
+
+      const payload: Record<string, unknown> = { config: updated };
+
+      if (existingTemplate) {
+        payload.proposalTemplate = ensureLockedFields(existingTemplate, {
+          titleLabel: t('Proposal title'),
+          categoryLabel: t('Category'),
+          categories: updated.categories,
+          allowMultipleCategories: updated.allowMultipleCategories,
+          requireCategorySelection: updated.requireCategorySelection,
+        });
+      }
+
+      saveChanges(payload);
       return updated;
     });
   };

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
@@ -13,6 +13,7 @@ import { LuLeaf, LuPencil, LuPlus, LuTrash2 } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
+import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
 import type { ProcessBuilderInstanceData } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
@@ -39,7 +40,7 @@ export function ProposalCategoriesSectionContent({
   const storeData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
-  const { saveChanges } = useProcessBuilderAutosave();
+  const { saveChanges, saveState } = useProcessBuilderAutosave();
 
   // Local state — immediate source of truth for UI
   // Seed from store (localStorage) first, then fall back to server data
@@ -156,9 +157,15 @@ export function ProposalCategoriesSectionContent({
   return (
     <div className="mx-auto w-full space-y-6 p-4 [scrollbar-gutter:stable] md:max-w-160 md:p-8">
       <div className="space-y-2">
-        <Header2 className="font-serif text-title-sm">
-          {t('Proposal Categories')}
-        </Header2>
+        <div className="flex items-center justify-between">
+          <Header2 className="font-serif text-title-sm">
+            {t('Proposal Categories')}
+          </Header2>
+          <SaveStatusIndicator
+            status={saveState.status}
+            savedAt={saveState.savedAt}
+          />
+        </div>
         <p className="text-neutral-gray4">
           {t(
             'Define the categories that proposals in this process should advance. Proposers will select which categories their proposal supports.',

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
@@ -1,23 +1,20 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { ProcessStatus } from '@op/api/encoders';
 import type { ReviewsPolicy } from '@op/common';
-import { useDebouncedCallback } from '@op/hooks';
 import { Chip } from '@op/ui/Chip';
 import { Header2, Header3 } from '@op/ui/Header';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { ToggleButton } from '@op/ui/ToggleButton';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
+import { useProcessBuilderAutosave } from '../../ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '../../components/SaveStatusIndicator';
 import { ToggleRow } from '../../components/ToggleRow';
 import type { SectionProps } from '../../contentRegistry';
 import { useProcessBuilderStore } from '../../stores/useProcessBuilderStore';
-
-const AUTOSAVE_DEBOUNCE_MS = 1000;
 
 interface ReviewSettings {
   reviewsPolicy: ReviewsPolicy;
@@ -30,25 +27,14 @@ export function ReviewSettingsContent({
   decisionProfileId,
 }: SectionProps) {
   const t = useTranslations();
-  const utils = trpc.useUtils();
 
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
-  const isDraft = instance.status === ProcessStatus.DRAFT;
   const config = instance.instanceData?.config;
 
   const instanceData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
-  const setInstanceData = useProcessBuilderStore((s) => s.setInstanceData);
-  const saveState = useProcessBuilderStore((s) =>
-    s.getSaveState(decisionProfileId),
-  );
-  const setSaveStatus = useProcessBuilderStore((s) => s.setSaveStatus);
-  const markSaved = useProcessBuilderStore((s) => s.markSaved);
-
-  useEffect(() => {
-    setSaveStatus(decisionProfileId, 'idle');
-  }, [decisionProfileId, setSaveStatus]);
+  const { saveChanges, saveState } = useProcessBuilderAutosave();
 
   const [settings, setSettings] = useState<ReviewSettings>({
     reviewsPolicy:
@@ -65,43 +51,10 @@ export function ReviewSettingsContent({
       false,
   });
 
-  const debouncedSaveRef = useRef<() => boolean>(null);
-  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
-    onSuccess: () => markSaved(decisionProfileId),
-    onError: () => setSaveStatus(decisionProfileId, 'error'),
-    onSettled: () => {
-      if (debouncedSaveRef.current?.()) {
-        return;
-      }
-      void utils.decision.getInstance.invalidate({ instanceId });
-    },
-  });
-
-  const debouncedSave = useDebouncedCallback((updated: ReviewSettings) => {
-    setSaveStatus(decisionProfileId, 'saving');
-
-    setInstanceData(decisionProfileId, {
-      config: {
-        ...instanceData?.config,
-        ...updated,
-      },
-    });
-
-    if (isDraft) {
-      updateInstance.mutate({
-        instanceId,
-        config: updated,
-      });
-    } else {
-      markSaved(decisionProfileId);
-    }
-  }, AUTOSAVE_DEBOUNCE_MS);
-  debouncedSaveRef.current = () => debouncedSave.isPending();
-
   const updateSettings = (updates: Partial<ReviewSettings>) => {
     setSettings((prev) => {
       const updated = { ...prev, ...updates };
-      debouncedSave(updated);
+      saveChanges({ config: updated });
       return updated;
     });
   };

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
@@ -34,7 +34,7 @@ export function ReviewSettingsContent({
   const instanceData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
-  const { saveChanges, saveState } = useProcessBuilderAutosave();
+  const { saveChanges, autosaveStatus } = useProcessBuilderAutosave();
 
   const [settings, setSettings] = useState<ReviewSettings>({
     reviewsPolicy:
@@ -64,8 +64,8 @@ export function ReviewSettingsContent({
       <div className="flex items-center justify-between">
         <Header2 className="font-serif text-title-base">{t('Reviews')}</Header2>
         <SaveStatusIndicator
-          status={saveState.status}
-          savedAt={saveState.savedAt}
+          status={autosaveStatus.status}
+          savedAt={autosaveStatus.savedAt}
         />
       </div>
 

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { ProcessStatus } from '@op/api/encoders';
 import type { RubricTemplateSchema } from '@op/common/client';
-import { useDebouncedCallback } from '@op/hooks';
 import { Accordion, AccordionItem } from '@op/ui/Accordion';
 import { Button } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
@@ -13,15 +11,14 @@ import { Sortable } from '@op/ui/Sortable';
 import { cn } from '@op/ui/utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LuLeaf, LuPlus } from 'react-icons/lu';
-import { useShallow } from 'zustand/react/shallow';
 
 import { useTranslations } from '@/lib/i18n';
 import type { TranslationKey } from '@/lib/i18n/routing';
 
 import { ConfirmDeleteModal } from '@/components/ConfirmDeleteModal';
+import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
-import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import type {
   CriterionView,
   RubricCriterionType,
@@ -50,18 +47,11 @@ import {
 } from './RubricCriterionCard';
 import { RubricParticipantPreview } from './RubricParticipantPreview';
 
-const AUTOSAVE_DEBOUNCE_MS = 1000;
-
-export function RubricEditorContent({
-  decisionProfileId,
-  instanceId,
-}: SectionProps) {
+export function RubricEditorContent({ instanceId }: SectionProps) {
   const t = useTranslations();
 
   // Load instance data from the backend
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
-  const isDraft = instance.status === ProcessStatus.DRAFT;
-  const utils = trpc.useUtils();
   const instanceData = instance.instanceData;
 
   const initialTemplate = useMemo(() => {
@@ -94,28 +84,7 @@ export function RubricEditorContent({
     Map<string, { maximum: number; oneOf: { const: number; title: string }[] }>
   >(new Map());
 
-  const { setRubricTemplateSchema, setSaveStatus, markSaved, getSaveState } =
-    useProcessBuilderStore(
-      useShallow((s) => ({
-        setRubricTemplateSchema: s.setRubricTemplateSchema,
-        setSaveStatus: s.setSaveStatus,
-        markSaved: s.markSaved,
-        getSaveState: s.getSaveState,
-      })),
-    );
-  const saveState = getSaveState(decisionProfileId);
-
-  const debouncedSaveRef = useRef<() => boolean>(null);
-  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
-    onSuccess: () => markSaved(decisionProfileId),
-    onError: () => setSaveStatus(decisionProfileId, 'error'),
-    onSettled: () => {
-      if (debouncedSaveRef.current?.()) {
-        return;
-      }
-      void utils.decision.getInstance.invalidate({ instanceId });
-    },
-  });
+  const { saveChanges, saveState } = useProcessBuilderAutosave();
 
   // Derive criterion views from the template
   const criteria = useMemo(() => getCriteria(template), [template]);
@@ -124,35 +93,14 @@ export function RubricEditorContent({
     [criteria],
   );
 
-  // TODO: Extract this debounced auto-save pattern into a shared useAutoSave() hook
-  // (same pattern is used in TemplateEditorContent and useProposalDraft)
-  const debouncedSave = useDebouncedCallback(
-    (updatedTemplate: RubricTemplateSchema) => {
-      setRubricTemplateSchema(decisionProfileId, updatedTemplate);
-
-      if (isDraft) {
-        updateInstance.mutate({
-          instanceId,
-          rubricTemplate: updatedTemplate,
-        });
-      } else {
-        markSaved(decisionProfileId);
-      }
-    },
-    AUTOSAVE_DEBOUNCE_MS,
-  );
-  debouncedSaveRef.current = () => debouncedSave.isPending();
-
-  // Trigger debounced save when template changes (skip initial load)
+  // Save rubric changes via the shared autosave context (skip initial load)
   useEffect(() => {
     if (isInitialLoadRef.current) {
       isInitialLoadRef.current = false;
       return;
     }
-
-    setSaveStatus(decisionProfileId, 'saving');
-    debouncedSave(template);
-  }, [template, decisionProfileId, setSaveStatus, debouncedSave]);
+    saveChanges({ rubricTemplate: template });
+  }, [template]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // --- Handlers ---
 

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -19,6 +19,7 @@ import { ConfirmDeleteModal } from '@/components/ConfirmDeleteModal';
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
+import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import type {
   CriterionView,
   RubricCriterionType,
@@ -47,20 +48,27 @@ import {
 } from './RubricCriterionCard';
 import { RubricParticipantPreview } from './RubricParticipantPreview';
 
-export function RubricEditorContent({ instanceId }: SectionProps) {
+export function RubricEditorContent({
+  instanceId,
+  decisionProfileId,
+}: SectionProps) {
   const t = useTranslations();
+
+  const storeRubricTemplate = useProcessBuilderStore(
+    (s) => s.instances[decisionProfileId]?.rubricTemplate,
+  );
 
   // Load instance data from the backend
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   const instanceData = instance.instanceData;
 
   const initialTemplate = useMemo(() => {
-    const saved = instanceData?.rubricTemplate;
+    const saved = storeRubricTemplate ?? instanceData?.rubricTemplate;
     if (saved && Object.keys(saved.properties ?? {}).length > 0) {
       return saved as RubricTemplateSchema;
     }
     return createEmptyRubricTemplate();
-  }, [instanceData?.rubricTemplate]);
+  }, [storeRubricTemplate, instanceData?.rubricTemplate]);
 
   const [template, setTemplate] =
     useState<RubricTemplateSchema>(initialTemplate);

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -92,7 +92,7 @@ export function RubricEditorContent({
     Map<string, { maximum: number; oneOf: { const: number; title: string }[] }>
   >(new Map());
 
-  const { saveChanges, saveState } = useProcessBuilderAutosave();
+  const { saveChanges, autosaveStatus } = useProcessBuilderAutosave();
 
   // Derive criterion views from the template
   const criteria = useMemo(() => getCriteria(template), [template]);
@@ -108,7 +108,7 @@ export function RubricEditorContent({
       return;
     }
     saveChanges({ rubricTemplate: template });
-  }, [template]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [template]);
 
   // --- Handlers ---
 
@@ -230,8 +230,8 @@ export function RubricEditorContent({
               {t('Review Criteria')}
             </Header2>
             <SaveStatusIndicator
-              status={saveState.status}
-              savedAt={saveState.savedAt}
+              status={autosaveStatus.status}
+              savedAt={autosaveStatus.savedAt}
             />
           </div>
 

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { ProcessStatus } from '@op/api/encoders';
 import { SYSTEM_FIELD_KEYS } from '@op/common/client';
 import type {
   ProposalTemplateSchema,
   XFormatPropertySchema,
 } from '@op/common/client';
-import { useDebouncedCallback, useMediaQuery } from '@op/hooks';
+import { useMediaQuery } from '@op/hooks';
 import { screens } from '@op/styles/constants';
 import { Button } from '@op/ui/Button';
 import { CollapsibleConfigCard } from '@op/ui/CollapsibleConfigCard';
@@ -21,6 +20,7 @@ import { LuAlignLeft, LuChevronDown, LuHash } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 
 import { ConfirmDeleteModal } from '@/components/ConfirmDeleteModal';
+import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
 import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import {
@@ -55,8 +55,6 @@ import {
 } from './TemplateEditorSidebar';
 import { getFieldLabelKey } from './fieldRegistry';
 
-const AUTOSAVE_DEBOUNCE_MS = 1000;
-
 export function TemplateEditorContent({
   decisionProfileId,
   instanceId,
@@ -67,8 +65,6 @@ export function TemplateEditorContent({
 
   // Load instance data from the backend
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
-  const isDraft = instance.status === ProcessStatus.DRAFT;
-  const utils = trpc.useUtils();
   const instanceData = instance.instanceData;
 
   const storeData = useProcessBuilderStore(
@@ -112,7 +108,6 @@ export function TemplateEditorContent({
 
   const [template, setTemplate] =
     useState<ProposalTemplateSchema>(initialTemplate);
-  const isInitialLoadRef = useRef(true);
 
   // Track which fields are expanded — multiple can be open simultaneously
   const [expandedFieldIds, setExpandedFieldIds] = useState<Set<string>>(
@@ -155,26 +150,7 @@ export function TemplateEditorContent({
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const sidebarOpen = isMobile ? mobileSidebarOpen : true;
 
-  const setProposalTemplateSchema = useProcessBuilderStore(
-    (s) => s.setProposalTemplateSchema,
-  );
-  const setSaveStatus = useProcessBuilderStore((s) => s.setSaveStatus);
-  const markSaved = useProcessBuilderStore((s) => s.markSaved);
-
-  const debouncedSaveRef = useRef<() => boolean>(null);
-  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
-    onSuccess: () => markSaved(decisionProfileId),
-    onError: () => setSaveStatus(decisionProfileId, 'error'),
-    onSettled: () => {
-      // Skip invalidation if another debounced save is pending — that save's
-      // onSettled will reconcile. This prevents a stale refetch from overwriting
-      // optimistic cache updates made between the two saves.
-      if (debouncedSaveRef.current?.()) {
-        return;
-      }
-      void utils.decision.getInstance.invalidate({ instanceId });
-    },
-  });
+  const { saveChanges } = useProcessBuilderAutosave();
 
   // Derive field views from the template, excluding locked system fields
   // that are always rendered separately above the sortable list.
@@ -216,44 +192,25 @@ export function TemplateEditorContent({
     ];
   }, [fields, hasCategories]);
 
-  // Debounced auto-save: draft persists to API, non-draft only buffers locally.
+  // Save template changes via the shared autosave context.
   // Runs ensureLockedFields before persisting so that x-field-order and
-  // required are always consistent — individual mutators only need to
-  // touch properties.
-  const debouncedSave = useDebouncedCallback(
-    (updatedTemplate: ProposalTemplateSchema) => {
-      const normalized = ensureLockedFields(updatedTemplate, {
-        titleLabel: t('Proposal title'),
-        categoryLabel: t('Category'),
-        categories,
-        allowMultipleCategories,
-        requireCategorySelection,
-      });
-      setProposalTemplateSchema(decisionProfileId, normalized);
-
-      if (isDraft) {
-        updateInstance.mutate({
-          instanceId,
-          proposalTemplate: normalized,
-        });
-      } else {
-        markSaved(decisionProfileId);
-      }
-    },
-    AUTOSAVE_DEBOUNCE_MS,
-  );
-  debouncedSaveRef.current = () => debouncedSave.isPending();
-
-  // Trigger debounced save when template changes (skip initial load)
+  // required are always consistent.
+  const isInitialLoadRef = useRef(true);
   useEffect(() => {
     if (isInitialLoadRef.current) {
       isInitialLoadRef.current = false;
       return;
     }
 
-    setSaveStatus(decisionProfileId, 'saving');
-    debouncedSave(template);
-  }, [template, decisionProfileId, setSaveStatus, debouncedSave]);
+    const normalized = ensureLockedFields(template, {
+      titleLabel: t('Proposal title'),
+      categoryLabel: t('Category'),
+      categories,
+      allowMultipleCategories,
+      requireCategorySelection,
+    });
+    saveChanges({ proposalTemplate: normalized });
+  }, [template]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleAddField = useCallback(
     (type: FieldType) => {

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
@@ -152,7 +152,7 @@ export function TemplateEditorContent({
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const sidebarOpen = isMobile ? mobileSidebarOpen : true;
 
-  const { saveChanges, saveState } = useProcessBuilderAutosave();
+  const { saveChanges, autosaveStatus } = useProcessBuilderAutosave();
 
   // Derive field views from the template, excluding locked system fields
   // that are always rendered separately above the sortable list.
@@ -212,7 +212,7 @@ export function TemplateEditorContent({
       requireCategorySelection,
     });
     saveChanges({ proposalTemplate: normalized });
-  }, [template]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [template]);
 
   const handleAddField = useCallback(
     (type: FieldType) => {
@@ -394,8 +394,8 @@ export function TemplateEditorContent({
                 {t('Proposal template')}
               </Header2>
               <SaveStatusIndicator
-                status={saveState.status}
-                savedAt={saveState.savedAt}
+                status={autosaveStatus.status}
+                savedAt={autosaveStatus.savedAt}
               />
             </div>
             <p className="text-neutral-charcoal">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
@@ -84,7 +84,7 @@ export function TemplateEditorContent({
   const hasCategories = categories.length > 0;
 
   const initialTemplate = useMemo(() => {
-    const saved = instanceData?.proposalTemplate;
+    const saved = storeData?.proposalTemplate ?? instanceData?.proposalTemplate;
 
     const base =
       saved && Object.keys(saved.properties ?? {}).length > 0

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
@@ -21,6 +21,7 @@ import { useTranslations } from '@/lib/i18n';
 
 import { ConfirmDeleteModal } from '@/components/ConfirmDeleteModal';
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
+import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
 import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import {
@@ -100,6 +101,7 @@ export function TemplateEditorContent({
       requireCategorySelection,
     });
   }, [
+    storeData?.proposalTemplate,
     instanceData?.proposalTemplate,
     categories,
     allowMultipleCategories,
@@ -150,7 +152,7 @@ export function TemplateEditorContent({
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const sidebarOpen = isMobile ? mobileSidebarOpen : true;
 
-  const { saveChanges } = useProcessBuilderAutosave();
+  const { saveChanges, saveState } = useProcessBuilderAutosave();
 
   // Derive field views from the template, excluding locked system fields
   // that are always rendered separately above the sortable list.
@@ -387,9 +389,15 @@ export function TemplateEditorContent({
 
         <main className="flex-1 basis-1/2 overflow-y-auto p-4 pb-24 [scrollbar-gutter:stable] md:p-8 md:pb-8">
           <div className="mx-auto max-w-160 space-y-4">
-            <Header2 className="hidden font-serif text-title-sm md:block">
-              {t('Proposal template')}
-            </Header2>
+            <div className="hidden items-center justify-between md:flex">
+              <Header2 className="font-serif text-title-sm">
+                {t('Proposal template')}
+              </Header2>
+              <SaveStatusIndicator
+                status={saveState.status}
+                savedAt={saveState.savedAt}
+              />
+            </div>
             <p className="text-neutral-charcoal">
               <span className="hidden md:inline">
                 {t('Build your proposal using the tools on the left')}

--- a/apps/app/src/components/decisions/ProcessBuilder/useNavigationConfig.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/useNavigationConfig.ts
@@ -19,6 +19,10 @@ export function useNavigationConfig(
     { enabled: !!instanceId },
   );
 
+  const storePhases = useProcessBuilderStore((s) =>
+    decisionProfileId ? s.instances[decisionProfileId]?.phases : undefined,
+  );
+
   const reviewFlowEnabled = useFeatureFlag('review_flow');
   const storeOrganizeByCategories = useProcessBuilderStore((s) =>
     decisionProfileId
@@ -30,7 +34,7 @@ export function useNavigationConfig(
     instance?.instanceData?.config?.organizeByCategories ??
     true;
 
-  const phases = instance?.instanceData?.phases ?? [];
+  const phases = storePhases ?? instance?.instanceData?.phases ?? [];
   const hasReviewPhase = phases.some(
     (p) => p.rules?.proposals?.review === true,
   );

--- a/tests/e2e/tests/create-process-instance.spec.ts
+++ b/tests/e2e/tests/create-process-instance.spec.ts
@@ -96,7 +96,8 @@ test.describe('Create Process Instance', () => {
     // Open the first phase detail form
     await phaseConfigureButtons.first().click();
 
-    const nextButton = authenticatedPage.getByRole('button', { name: 'Next' });
+    const footer = authenticatedPage.getByRole('contentinfo');
+    const nextButton = footer.getByRole('button', { name: 'Next' }).first();
 
     for (let i = 0; i < phaseCount; i++) {
       // Wait for the phase detail form to load
@@ -178,6 +179,22 @@ test.describe('Create Process Instance', () => {
     await expect(
       authenticatedPage.getByText('Proposal template').first(),
     ).toBeVisible({ timeout: 12_000 });
+
+    // 10b. Add a custom field so the template passes validation (requires at
+    //       least 1 non-system field). Click "Add field" in the sidebar, then
+    //       pick "Short text" from the menu.
+    const addFieldButton = authenticatedPage.getByRole('button', {
+      name: 'Add field',
+    });
+    await expect(addFieldButton).toBeVisible({ timeout: 6_000 });
+    await addFieldButton.click();
+    await authenticatedPage
+      .getByRole('menuitem', { name: 'Short text' })
+      .click();
+
+    // Wait for the autosave to persist the new field
+    const templateFieldSaved = waitForAutoSave(authenticatedPage);
+    await templateFieldSaved;
 
     // 11. Expand the Budget card — budget is enabled by default in the template
     //     Use a regex to match "Budget Optional" or "Budget Required" while

--- a/tests/e2e/tests/edit-published-process.spec.ts
+++ b/tests/e2e/tests/edit-published-process.spec.ts
@@ -1,0 +1,182 @@
+import { createDecisionInstance, getSeededTemplate } from '@op/test';
+
+import { expect, test } from '../fixtures/index.js';
+
+test.use({ viewport: { width: 1440, height: 900 } });
+
+test.describe('Edit Published Process', () => {
+  test('enabling review on a phase shows Review Rubric and fields survive navigation', async ({
+    authenticatedPage,
+    org,
+  }) => {
+    test.setTimeout(120_000);
+
+    // 1. Create a published process (review NOT enabled on any phase)
+    const template = await getSeededTemplate();
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: template.processSchema,
+    });
+
+    // 2. Navigate to the process builder editor
+    await authenticatedPage.goto(`/en/decisions/${instance.slug}/edit`);
+
+    const sidebarNav = authenticatedPage.getByRole('navigation', {
+      name: 'Section navigation',
+    });
+
+    // 3. Wait for the editor to load
+    await expect(authenticatedPage.getByText('Process Overview')).toBeVisible({
+      timeout: 18_000,
+    });
+
+    // 4. Verify Review Rubric is NOT in the sidebar
+    await expect(
+      sidebarNav.getByRole('button', { name: 'Review Rubric' }),
+    ).not.toBeVisible();
+
+    // 5. Navigate to the Review & Shortlist phase and enable review
+    const reviewPhaseButton = sidebarNav.getByRole('button', {
+      name: 'Review & Shortlist',
+    });
+    await expect(reviewPhaseButton).toBeVisible({ timeout: 6_000 });
+    await reviewPhaseButton.click();
+
+    // Wait for phase detail to load
+    await expect(
+      authenticatedPage.getByText('Proposal review'),
+    ).toBeVisible({ timeout: 12_000 });
+
+    // Toggle "Proposal review" on
+    const reviewToggle = authenticatedPage
+      .getByText('Proposal review')
+      .locator('..')
+      .locator('..')
+      .getByRole('button');
+    await reviewToggle.click();
+
+    // 6. Verify Review Rubric now appears in the sidebar
+    const reviewRubricButton = sidebarNav.getByRole('button', {
+      name: 'Review Rubric',
+    });
+    await expect(reviewRubricButton).toBeVisible({ timeout: 6_000 });
+
+    // 7. Navigate to Review Rubric
+    await reviewRubricButton.click();
+
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Review Criteria' }),
+    ).toBeVisible({ timeout: 12_000 });
+
+    // 8. Add a rubric criterion
+    const addButton = authenticatedPage.getByRole('button', {
+      name: 'Add your first criterion',
+    });
+    await expect(addButton).toBeVisible({ timeout: 6_000 });
+    await addButton.click();
+
+    // 9. Verify the criterion was added
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'New criterion' }),
+    ).toBeVisible({ timeout: 6_000 });
+
+    // 10. Navigate away to Overview
+    const overviewButton = sidebarNav.getByRole('button', {
+      name: 'Overview',
+    });
+    await overviewButton.click();
+    await expect(authenticatedPage.getByText('Process Overview')).toBeVisible({
+      timeout: 12_000,
+    });
+
+    // 11. Verify Review Rubric is still in the sidebar
+    await expect(reviewRubricButton).toBeVisible({ timeout: 6_000 });
+
+    // 12. Navigate back to Review Rubric
+    await reviewRubricButton.click();
+    await expect(authenticatedPage.getByText('Review Criteria')).toBeVisible({
+      timeout: 12_000,
+    });
+
+    // 13. Verify the criterion is still there
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'New criterion' }),
+    ).toBeVisible({ timeout: 6_000 });
+  });
+
+  test('proposal template fields survive section navigation', async ({
+    authenticatedPage,
+    org,
+  }) => {
+    test.setTimeout(120_000);
+
+    // 1. Create a published process instance
+    const template = await getSeededTemplate();
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: template.processSchema,
+    });
+
+    // 2. Navigate to the process builder editor
+    await authenticatedPage.goto(`/en/decisions/${instance.slug}/edit`);
+
+    const sidebarNav = authenticatedPage.getByRole('navigation', {
+      name: 'Section navigation',
+    });
+
+    // 3. Wait for the editor to load
+    await expect(authenticatedPage.getByText('Process Overview')).toBeVisible({
+      timeout: 18_000,
+    });
+
+    // 4. Navigate to Proposal Template
+    const templateButton = sidebarNav.getByRole('button', {
+      name: 'Proposal Template',
+    });
+    await templateButton.click();
+    await expect(
+      authenticatedPage.getByText('Proposal template').first(),
+    ).toBeVisible({ timeout: 12_000 });
+
+    // 5. Add a custom field via the sidebar
+    const addFieldButton = authenticatedPage.getByRole('button', {
+      name: 'Add field',
+    });
+    await expect(addFieldButton).toBeVisible({ timeout: 6_000 });
+    await addFieldButton.click();
+    await authenticatedPage
+      .getByRole('menuitem', { name: 'Short text' })
+      .click();
+
+    // 6. Verify the field was added (card appears in the sortable list)
+    await expect(authenticatedPage.getByText('Short text').first()).toBeVisible(
+      { timeout: 6_000 },
+    );
+
+    // 7. Navigate away to Overview
+    const overviewButton = sidebarNav.getByRole('button', {
+      name: 'Overview',
+    });
+    await overviewButton.click();
+    await expect(authenticatedPage.getByText('Process Overview')).toBeVisible({
+      timeout: 12_000,
+    });
+
+    // 8. Navigate back to Proposal Template
+    await templateButton.click();
+    await expect(
+      authenticatedPage.getByText('Proposal template').first(),
+    ).toBeVisible({ timeout: 12_000 });
+
+    // 9. Verify the custom field is still there
+    await expect(authenticatedPage.getByText('Short text').first()).toBeVisible(
+      { timeout: 6_000 },
+    );
+  });
+});

--- a/tests/e2e/tests/edit-published-process.spec.ts
+++ b/tests/e2e/tests/edit-published-process.spec.ts
@@ -46,9 +46,9 @@ test.describe('Edit Published Process', () => {
     await reviewPhaseButton.click();
 
     // Wait for phase detail to load
-    await expect(
-      authenticatedPage.getByText('Proposal review'),
-    ).toBeVisible({ timeout: 12_000 });
+    await expect(authenticatedPage.getByText('Proposal review')).toBeVisible({
+      timeout: 12_000,
+    });
 
     // Toggle "Proposal review" on
     const reviewToggle = authenticatedPage


### PR DESCRIPTION
## Summary

- Centralizes process builder autosave into a shared `ProcessBuilderAutosaveProvider` — replaces duplicated per-section debounce/mutation/save-status logic across 7 components
- Store writes are immediate (survives navigation), API calls are debounced centrally
- Fixes rubric template fields lost when navigating between sections on published processes
- Fixes Review Rubric sidebar tab disappearing when clicked
- Flushes pending saves before launch/update; reverts store on phase delete failure
- Deep-merges `config` in dirty field accumulator to prevent cross-section data loss

## E2E tests

- `edit-published-process.spec.ts` (new): enables review on a phase → verifies sidebar tab persists → adds rubric criterion → navigates away and back → verifies data survived. Same pattern for proposal template fields.
- `create-process-instance.spec.ts` (fixed): scoped Next button selector, added template field to satisfy launch validation.