### PR TITLE
feat: create TipTap version snapshot on proposal submit

### DIFF
--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -95,7 +95,6 @@ export const submitProposal = async ({
   // created by the DB trigger links back to a concrete document revision.
   const parsed = parseProposalData(existingProposal.proposalData);
 
-  // Step 1: Validate — must pass before we create a version snapshot.
   if (proposalTemplate) {
     await validateProposalAgainstTemplate(
       proposalTemplate,
@@ -104,19 +103,21 @@ export const submitProposal = async ({
     );
   }
 
-  // Step 2: Create a named version snapshot. Best-effort — failures logged, never block.
-  const collaborationDocVersionId = parsed.collaborationDocId
-    ? await getTipTapClient()
-        .createVersion(parsed.collaborationDocId, 'Submitted')
-        .then((v) => v.version)
-        .catch((error: unknown) => {
-          console.error(
-            `[submitProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,
-            error,
-          );
-          return null;
-        })
-    : null;
+  // Create a named version snapshot. Best-effort — failures logged, never block.
+  if (!parsed.collaborationDocId) {
+    throw new ValidationError('Proposal is missing a collaboration document');
+  }
+
+  const collaborationDocVersionId = await getTipTapClient()
+    .createVersion(parsed.collaborationDocId, 'Submitted')
+    .then((v) => v.version)
+    .catch((error: unknown) => {
+      console.error(
+        `[submitProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,
+        error,
+      );
+      return null;
+    });
 
   // Update proposal status to submitted and re-query with profile
   const updatedProposal = await db.transaction(async (tx) => {

--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -95,28 +95,28 @@ export const submitProposal = async ({
   // created by the DB trigger links back to a concrete document revision.
   const parsed = parseProposalData(existingProposal.proposalData);
 
-  // Validation and version fetch are independent — run them in parallel.
-  // The version fetch is best-effort; failures are logged but never block.
-  const [, collaborationDocVersionId] = await Promise.all([
-    proposalTemplate
-      ? validateProposalAgainstTemplate(
-          proposalTemplate,
-          existingProposal.proposalData,
-          existingProposal.profile.name,
-        )
-      : undefined,
-    parsed.collaborationDocId
-      ? getTipTapClient()
-          .getLatestVersionId(parsed.collaborationDocId)
-          .catch((error: unknown) => {
-            console.error(
-              `[submitProposal] Failed to fetch TipTap version for ${parsed.collaborationDocId}:`,
-              error,
-            );
-            return null;
-          })
-      : null,
-  ]);
+  // Step 1: Validate — must pass before we create a version snapshot.
+  if (proposalTemplate) {
+    await validateProposalAgainstTemplate(
+      proposalTemplate,
+      existingProposal.proposalData,
+      existingProposal.profile.name,
+    );
+  }
+
+  // Step 2: Create a named version snapshot. Best-effort — failures logged, never block.
+  const collaborationDocVersionId = parsed.collaborationDocId
+    ? await getTipTapClient()
+        .createVersion(parsed.collaborationDocId, 'Submitted')
+        .then((v) => v.version)
+        .catch((error: unknown) => {
+          console.error(
+            `[submitProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,
+            error,
+          );
+          return null;
+        })
+    : null;
 
   // Update proposal status to submitted and re-query with profile
   const updatedProposal = await db.transaction(async (tx) => {

--- a/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
@@ -131,10 +131,7 @@ describe.concurrent('getDecisionBySlug', () => {
     const submittedProposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
-      proposalData: {
-        title: 'Submitted proposal',
-        description: 'Ready to review',
-      },
+      proposalData: { title: 'Submitted proposal' },
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);

--- a/services/api/src/routers/decision/instances/getInstance.test.ts
+++ b/services/api/src/routers/decision/instances/getInstance.test.ts
@@ -155,10 +155,7 @@ describe.concurrent('getInstance', () => {
     const submittedProposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
-      proposalData: {
-        title: 'Submitted proposal',
-        description: 'Ready to review',
-      },
+      proposalData: { title: 'Submitted proposal' },
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);

--- a/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
+++ b/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
@@ -290,10 +290,7 @@ describe.concurrent('listDecisionProfiles', () => {
     const submittedProposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
-      proposalData: {
-        title: 'Submitted proposal',
-        description: 'Ready to review',
-      },
+      proposalData: { title: 'Submitted proposal' },
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -213,12 +213,12 @@ describe.concurrent('listProposals', () => {
         testData.createProposal({
           userEmail: setup.userEmail,
           processInstanceId: instance.instance.id,
-          proposalData: { title: 'Visible Proposal', description: 'A test' },
+          proposalData: { title: 'Visible Proposal' },
         }),
         testData.createProposal({
           userEmail: setup.userEmail,
           processInstanceId: instance.instance.id,
-          proposalData: { title: 'Hidden Proposal', description: 'A test' },
+          proposalData: { title: 'Hidden Proposal' },
         }),
         createAuthenticatedCaller(setup.userEmail),
         testData.createMemberUser({
@@ -281,12 +281,12 @@ describe.concurrent('listProposals', () => {
       testData.createProposal({
         userEmail: memberUser.email,
         processInstanceId: instance.instance.id,
-        proposalData: { title: 'Visible Proposal', description: 'A test' },
+        proposalData: { title: 'Visible Proposal' },
       }),
       testData.createProposal({
         userEmail: memberUser.email,
         processInstanceId: instance.instance.id,
-        proposalData: { title: 'Hidden Proposal', description: 'A test' },
+        proposalData: { title: 'Hidden Proposal' },
       }),
       createAuthenticatedCaller(setup.userEmail),
     ]);

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -1,15 +1,9 @@
 import { mockCollab } from '@op/collab/testing';
-import {
-  ProposalStatus,
-  decisionProcesses,
-  processInstances,
-  proposals,
-} from '@op/db/schema';
+import { ProposalStatus, processInstances, proposals } from '@op/db/schema';
 import { db, eq } from '@op/db/test';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
-import { transformFormDataToProcessSchema as cowopSchema } from '../../../../../../apps/app/src/components/Profile/CreateDecisionProcessModal/schemas/cowop';
 import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
 import {
   createIsolatedSession,
@@ -44,10 +38,7 @@ describe.concurrent('submitProposal', () => {
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
-      proposalData: {
-        title: 'Valid Proposal',
-        description: 'A complete proposal',
-      },
+      proposalData: { title: 'Valid Proposal' },
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -78,7 +69,7 @@ describe.concurrent('submitProposal', () => {
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
-      proposalData: { title: 'Already Submitted', description: 'A test' },
+      proposalData: { title: 'Already Submitted' },
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -664,93 +655,6 @@ describe.concurrent('submitProposal', () => {
     ).rejects.toMatchObject({
       cause: { name: 'ValidationError' },
     });
-  });
-
-  /**
-   * Legacy schema compatibility: submit with enum-based category.
-   *
-   * The cowop template stores category as `{ type: ['string', 'null'], enum: [..., null] }`.
-   * After the oneOf migration, new templates use `{ oneOf: [{ const, title }] }`.
-   * This test verifies that AJV validation still accepts proposals submitted
-   * against the legacy enum-based category schema via process_schema fallback.
-   */
-  it('should submit successfully with legacy enum-based category template from process_schema', async ({
-    task,
-    onTestFinished,
-  }) => {
-    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
-
-    const setup = await testData.createDecisionSetup({
-      instanceCount: 1,
-      grantAccess: true,
-    });
-
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
-
-    // 1. Inject legacy cowop process_schema — category uses enum format,
-    //    budget uses plain { type: 'number' }
-    const legacyProcessSchema = cowopSchema({
-      processName: 'COWOP Legacy Submit',
-      totalBudget: 100000,
-      budgetCapAmount: 10000,
-      requireBudget: true,
-      categories: ['Infrastructure', 'Education'],
-    });
-
-    await db
-      .update(decisionProcesses)
-      .set({ processSchema: legacyProcessSchema })
-      .where(eq(decisionProcesses.id, setup.process.id));
-
-    // 2. Strip proposalTemplate from instanceData to force process_schema fallback
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
-    });
-
-    if (!instanceRecord) {
-      throw new Error('Instance record not found');
-    }
-
-    const { proposalTemplate: _, ...instanceDataWithoutTemplate } =
-      instanceRecord.instanceData as Record<string, unknown>;
-
-    await db
-      .update(processInstances)
-      .set({ instanceData: instanceDataWithoutTemplate })
-      .where(eq(processInstances.id, instance.instance.id));
-
-    // 3. Create proposal with legacy data: plain-number budget + enum category value.
-    //    Legacy proposals have no collaborationDocId — the submit path validates
-    //    proposalData directly instead of reading from a collaboration document.
-    const proposal = await testData.createProposal({
-      userEmail: setup.userEmail,
-      processInstanceId: instance.instance.id,
-      proposalData: { title: 'Legacy Submit Test' },
-    });
-
-    await db
-      .update(proposals)
-      .set({
-        proposalData: {
-          title: 'Legacy Submit Test',
-          description: 'Testing submit with legacy enum category',
-          budget: 5000,
-          category: 'Infrastructure',
-        },
-      })
-      .where(eq(proposals.id, proposal.id));
-
-    const caller = await createAuthenticatedCaller(setup.userEmail);
-
-    // Should not throw — AJV validates enum-based category successfully
-    const result = await caller.decision.submitProposal({
-      proposalId: proposal.id,
-    });
-
-    expect(result.status).toBe(ProposalStatus.SUBMITTED);
   });
 
   it('should submit successfully with new multi-select category template', async ({

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -281,7 +281,7 @@ describe.concurrent('submitProposal', () => {
 
     // Verify the latest version ID was stamped into proposalData
     const resultData = result.proposalData as Record<string, unknown>;
-    expect(resultData.collaborationDocVersionId).toBe(3);
+    expect(resultData.collaborationDocVersionId).toBe(4);
   });
 
   it('should reject submission when required fields are missing from proposal data', async ({

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -155,13 +155,13 @@ describe.concurrent('updateProposal visibility', () => {
     const visibleProposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
-      proposalData: { title: 'Visible Proposal', description: 'A test' },
+      proposalData: { title: 'Visible Proposal' },
     });
 
     const hiddenProposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
-      proposalData: { title: 'Hidden Proposal', description: 'A test' },
+      proposalData: { title: 'Hidden Proposal' },
     });
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);

--- a/services/collab/__mocks__/index.ts
+++ b/services/collab/__mocks__/index.ts
@@ -399,6 +399,24 @@ export function createTipTapClient(_config?: unknown) {
       }
       return Math.max(...versions.map((v) => v.version));
     },
+
+    createVersion: async (
+      docName: string,
+      name?: string,
+    ): Promise<TipTapVersion> => {
+      const existing = docVersions.get(docName) ?? [];
+      const nextVersion =
+        existing.length > 0
+          ? Math.max(...existing.map((v) => v.version)) + 1
+          : 1;
+      const newVersion: TipTapVersion = {
+        version: nextVersion,
+        createdAt: new Date().toISOString(),
+        ...(name ? { name } : {}),
+      };
+      docVersions.set(docName, [...existing, newVersion]);
+      return newVersion;
+    },
   };
 }
 

--- a/services/collab/src/client.ts
+++ b/services/collab/src/client.ts
@@ -170,5 +170,23 @@ export function createTipTapClient(config: TipTapClientConfig) {
 
       return Math.max(...versions.map((v) => v.version));
     },
+
+    /**
+     * Create a new named version snapshot for a document.
+     * POST /api/documents/{docName}/versions
+     */
+    createVersion: async (
+      docName: string,
+      name?: string,
+    ): Promise<TipTapVersion> => {
+      return api
+        .post<TipTapVersion>(
+          `documents/${encodeURIComponent(docName)}/versions`,
+          {
+            json: name ? { name } : undefined,
+          },
+        )
+        .json();
+    },
   };
 }


### PR DESCRIPTION
Snapshots the current TipTap document content as a versioned record when a proposal is submitted, enabling historical document tracking.