### PR TITLE
refactor: replace raw h2/h3 with Header2/Header3 components

### DIFF
--- a/apps/app/src/components/Profile/ProfileDecisions/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDecisions/index.tsx
@@ -3,6 +3,7 @@
 import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { VISIBLE_DECISION_STATUSES } from '@op/api/encoders';
+import { Header2 } from '@op/ui/Header';
 import { useParams } from 'next/navigation';
 import { Suspense } from 'react';
 import { LuLeaf } from 'react-icons/lu';
@@ -86,11 +87,11 @@ const EmptyDecisions = ({ profileId }: { profileId: string }) => {
         <LuLeaf className="size-6 text-neutral-gray4" />
       </div>
       <div className="flex max-w-md flex-col gap-2">
-        <h2 className="font-serif text-title-base text-neutral-black">
+        <Header2 className="font-serif text-title-base">
           {isProcessAdmin
             ? t('Set up your decision-making process')
             : t('There are no current decision-making processes')}
-        </h2>
+        </Header2>
         {isProcessAdmin && (
           <p className="text-base text-neutral-charcoal">
             {t(

--- a/apps/app/src/components/decisions/DecisionStats.tsx
+++ b/apps/app/src/components/decisions/DecisionStats.tsx
@@ -2,6 +2,7 @@
 
 import { formatCurrency, formatDateRange } from '@/utils/formatting';
 import { type ProcessPhase } from '@op/api/encoders';
+import { Header3 } from '@op/ui/Header';
 import { useLocale } from 'next-intl';
 
 import { useTranslations } from '@/lib/i18n';
@@ -25,9 +26,9 @@ export function DecisionStats({
     <div className="space-y-6">
       {/* Current Phase */}
       <div>
-        <h3 className="text-xs font-semibold tracking-wider text-neutral-gray2 uppercase">
+        <Header3 className="text-xs font-semibold tracking-wider text-neutral-gray2 uppercase">
           {t('Current Phase')}
-        </h3>
+        </Header3>
         <p className="mt-1 text-lg font-medium text-neutral-charcoal">
           {currentPhase?.name || t('Proposal Submissions')}
         </p>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
@@ -3,6 +3,7 @@
 import { trpc } from '@op/api/client';
 import { ProcessStatus } from '@op/api/encoders';
 import { useDebouncedCallback } from '@op/hooks';
+import { Header2 } from '@op/ui/Header';
 import { SelectItem } from '@op/ui/Select';
 import { useEffect, useRef } from 'react';
 import { z } from 'zod';
@@ -217,9 +218,9 @@ export function OverviewSectionForm({
           <section className="space-y-6">
             <div>
               <div className="flex items-center justify-between">
-                <h2 className="font-serif text-title-sm">
+                <Header2 className="font-serif text-title-sm">
                   {t('Process Overview')}
-                </h2>
+                </Header2>
                 <SaveStatusIndicator
                   status={saveState.status}
                   savedAt={saveState.savedAt}
@@ -342,7 +343,9 @@ export function OverviewSectionForm({
 
           {/* Visibility Section */}
           <section className="space-y-6">
-            <h2 className="font-serif text-title-sm">{t('Visibility')}</h2>
+            <Header2 className="font-serif text-title-sm">
+              {t('Visibility')}
+            </Header2>
 
             <form.AppField
               name="isPrivate"

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/RolesSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/RolesSection.tsx
@@ -9,6 +9,7 @@ import { Button } from '@op/ui/Button';
 import { Checkbox } from '@op/ui/Checkbox';
 import { DialogTrigger } from '@op/ui/Dialog';
 import { EmptyState } from '@op/ui/EmptyState';
+import { Header2, Header3 } from '@op/ui/Header';
 import { IconButton } from '@op/ui/IconButton';
 import { Menu, MenuItem } from '@op/ui/Menu';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
@@ -403,9 +404,9 @@ function RolesSectionContent({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
-        <h2 className="font-serif text-title-sm font-light text-neutral-black">
+        <Header2 className="font-serif text-title-sm font-light">
           {t('Roles & permissions')}
-        </h2>
+        </Header2>
         <Button
           color="ghost"
           className="text-primary-teal hover:text-primary-tealBlack"
@@ -573,9 +574,7 @@ function MobileRoleCard({
   return (
     <div className="flex flex-col gap-4 rounded-lg border border-neutral-gray1 p-4">
       <div className="flex items-center justify-between">
-        <h3 className="font-serif text-sm font-light text-neutral-black">
-          {role.name}
-        </h3>
+        <Header3 className="font-serif text-sm font-light">{role.name}</Header3>
         {(onDelete || onEdit) && (
           <OptionMenu variant="outline" className="rounded-lg">
             <Menu className="min-w-28 p-2">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
@@ -5,7 +5,7 @@ import { ProcessStatus } from '@op/api/encoders';
 import type { ReviewsPolicy } from '@op/common';
 import { useDebouncedCallback } from '@op/hooks';
 import { Chip } from '@op/ui/Chip';
-import { Header2 } from '@op/ui/Header';
+import { Header2, Header3 } from '@op/ui/Header';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { ToggleButton } from '@op/ui/ToggleButton';
 import { useEffect, useRef, useState } from 'react';
@@ -118,9 +118,7 @@ export function ReviewSettingsContent({
 
       {/* Coverage */}
       <section className="space-y-4">
-        <h3 className="font-serif text-title-sm text-neutral-black">
-          {t('Coverage')}
-        </h3>
+        <Header3 className="font-serif text-title-sm">{t('Coverage')}</Header3>
         <RadioGroup
           value={settings.reviewsPolicy}
           onChange={(value) =>
@@ -170,9 +168,7 @@ export function ReviewSettingsContent({
 
       {/* Revisions */}
       <section className="space-y-4">
-        <h3 className="font-serif text-title-sm text-neutral-black">
-          {t('Revisions')}
-        </h3>
+        <Header3 className="font-serif text-title-sm">{t('Revisions')}</Header3>
         <div className="space-y-2">
           <ToggleRow
             label={t('Reviewers can request revisions')}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricParticipantPreview.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricParticipantPreview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { RubricTemplateSchema } from '@op/common/client';
+import { Header2 } from '@op/ui/Header';
 import { useMemo } from 'react';
 import { LuEye } from 'react-icons/lu';
 
@@ -37,9 +38,9 @@ export function RubricParticipantPreview({
           <span>{t('Participant Preview')}</span>
         </div>
 
-        <h2 className="mb-6 font-serif text-title-lg text-neutral-charcoal">
+        <Header2 className="mb-6 font-serif text-neutral-charcoal">
           {t('Review Proposal')}
-        </h2>
+        </Header2>
 
         <RubricFormPreviewRenderer fields={fields} />
       </div>

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -7,6 +7,7 @@ import type { Proposal, ProposalTemplateSchema } from '@op/common/client';
 import { isNullish, match } from '@op/core';
 import { Avatar } from '@op/ui/Avatar';
 import { Chip } from '@op/ui/Chip';
+import { Header3 } from '@op/ui/Header';
 import { Surface } from '@op/ui/Surface';
 import { cn } from '@op/ui/utils';
 import Image from 'next/image';
@@ -134,7 +135,7 @@ export function ProposalCardTitle({
     );
   }
 
-  return <h3 className={titleClasses}>{titleText}</h3>;
+  return <Header3 className={titleClasses}>{titleText}</Header3>;
 }
 
 /**

--- a/apps/app/src/components/decisions/ProposalEditorAside.tsx
+++ b/apps/app/src/components/decisions/ProposalEditorAside.tsx
@@ -2,6 +2,7 @@
 
 import { useMediaQuery } from '@op/hooks';
 import { screens } from '@op/styles/constants';
+import { Header2 } from '@op/ui/Header';
 import { Sheet, SheetBody } from '@op/ui/Sheet';
 import { cn } from '@op/ui/utils';
 import type { ReactNode } from 'react';
@@ -102,7 +103,7 @@ function ProposalEditorAsideHeader({
 }) {
   return (
     <div className="flex h-editor-topbar shrink-0 items-center justify-between border-b border-neutral-gray1 px-6">
-      <h2 className="font-serif text-title-sm14 text-neutral-black">{title}</h2>
+      <Header2 className="font-serif text-title-sm14">{title}</Header2>
       <button
         onClick={onClose}
         className="cursor-pointer text-neutral-black hover:text-neutral-charcoal"

--- a/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
+++ b/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ButtonLink } from '@op/ui/Button';
+import { Header2, Header3 } from '@op/ui/Header';
 import { LogoLoop } from '@op/ui/LogoLoop';
 import { cn } from '@op/ui/utils';
 import type { Variants } from 'motion/react';
@@ -105,7 +106,7 @@ export const ComingSoonScreen = () => {
         </section>
         <FadeInWrapper>
           <section className="space-y-6">
-            <h3 className="text-base">{t('Trusted by')}</h3>
+            <Header3 className="text-base">{t('Trusted by')}</Header3>
             <LogoLoop
               logos={logos}
               speed={20}
@@ -121,9 +122,9 @@ export const ComingSoonScreen = () => {
         </FadeInWrapper>
         <FadeInWrapper>
           <section className="flex flex-col items-center gap-6 p-6">
-            <h2 className="font-serif text-title-md">
+            <Header2 className="font-serif text-title-md">
               {t('Get early access')}
-            </h2>
+            </Header2>
             <div className="sm:text-lg">
               <p>
                 {t(

--- a/apps/app/src/components/screens/PlatformAdmin/UsersTable.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/UsersTable.tsx
@@ -3,6 +3,7 @@
 import type { RouterInput } from '@op/api/client';
 import { trpc } from '@op/api/client';
 import { useCursorPagination, useDebounce } from '@op/hooks';
+import { Header2 } from '@op/ui/Header';
 import { Menu, MenuItem } from '@op/ui/Menu';
 import { OptionMenu } from '@op/ui/OptionMenu';
 import { Pagination } from '@op/ui/Pagination';
@@ -92,9 +93,9 @@ export const UsersTable = () => {
   return (
     <div className="mt-8">
       <div className="mb-4 flex items-center justify-between gap-4">
-        <h2 className="text-md font-serif text-neutral-black">
+        <Header2 className="text-md font-serif">
           {t('platformAdmin_allUsers')}
-        </h2>
+        </Header2>
         <div className="flex items-center gap-2">
           <div className="w-64">
             <SearchField

--- a/packages/ui/src/components/AvatarUploader.tsx
+++ b/packages/ui/src/components/AvatarUploader.tsx
@@ -3,6 +3,7 @@ import { useButton } from 'react-aria';
 import { LuCamera } from 'react-icons/lu';
 
 import { cn } from '../lib/utils';
+import { Header2 } from './Header';
 import { LoadingSpinner } from './LoadingSpinner';
 
 interface ImageUploaderProps {
@@ -81,7 +82,7 @@ export const AvatarUploader = ({
       </div>
 
       <div className="text-center">
-        <h2 className="text-sm">{label}</h2>
+        <Header2 className="text-sm">{label}</Header2>
       </div>
     </div>
   );

--- a/packages/ui/src/components/BannerUploader.tsx
+++ b/packages/ui/src/components/BannerUploader.tsx
@@ -3,6 +3,7 @@ import { useButton } from 'react-aria';
 import { LuCamera } from 'react-icons/lu';
 
 import { cn } from '../lib/utils';
+import { Header2 } from './Header';
 import { LoadingSpinner } from './LoadingSpinner';
 
 export const BannerUploader = ({
@@ -75,7 +76,7 @@ export const BannerUploader = ({
       </div>
 
       <div className="text-center">
-        <h2 className="text-xs">{label}</h2>
+        <Header2 className="text-xs">{label}</Header2>
         {error && <p className="mt-2 text-functional-red">{error}</p>}
       </div>
     </div>


### PR DESCRIPTION
Replaces all raw `<h2>` and `<h3>` tags with <Header2> and <Header3> from @op/ui/Header for consistent typography. 12 files updated, global-error.tsx skipped since @op/ui is unavailable there.