### PR TITLE
fix(i18n): translate attachments dropzone in proposal form

### DIFF
--- a/apps/app/src/components/decisions/ProposalAttachments.tsx
+++ b/apps/app/src/components/decisions/ProposalAttachments.tsx
@@ -3,7 +3,7 @@
 import { trpc } from '@op/api/client';
 import { FileDropZone } from '@op/ui/FileDropZone';
 import { toast } from '@op/ui/Toast';
-import { startTransition, useOptimistic } from 'react';
+import { type ReactNode, startTransition, useOptimistic } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -177,6 +177,13 @@ export function ProposalAttachments({
       <FileDropZone
         acceptedFileTypes={ACCEPTED_TYPES}
         onSelectFiles={handleSelectFiles}
+        label={t.rich('Drag a file here or <browse>browse</browse>', {
+          browse: (chunks: ReactNode) => (
+            <span className="text-primary-teal hover:text-primary-tealBlack hover:underline">
+              {chunks}
+            </span>
+          ),
+        })}
         description={t('Accepts {types} and more up to {size}MB', {
           types: 'PDF, DOCX, XLSX',
           size: MAX_SIZE_MB,

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -736,6 +736,7 @@
   "Pending launch": "লঞ্চ মুলতুবি",
   "This process is still in draft. Participants with \"Manage Process\" access will be invited immediately. Invites without edit access will be sent when the process launches.": "এই প্রক্রিয়াটি এখনও খসড়া অবস্থায় আছে। \"প্রক্রিয়া পরিচালনা\" অ্যাক্সেস সহ অংশগ্রহণকারীদের অবিলম্বে আমন্ত্রণ জানানো হবে। সম্পাদনা অ্যাক্সেস ছাড়া আমন্ত্রণগুলি প্রক্রিয়া চালু হলে পাঠানো হবে।",
   "Failed to cancel invite": "আমন্ত্রণ বাতিল করতে ব্যর্থ",
+  "Drag a file here or <browse>browse</browse>": "এখানে একটি ফাইল টেনে আনুন বা <browse>ব্রাউজ করুন</browse>",
   "Accepts {types} and more up to {size}MB": "{types} এবং আরও {size}MB পর্যন্ত গ্রহণ করে",
   "Define the categories that proposals in this process should advance. Proposers will select which categories their proposal supports.": "এই প্রক্রিয়ায় প্রস্তাবগুলি যে বিভাগগুলি এগিয়ে নেওয়া উচিত তা সংজ্ঞায়িত করুন। প্রস্তাবকারীরা তাদের প্রস্তাব কোন বিভাগগুলি সমর্থন করে তা নির্বাচন করবেন।",
   "No categories defined yet": "এখনও কোনো বিভাগ সংজ্ঞায়িত হয়নি",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -645,6 +645,7 @@
   "Attachments": "Attachments",
   "Attachments (optional)": "Attachments (optional)",
   "Support your proposal with relevant documents like budgets or supporting research.": "Support your proposal with relevant documents like budgets or supporting research.",
+  "Drag a file here or <browse>browse</browse>": "Drag a file here or <browse>browse</browse>",
   "Accepts {types} and more up to {size}MB": "Accepts {types} and more up to {size}MB",
   "{count}/{max} attachments added": "{count}/{max} attachments added",
   "Drag to reorder": "Drag to reorder",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -644,6 +644,7 @@
   "Attachments": "Adjuntos",
   "Attachments (optional)": "Archivos adjuntos (opcional)",
   "Support your proposal with relevant documents like budgets or supporting research.": "Apoye su propuesta con documentos relevantes como presupuestos o investigación de respaldo.",
+  "Drag a file here or <browse>browse</browse>": "Arrastra un archivo aquí o <browse>explorar</browse>",
   "Accepts {types} and more up to {size}MB": "Acepta {types} y más hasta {size}MB",
   "{count}/{max} attachments added": "{count}/{max} archivos adjuntos agregados",
   "Drag to reorder": "Arrastrar para reordenar",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -645,6 +645,7 @@
   "Attachments": "Pièces jointes",
   "Attachments (optional)": "Pièces jointes (facultatif)",
   "Support your proposal with relevant documents like budgets or supporting research.": "Soutenez votre proposition avec des documents pertinents comme des budgets ou des recherches de soutien.",
+  "Drag a file here or <browse>browse</browse>": "Glissez un fichier ici ou <browse>parcourir</browse>",
   "Accepts {types} and more up to {size}MB": "Accepte {types} et plus jusqu'à {size}Mo",
   "{count}/{max} attachments added": "{count}/{max} pièces jointes ajoutées",
   "Drag to reorder": "Glisser pour réorganiser",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -645,6 +645,7 @@
   "Attachments": "Anexos",
   "Attachments (optional)": "Anexos (opcional)",
   "Support your proposal with relevant documents like budgets or supporting research.": "Apoie sua proposta com documentos relevantes como orçamentos ou pesquisa de suporte.",
+  "Drag a file here or <browse>browse</browse>": "Arraste um arquivo aqui ou <browse>procurar</browse>",
   "Accepts {types} and more up to {size}MB": "Aceita {types} e mais até {size}MB",
   "{count}/{max} attachments added": "{count}/{max} anexos adicionados",
   "Join decision-making processes": "Participe de processos de tomada de decisão",

--- a/packages/ui/src/components/FileDropZone.tsx
+++ b/packages/ui/src/components/FileDropZone.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import type { DropEvent } from 'react-aria';
 import {
   Button,
@@ -21,8 +22,8 @@ export interface FileDropZoneProps {
   /** Callback when files are selected via drop or file picker. */
   onSelectFiles: (files: File[]) => void;
 
-  /** Main label text. */
-  label?: string;
+  /** Main label content. */
+  label?: ReactNode;
 
   /** Description text shown below the label (e.g., accepted formats, size limits). */
   description?: string;


### PR DESCRIPTION
The FileDropZone default label was hardcoded in English and never translated. Changed label prop to ReactNode so ProposalAttachments can pass translated content via t.rich(), preserving the teal "browse" styling.

## Demo

<img width="2160" height="654" alt="CleanShot 2026-04-09 at 11 34 31@2x" src="https://github.com/user-attachments/assets/06337c0b-19fd-41d2-a277-c0b69e53eaeb" />
