### PR TITLE
fix(ui): Improve Button focus ring and pressed state for a11y

### DIFF
--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -53,7 +53,7 @@ const buttonStyle = tv({
     unstyled: {
       true: '',
       false:
-        'appearance-noned outline-hidden duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lightGray pressed:shadow-[inset_0_1px_2px_rgba(0,0,0,0.1)]',
+        'appearance-noned outline-hidden duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue pressed:shadow-[inset_0_2px_4px_rgba(0,0,0,0.2)]',
     },
 
     isDisabled: {
@@ -99,8 +99,7 @@ type ButtonVariants = VariantProps<typeof buttonStyle>;
 // type ButtonProps = React.ComponentProps<typeof RACButton>;
 
 export interface ButtonProps
-  extends React.ComponentProps<typeof RACButton>,
-    ButtonVariants {
+  extends React.ComponentProps<typeof RACButton>, ButtonVariants {
   className?: string;
   isLoading?: boolean;
 }
@@ -152,7 +151,8 @@ type LowLevelPressHandlers =
   | 'onPressUp';
 
 export interface ButtonLinkProps
-  extends Omit<React.ComponentProps<typeof RACLink>, LowLevelPressHandlers>,
+  extends
+    Omit<React.ComponentProps<typeof RACLink>, LowLevelPressHandlers>,
     ButtonVariants {
   className?: string;
   isLoading?: boolean;

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -53,7 +53,7 @@ const buttonStyle = tv({
     unstyled: {
       true: '',
       false:
-        'appearance-noned outline-hidden duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue pressed:shadow-[inset_0_2px_4px_rgba(0,0,0,0.2)]',
+        'appearance-noned outline-hidden duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue pressed:shadow-[inset_0_2px_4px_rgba(0,0,0,0.2)]',
     },
 
     isDisabled: {

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -99,7 +99,8 @@ type ButtonVariants = VariantProps<typeof buttonStyle>;
 // type ButtonProps = React.ComponentProps<typeof RACButton>;
 
 export interface ButtonProps
-  extends React.ComponentProps<typeof RACButton>, ButtonVariants {
+  extends React.ComponentProps<typeof RACButton>,
+    ButtonVariants {
   className?: string;
   isLoading?: boolean;
 }
@@ -151,8 +152,7 @@ type LowLevelPressHandlers =
   | 'onPressUp';
 
 export interface ButtonLinkProps
-  extends
-    Omit<React.ComponentProps<typeof RACLink>, LowLevelPressHandlers>,
+  extends Omit<React.ComponentProps<typeof RACLink>, LowLevelPressHandlers>,
     ButtonVariants {
   className?: string;
   isLoading?: boolean;

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -53,7 +53,7 @@ const buttonStyle = tv({
     unstyled: {
       true: '',
       false:
-        'appearance-noned outline-hidden duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue pressed:shadow-[inset_0_2px_4px_rgba(0,0,0,0.2)]',
+        'appearance-noned outline-0 outline-transparent duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue pressed:shadow-[inset_0_2px_4px_rgba(0,0,0,0.2)]',
     },
 
     isDisabled: {

--- a/packages/ui/src/components/DropDownButton.tsx
+++ b/packages/ui/src/components/DropDownButton.tsx
@@ -9,7 +9,7 @@ import { Menu, MenuItem, MenuTrigger } from './Menu';
 import { Popover } from './Popover';
 
 const dropdownButtonStyle = tv({
-  base: 'flex h-10 w-fit items-center justify-center gap-1 rounded-lg border border-solid p-4 text-center text-sm leading-6 font-normal shadow-md outline-hidden duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lightGray',
+  base: 'flex h-10 w-fit items-center justify-center gap-1 rounded-lg border border-solid p-4 text-center text-sm leading-6 font-normal shadow-md outline-hidden duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue',
   variants: {
     color: {
       primary:

--- a/packages/ui/src/components/DropDownButton.tsx
+++ b/packages/ui/src/components/DropDownButton.tsx
@@ -9,7 +9,7 @@ import { Menu, MenuItem, MenuTrigger } from './Menu';
 import { Popover } from './Popover';
 
 const dropdownButtonStyle = tv({
-  base: 'flex h-10 w-fit items-center justify-center gap-1 rounded-lg border border-solid p-4 text-center text-sm leading-6 font-normal shadow-md outline-hidden duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue',
+  base: 'flex h-10 w-fit items-center justify-center gap-1 rounded-lg border border-solid p-4 text-center text-sm leading-6 font-normal shadow-md outline-hidden duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue',
   variants: {
     color: {
       primary:

--- a/packages/ui/src/components/DropDownButton.tsx
+++ b/packages/ui/src/components/DropDownButton.tsx
@@ -9,7 +9,7 @@ import { Menu, MenuItem, MenuTrigger } from './Menu';
 import { Popover } from './Popover';
 
 const dropdownButtonStyle = tv({
-  base: 'flex h-10 w-fit items-center justify-center gap-1 rounded-lg border border-solid p-4 text-center text-sm leading-6 font-normal shadow-md outline-hidden duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue',
+  base: 'flex h-10 w-fit items-center justify-center gap-1 rounded-lg border border-solid p-4 text-center text-sm leading-6 font-normal shadow-md outline-0 outline-transparent duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue',
   variants: {
     color: {
       primary:

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -5,7 +5,7 @@ import { tv } from 'tailwind-variants';
 import type { VariantProps } from 'tailwind-variants';
 
 const iconButtonStyle = tv({
-  base: 'flex cursor-pointer items-center justify-center outline-hidden duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-primary-tealBlack',
+  base: 'flex cursor-pointer items-center justify-center outline-0 outline-transparent duration-200 focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-primary-tealBlack',
   variants: {
     size: {
       small: 'h-6 w-6 rounded-full',

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -5,7 +5,7 @@ import { tv } from 'tailwind-variants';
 import type { VariantProps } from 'tailwind-variants';
 
 const iconButtonStyle = tv({
-  base: 'flex cursor-pointer items-center justify-center outline-hidden duration-200 focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-primary-tealBlack',
+  base: 'flex cursor-pointer items-center justify-center outline-hidden duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-primary-tealBlack',
   variants: {
     size: {
       small: 'h-6 w-6 rounded-full',

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -7,10 +7,10 @@ export const focusRing = tv({
   base: 'outline-auto -outline-offset-8 outline-transparent focus-within:outline-offWhite focus-visible:outline-offWhite',
   variants: {
     isFocused: {
-      true: 'outline-lightGray',
+      true: 'outline-ring',
     },
     isFocusVisible: {
-      true: 'outline-lightGray',
+      true: 'outline-ring',
     },
   },
 });


### PR DESCRIPTION
Fixes missing visible focus ring and weak pressed state on the @op/ui Button component. Changes `focus-visible:outline-lightGray` to `focus-visible:outline-data-blue` (consistent with other components) and strengthens the pressed inset shadow for better keyboard navigation feedback (WCAG 2.4.7).

https://github.com/user-attachments/assets/5a88bddc-ef54-4050-a10e-8a2bdf28ea88


