### PR TITLE
feat: wire frontend to draft/live model

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
@@ -32,17 +32,19 @@ const EditDecisionPage = async ({
 
   const { processInstance } = decisionProfile;
   const instanceId = processInstance.id;
-  const instanceData = processInstance.instanceData;
+  const { instanceData } = processInstance;
 
-  // Seed the store with server data so validation works immediately.
+  // Seed the store from draftInstanceData (the editable version).
+  // Falls back to instanceData for instances that predate the migration.
+  const draft = processInstance.draftInstanceData;
   const serverData: ProcessBuilderInstanceData = {
-    name: decisionProfile.name ?? undefined,
-    description: processInstance.description ?? undefined,
-    stewardProfileId: processInstance.steward?.id,
-    phases: instanceData.phases,
-    proposalTemplate:
-      instanceData.proposalTemplate as ProcessBuilderInstanceData['proposalTemplate'],
-    config: instanceData.config,
+    name: draft?.name ?? decisionProfile.name ?? undefined,
+    description: draft?.description ?? processInstance.description ?? undefined,
+    stewardProfileId: draft?.stewardProfileId ?? processInstance.steward?.id,
+    phases: draft?.phases ?? instanceData.phases,
+    proposalTemplate: (draft?.proposalTemplate ??
+      instanceData.proposalTemplate) as ProcessBuilderInstanceData['proposalTemplate'],
+    config: draft?.config ?? instanceData.config,
   };
 
   return (

--- a/apps/app/src/components/decisions/DecisionListItem.tsx
+++ b/apps/app/src/components/decisions/DecisionListItem.tsx
@@ -38,10 +38,26 @@ const isClosingSoon = (dateString: string) => {
   return daysUntilClose >= 0 && daysUntilClose <= 7;
 };
 
+/** For drafts, draftInstanceData has the latest edits (instanceData may be
+ *  stale since autosave writes to draftInstanceData only). For published
+ *  instances, instanceData is the promoted live version. */
+function getDisplayName(item: DecisionProfile): string {
+  const { processInstance } = item;
+  const isDraft = processInstance.status === ProcessStatus.DRAFT;
+  if (isDraft && processInstance.draftInstanceData) {
+    const draft = processInstance.draftInstanceData as Record<string, unknown>;
+    if (typeof draft.name === 'string' && draft.name) {
+      return draft.name;
+    }
+  }
+  return processInstance.name || item.name;
+}
+
 export const DecisionListItem = ({ item }: { item: DecisionProfile }) => {
   const t = useTranslations();
   const utils = trpc.useUtils();
   const { processInstance } = item;
+  const displayName = getDisplayName(item);
   const isDraft = processInstance.status === ProcessStatus.DRAFT;
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
@@ -83,7 +99,7 @@ export const DecisionListItem = ({ item }: { item: DecisionProfile }) => {
           className="flex flex-1 flex-col gap-4 p-4 hover:no-underline sm:flex-row sm:items-center sm:justify-between"
         >
           <DecisionCardHeader
-            name={processInstance.name || item.name}
+            name={displayName}
             currentState={currentPhaseName}
             stewardName={displayProfile?.name}
             stewardAvatarPath={displayProfile?.avatarImage?.name}
@@ -167,7 +183,7 @@ export const DecisionListItem = ({ item }: { item: DecisionProfile }) => {
           {isDraft
             ? t('Delete draft?')
             : t('Delete {name}?', {
-                name: processInstance.name || item.name,
+                name: displayName,
               })}
         </ModalHeader>
         <ModalBody>
@@ -210,6 +226,7 @@ export const ProfileDecisionListItem = ({
   className?: string;
 }) => {
   const { processInstance } = item;
+  const displayName = getDisplayName(item);
 
   // Get current phase from instanceData phases
   const currentPhase = processInstance.instanceData?.phases?.find(
@@ -223,10 +240,7 @@ export const ProfileDecisionListItem = ({
       href={`/decisions/${item.slug}`}
       className={cn('flex flex-col gap-4 pb-4 hover:no-underline', className)}
     >
-      <DecisionCardHeader
-        name={processInstance.name || item.name}
-        currentState={currentPhaseName}
-      >
+      <DecisionCardHeader name={displayName} currentState={currentPhaseName}>
         <div className="flex flex-col flex-wrap gap-2 py-1 text-xs sm:flex-row sm:items-center sm:justify-between">
           {closingDate && <DecisionClosingDate closingDate={closingDate} />}
           <div className="flex items-end gap-4 text-neutral-black">

--- a/apps/app/src/components/decisions/DuplicateProcessModal.tsx
+++ b/apps/app/src/components/decisions/DuplicateProcessModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import type { DecisionProfile } from '@op/api/encoders';
+import { type DecisionProfile, ProcessStatus } from '@op/api/encoders';
 import { Button } from '@op/ui/Button';
 import { Checkbox, CheckboxGroup } from '@op/ui/Checkbox';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
@@ -59,8 +59,20 @@ const DuplicateFormContent = ({
   const router = useRouter();
   const utils = trpc.useUtils();
 
+  // For drafts, draftInstanceData has the latest name (live column may be stale)
+  const draftName =
+    item.processInstance.status === ProcessStatus.DRAFT
+      ? ((
+          item.processInstance.draftInstanceData as Record<
+            string,
+            unknown
+          > | null
+        )?.name as string | undefined)
+      : undefined;
   const [name, setName] = useState(
-    t('Duplicate of {name}', { name: item.name || item.processInstance.name }),
+    t('Duplicate of {name}', {
+      name: draftName || item.name || item.processInstance.name,
+    }),
   );
   const [stewardProfileId, setStewardProfileId] = useState('');
 

--- a/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
@@ -48,7 +48,7 @@ export const LaunchProcessModal = ({
 
   const utils = trpc.useUtils();
 
-  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
+  const publishInstance = trpc.decision.publishDecisionInstance.useMutation({
     onSuccess: async (data) => {
       onOpenChange(false);
       await utils.decision.getDecisionBySlug.invalidate();
@@ -63,7 +63,7 @@ export const LaunchProcessModal = ({
   });
 
   const handleLaunch = () => {
-    updateInstance.mutate({
+    publishInstance.mutate({
       instanceId,
       status: ProcessStatus.PUBLISHED,
     });
@@ -132,8 +132,8 @@ export const LaunchProcessModal = ({
         </Button>
         <Button
           onPress={handleLaunch}
-          isPending={updateInstance.isPending}
-          isDisabled={updateInstance.isPending}
+          isPending={publishInstance.isPending}
+          isDisabled={publishInstance.isPending}
           className="w-full sm:w-auto"
         >
           {t('Launch Process')}

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -62,7 +62,7 @@ export const ProcessBuilderFooter = ({
 
   const utils = trpc.useUtils();
 
-  const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
+  const publishInstance = trpc.decision.publishDecisionInstance.useMutation({
     onSuccess: async (data) => {
       toast.success({ message: t('Changes saved successfully') });
       await utils.decision.getDecisionBySlug.invalidate({ slug });
@@ -83,16 +83,9 @@ export const ProcessBuilderFooter = ({
     if (isDraft) {
       setIsLaunchModalOpen(true);
     } else {
-      updateInstance.mutate({
-        instanceId,
-        name: storeData?.name || undefined,
-        description: storeData?.description || undefined,
-        stewardProfileId: storeData?.stewardProfileId || undefined,
-        phases: storeData?.phases,
-        proposalTemplate: storeData?.proposalTemplate,
-        rubricTemplate: storeData?.rubricTemplate,
-        config: storeData?.config,
-      });
+      // Promote draftInstanceData to live — no payload needed,
+      // the server reads from the draft column.
+      publishInstance.mutate({ instanceId });
     }
   };
 
@@ -148,7 +141,7 @@ export const ProcessBuilderFooter = ({
                 (validation.isReadyToLaunch && !isTerminalStatus)) && (
                 <Button
                   onPress={handleLaunchOrSave}
-                  isDisabled={updateInstance.isPending}
+                  isDisabled={publishInstance.isPending}
                 >
                   {isDraft ? t('Launch Process') : t('Update Process')}
                 </Button>
@@ -174,7 +167,7 @@ export const ProcessBuilderFooter = ({
               <Button
                 className="h-8 rounded-lg"
                 onPress={handleLaunchOrSave}
-                isDisabled={updateInstance.isPending}
+                isDisabled={publishInstance.isPending}
               >
                 {isDraft ? t('Launch') : t('Update')}
               </Button>


### PR DESCRIPTION
## Summary

Connects the frontend to the new draft/live endpoints:

- **Edit page** seeds the store from `draftInstanceData` (falls back to `instanceData` for pre-migration instances)
- **Footer** "Update Process" calls `publishDecisionInstance` instead of `updateDecisionInstance` — no payload needed, the server reads from the draft column
- **Launch modal** calls `publishDecisionInstance` with `status: PUBLISHED`
- **DecisionListItem** reads draft name from `draftInstanceData` for drafts (autosave writes there, so the live `name` column may be stale)
- **DuplicateProcessModal** reads draft name for the duplicate naming default

## Stack

1. #917 — migration
2. #921 — backend (base)
3. **This PR** — frontend wiring

## Dependencies

- Assumes #916 (autosave centralization) merges first or concurrently. After #916 merges, the autosave context will need a one-line change: `updateDecisionInstance` → `updateDraftInstanceData` in the debounced save.

## Follow-up (after #916 merges)

- Flatten store to single instance (remove keyed maps)
- Remove hydration provider, seed from autosave provider
- Simplify hooks (drop query fallbacks from useNavigationConfig, useProcessPhases, usePhaseValidation)
- Remove getInstance query fallbacks from section components

## Test plan

- [ ] Edit page shows data from `draftInstanceData` when available
- [ ] "Update Process" promotes draft to live via `publishDecisionInstance`
- [ ] "Launch Process" publishes via `publishDecisionInstance` with status change
- [ ] Draft list items show the draft name, not the stale live name
- [ ] Duplicate modal uses draft name for the default
- [ ] Pre-migration instances (null `draftInstanceData`) fall back to `instanceData`