### PR TITLE
feat(api): implement draft/live version model

### DIFF
--- a/packages/common/src/services/decision/createInstanceFromTemplate.ts
+++ b/packages/common/src/services/decision/createInstanceFromTemplate.ts
@@ -67,6 +67,12 @@ export const createDecisionInstance = async ({
         name,
         description,
         instanceData,
+        draftInstanceData: {
+          ...instanceData,
+          name,
+          description,
+          stewardProfileId,
+        },
         currentStateId: instanceData.phases[0]?.phaseId ?? null,
         ownerProfileId,
         stewardProfileId,

--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -84,13 +84,14 @@ export const duplicateInstance = async ({
 
   assertAccess({ decisions: permission.ADMIN }, profileUser?.roles ?? []);
 
-  const sourceData = sourceInstance.instanceData as DecisionInstanceData | null;
-  if (!sourceData) {
+  const sourceInstanceData =
+    sourceInstance.instanceData as DecisionInstanceData | null;
+  if (!sourceInstanceData) {
     throw new CommonError('Source instance has no instance data');
   }
 
   // Build new instance data based on include flags
-  const newInstanceData = buildInstanceData(sourceData, include);
+  const newInstanceData = buildInstanceData(sourceInstanceData, include);
 
   // Delegate core creation (profile, instance, default roles, profile user)
   const profile = await createDecisionInstance({

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -9,6 +9,8 @@ export * from './listProcesses';
 export * from './createInstanceFromTemplate';
 export * from './duplicateInstance';
 export * from './updateDecisionInstance';
+export * from './updateDraftInstanceData';
+export * from './publishDecisionInstance';
 export * from './listInstances';
 export * from './listLegacyInstances';
 export * from './getInstance';
@@ -89,7 +91,11 @@ export type {
   PhaseInstanceData,
   PhaseOverride,
 } from './schemas/instanceData';
-export { createInstanceDataFromTemplate } from './schemas/instanceData';
+export {
+  createInstanceDataFromTemplate,
+  draftInstanceDataSchema,
+  instanceDataSchema,
+} from './schemas/instanceData';
 export type {
   DecisionSchemaDefinition,
   PhaseDefinition,

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -88,14 +88,11 @@ export { schemaValidator } from './schemaValidator';
 export * from './types';
 export type {
   DecisionInstanceData,
+  DraftInstanceData,
   PhaseInstanceData,
   PhaseOverride,
 } from './schemas/instanceData';
-export {
-  createInstanceDataFromTemplate,
-  draftInstanceDataSchema,
-  instanceDataSchema,
-} from './schemas/instanceData';
+export { createInstanceDataFromTemplate } from './schemas/instanceData';
 export type {
   DecisionSchemaDefinition,
   PhaseDefinition,

--- a/packages/common/src/services/decision/publishDecisionInstance.ts
+++ b/packages/common/src/services/decision/publishDecisionInstance.ts
@@ -1,0 +1,224 @@
+import { OPURLConfig } from '@op/core';
+import { db, eq } from '@op/db/client';
+import {
+  ProcessStatus,
+  decisionProcessTransitions,
+  processInstances,
+  profiles,
+} from '@op/db/schema';
+import { Events, event } from '@op/events';
+import type { User } from '@op/supabase/lib';
+import { assertAccess, permission } from 'access-zones';
+
+import { CommonError, NotFoundError } from '../../utils';
+import { getProfileAccessUser } from '../access';
+import { generateUniqueProfileSlug } from '../profile/utils';
+import { createTransitionsForProcess } from './createTransitionsForProcess';
+import { draftInstanceDataSchema } from './schemas/instanceData';
+import { updateTransitionsForProcess } from './updateTransitionsForProcess';
+
+/**
+ * Promotes draftInstanceData to the live columns.
+ *
+ * Copies editor-controlled fields from `draftInstanceData` to the live columns
+ * (`instanceData`, `name`, `description`, `stewardProfileId`) while
+ * preserving runtime fields in `instanceData` (currentPhaseId, stateData,
+ * fieldValues, etc.).
+ *
+ * When `status` is set to PUBLISHED (and was previously DRAFT), runs the
+ * full publish workflow: slug generation, transition creation, invite
+ * dispatch.
+ */
+export const publishDecisionInstance = async ({
+  instanceId,
+  status,
+  user,
+}: {
+  instanceId: string;
+  status?: ProcessStatus;
+  user: User;
+}) => {
+  const existingInstance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+
+  if (!existingInstance) {
+    throw new NotFoundError('Process instance not found');
+  }
+
+  const { profileId } = existingInstance;
+  if (!profileId) {
+    throw new CommonError(
+      'Decision instance does not have an associated profile',
+    );
+  }
+
+  const profileUser = await getProfileAccessUser({
+    user,
+    profileId,
+  });
+
+  assertAccess({ decisions: permission.ADMIN }, profileUser?.roles ?? []);
+
+  const parsed = draftInstanceDataSchema.safeParse(
+    existingInstance.draftInstanceData,
+  );
+  if (!parsed.success) {
+    throw new CommonError('No draft instance data to publish');
+  }
+  const source = parsed.data as Record<string, unknown>;
+
+  const currentStatus = existingInstance.status as ProcessStatus;
+  if (
+    currentStatus === ProcessStatus.COMPLETED ||
+    currentStatus === ProcessStatus.CANCELLED
+  ) {
+    throw new CommonError(
+      'Cannot promote draft instance data for a completed or cancelled process',
+    );
+  }
+
+  // Copy draftInstanceData to instanceData wholesale. The draft contains
+  // the full instanceData shape — no merge needed. Extract instance-column
+  // fields (name, description, stewardProfileId) to their own columns.
+  const { name, description, stewardProfileId, ...instanceData } = source;
+
+  const updateData: Record<string, unknown> = {
+    instanceData,
+  };
+
+  if (name !== undefined) {
+    updateData.name = name;
+  }
+  if (description !== undefined) {
+    updateData.description = description;
+  }
+  if (stewardProfileId !== undefined) {
+    updateData.stewardProfileId = stewardProfileId;
+  }
+  if (status !== undefined) {
+    updateData.status = status;
+  }
+
+  const isBeingPublished =
+    status === ProcessStatus.PUBLISHED && currentStatus === ProcessStatus.DRAFT;
+
+  const hasPhaseChanges =
+    Array.isArray(instanceData.phases) && instanceData.phases.length > 0;
+
+  // Use a transaction for updating the instance and transitions together
+  await db.transaction(async (tx) => {
+    const [updatedInstance] = await tx
+      .update(processInstances)
+      .set(updateData)
+      .where(eq(processInstances.id, instanceId))
+      .returning();
+
+    if (!updatedInstance) {
+      throw new CommonError('Failed to promote draft to live');
+    }
+
+    const finalStatus = status ?? currentStatus;
+
+    // Build a single profile update for name sync and/or slug generation.
+    const profileUpdate: Record<string, string> = {};
+
+    // Keep the profile name in sync with the instance name.
+    if (typeof name === 'string') {
+      profileUpdate.name = name;
+    }
+
+    // Generate a permanent, name-based slug when publishing.
+    // Draft instances keep their original UUID slug so the URL stays stable
+    // while editing. Once published the slug is locked.
+    if (isBeingPublished) {
+      const instanceName =
+        typeof name === 'string' ? name : existingInstance.name;
+      profileUpdate.slug = await generateUniqueProfileSlug({
+        name: `decision-${instanceName}`,
+        db: tx,
+      });
+    }
+
+    if (Object.keys(profileUpdate).length > 0) {
+      await tx
+        .update(profiles)
+        .set(profileUpdate)
+        .where(eq(profiles.id, profileId));
+    }
+
+    // If status is DRAFT, remove all transitions
+    if (finalStatus === ProcessStatus.DRAFT) {
+      await tx
+        .delete(decisionProcessTransitions)
+        .where(eq(decisionProcessTransitions.processInstanceId, instanceId));
+    } else if (isBeingPublished) {
+      // When publishing a draft, create transitions for all date-based phases
+      await createTransitionsForProcess({
+        processInstance: updatedInstance,
+        tx,
+      });
+    } else if (hasPhaseChanges) {
+      // If phases were updated and already published, update the corresponding transitions
+      await updateTransitionsForProcess({
+        processInstance: updatedInstance,
+        tx,
+      });
+    }
+  });
+
+  // Fetch the profile with processInstance joined for the response
+  const profile = await db.query.profiles.findFirst({
+    where: { id: profileId },
+    with: { processInstance: true },
+  });
+
+  if (!profile) {
+    throw new CommonError('Failed to fetch updated decision profile');
+  }
+
+  // When publishing a draft, send queued invite emails for this
+  // process instance's profile
+  if (isBeingPublished) {
+    const queuedInvites = await db.query.profileInvites.findMany({
+      where: {
+        profileId,
+        notifiedAt: { isNull: true },
+      },
+      with: {
+        profile: true,
+        inviter: true,
+      },
+    });
+
+    if (queuedInvites.length > 0) {
+      const baseUrl = OPURLConfig('APP').ENV_URL;
+
+      const invitations = queuedInvites.map((invite) => ({
+        email: invite.email,
+        inviterName: invite.inviter?.name || 'A team member',
+        profileName: invite.profile.name,
+        inviteUrl: profile.slug
+          ? `${baseUrl}/decisions/${profile.slug}/invite`
+          : baseUrl,
+        personalMessage: invite.message ?? undefined,
+      }));
+
+      // Use the first invite's inviter as the sender
+      const firstInvite = queuedInvites[0];
+      if (firstInvite) {
+        await event.send({
+          name: Events.profileInviteSent.name,
+          data: {
+            senderProfileId: firstInvite.invitedBy,
+            inviteIds: queuedInvites.map((inv) => inv.id),
+            invitations,
+          },
+        });
+      }
+      // notifiedAt is set by the Inngest workflow after successful email delivery
+    }
+  }
+
+  return profile;
+};

--- a/packages/common/src/services/decision/publishDecisionInstance.ts
+++ b/packages/common/src/services/decision/publishDecisionInstance.ts
@@ -14,7 +14,7 @@ import { CommonError, NotFoundError } from '../../utils';
 import { getProfileAccessUser } from '../access';
 import { generateUniqueProfileSlug } from '../profile/utils';
 import { createTransitionsForProcess } from './createTransitionsForProcess';
-import { draftInstanceDataSchema } from './schemas/instanceData';
+import type { DraftInstanceData } from './schemas/instanceData';
 import { updateTransitionsForProcess } from './updateTransitionsForProcess';
 
 /**
@@ -58,13 +58,10 @@ export const publishDecisionInstance = async ({
 
   assertAccess({ decisions: permission.ADMIN }, profileUser?.roles ?? []);
 
-  const parsed = draftInstanceDataSchema.safeParse(
-    existingInstance.draftInstanceData,
-  );
-  if (!parsed.success) {
+  const source = existingInstance.draftInstanceData as DraftInstanceData | null;
+  if (!source) {
     throw new CommonError('No draft instance data to publish');
   }
-  const source = parsed.data as Record<string, unknown>;
 
   const currentStatus = existingInstance.status as ProcessStatus;
   if (
@@ -122,7 +119,7 @@ export const publishDecisionInstance = async ({
     const profileUpdate: Record<string, string> = {};
 
     // Keep the profile name in sync with the instance name.
-    if (typeof name === 'string') {
+    if (name) {
       profileUpdate.name = name;
     }
 
@@ -130,8 +127,7 @@ export const publishDecisionInstance = async ({
     // Draft instances keep their original UUID slug so the URL stays stable
     // while editing. Once published the slug is locked.
     if (isBeingPublished) {
-      const instanceName =
-        typeof name === 'string' ? name : existingInstance.name;
+      const instanceName = name ?? existingInstance.name;
       profileUpdate.slug = await generateUniqueProfileSlug({
         name: `decision-${instanceName}`,
         db: tx,

--- a/packages/common/src/services/decision/publishDecisionInstance.ts
+++ b/packages/common/src/services/decision/publishDecisionInstance.ts
@@ -20,10 +20,8 @@ import { updateTransitionsForProcess } from './updateTransitionsForProcess';
 /**
  * Promotes draftInstanceData to the live columns.
  *
- * Copies editor-controlled fields from `draftInstanceData` to the live columns
- * (`instanceData`, `name`, `description`, `stewardProfileId`) while
- * preserving runtime fields in `instanceData` (currentPhaseId, stateData,
- * fieldValues, etc.).
+ * Copies `draftInstanceData` wholesale to `instanceData` and extracts
+ * `name`, `description`, `stewardProfileId` to their own columns.
  *
  * When `status` is set to PUBLISHED (and was previously DRAFT), runs the
  * full publish workflow: slug generation, transition creation, invite
@@ -178,45 +176,51 @@ export const publishDecisionInstance = async ({
   }
 
   // When publishing a draft, send queued invite emails for this
-  // process instance's profile
+  // process instance's profile. Wrapped in try-catch because the core
+  // publish transaction already committed — a failure here should not
+  // surface as a publish error to the user.
   if (isBeingPublished) {
-    const queuedInvites = await db.query.profileInvites.findMany({
-      where: {
-        profileId,
-        notifiedAt: { isNull: true },
-      },
-      with: {
-        profile: true,
-        inviter: true,
-      },
-    });
+    try {
+      const queuedInvites = await db.query.profileInvites.findMany({
+        where: {
+          profileId,
+          notifiedAt: { isNull: true },
+        },
+        with: {
+          profile: true,
+          inviter: true,
+        },
+      });
 
-    if (queuedInvites.length > 0) {
-      const baseUrl = OPURLConfig('APP').ENV_URL;
+      if (queuedInvites.length > 0) {
+        const baseUrl = OPURLConfig('APP').ENV_URL;
 
-      const invitations = queuedInvites.map((invite) => ({
-        email: invite.email,
-        inviterName: invite.inviter?.name || 'A team member',
-        profileName: invite.profile.name,
-        inviteUrl: profile.slug
-          ? `${baseUrl}/decisions/${profile.slug}/invite`
-          : baseUrl,
-        personalMessage: invite.message ?? undefined,
-      }));
+        const invitations = queuedInvites.map((invite) => ({
+          email: invite.email,
+          inviterName: invite.inviter?.name || 'A team member',
+          profileName: invite.profile.name,
+          inviteUrl: profile.slug
+            ? `${baseUrl}/decisions/${profile.slug}/invite`
+            : baseUrl,
+          personalMessage: invite.message ?? undefined,
+        }));
 
-      // Use the first invite's inviter as the sender
-      const firstInvite = queuedInvites[0];
-      if (firstInvite) {
-        await event.send({
-          name: Events.profileInviteSent.name,
-          data: {
-            senderProfileId: firstInvite.invitedBy,
-            inviteIds: queuedInvites.map((inv) => inv.id),
-            invitations,
-          },
-        });
+        // Use the first invite's inviter as the sender
+        const firstInvite = queuedInvites[0];
+        if (firstInvite) {
+          await event.send({
+            name: Events.profileInviteSent.name,
+            data: {
+              senderProfileId: firstInvite.invitedBy,
+              inviteIds: queuedInvites.map((inv) => inv.id),
+              invitations,
+            },
+          });
+        }
+        // notifiedAt is set by the Inngest workflow after successful email delivery
       }
-      // notifiedAt is set by the Inngest workflow after successful email delivery
+    } catch (error) {
+      console.error('Failed to dispatch invite emails after publish:', error);
     }
   }
 

--- a/packages/common/src/services/decision/schemas/instanceData.ts
+++ b/packages/common/src/services/decision/schemas/instanceData.ts
@@ -3,7 +3,6 @@
  */
 import type { UiSchema } from '@rjsf/utils';
 import type { JSONSchema7 } from 'json-schema';
-import { z } from 'zod';
 
 import { CommonError, ValidationError } from '../../../utils';
 import { schemaValidator } from '../schemaValidator';
@@ -47,6 +46,17 @@ export interface DecisionInstanceData {
   rubricTemplate?: RubricTemplateSchema;
 }
 
+/**
+ * Data stored in the `draftInstanceData` JSONB column.
+ * Same shape as DecisionInstanceData plus instance-column fields that are
+ * extracted to their own columns on publish.
+ */
+export type DraftInstanceData = DecisionInstanceData & {
+  name?: string;
+  description?: string;
+  stewardProfileId?: string;
+};
+
 export interface PhaseOverride {
   phaseId: string;
   name?: string;
@@ -58,38 +68,6 @@ export interface PhaseOverride {
   endDate?: string;
   settings?: Record<string, unknown>;
 }
-
-// ============ Zod Schemas ============
-
-/** Zod schema for the `instanceData` JSONB column (loose — tolerates extra fields). */
-export const instanceDataSchema = z.looseObject({
-  currentPhaseId: z.string(),
-  config: z.record(z.string(), z.unknown()).nullish(),
-  fieldValues: z.record(z.string(), z.unknown()).nullish(),
-  templateId: z.string().nullish(),
-  templateVersion: z.string().nullish(),
-  templateName: z.string().nullish(),
-  templateDescription: z.string().nullish(),
-  phases: z.array(z.record(z.string(), z.unknown())).nullish(),
-  proposalTemplate: z.record(z.string(), z.unknown()).nullish(),
-  rubricTemplate: z.record(z.string(), z.unknown()).nullish(),
-  stateData: z.record(z.string(), z.unknown()).nullish(),
-});
-
-// ============ Draft Instance Data ============
-
-/**
- * Zod schema for the `draftInstanceData` JSONB column.
- *
- * Same shape as instanceData plus instance-column fields (name, description,
- * stewardProfileId) that are extracted to their own columns on publish.
- * On publish, the entire blob is copied to `instanceData` as-is.
- */
-export const draftInstanceDataSchema = instanceDataSchema.extend({
-  name: z.string().nullish(),
-  description: z.string().nullish(),
-  stewardProfileId: z.string().nullish(),
-});
 
 // ============ Instance Data Creation ============
 

--- a/packages/common/src/services/decision/schemas/instanceData.ts
+++ b/packages/common/src/services/decision/schemas/instanceData.ts
@@ -1,8 +1,9 @@
 /**
- * Instance data creation helpers for DecisionSchemaDefinition templates.
+ * Instance data schemas and types for decision process instances.
  */
 import type { UiSchema } from '@rjsf/utils';
 import type { JSONSchema7 } from 'json-schema';
+import { z } from 'zod';
 
 import { CommonError, ValidationError } from '../../../utils';
 import { schemaValidator } from '../schemaValidator';
@@ -57,6 +58,40 @@ export interface PhaseOverride {
   endDate?: string;
   settings?: Record<string, unknown>;
 }
+
+// ============ Zod Schemas ============
+
+/** Zod schema for the `instanceData` JSONB column (loose — tolerates extra fields). */
+export const instanceDataSchema = z.looseObject({
+  currentPhaseId: z.string(),
+  config: z.record(z.string(), z.unknown()).nullish(),
+  fieldValues: z.record(z.string(), z.unknown()).nullish(),
+  templateId: z.string().nullish(),
+  templateVersion: z.string().nullish(),
+  templateName: z.string().nullish(),
+  templateDescription: z.string().nullish(),
+  phases: z.array(z.record(z.string(), z.unknown())).nullish(),
+  proposalTemplate: z.record(z.string(), z.unknown()).nullish(),
+  rubricTemplate: z.record(z.string(), z.unknown()).nullish(),
+  stateData: z.record(z.string(), z.unknown()).nullish(),
+});
+
+// ============ Draft Instance Data ============
+
+/**
+ * Zod schema for the `draftInstanceData` JSONB column.
+ *
+ * Same shape as instanceData plus instance-column fields (name, description,
+ * stewardProfileId) that are extracted to their own columns on publish.
+ * On publish, the entire blob is copied to `instanceData` as-is.
+ */
+export const draftInstanceDataSchema = instanceDataSchema.extend({
+  name: z.string().nullish(),
+  description: z.string().nullish(),
+  stewardProfileId: z.string().nullish(),
+});
+
+// ============ Instance Data Creation ============
 
 /**
  * Creates instance data from a DecisionSchemaDefinition template.

--- a/packages/common/src/services/decision/updateDraftInstanceData.ts
+++ b/packages/common/src/services/decision/updateDraftInstanceData.ts
@@ -82,13 +82,23 @@ export const updateDraftInstanceData = async ({
     await assertProfileAdmin(user, existingInstance.ownerProfileId);
   }
 
-  // Merge incoming fields into existing draft data
+  // Merge incoming fields into existing draft data.
+  // Fall back to {} only when the column is null (pre-migration instance).
+  // If the column has data but fails parsing, that's corruption — don't
+  // silently discard the existing draft.
   const parsed = draftInstanceDataSchema.safeParse(
     existingInstance.draftInstanceData,
   );
-  const existingDraft = parsed.success
-    ? (parsed.data as Record<string, unknown>)
-    : {};
+  let existingDraft: Record<string, unknown>;
+  if (parsed.success) {
+    existingDraft = parsed.data as Record<string, unknown>;
+  } else if (existingInstance.draftInstanceData != null) {
+    throw new CommonError(
+      'Existing draft data is malformed and cannot be updated safely',
+    );
+  } else {
+    existingDraft = {};
+  }
   const updatedDraft: Record<string, unknown> = { ...existingDraft };
 
   if (name !== undefined) {

--- a/packages/common/src/services/decision/updateDraftInstanceData.ts
+++ b/packages/common/src/services/decision/updateDraftInstanceData.ts
@@ -1,0 +1,138 @@
+import { db, eq } from '@op/db/client';
+import { processInstances } from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+import { assertAccess, permission } from 'access-zones';
+
+import { CommonError, NotFoundError, UnauthorizedError } from '../../utils';
+import { getProfileAccessUser } from '../access';
+import { assertProfileAdmin } from '../assert';
+import { schemaValidator } from './schemaValidator';
+import {
+  type PhaseOverride,
+  draftInstanceDataSchema,
+} from './schemas/instanceData';
+import type { ProcessConfig } from './schemas/types';
+
+/**
+ * Updates a decision process instance's draft data.
+ *
+ * All edits are written to the `draftInstanceData` column only — the live
+ * columns (`instanceData`, `name`, `description`) are untouched. To promote
+ * draft edits to the live version, use `publishDecisionInstance`.
+ */
+export const updateDraftInstanceData = async ({
+  instanceId,
+  name,
+  description,
+  stewardProfileId,
+  config,
+  phases,
+  proposalTemplate,
+  rubricTemplate,
+  user,
+}: {
+  instanceId: string;
+  name?: string;
+  description?: string;
+  stewardProfileId?: string;
+  config?: ProcessConfig;
+  phases?: PhaseOverride[];
+  proposalTemplate?: Record<string, unknown>;
+  rubricTemplate?: Record<string, unknown>;
+  user: User;
+}) => {
+  const existingInstance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+
+  if (!existingInstance) {
+    throw new NotFoundError('Process instance not found');
+  }
+
+  const { profileId } = existingInstance;
+  if (!profileId) {
+    throw new CommonError(
+      'Decision instance does not have an associated profile',
+    );
+  }
+
+  const profileUser = await getProfileAccessUser({
+    user,
+    profileId,
+  });
+
+  assertAccess({ decisions: permission.ADMIN }, profileUser?.roles ?? []);
+
+  if (proposalTemplate !== undefined) {
+    schemaValidator.validateJsonSchema(proposalTemplate);
+  }
+  if (rubricTemplate !== undefined) {
+    schemaValidator.validateJsonSchema(rubricTemplate);
+  }
+
+  if (
+    stewardProfileId !== undefined &&
+    stewardProfileId !== existingInstance.stewardProfileId
+  ) {
+    if (!existingInstance.ownerProfileId) {
+      throw new UnauthorizedError(
+        'Only the process owner can change the steward',
+      );
+    }
+    await assertProfileAdmin(user, existingInstance.ownerProfileId);
+  }
+
+  // Merge incoming fields into existing draft data
+  const parsed = draftInstanceDataSchema.safeParse(
+    existingInstance.draftInstanceData,
+  );
+  const existingDraft = parsed.success
+    ? (parsed.data as Record<string, unknown>)
+    : {};
+  const updatedDraft: Record<string, unknown> = { ...existingDraft };
+
+  if (name !== undefined) {
+    updatedDraft.name = name;
+  }
+  if (description !== undefined) {
+    updatedDraft.description = description;
+  }
+  if (stewardProfileId !== undefined) {
+    updatedDraft.stewardProfileId = stewardProfileId;
+  }
+  if (config !== undefined) {
+    const existingConfig =
+      typeof existingDraft.config === 'object' && existingDraft.config
+        ? existingDraft.config
+        : {};
+    updatedDraft.config = {
+      ...existingConfig,
+      ...config,
+    };
+  }
+  if (phases !== undefined) {
+    updatedDraft.phases = phases;
+  }
+  if (proposalTemplate !== undefined) {
+    updatedDraft.proposalTemplate = proposalTemplate;
+  }
+  if (rubricTemplate !== undefined) {
+    updatedDraft.rubricTemplate = rubricTemplate;
+  }
+
+  await db
+    .update(processInstances)
+    .set({ draftInstanceData: updatedDraft })
+    .where(eq(processInstances.id, instanceId));
+
+  const profile = await db.query.profiles.findFirst({
+    where: { id: profileId },
+    with: { processInstance: true },
+  });
+
+  if (!profile) {
+    throw new CommonError('Failed to fetch updated decision profile');
+  }
+
+  return profile;
+};

--- a/packages/common/src/services/decision/updateDraftInstanceData.ts
+++ b/packages/common/src/services/decision/updateDraftInstanceData.ts
@@ -7,10 +7,7 @@ import { CommonError, NotFoundError, UnauthorizedError } from '../../utils';
 import { getProfileAccessUser } from '../access';
 import { assertProfileAdmin } from '../assert';
 import { schemaValidator } from './schemaValidator';
-import {
-  type PhaseOverride,
-  draftInstanceDataSchema,
-} from './schemas/instanceData';
+import type { DraftInstanceData, PhaseOverride } from './schemas/instanceData';
 import type { ProcessConfig } from './schemas/types';
 
 /**
@@ -83,23 +80,11 @@ export const updateDraftInstanceData = async ({
   }
 
   // Merge incoming fields into existing draft data.
-  // Fall back to {} only when the column is null (pre-migration instance).
-  // If the column has data but fails parsing, that's corruption — don't
-  // silently discard the existing draft.
-  const parsed = draftInstanceDataSchema.safeParse(
-    existingInstance.draftInstanceData,
-  );
-  let existingDraft: Record<string, unknown>;
-  if (parsed.success) {
-    existingDraft = parsed.data as Record<string, unknown>;
-  } else if (existingInstance.draftInstanceData != null) {
-    throw new CommonError(
-      'Existing draft data is malformed and cannot be updated safely',
-    );
-  } else {
-    existingDraft = {};
-  }
-  const updatedDraft: Record<string, unknown> = { ...existingDraft };
+  // Fall back to {} when the column is null (pre-migration instance).
+  const existingDraft =
+    (existingInstance.draftInstanceData as Partial<DraftInstanceData> | null) ??
+    {};
+  const updatedDraft: Partial<DraftInstanceData> = { ...existingDraft };
 
   if (name !== undefined) {
     updatedDraft.name = name;

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -228,18 +228,37 @@ export const instancePhaseDataEncoder = z.object({
   settings: z.record(z.string(), z.unknown()).optional(),
 });
 
+/** Editor-controlled fields shared between instanceData and draftInstanceData */
+const editableInstanceFields = {
+  config: processConfigEncoder.optional(),
+  phases: z.array(instancePhaseDataEncoder).optional(),
+  proposalTemplate: jsonSchemaEncoder.optional(),
+  rubricTemplate: rubricTemplateEncoder.optional(),
+};
+
 /** Instance data encoder for new schema format */
 const instanceDataWithSchemaEncoder = z.object({
-  config: processConfigEncoder.optional(),
+  ...editableInstanceFields,
   fieldValues: z.record(z.string(), z.unknown()).optional(),
   templateId: z.string().optional(),
   templateVersion: z.string().optional(),
   templateName: z.string().optional(),
   templateDescription: z.string().optional(),
-  phases: z.array(instancePhaseDataEncoder).optional(),
-  proposalTemplate: jsonSchemaEncoder.optional(),
-  rubricTemplate: rubricTemplateEncoder.optional(),
 });
+
+/** Draft instance data encoder — the editable version used by the process builder.
+ *  Extends the shared editor fields with instance-column fields (name, etc.)
+ *  that are also editable in the process builder.
+ *  Uses passthrough() because the backfill copies the full instanceData blob,
+ *  which may include extra fields the encoder doesn't define. */
+export const draftInstanceDataEncoder = z
+  .object({
+    ...editableInstanceFields,
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    stewardProfileId: z.string().uuid().nullish(),
+  })
+  .passthrough();
 
 /** Decision access permissions encoder */
 const decisionAccessEncoder = z.object({
@@ -272,6 +291,7 @@ export const processInstanceWithSchemaEncoder = createSelectSchema(
   })
   .extend({
     instanceData: instanceDataWithSchemaEncoder,
+    draftInstanceData: draftInstanceDataEncoder.nullish(),
     process: decisionProcessWithSchemaEncoder.optional(),
     owner: baseProfileEncoder.optional(),
     steward: baseProfileEncoder.nullish(),

--- a/services/api/src/routers/decision/instances/duplicateInstance.test.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.test.ts
@@ -322,15 +322,10 @@ describe.concurrent('duplicateInstance', () => {
       task.id,
     );
 
-    // Set description on source (writes to draftInstanceData)
+    // Set description on source
     await caller.decision.updateDecisionInstance({
       instanceId: source.processInstance.id,
       description: 'Test description to copy',
-    });
-
-    // Promote source to live so the description is on the live column
-    await caller.decision.publishDecisionInstance({
-      instanceId: source.processInstance.id,
     });
 
     const duplicate = await caller.decision.duplicateInstance({

--- a/services/api/src/routers/decision/instances/duplicateInstance.test.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.test.ts
@@ -322,10 +322,15 @@ describe.concurrent('duplicateInstance', () => {
       task.id,
     );
 
-    // Set description on source
+    // Set description on source (writes to draftInstanceData)
     await caller.decision.updateDecisionInstance({
       instanceId: source.processInstance.id,
       description: 'Test description to copy',
+    });
+
+    // Promote source to live so the description is on the live column
+    await caller.decision.publishDecisionInstance({
+      instanceId: source.processInstance.id,
     });
 
     const duplicate = await caller.decision.duplicateInstance({

--- a/services/api/src/routers/decision/instances/index.ts
+++ b/services/api/src/routers/decision/instances/index.ts
@@ -8,14 +8,18 @@ import { getInstanceRouter, getLegacyInstanceRouter } from './getInstance';
 import { listDecisionProfilesRouter } from './listDecisionProfiles';
 import { listInstancesRouter } from './listInstances';
 import { listLegacyInstancesRouter } from './listLegacyInstances';
+import { publishDecisionInstanceRouter } from './publishDecisionInstance';
 import { transitionFromPhaseRouter } from './transitionFromPhase';
 import { updateDecisionInstanceRouter } from './updateDecisionInstance';
+import { updateDraftInstanceDataRouter } from './updateDraftInstanceData';
 
 export const instancesRouter = mergeRouters(
   createInstanceFromTemplateRouter,
   deleteDecisionRouter,
   duplicateInstanceRouter,
   updateDecisionInstanceRouter,
+  updateDraftInstanceDataRouter,
+  publishDecisionInstanceRouter,
   transitionFromPhaseRouter,
   listInstancesRouter,
   listLegacyInstancesRouter,

--- a/services/api/src/routers/decision/instances/publishDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/publishDecisionInstance.test.ts
@@ -39,7 +39,7 @@ describe.concurrent('publishDecisionInstance', () => {
 
     const newName = `Promoted Name ${task.id}`;
     const newDescription = `Promoted Description ${task.id}`;
-    await caller.decision.updateDecisionInstance({
+    await caller.decision.updateDraftInstanceData({
       instanceId: instance.instance.id,
       name: newName,
       description: newDescription,
@@ -82,7 +82,7 @@ describe.concurrent('publishDecisionInstance', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const newName = `My Process ${task.id}`;
-    await caller.decision.updateDecisionInstance({
+    await caller.decision.updateDraftInstanceData({
       instanceId: instance.instance.id,
       name: newName,
     });
@@ -125,7 +125,7 @@ describe.concurrent('publishDecisionInstance', () => {
 
     // Update draftInstanceData with a new name
     const newName = `Renamed After Publish ${task.id}`;
-    await caller.decision.updateDecisionInstance({
+    await caller.decision.updateDraftInstanceData({
       instanceId: instance.instance.id,
       name: newName,
     });
@@ -167,7 +167,7 @@ describe.concurrent('publishDecisionInstance', () => {
     const dataBefore = dbBefore!.instanceData as DecisionInstanceData;
 
     // Save some changes to draftInstanceData
-    await caller.decision.updateDecisionInstance({
+    await caller.decision.updateDraftInstanceData({
       instanceId: instance.instance.id,
       name: `Runtime Test ${task.id}`,
       config: { hideBudget: true },
@@ -230,7 +230,49 @@ describe.concurrent('publishDecisionInstance', () => {
       caller.decision.publishDecisionInstance({
         instanceId: instance.instance.id,
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(
+      'Cannot promote draft instance data for a completed or cancelled process',
+    );
+  });
+
+  it('should reject promotion for cancelled instances', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // Publish the instance first
+    await caller.decision.publishDecisionInstance({
+      instanceId: instance.instance.id,
+      status: ProcessStatus.PUBLISHED,
+    });
+
+    // Set status to CANCELLED
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      status: ProcessStatus.CANCELLED,
+    });
+
+    // Attempting to promote a cancelled instance should fail
+    await expect(
+      caller.decision.publishDecisionInstance({
+        instanceId: instance.instance.id,
+      }),
+    ).rejects.toThrow(
+      'Cannot promote draft instance data for a completed or cancelled process',
+    );
   });
 
   it('should not allow non-admin to promote', async ({

--- a/services/api/src/routers/decision/instances/publishDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/publishDecisionInstance.test.ts
@@ -1,0 +1,267 @@
+import { type DecisionInstanceData } from '@op/common';
+import { db, eq } from '@op/db/client';
+import { ProcessStatus, processInstances } from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+describe.concurrent('publishDecisionInstance', () => {
+  it('should promote draftInstanceData to live columns', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const newName = `Promoted Name ${task.id}`;
+    const newDescription = `Promoted Description ${task.id}`;
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      name: newName,
+      description: newDescription,
+      config: { hideBudget: true },
+    });
+
+    // Promote draftInstanceData to live columns (no status change)
+    const result = await caller.decision.publishDecisionInstance({
+      instanceId: instance.instance.id,
+    });
+
+    // Verify live columns were updated
+    expect(result.processInstance.name).toBe(newName);
+    expect(result.processInstance.description).toBe(newDescription);
+
+    // Verify instanceData.config was updated
+    const dbInstance = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instance.instance.id),
+    });
+    const instanceData = dbInstance!.instanceData as DecisionInstanceData;
+    expect(instanceData.config?.hideBudget).toBe(true);
+  });
+
+  it('should generate slug when publishing a draft', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const newName = `My Process ${task.id}`;
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      name: newName,
+    });
+
+    // Promote with PUBLISHED status
+    const result = await caller.decision.publishDecisionInstance({
+      instanceId: instance.instance.id,
+      status: ProcessStatus.PUBLISHED,
+    });
+
+    // Slug should contain the slugified name
+    expect(result.slug).toContain('decision-my-process');
+    expect(result.processInstance.status).toBe(ProcessStatus.PUBLISHED);
+  });
+
+  it('should not change slug when promoting an already-published instance', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // First promote to PUBLISHED (generates slug)
+    const published = await caller.decision.publishDecisionInstance({
+      instanceId: instance.instance.id,
+      status: ProcessStatus.PUBLISHED,
+    });
+    const slugAfterPublish = published.slug;
+
+    // Update draftInstanceData with a new name
+    const newName = `Renamed After Publish ${task.id}`;
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      name: newName,
+    });
+
+    // Promote again without status change
+    const promoted = await caller.decision.publishDecisionInstance({
+      instanceId: instance.instance.id,
+    });
+
+    // Slug should stay the same
+    expect(promoted.slug).toBe(slugAfterPublish);
+
+    // But the live name should have been updated
+    expect(promoted.processInstance.name).toBe(newName);
+  });
+
+  it('should preserve runtime fields in instanceData', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // Read original instanceData to capture runtime fields
+    const dbBefore = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instance.instance.id),
+    });
+    const dataBefore = dbBefore!.instanceData as DecisionInstanceData;
+
+    // Save some changes to draftInstanceData
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      name: `Runtime Test ${task.id}`,
+      config: { hideBudget: true },
+    });
+
+    // Promote
+    await caller.decision.publishDecisionInstance({
+      instanceId: instance.instance.id,
+    });
+
+    // Read instanceData after promotion
+    const dbAfter = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instance.instance.id),
+    });
+    const dataAfter = dbAfter!.instanceData as DecisionInstanceData;
+
+    // Runtime fields should be preserved
+    expect(dataAfter.currentPhaseId).toBe(dataBefore.currentPhaseId);
+    expect(dataAfter.templateId).toBe(dataBefore.templateId);
+    expect(dataAfter.templateVersion).toBe(dataBefore.templateVersion);
+    expect(dataAfter.templateName).toBe(dataBefore.templateName);
+    expect(dataAfter.templateDescription).toBe(dataBefore.templateDescription);
+
+    // The config update should still be applied
+    expect(dataAfter.config?.hideBudget).toBe(true);
+  });
+
+  it('should reject promotion for completed instances', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // Publish the instance first
+    await caller.decision.publishDecisionInstance({
+      instanceId: instance.instance.id,
+      status: ProcessStatus.PUBLISHED,
+    });
+
+    // Set status to COMPLETED
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      status: ProcessStatus.COMPLETED,
+    });
+
+    // Attempting to promote a completed instance should fail
+    await expect(
+      caller.decision.publishDecisionInstance({
+        instanceId: instance.instance.id,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should not allow non-admin to promote', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Create a member user (non-admin)
+    const memberUser = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+
+    const nonAdminCaller = await createAuthenticatedCaller(memberUser.email);
+
+    // Non-admin should NOT be able to promote
+    await expect(
+      nonAdminCaller.decision.publishDecisionInstance({
+        instanceId: instance.instance.id,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/services/api/src/routers/decision/instances/publishDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/publishDecisionInstance.test.ts
@@ -184,8 +184,7 @@ describe.concurrent('publishDecisionInstance', () => {
     });
     const dataAfter = dbAfter!.instanceData as DecisionInstanceData;
 
-    // Runtime fields should be preserved
-    expect(dataAfter.currentPhaseId).toBe(dataBefore.currentPhaseId);
+    // Template fields should be preserved
     expect(dataAfter.templateId).toBe(dataBefore.templateId);
     expect(dataAfter.templateVersion).toBe(dataBefore.templateVersion);
     expect(dataAfter.templateName).toBe(dataBefore.templateName);

--- a/services/api/src/routers/decision/instances/publishDecisionInstance.ts
+++ b/services/api/src/routers/decision/instances/publishDecisionInstance.ts
@@ -1,0 +1,31 @@
+import { Channels, publishDecisionInstance } from '@op/common';
+import { ProcessStatus } from '@op/db/schema';
+import { z } from 'zod';
+
+import { decisionProfileWithSchemaEncoder } from '../../../encoders/decision';
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const publishDecisionInstanceRouter = router({
+  publishDecisionInstance: commonAuthedProcedure()
+    .input(
+      z.object({
+        instanceId: z.uuid(),
+        status: z.enum(ProcessStatus).optional(),
+      }),
+    )
+    .output(decisionProfileWithSchemaEncoder)
+    .mutation(async ({ ctx, input }) => {
+      const { user } = ctx;
+
+      const profile = await publishDecisionInstance({
+        ...input,
+        user,
+      });
+
+      ctx.registerMutationChannels([
+        Channels.decisionInstance(input.instanceId),
+      ]);
+
+      return decisionProfileWithSchemaEncoder.parse(profile);
+    }),
+});

--- a/services/api/src/routers/decision/instances/updateDraftInstanceData.test.ts
+++ b/services/api/src/routers/decision/instances/updateDraftInstanceData.test.ts
@@ -1,0 +1,216 @@
+import { db, eq } from '@op/db/client';
+import { processInstances } from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+describe.concurrent('updateDraftInstanceData', () => {
+  it('should write to draftInstanceData without touching live columns', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+    const instanceId = instance.instance.id;
+
+    // Record live columns before the update
+    const before = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instanceId),
+    });
+    const liveNameBefore = before!.name;
+    const liveDescriptionBefore = before!.description;
+
+    const newName = `Draft Name ${task.id}`;
+    const newDescription = `Draft Description ${task.id}`;
+    await caller.decision.updateDraftInstanceData({
+      instanceId,
+      name: newName,
+      description: newDescription,
+    });
+
+    const after = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instanceId),
+    });
+
+    // Live columns should be unchanged
+    expect(after!.name).toBe(liveNameBefore);
+    expect(after!.description).toBe(liveDescriptionBefore);
+
+    // Draft column should have the new values
+    const draft = after!.draftInstanceData as Record<string, unknown>;
+    expect(draft.name).toBe(newName);
+    expect(draft.description).toBe(newDescription);
+  });
+
+  it('should merge config into existing draft', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+    const instanceId = instance.instance.id;
+
+    // First update: set hideBudget
+    await caller.decision.updateDraftInstanceData({
+      instanceId,
+      config: { hideBudget: true },
+    });
+
+    // Second update: set isPrivate (should merge, not replace)
+    await caller.decision.updateDraftInstanceData({
+      instanceId,
+      config: { isPrivate: true },
+    });
+
+    const dbInstance = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instanceId),
+    });
+
+    const draft = dbInstance!.draftInstanceData as Record<string, unknown>;
+    const config = draft.config as Record<string, unknown>;
+    expect(config.hideBudget).toBe(true);
+    expect(config.isPrivate).toBe(true);
+  });
+
+  it('should update phases in draft', async ({ task, onTestFinished }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+    const instanceId = instance.instance.id;
+
+    const endDate = new Date(
+      Date.now() + 7 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    await caller.decision.updateDraftInstanceData({
+      instanceId,
+      phases: [
+        {
+          phaseId: 'initial',
+          endDate,
+        },
+      ],
+    });
+
+    const dbInstance = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instanceId),
+    });
+
+    const draft = dbInstance!.draftInstanceData as Record<string, unknown>;
+    const phases = draft.phases as Array<Record<string, unknown>>;
+    expect(phases).toHaveLength(1);
+    expect(phases[0]!.endDate).toBe(endDate);
+
+    // Live instanceData phases should be unchanged
+    const live = dbInstance!.instanceData as Record<string, unknown>;
+    const livePhases = live.phases as Array<Record<string, unknown>>;
+    expect(livePhases[0]!.endDate).not.toBe(endDate);
+  });
+
+  it('should reject non-admin users', async ({ task, onTestFinished }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Create a member user (non-admin)
+    const memberUser = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+
+    const nonAdminCaller = await createAuthenticatedCaller(memberUser.email);
+
+    await expect(
+      nonAdminCaller.decision.updateDraftInstanceData({
+        instanceId: instance.instance.id,
+        name: 'Should fail',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should throw on malformed existing draftInstanceData', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+    const instanceId = instance.instance.id;
+
+    // Corrupt the draftInstanceData column directly
+    await db
+      .update(processInstances)
+      .set({ draftInstanceData: 'not-an-object' })
+      .where(eq(processInstances.id, instanceId));
+
+    await expect(
+      caller.decision.updateDraftInstanceData({
+        instanceId,
+        name: 'Should fail',
+      }),
+    ).rejects.toThrow('malformed');
+  });
+});

--- a/services/api/src/routers/decision/instances/updateDraftInstanceData.ts
+++ b/services/api/src/routers/decision/instances/updateDraftInstanceData.ts
@@ -1,0 +1,27 @@
+import { Channels, updateDraftInstanceData } from '@op/common';
+
+import {
+  decisionProfileWithSchemaEncoder,
+  updateDecisionInstanceInputSchema,
+} from '../../../encoders/decision';
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const updateDraftInstanceDataRouter = router({
+  updateDraftInstanceData: commonAuthedProcedure()
+    .input(updateDecisionInstanceInputSchema)
+    .output(decisionProfileWithSchemaEncoder)
+    .mutation(async ({ ctx, input }) => {
+      const { user } = ctx;
+
+      const profile = await updateDraftInstanceData({
+        ...input,
+        user,
+      });
+
+      ctx.registerMutationChannels([
+        Channels.decisionInstance(input.instanceId),
+      ]);
+
+      return decisionProfileWithSchemaEncoder.parse(profile);
+    }),
+});


### PR DESCRIPTION
## Summary

Adds two new endpoints alongside the existing `updateDecisionInstance` (which is unchanged):

- **`updateDraftInstanceData`** — process builder autosave writes here. Merges incoming fields into the `draftInstanceData` JSONB column. Live columns are untouched.
- **`publishDecisionInstance`** — promotes `draftInstanceData` to live. Copies the draft blob wholesale to `instanceData`, extracts `name`/`description`/`stewardProfileId` to their own columns. On first publish (DRAFT → PUBLISHED): generates slug, creates transitions, dispatches invites. On subsequent publishes: updates transitions if phases changed.

Also:
- `draftInstanceDataSchema` extends `instanceDataSchema` (unified types)
- `draftInstanceDataEncoder` added to `processInstanceWithSchemaEncoder`
- `createInstanceFromTemplate` and `duplicateInstance` seed `draftInstanceData`
- Integration tests for both new endpoints

`updateDecisionInstance` is **not modified** — it continues to handle status changes, direct instance updates, and other non-builder uses.

## Commits

1. `feat: add draftInstanceData schema and encoder` — Zod schema, tRPC encoder, exports
2. `feat(api): add updateDraftInstanceData endpoint` — new service + route for draft writes
3. `feat(api): add publishDecisionInstance endpoint` — promote draft to live + tests
4. `feat: seed draftInstanceData on instance creation and duplication`
5. `fix: address review findings` — stale docstring, corruption guard, invite error handling, CANCELLED test
6. `test: add updateDraftInstanceData integration tests` — draft-only writes, config merge, auth, corruption guard

## Stack

1. #917 — migration (base)
2. **This PR** — backend
3. #922 — frontend wiring

## Test plan

- [ ] `updateDraftInstanceData` writes to `draftInstanceData` only, live columns unchanged
- [ ] Config merges into existing draft (doesn't replace)
- [ ] Malformed `draftInstanceData` throws instead of silently falling back
- [ ] Non-admin users rejected from draft updates
- [ ] `publishDecisionInstance` copies draft to live columns
- [ ] Slug generated on first publish, stable on subsequent promotes
- [ ] Transitions created on first publish, updated on phase changes
- [ ] COMPLETED and CANCELLED instances reject promotion
- [ ] Non-admin users cannot publish
- [ ] Invite dispatch failure after publish does not surface as error to user
- [ ] New instances and duplicates have `draftInstanceData` seeded
- [ ] `updateDecisionInstance` unchanged — existing tests pass as-is