### PR TITLE
chore: remove all eslint references from codebase

### DIFF
--- a/apps/app/src/components/LoginPanel.tsx
+++ b/apps/app/src/components/LoginPanel.tsx
@@ -280,7 +280,6 @@ export const LoginPanel = () => {
                             placeholder: 'admin@yourorganization.org',
                             spellCheck: false,
                           }}
-                          // eslint-disable-next-line jsx-a11y/no-autofocus
                           autoFocus
                           defaultValue={undefined}
                           isDisabled={
@@ -318,7 +317,6 @@ export const LoginPanel = () => {
                             spellCheck: false,
                           }}
                           fieldClassName="h-auto"
-                          // eslint-disable-next-line jsx-a11y/no-autofocus
                           autoFocus
                           defaultValue={undefined}
                           isDisabled={login.isFetching || !!combinedError}

--- a/apps/app/src/components/OTelBrowserProvider.tsx
+++ b/apps/app/src/components/OTelBrowserProvider.tsx
@@ -77,7 +77,6 @@ function initOTelBrowser() {
       }
     });
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.warn('[OTel] Failed to initialize browser tracing:', error);
   }
 }

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -714,7 +714,6 @@ export const ProposalsList = ({
       return;
     }
     updateURLParams({ filter: proposalFilter });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [proposalFilter]);
 
   // Handle export

--- a/apps/app/src/lib/i18n/routing.tsx
+++ b/apps/app/src/lib/i18n/routing.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
 import { cn } from '@op/ui/utils';
 import { useTranslations as _useTranslations } from 'next-intl';
 import { createNavigation } from 'next-intl/navigation';

--- a/apps/app/src/proxy.ts
+++ b/apps/app/src/proxy.ts
@@ -89,7 +89,6 @@ export async function proxy(request: NextRequest, event: NextFetchEvent) {
             request,
           });
           cookiesToSet.forEach(({ name, value, options }) =>
-            // eslint-disable-next-line ts/no-unsafe-argument
             supabaseResponse.cookies.set(name, value, options),
           );
         },

--- a/packages/analytics/src/testing.ts
+++ b/packages/analytics/src/testing.ts
@@ -14,8 +14,6 @@ export function PostHogClient() {
   };
 }
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 export async function trackEvent(_event: AnalyticsEvent): Promise<void> {}
 
 export async function trackEventWithContext(

--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -159,7 +159,6 @@ function buildInstanceData(
     const config: ProcessConfig = {};
     for (const key of CATEGORY_KEYS) {
       if (source.config[key] !== undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (config as any)[key] = source.config[key];
       }
     }

--- a/packages/ui/src/components/ShaderBackground/SoftBlobs.tsx
+++ b/packages/ui/src/components/ShaderBackground/SoftBlobs.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-/* eslint-disable react/no-unknown-property */
 import { Loader } from '@react-three/drei';
 import { Canvas, RootState, useFrame, useThree } from '@react-three/fiber';
 import React, {

--- a/scripts/migrationsCheck.ts
+++ b/scripts/migrationsCheck.ts
@@ -5,7 +5,6 @@ try {
   const output = execSync('git diff --cached --name-status').toString();
 
   // Check for modifications or deletions of .sql files in the migrations directory
-  // eslint-disable-next-line regexp/no-unused-capturing-group
   if (/^(D|M)\s+services\/db\/migrations\/.*\.sql$/m.test(output)) {
     console.error(
       'Error: You cannot remove or modify SQL migration files in the "services/db/migrations" directory.',

--- a/scripts/visualize-deps.mjs
+++ b/scripts/visualize-deps.mjs
@@ -36,7 +36,7 @@ function parseDotGraph(dotString) {
   const taskMap = {}; // Stores node objects keyed by ID
   const internalDependencies = new Set(); // Keep track of nodes that are targeted by links
 
-  // Regular expression to match edge definitions (e.g., "@op/core" -> "@op/eslint-config";)
+  // Regular expression to match edge definitions (e.g., "@op/core" -> "@op/ui";)
   const edgeRegex = /^\s*"([^"]+)"\s*->\s*"([^"]+)"/;
   // Regex to match node definitions with labels (e.g., "ROOT" [label="ROOT"];)
   const nodeRegex = /^\s*"([^"]+)"\s*\[label="([^"]+)"\];$/;

--- a/services/api/src/TRPCProvider.tsx
+++ b/services/api/src/TRPCProvider.tsx
@@ -69,7 +69,6 @@ export function TRPCProvider({
 
   return (
     <SSRCookiesContext.Provider value={ssrCookies}>
-      {/* eslint-disable-next-line react/no-context-provider */}
       <trpc.Provider client={trpcClient} queryClient={queryClient}>
         <PersistQueryClientProvider
           client={queryClient}

--- a/services/api/src/links.ts
+++ b/services/api/src/links.ts
@@ -32,7 +32,6 @@ function getPostHogDistinctId(): string | null {
 
   try {
     // Dynamic import to avoid server-side issues with posthog-js
-    // eslint-disable-next-line ts/no-require-imports
     const posthog = require('posthog-js').default;
     if (posthog?.__loaded) {
       return posthog.get_distinct_id();

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ts/no-empty-object-type */
 import type { ChannelName } from '@op/common/realtime';
 import type { db } from '@op/db/client';
 import type { tables } from '@op/db/tables';

--- a/services/db/migrate.ts
+++ b/services/db/migrate.ts
@@ -1,4 +1,3 @@
-/* eslint-disable antfu/no-top-level-await */
 import { createServerClient } from '@supabase/ssr';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 

--- a/services/db/seed-test.ts
+++ b/services/db/seed-test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable antfu/no-top-level-await */
 import { createServerClient } from '@supabase/ssr';
 import dotenv from 'dotenv';
 import { reset } from 'drizzle-seed';

--- a/services/db/seed.ts
+++ b/services/db/seed.ts
@@ -1,4 +1,3 @@
-/* eslint-disable antfu/no-top-level-await */
 import { adminEmails } from '@op/core';
 import { createServerClient } from '@supabase/ssr';
 import type { User } from '@supabase/supabase-js';

--- a/services/supabase/package.json
+++ b/services/supabase/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "format:check": "prettier --log-level=warn --check \"**/*.{ts,tsx}\"",
     "typecheck": "tsgo --noEmit",
-    "typegen": "pnpm --dir ../.. exec supabase gen types --workdir=\"../..\" --lang=typescript --local --schema public > ./src/types.ts && pnpm eslint --fix ./src/types.ts"
+    "typegen": "pnpm --dir ../.. exec supabase gen types --workdir=\"../..\" --lang=typescript --local --schema public > ./src/types.ts"
   },
   "dependencies": {
     "@op/core": "workspace:*",

--- a/services/supabase/tsconfig.json
+++ b/services/supabase/tsconfig.json
@@ -21,8 +21,7 @@
     "./*.ts",
     "./*.tsx",
     "./*.js",
-    "./*.jsx",
-    ".eslintrc.js"
+    "./*.jsx"
   ],
   "exclude": ["node_modules", "dist"]
 }

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -199,7 +199,6 @@ export async function authenticateAsUser(
  */
 export const test = base.extend<TestFixtures, WorkerFixtures>({
   supabaseAdmin: [
-    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     async ({}, use) => {
       const client = createSupabaseAdminClient();
       await use(client);

--- a/tests/e2e/supabase-e2e.ts
+++ b/tests/e2e/supabase-e2e.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable no-template-curly-in-string */
-/* eslint-disable prefer-template */
 /**
  * Script to manage the e2e Supabase instance
  * This instance runs on port 56xxx, completely isolated from dev (54xxx) and test (55xxx)


### PR DESCRIPTION
ESLint is not used — quality is enforced via Prettier and TypeScript only. Removes all leftover eslint-disable comments, the eslint --fix step in supabase typegen, and a stale .eslintrc.js tsconfig include.