### PR TITLE
fix: use i18n-aware Link instead of direct next/link

### DIFF
--- a/apps/app/src/app/[locale]/start/layout.tsx
+++ b/apps/app/src/app/[locale]/start/layout.tsx
@@ -9,7 +9,10 @@ const StartLayout = ({ children }: { children: React.ReactNode }) => {
       <main className="relative flex size-full flex-col overflow-y-scroll p-4 md:p-8">
         <section className="sticky top-0 hidden lg:block">
           <div className="flex items-center gap-2">
-            <Link href="/" className="flex items-center gap-2 hover:no-underline">
+            <Link
+              href="/"
+              className="flex items-center gap-2 hover:no-underline"
+            >
               <CommonLogo />
             </Link>
           </div>

--- a/apps/app/src/app/[locale]/start/layout.tsx
+++ b/apps/app/src/app/[locale]/start/layout.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/i18n/routing';
 
 import { CommonLogo } from '@/components/CommonLogo';
 
@@ -9,7 +9,7 @@ const StartLayout = ({ children }: { children: React.ReactNode }) => {
       <main className="relative flex size-full flex-col overflow-y-scroll p-4 md:p-8">
         <section className="sticky top-0 hidden lg:block">
           <div className="flex items-center gap-2">
-            <Link href="/" className="flex items-center gap-2">
+            <Link href="/" className="flex items-center gap-2 hover:no-underline">
               <CommonLogo />
             </Link>
           </div>

--- a/apps/app/src/components/layout/split/FullScreenSplitMain.tsx
+++ b/apps/app/src/components/layout/split/FullScreenSplitMain.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/i18n/routing';
 
 import { CommonLogo } from '@/components/CommonLogo';
 
@@ -14,7 +14,7 @@ export const FullScreenSplitMain = ({
       <section className="sticky top-0 hidden lg:block">
         <div className="flex items-center gap-2">
           {logo ? (
-            <Link href="/" className="flex items-center gap-2">
+            <Link href="/" className="flex items-center gap-2 hover:no-underline">
               <CommonLogo />
             </Link>
           ) : null}

--- a/apps/app/src/components/layout/split/FullScreenSplitMain.tsx
+++ b/apps/app/src/components/layout/split/FullScreenSplitMain.tsx
@@ -14,7 +14,10 @@ export const FullScreenSplitMain = ({
       <section className="sticky top-0 hidden lg:block">
         <div className="flex items-center gap-2">
           {logo ? (
-            <Link href="/" className="flex items-center gap-2 hover:no-underline">
+            <Link
+              href="/"
+              className="flex items-center gap-2 hover:no-underline"
+            >
               <CommonLogo />
             </Link>
           ) : null}


### PR DESCRIPTION
Replaces direct next/link imports with the i18n routing Link so locale prefixing works correctly in the start layout and full-screen split layout.