### PR TITLE
feat(api): add source/live version model for process builder

### DIFF
--- a/packages/common/src/services/decision/createInstanceFromTemplate.ts
+++ b/packages/common/src/services/decision/createInstanceFromTemplate.ts
@@ -67,6 +67,15 @@ export const createDecisionInstance = async ({
         name,
         description,
         instanceData,
+        sourceData: {
+          name,
+          description,
+          stewardProfileId,
+          phases: instanceData.phases,
+          proposalTemplate: instanceData.proposalTemplate,
+          rubricTemplate: instanceData.rubricTemplate,
+          config: instanceData.config,
+        },
         currentStateId: instanceData.currentPhaseId, // DB column is currentStateId but stores phaseId
         ownerProfileId,
         stewardProfileId,

--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -84,13 +84,14 @@ export const duplicateInstance = async ({
 
   assertAccess({ decisions: permission.ADMIN }, profileUser?.roles ?? []);
 
-  const sourceData = sourceInstance.instanceData as DecisionInstanceData | null;
-  if (!sourceData) {
+  const sourceInstanceData =
+    sourceInstance.instanceData as DecisionInstanceData | null;
+  if (!sourceInstanceData) {
     throw new CommonError('Source instance has no instance data');
   }
 
   // Build new instance data based on include flags
-  const newInstanceData = buildInstanceData(sourceData, include);
+  const newInstanceData = buildInstanceData(sourceInstanceData, include);
 
   // Delegate core creation (profile, instance, default roles, profile user)
   const profile = await createDecisionInstance({

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -10,6 +10,7 @@ export * from './createInstanceFromTemplate';
 export * from './duplicateInstance';
 export * from './updateInstance';
 export * from './updateDecisionInstance';
+export * from './promoteSourceToLive';
 export * from './listInstances';
 export * from './listLegacyInstances';
 export * from './getInstance';

--- a/packages/common/src/services/decision/promoteSourceToLive.ts
+++ b/packages/common/src/services/decision/promoteSourceToLive.ts
@@ -1,0 +1,252 @@
+import { OPURLConfig } from '@op/core';
+import { db, eq } from '@op/db/client';
+import {
+  ProcessStatus,
+  decisionProcessTransitions,
+  processInstances,
+  profiles,
+} from '@op/db/schema';
+import { Events, event } from '@op/events';
+import type { User } from '@op/supabase/lib';
+import { assertAccess, permission } from 'access-zones';
+
+import { CommonError, NotFoundError } from '../../utils';
+import { getProfileAccessUser } from '../access';
+import { generateUniqueProfileSlug } from '../profile/utils';
+import { createTransitionsForProcess } from './createTransitionsForProcess';
+import type { DecisionInstanceData } from './schemas/instanceData';
+import { updateTransitionsForProcess } from './updateTransitionsForProcess';
+
+interface SourceData {
+  name?: string;
+  description?: string;
+  stewardProfileId?: string;
+  phases?: Array<Record<string, unknown>>;
+  proposalTemplate?: Record<string, unknown>;
+  rubricTemplate?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+}
+
+/**
+ * Promotes sourceData to the live columns.
+ *
+ * This copies editor-controlled fields from `sourceData` to the live
+ * columns (`instanceData`, `name`, `description`, `stewardProfileId`)
+ * while preserving runtime fields in `instanceData` (currentPhaseId,
+ * stateData, fieldValues, etc.).
+ *
+ * When `status` is set to PUBLISHED (and was previously DRAFT), runs
+ * the full publish workflow: slug generation, transition creation,
+ * invite dispatch.
+ */
+export const promoteSourceToLive = async ({
+  instanceId,
+  status,
+  user,
+}: {
+  instanceId: string;
+  status?: ProcessStatus;
+  user: User;
+}) => {
+  const existingInstance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+
+  if (!existingInstance) {
+    throw new NotFoundError('Process instance not found');
+  }
+
+  const { profileId } = existingInstance;
+  if (!profileId) {
+    throw new CommonError(
+      'Decision instance does not have an associated profile',
+    );
+  }
+
+  const profileUser = await getProfileAccessUser({
+    user,
+    profileId,
+  });
+
+  assertAccess({ decisions: permission.ADMIN }, profileUser?.roles ?? []);
+
+  const source = existingInstance.sourceData as SourceData | null;
+  if (!source) {
+    throw new CommonError('No source data to promote');
+  }
+
+  // Reject promotion for terminal statuses
+  const currentStatus = existingInstance.status as ProcessStatus;
+  if (
+    currentStatus === ProcessStatus.COMPLETED ||
+    currentStatus === ProcessStatus.CANCELLED
+  ) {
+    throw new CommonError(
+      'Cannot promote source data for a completed or cancelled process',
+    );
+  }
+
+  // Build the live instanceData by merging source fields into existing,
+  // preserving runtime fields (currentPhaseId, stateData, fieldValues, etc.)
+  const existingInstanceData =
+    existingInstance.instanceData as DecisionInstanceData;
+  const updatedInstanceData: DecisionInstanceData = {
+    ...existingInstanceData,
+  };
+
+  if (source.config !== undefined) {
+    updatedInstanceData.config = {
+      ...existingInstanceData.config,
+      ...source.config,
+    };
+  }
+
+  if (source.phases && source.phases.length > 0) {
+    const existingPhaseMap = new Map(
+      existingInstanceData.phases.map((p) => [p.phaseId, p]),
+    );
+
+    updatedInstanceData.phases = source.phases.map((phase) => {
+      const phaseId = phase.phaseId as string;
+      const existing = existingPhaseMap.get(phaseId);
+      return {
+        ...existing,
+        ...phase,
+        phaseId,
+      };
+    });
+  }
+
+  if (source.proposalTemplate !== undefined) {
+    updatedInstanceData.proposalTemplate = source.proposalTemplate;
+  }
+
+  if (source.rubricTemplate !== undefined) {
+    updatedInstanceData.rubricTemplate = source.rubricTemplate;
+  }
+
+  // Build the update payload
+  const updateData: Record<string, unknown> = {
+    instanceData: updatedInstanceData,
+  };
+
+  if (source.name !== undefined) {
+    updateData.name = source.name;
+  }
+  if (source.description !== undefined) {
+    updateData.description = source.description;
+  }
+  if (source.stewardProfileId !== undefined) {
+    updateData.stewardProfileId = source.stewardProfileId;
+  }
+  if (status !== undefined) {
+    updateData.status = status;
+  }
+
+  const isBeingPublished =
+    status === ProcessStatus.PUBLISHED && currentStatus === ProcessStatus.DRAFT;
+
+  const hasPhaseChanges = source.phases && source.phases.length > 0;
+
+  await db.transaction(async (tx) => {
+    const [updatedInstance] = await tx
+      .update(processInstances)
+      .set(updateData)
+      .where(eq(processInstances.id, instanceId))
+      .returning();
+
+    if (!updatedInstance) {
+      throw new CommonError('Failed to promote source to live');
+    }
+
+    const finalStatus = status ?? currentStatus;
+
+    const profileUpdate: Record<string, string> = {};
+    if (source.name !== undefined) {
+      profileUpdate.name = source.name;
+    }
+    if (isBeingPublished) {
+      const instanceName = source.name ?? existingInstance.name;
+      profileUpdate.slug = await generateUniqueProfileSlug({
+        name: `decision-${instanceName}`,
+        db: tx,
+      });
+    }
+
+    if (Object.keys(profileUpdate).length > 0) {
+      await tx
+        .update(profiles)
+        .set(profileUpdate)
+        .where(eq(profiles.id, profileId));
+    }
+
+    if (finalStatus === ProcessStatus.DRAFT) {
+      await tx
+        .delete(decisionProcessTransitions)
+        .where(eq(decisionProcessTransitions.processInstanceId, instanceId));
+    } else if (isBeingPublished) {
+      await createTransitionsForProcess({
+        processInstance: updatedInstance,
+        tx,
+      });
+    } else if (hasPhaseChanges) {
+      await updateTransitionsForProcess({
+        processInstance: updatedInstance,
+        tx,
+      });
+    }
+  });
+
+  const profile = await db.query.profiles.findFirst({
+    where: { id: profileId },
+    with: {
+      processInstance: true,
+    },
+  });
+
+  if (!profile) {
+    throw new CommonError('Failed to fetch updated decision profile');
+  }
+
+  // When publishing a draft, send queued invite emails
+  if (isBeingPublished) {
+    const queuedInvites = await db.query.profileInvites.findMany({
+      where: {
+        profileId,
+        notifiedAt: { isNull: true },
+      },
+      with: {
+        profile: true,
+        inviter: true,
+      },
+    });
+
+    if (queuedInvites.length > 0) {
+      const baseUrl = OPURLConfig('APP').ENV_URL;
+
+      const invitations = queuedInvites.map((invite) => ({
+        email: invite.email,
+        inviterName: invite.inviter?.name || 'A team member',
+        profileName: invite.profile.name,
+        inviteUrl: profile.slug
+          ? `${baseUrl}/decisions/${profile.slug}/invite`
+          : baseUrl,
+        personalMessage: invite.message ?? undefined,
+      }));
+
+      const firstInvite = queuedInvites[0];
+      if (firstInvite) {
+        await event.send({
+          name: Events.profileInviteSent.name,
+          data: {
+            senderProfileId: firstInvite.invitedBy,
+            inviteIds: queuedInvites.map((inv) => inv.id),
+            invitations,
+          },
+        });
+      }
+    }
+  }
+
+  return profile;
+};

--- a/packages/common/src/services/decision/promoteSourceToLive.ts
+++ b/packages/common/src/services/decision/promoteSourceToLive.ts
@@ -103,7 +103,7 @@ export const promoteSourceToLive = async ({
 
   if (source.phases && source.phases.length > 0) {
     const existingPhaseMap = new Map(
-      existingInstanceData.phases.map((p) => [p.phaseId, p]),
+      (existingInstanceData.phases ?? []).map((p) => [p.phaseId, p]),
     );
 
     updatedInstanceData.phases = source.phases.map((phase) => {

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -196,34 +196,47 @@ export const updateDecisionInstance = async ({
   // description, stewardProfileId, phases, templates, config) used by
   // the process builder. This prepares for the source/live model where
   // the process builder will read/write only sourceData.
-  const existingSourceData =
-    (existingInstance.sourceData as Record<string, unknown>) ?? {};
-  const sourceDataUpdate: Record<string, unknown> = { ...existingSourceData };
-  if (name !== undefined) {
-    sourceDataUpdate.name = name;
-  }
-  if (description !== undefined) {
-    sourceDataUpdate.description = description;
-  }
-  if (stewardProfileId !== undefined) {
-    sourceDataUpdate.stewardProfileId = stewardProfileId;
-  }
-  if (config !== undefined) {
-    sourceDataUpdate.config = {
-      ...(existingSourceData.config as Record<string, unknown>),
-      ...config,
+  const hasSourceChanges =
+    name !== undefined ||
+    description !== undefined ||
+    stewardProfileId !== undefined ||
+    config !== undefined ||
+    (phases && phases.length > 0) ||
+    proposalTemplate !== undefined ||
+    rubricTemplate !== undefined;
+
+  if (hasSourceChanges) {
+    const existingSourceData =
+      (existingInstance.sourceData as Record<string, unknown>) ?? {};
+    const sourceDataUpdate: Record<string, unknown> = {
+      ...existingSourceData,
     };
+    if (name !== undefined) {
+      sourceDataUpdate.name = name;
+    }
+    if (description !== undefined) {
+      sourceDataUpdate.description = description;
+    }
+    if (stewardProfileId !== undefined) {
+      sourceDataUpdate.stewardProfileId = stewardProfileId;
+    }
+    if (config !== undefined) {
+      sourceDataUpdate.config = {
+        ...(existingSourceData.config as Record<string, unknown>),
+        ...config,
+      };
+    }
+    if (phases && phases.length > 0) {
+      sourceDataUpdate.phases = phases;
+    }
+    if (proposalTemplate !== undefined) {
+      sourceDataUpdate.proposalTemplate = proposalTemplate;
+    }
+    if (rubricTemplate !== undefined) {
+      sourceDataUpdate.rubricTemplate = rubricTemplate;
+    }
+    updateData.sourceData = sourceDataUpdate;
   }
-  if (phases && phases.length > 0) {
-    sourceDataUpdate.phases = phases;
-  }
-  if (proposalTemplate !== undefined) {
-    sourceDataUpdate.proposalTemplate = proposalTemplate;
-  }
-  if (rubricTemplate !== undefined) {
-    sourceDataUpdate.rubricTemplate = rubricTemplate;
-  }
-  updateData.sourceData = sourceDataUpdate;
 
   // Only update if there's something to update
   if (Object.keys(updateData).length === 0) {

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -191,6 +191,40 @@ export const updateDecisionInstance = async ({
     updateData.instanceData = updatedInstanceData;
   }
 
+  // Dual-write: also update sourceData so it stays in sync.
+  // sourceData stores the editor-controlled subset of fields (name,
+  // description, stewardProfileId, phases, templates, config) used by
+  // the process builder. This prepares for the source/live model where
+  // the process builder will read/write only sourceData.
+  const existingSourceData =
+    (existingInstance.sourceData as Record<string, unknown>) ?? {};
+  const sourceDataUpdate: Record<string, unknown> = { ...existingSourceData };
+  if (name !== undefined) {
+    sourceDataUpdate.name = name;
+  }
+  if (description !== undefined) {
+    sourceDataUpdate.description = description;
+  }
+  if (stewardProfileId !== undefined) {
+    sourceDataUpdate.stewardProfileId = stewardProfileId;
+  }
+  if (config !== undefined) {
+    sourceDataUpdate.config = {
+      ...(existingSourceData.config as Record<string, unknown>),
+      ...config,
+    };
+  }
+  if (phases && phases.length > 0) {
+    sourceDataUpdate.phases = phases;
+  }
+  if (proposalTemplate !== undefined) {
+    sourceDataUpdate.proposalTemplate = proposalTemplate;
+  }
+  if (rubricTemplate !== undefined) {
+    sourceDataUpdate.rubricTemplate = rubricTemplate;
+  }
+  updateData.sourceData = sourceDataUpdate;
+
   // Only update if there's something to update
   if (Object.keys(updateData).length === 0) {
     // Nothing to update, just return the existing profile

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -261,6 +261,19 @@ const decisionAccessEncoder = z.object({
 });
 export type DecisionAccess = z.infer<typeof decisionAccessEncoder>;
 
+/** Source data encoder — the editable version used by the process builder */
+export const sourceDataEncoder = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().nullish(),
+    stewardProfileId: z.string().uuid().optional(),
+    config: processConfigEncoder.optional(),
+    phases: z.array(instancePhaseDataEncoder).optional(),
+    proposalTemplate: jsonSchemaEncoder.optional(),
+    rubricTemplate: rubricTemplateEncoder.optional(),
+  })
+  .passthrough();
+
 /** Process instance encoder  */
 export const processInstanceWithSchemaEncoder = createSelectSchema(
   processInstances,
@@ -278,6 +291,7 @@ export const processInstanceWithSchemaEncoder = createSelectSchema(
   })
   .extend({
     instanceData: instanceDataWithSchemaEncoder,
+    sourceData: sourceDataEncoder.nullish(),
     process: decisionProcessWithSchemaEncoder.optional(),
     owner: baseProfileEncoder.optional(),
     steward: baseProfileEncoder.nullish(),

--- a/services/api/src/routers/decision/instances/index.ts
+++ b/services/api/src/routers/decision/instances/index.ts
@@ -8,6 +8,7 @@ import { getInstanceRouter, getLegacyInstanceRouter } from './getInstance';
 import { listDecisionProfilesRouter } from './listDecisionProfiles';
 import { listInstancesRouter } from './listInstances';
 import { listLegacyInstancesRouter } from './listLegacyInstances';
+import { promoteSourceToLiveRouter } from './promoteSourceToLive';
 import { updateDecisionInstanceRouter } from './updateDecisionInstance';
 import { updateInstanceRouter } from './updateInstance';
 
@@ -17,6 +18,7 @@ export const instancesRouter = mergeRouters(
   duplicateInstanceRouter,
   updateInstanceRouter,
   updateDecisionInstanceRouter,
+  promoteSourceToLiveRouter,
   listInstancesRouter,
   listLegacyInstancesRouter,
   getInstanceRouter,

--- a/services/api/src/routers/decision/instances/promoteSourceToLive.ts
+++ b/services/api/src/routers/decision/instances/promoteSourceToLive.ts
@@ -1,0 +1,31 @@
+import { Channels, promoteSourceToLive } from '@op/common';
+import { ProcessStatus } from '@op/db/schema';
+import { z } from 'zod';
+
+import { decisionProfileWithSchemaEncoder } from '../../../encoders/decision';
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const promoteSourceToLiveRouter = router({
+  promoteSourceToLive: commonAuthedProcedure()
+    .input(
+      z.object({
+        instanceId: z.uuid(),
+        status: z.enum(ProcessStatus).optional(),
+      }),
+    )
+    .output(decisionProfileWithSchemaEncoder)
+    .mutation(async ({ ctx, input }) => {
+      const { user } = ctx;
+
+      const profile = await promoteSourceToLive({
+        ...input,
+        user,
+      });
+
+      ctx.registerMutationChannels([
+        Channels.decisionInstance(input.instanceId),
+      ]);
+
+      return decisionProfileWithSchemaEncoder.parse(profile);
+    }),
+});


### PR DESCRIPTION
## Summary

- `updateDecisionInstance` now dual-writes to `sourceData` alongside live columns
- New `promoteSourceToLive` mutation copies `sourceData` to live columns with full publish workflow (slug generation, transitions, invites)
- `sourceData` included in process instance encoder for frontend consumption
- `sourceData` populated on instance creation and duplication

## Context

Part 2 of the source/live version model (stacked on #917):
1. #917: Migration — add `sourceData` column + backfill
2. **This PR**: Backend — dual-write, `promoteSourceToLive`, query changes
3. PR 3: Frontend — read from `sourceData`, remove localStorage, always autosave to API

## Test plan

- [ ] Autosave writes populate `sourceData` alongside live columns (dual-write)
- [ ] `promoteSourceToLive` copies source to live and triggers publish workflow for DRAFT → PUBLISHED
- [ ] `promoteSourceToLive` updates transitions when phases change on already-published instances
- [ ] `promoteSourceToLive` rejects promotion for COMPLETED/CANCELLED instances
- [ ] New instances have `sourceData` populated
- [ ] Duplicated instances have `sourceData` populated
- [ ] `getInstance` / `getDecisionBySlug` return `sourceData` in response