### PR TITLE
feat(proposals): add checkpoint support to updateProposal for explicit version stamping

### DIFF
--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -327,6 +327,7 @@ function ProposalEditorInner({
         data: {
           title: currentDraft.title,
           proposalData,
+          ...(!isDraft ? { checkpointVersion: { type: 'update' } } : {}),
         },
       });
 

--- a/packages/common/src/services/decision/proposalDataSchema.ts
+++ b/packages/common/src/services/decision/proposalDataSchema.ts
@@ -68,6 +68,13 @@ export type ProposalData = z.infer<typeof proposalDataSchema>;
 /** Input type for proposal data (before parsing/defaults) */
 export type ProposalDataInput = z.input<typeof proposalDataSchema>;
 
+/** Discriminated union for explicit proposal version checkpoints. */
+export const checkpointVersionSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('update') }),
+]);
+
+export type CheckpointVersion = z.infer<typeof checkpointVersionSchema>;
+
 export function normalizeProposalCategories(raw: unknown): string[] {
   if (typeof raw === 'string') {
     try {

--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -110,7 +110,6 @@ export const submitProposal = async ({
 
   const collaborationDocVersionId = await getTipTapClient()
     .createVersion(parsed.collaborationDocId, 'Submitted')
-    .then((v) => v.version)
     .catch((error: unknown) => {
       console.error(
         `[submitProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,

--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -110,6 +110,7 @@ export const submitProposal = async ({
 
   const collaborationDocVersionId = await getTipTapClient()
     .createVersion(parsed.collaborationDocId, 'Submitted')
+    .then((v) => v?.version ?? null)
     .catch((error: unknown) => {
       console.error(
         `[submitProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -258,6 +258,7 @@ async function createCheckpointVersion(
 
   const latestVersion = await getTipTapClient()
     .createVersion(parsed.collaborationDocId, 'Updated')
+    .then((v) => v?.version ?? null)
     .catch((error: unknown) => {
       console.error(
         `[updateProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -179,37 +179,10 @@ export const updateProposal = async ({
       }
     }
 
-    // Create a named version snapshot when explicitly checkpointing.
-    // Best-effort — failures logged, never block.
-    let collaborationDocVersionId: number | null = null;
-    if (
-      data.checkpointVersion &&
-      existingProposal.status !== ProposalStatus.DRAFT
-    ) {
-      const parsed = parseProposalData(existingProposal.proposalData);
-
-      if (parsed.collaborationDocId) {
-        const versionName = 'Updated';
-
-        const latestVersion = await getTipTapClient()
-          .createVersion(parsed.collaborationDocId, versionName)
-          .then((v) => v.version)
-          .catch((error: unknown) => {
-            console.error(
-              `[updateProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,
-              error,
-            );
-            return null;
-          });
-
-        if (
-          latestVersion != null &&
-          latestVersion !== parsed.collaborationDocVersionId
-        ) {
-          collaborationDocVersionId = latestVersion;
-        }
-      }
-    }
+    const collaborationDocVersionId =
+      data.checkpointVersion && existingProposal.status !== ProposalStatus.DRAFT
+        ? await createCheckpointVersion(existingProposal.proposalData)
+        : null;
 
     const {
       title: nextTitle,
@@ -290,3 +263,33 @@ export const updateProposal = async ({
     throw new CommonError('Failed to update proposal');
   }
 };
+
+async function createCheckpointVersion(
+  proposalData: unknown,
+): Promise<number | null> {
+  const parsed = parseProposalData(proposalData);
+
+  if (!parsed.collaborationDocId) {
+    throw new ValidationError('Proposal is missing a collaboration document');
+  }
+
+  const latestVersion = await getTipTapClient()
+    .createVersion(parsed.collaborationDocId, 'Updated')
+    .then((v) => v.version)
+    .catch((error: unknown) => {
+      console.error(
+        `[updateProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,
+        error,
+      );
+      return null;
+    });
+
+  if (
+    latestVersion != null &&
+    latestVersion !== parsed.collaborationDocVersionId
+  ) {
+    return latestVersion;
+  }
+
+  return null;
+}

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -20,7 +20,10 @@ import {
 } from '../../utils';
 import { assertInstanceProfileAccess, getProfileAccessUser } from '../access';
 import { assertUserByAuthId } from '../assert';
-import type { ProposalDataInput } from './proposalDataSchema';
+import type {
+  CheckpointVersion,
+  ProposalDataInput,
+} from './proposalDataSchema';
 import { parseProposalData } from './proposalDataSchema';
 import { resolveProposalTemplate } from './resolveProposalTemplate';
 import type { DecisionInstanceData } from './schemas/instanceData';
@@ -80,16 +83,12 @@ async function updateProposalCategoryLink(
   }
 }
 
-export type ProposalCheckpoint =
-  | { type: 'update' }
-  | { type: 'reviewRevision'; reviewRequestId: string };
-
 export interface UpdateProposalInput {
   title?: string;
   proposalData?: ProposalDataInput;
   status?: ProposalStatus;
   visibility?: Visibility;
-  checkpoint?: ProposalCheckpoint;
+  checkpointVersion?: CheckpointVersion;
 }
 
 export const updateProposal = async ({
@@ -183,12 +182,14 @@ export const updateProposal = async ({
     // Create a named version snapshot when explicitly checkpointing.
     // Best-effort — failures logged, never block.
     let collaborationDocVersionId: number | null = null;
-    if (data.checkpoint && existingProposal.status !== ProposalStatus.DRAFT) {
+    if (
+      data.checkpointVersion &&
+      existingProposal.status !== ProposalStatus.DRAFT
+    ) {
       const parsed = parseProposalData(existingProposal.proposalData);
 
       if (parsed.collaborationDocId) {
-        const versionName =
-          data.checkpoint.type === 'reviewRevision' ? 'Revision' : 'Updated';
+        const versionName = 'Updated';
 
         const latestVersion = await getTipTapClient()
           .createVersion(parsed.collaborationDocId, versionName)
@@ -212,7 +213,7 @@ export const updateProposal = async ({
 
     const {
       title: nextTitle,
-      checkpoint: _checkpoint,
+      checkpointVersion: _checkpointVersion,
       ...proposalFields
     } = data;
 

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -258,7 +258,6 @@ async function createCheckpointVersion(
 
   const latestVersion = await getTipTapClient()
     .createVersion(parsed.collaborationDocId, 'Updated')
-    .then((v) => v.version)
     .catch((error: unknown) => {
       console.error(
         `[updateProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -100,168 +100,151 @@ export const updateProposal = async ({
   data: UpdateProposalInput;
   user: User;
 }) => {
-  try {
-    const dbUser = await assertUserByAuthId(user.id);
+  const dbUser = await assertUserByAuthId(user.id);
 
-    if (!dbUser.currentProfileId) {
-      throw new UnauthorizedError('User must have an active profile');
-    }
+  if (!dbUser.profileId) {
+    throw new UnauthorizedError('User must have an active profile');
+  }
 
-    // Check if proposal exists and user has permission to update it
-    const existingProposal = await db.query.proposals.findFirst({
-      where: { id: proposalId },
-      with: {
-        processInstance: true,
-        profile: true,
-      },
+  // Check if proposal exists and user has permission to update it
+  const existingProposal = await db.query.proposals.findFirst({
+    where: { id: proposalId },
+    with: {
+      processInstance: true,
+      profile: true,
+    },
+  });
+
+  if (!existingProposal) {
+    throw new NotFoundError('Proposal');
+  }
+
+  const processInstance = existingProposal.processInstance;
+
+  // Reject updates when the instance is in the results phase
+  if (processInstance.currentStateId === 'results') {
+    throw new ValidationError(
+      'Proposals cannot be edited during the results phase',
+    );
+  }
+
+  // Status and visibility changes only require instance-level decisions: ADMIN
+  if (data.status || data.visibility) {
+    await assertInstanceProfileAccess({
+      user: { id: user.id },
+      instance: processInstance,
+      profilePermissions: { decisions: permission.ADMIN },
+      orgFallbackPermissions: [{ decisions: permission.ADMIN }],
+    });
+  } else {
+    // Data updates require profile-level update permission on the proposal's profile
+    const proposalProfileUser = await getProfileAccessUser({
+      user: { id: user.id },
+      profileId: existingProposal.profileId,
     });
 
-    if (!existingProposal) {
-      throw new NotFoundError('Proposal');
-    }
+    const hasProposalUpdate = checkPermission(
+      { profile: permission.UPDATE },
+      proposalProfileUser?.roles ?? [],
+    );
 
-    const processInstance = existingProposal.processInstance;
-
-    // Reject updates when the instance is in the results phase
-    if (processInstance.currentStateId === 'results') {
-      throw new ValidationError(
-        'Proposals cannot be edited during the results phase',
-      );
-    }
-
-    // Status and visibility changes only require instance-level decisions: ADMIN
-    if (data.status || data.visibility) {
+    if (!hasProposalUpdate) {
       await assertInstanceProfileAccess({
         user: { id: user.id },
         instance: processInstance,
-        profilePermissions: { decisions: permission.ADMIN },
+        profilePermissions: { decisions: permission.UPDATE },
         orgFallbackPermissions: [{ decisions: permission.ADMIN }],
       });
-    } else {
-      // Data updates require profile-level update permission on the proposal's profile
-      const proposalProfileUser = await getProfileAccessUser({
-        user: { id: user.id },
-        profileId: existingProposal.profileId,
-      });
+    }
+  }
 
-      const hasProposalUpdate = checkPermission(
-        { profile: permission.UPDATE },
-        proposalProfileUser?.roles ?? [],
+  // Validate proposal data against template schema when updating non-draft proposals.
+  // Drafts are inherently incomplete — validation is enforced on submission.
+  if (data.proposalData && existingProposal.status !== ProposalStatus.DRAFT) {
+    const instanceData =
+      processInstance.instanceData as DecisionInstanceData | null;
+
+    const proposalTemplate = await resolveProposalTemplate(
+      instanceData,
+      processInstance.processId,
+    );
+
+    if (proposalTemplate) {
+      await validateProposalAgainstTemplate(
+        proposalTemplate,
+        data.proposalData,
+        data.title ?? existingProposal.profile.name,
       );
+    }
+  }
 
-      if (!hasProposalUpdate) {
-        await assertInstanceProfileAccess({
-          user: { id: user.id },
-          instance: processInstance,
-          profilePermissions: { decisions: permission.UPDATE },
-          orgFallbackPermissions: [{ decisions: permission.ADMIN }],
-        });
-      }
+  const collaborationDocVersionId =
+    data.checkpointVersion && existingProposal.status !== ProposalStatus.DRAFT
+      ? await createCheckpointVersion(existingProposal.proposalData)
+      : null;
+
+  const {
+    title: nextTitle,
+    checkpointVersion: _checkpointVersion,
+    ...proposalFields
+  } = data;
+
+  const updatedProposal = await db.transaction(async (tx) => {
+    const proposalDataWithVersion =
+      collaborationDocVersionId !== null
+        ? {
+            ...(proposalFields.proposalData ??
+              (existingProposal.proposalData as Record<string, unknown>)),
+            collaborationDocVersionId,
+          }
+        : proposalFields.proposalData;
+
+    const [updatedProposalRow] = await tx
+      .update(proposals)
+      .set({
+        ...proposalFields,
+        ...(proposalDataWithVersion
+          ? { proposalData: proposalDataWithVersion }
+          : {}),
+        lastEditedByProfileId: dbUser.profileId,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(proposals.id, proposalId))
+      .returning();
+
+    if (!updatedProposalRow) {
+      throw new CommonError('Failed to update proposal');
     }
 
-    // Validate proposal data against template schema when updating non-draft proposals.
-    // Drafts are inherently incomplete — validation is enforced on submission.
-    if (data.proposalData && existingProposal.status !== ProposalStatus.DRAFT) {
-      const instanceData =
-        processInstance.instanceData as DecisionInstanceData | null;
-
-      const proposalTemplate = await resolveProposalTemplate(
-        instanceData,
-        processInstance.processId,
-      );
-
-      if (proposalTemplate) {
-        await validateProposalAgainstTemplate(
-          proposalTemplate,
-          data.proposalData,
-          data.title ?? existingProposal.profile.name,
-        );
-      }
-    }
-
-    const collaborationDocVersionId =
-      data.checkpointVersion && existingProposal.status !== ProposalStatus.DRAFT
-        ? await createCheckpointVersion(existingProposal.proposalData)
-        : null;
-
-    const {
-      title: nextTitle,
-      checkpointVersion: _checkpointVersion,
-      ...proposalFields
-    } = data;
-
-    const updatedProposal = await db.transaction(async (tx) => {
-      const proposalDataWithVersion =
-        collaborationDocVersionId != null && proposalFields.proposalData
-          ? {
-              ...proposalFields.proposalData,
-              collaborationDocVersionId,
-            }
-          : collaborationDocVersionId != null
-            ? {
-                ...(existingProposal.proposalData as Record<string, unknown>),
-                collaborationDocVersionId,
-              }
-            : proposalFields.proposalData;
-
-      const [updatedProposalRow] = await tx
-        .update(proposals)
+    if (nextTitle !== undefined) {
+      await tx
+        .update(profiles)
         .set({
-          ...proposalFields,
-          ...(proposalDataWithVersion
-            ? { proposalData: proposalDataWithVersion }
-            : {}),
-          lastEditedByProfileId: dbUser.currentProfileId,
+          name: nextTitle,
           updatedAt: new Date().toISOString(),
         })
-        .where(eq(proposals.id, proposalId))
-        .returning();
+        .where(eq(profiles.id, existingProposal.profileId));
+    }
 
-      if (!updatedProposalRow) {
-        throw new CommonError('Failed to update proposal');
-      }
+    // Update category link if proposal data was updated
+    if (data.proposalData) {
+      const newCategoryLabels = parseProposalData(data.proposalData).category;
+      await updateProposalCategoryLink(tx, proposalId, newCategoryLabels);
+    }
 
-      if (nextTitle !== undefined) {
-        await tx
-          .update(profiles)
-          .set({
-            name: nextTitle,
-            updatedAt: new Date().toISOString(),
-          })
-          .where(eq(profiles.id, existingProposal.profileId));
-      }
-
-      // Update category link if proposal data was updated
-      if (data.proposalData) {
-        const newCategoryLabels = parseProposalData(data.proposalData).category;
-        await updateProposalCategoryLink(tx, proposalId, newCategoryLabels);
-      }
-
-      const proposal = await tx.query.proposals.findFirst({
-        where: { id: updatedProposalRow.id },
-        with: { profile: true },
-      });
-
-      if (!proposal) {
-        throw new CommonError('Failed to update proposal');
-      }
-
-      return proposal;
+    const proposal = await tx.query.proposals.findFirst({
+      where: { id: updatedProposalRow.id },
+      with: { profile: true },
     });
 
-    return updatedProposal;
-  } catch (error) {
-    if (
-      error instanceof UnauthorizedError ||
-      error instanceof NotFoundError ||
-      error instanceof ValidationError ||
-      error instanceof CommonError
-    ) {
-      throw error;
+    if (!proposal) {
+      throw new CommonError('Failed to update proposal');
     }
-    console.error('Error updating proposal:', error);
-    throw new CommonError('Failed to update proposal');
-  }
+
+    return proposal;
+  });
+
+  return updatedProposal;
 };
 
 async function createCheckpointVersion(

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -1,3 +1,4 @@
+import { getTipTapClient } from '@op/collab';
 import { type TransactionType, and, db, eq } from '@op/db/client';
 import {
   ProposalStatus,
@@ -79,11 +80,16 @@ async function updateProposalCategoryLink(
   }
 }
 
+export type ProposalCheckpoint =
+  | { type: 'update' }
+  | { type: 'reviewRevision'; reviewRequestId: string };
+
 export interface UpdateProposalInput {
   title?: string;
   proposalData?: ProposalDataInput;
   status?: ProposalStatus;
   visibility?: Visibility;
+  checkpoint?: ProposalCheckpoint;
 }
 
 export const updateProposal = async ({
@@ -174,13 +180,63 @@ export const updateProposal = async ({
       }
     }
 
-    const { title: nextTitle, ...proposalFields } = data;
+    // Create a named version snapshot when explicitly checkpointing.
+    // Best-effort — failures logged, never block.
+    let collaborationDocVersionId: number | null = null;
+    if (data.checkpoint && existingProposal.status !== ProposalStatus.DRAFT) {
+      const parsed = parseProposalData(existingProposal.proposalData);
+
+      if (parsed.collaborationDocId) {
+        const versionName =
+          data.checkpoint.type === 'reviewRevision' ? 'Revision' : 'Updated';
+
+        const latestVersion = await getTipTapClient()
+          .createVersion(parsed.collaborationDocId, versionName)
+          .then((v) => v.version)
+          .catch((error: unknown) => {
+            console.error(
+              `[updateProposal] Failed to create TipTap version for ${parsed.collaborationDocId}:`,
+              error,
+            );
+            return null;
+          });
+
+        if (
+          latestVersion != null &&
+          latestVersion !== parsed.collaborationDocVersionId
+        ) {
+          collaborationDocVersionId = latestVersion;
+        }
+      }
+    }
+
+    const {
+      title: nextTitle,
+      checkpoint: _checkpoint,
+      ...proposalFields
+    } = data;
 
     const updatedProposal = await db.transaction(async (tx) => {
+      const proposalDataWithVersion =
+        collaborationDocVersionId != null && proposalFields.proposalData
+          ? {
+              ...proposalFields.proposalData,
+              collaborationDocVersionId,
+            }
+          : collaborationDocVersionId != null
+            ? {
+                ...(existingProposal.proposalData as Record<string, unknown>),
+                collaborationDocVersionId,
+              }
+            : proposalFields.proposalData;
+
       const [updatedProposalRow] = await tx
         .update(proposals)
         .set({
           ...proposalFields,
+          ...(proposalDataWithVersion
+            ? { proposalData: proposalDataWithVersion }
+            : {}),
           lastEditedByProfileId: dbUser.currentProfileId,
           updatedAt: new Date().toISOString(),
         })

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -1,4 +1,8 @@
-import { REVIEWS_POLICIES, proposalSchema } from '@op/common/client';
+import {
+  REVIEWS_POLICIES,
+  checkpointVersionSchema,
+  proposalSchema,
+} from '@op/common/client';
 import {
   ProcessStatus,
   ProposalStatus,
@@ -582,15 +586,7 @@ export const updateProposalInputSchema = createProposalInputSchema
       ])
       .optional(),
     /** Stamps a TipTap version snapshot for the collaboration document. */
-    checkpoint: z
-      .discriminatedUnion('type', [
-        z.object({ type: z.literal('update') }),
-        z.object({
-          type: z.literal('reviewRevision'),
-          reviewRequestId: z.uuid(),
-        }),
-      ])
-      .optional(),
+    checkpointVersion: checkpointVersionSchema.optional(),
   });
 
 export const submitDecisionInputSchema = z.object({

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -581,6 +581,16 @@ export const updateProposalInputSchema = createProposalInputSchema
         ProposalStatus.SELECTED,
       ])
       .optional(),
+    /** Stamps a TipTap version snapshot for the collaboration document. */
+    checkpoint: z
+      .discriminatedUnion('type', [
+        z.object({ type: z.literal('update') }),
+        z.object({
+          type: z.literal('reviewRevision'),
+          reviewRequestId: z.uuid(),
+        }),
+      ])
+      .optional(),
   });
 
 export const submitDecisionInputSchema = z.object({

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -164,6 +164,30 @@ describe.concurrent('updateProposal visibility', () => {
       proposalData: { title: 'Hidden Proposal' },
     });
 
+    // Set collaborationDocId on both proposals so submit succeeds
+    const visibleDocId = `proposal-${visibleProposal.id}`;
+    const hiddenDocId = `proposal-${hiddenProposal.id}`;
+    await Promise.all([
+      db
+        .update(proposals)
+        .set({
+          proposalData: {
+            title: 'Visible Proposal',
+            collaborationDocId: visibleDocId,
+          },
+        })
+        .where(eq(proposals.id, visibleProposal.id)),
+      db
+        .update(proposals)
+        .set({
+          proposalData: {
+            title: 'Hidden Proposal',
+            collaborationDocId: hiddenDocId,
+          },
+        })
+        .where(eq(proposals.id, hiddenProposal.id)),
+    ]);
+
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
 
     // Submit both proposals first (drafts are only visible to proposal-level access holders)
@@ -601,5 +625,150 @@ describe.concurrent('updateProposal validation', () => {
     ).rejects.toMatchObject({
       code: 'BAD_REQUEST',
     });
+  });
+});
+
+describe.concurrent('updateProposal checkpoint', () => {
+  it('should stamp collaborationDocVersionId when checkpoint is true on a submitted proposal', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Test Proposal', description: 'A test' },
+    });
+
+    const collaborationDocId = `proposal-${proposal.id}`;
+
+    // Move proposal to submitted and set up collaboration doc
+    await db
+      .update(proposals)
+      .set({
+        status: ProposalStatus.SUBMITTED,
+        proposalData: { title: 'Test Proposal', collaborationDocId },
+      })
+      .where(eq(proposals.id, proposal.id));
+
+    mockCollab.setDocFragments(collaborationDocId, {
+      title: 'Test Proposal',
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.updateProposal({
+      proposalId: proposal.id,
+      data: {
+        proposalData: { title: 'Updated Proposal' },
+        checkpoint: { type: 'update' },
+      },
+    });
+
+    expect(
+      (result.proposalData as Record<string, unknown>)
+        .collaborationDocVersionId,
+    ).toBe(1);
+  });
+
+  it('should not stamp collaborationDocVersionId when checkpoint is omitted', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Test Proposal', description: 'A test' },
+    });
+
+    const collaborationDocId = `proposal-${proposal.id}`;
+
+    await db
+      .update(proposals)
+      .set({
+        status: ProposalStatus.SUBMITTED,
+        proposalData: { title: 'Test Proposal', collaborationDocId },
+      })
+      .where(eq(proposals.id, proposal.id));
+
+    mockCollab.setDocFragments(collaborationDocId, {
+      title: 'Test Proposal',
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.updateProposal({
+      proposalId: proposal.id,
+      data: {
+        proposalData: { title: 'Updated Proposal' },
+      },
+    });
+
+    expect(
+      (result.proposalData as Record<string, unknown>)
+        .collaborationDocVersionId,
+    ).toBeUndefined();
+  });
+
+  it('should not stamp collaborationDocVersionId on a draft even with checkpoint true', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Proposal is created in DRAFT status by default
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Draft Proposal', description: 'A test' },
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.updateProposal({
+      proposalId: proposal.id,
+      data: {
+        proposalData: { title: 'Updated Draft' },
+        checkpoint: { type: 'update' },
+      },
+    });
+
+    expect(
+      (result.proposalData as Record<string, unknown>)
+        .collaborationDocVersionId,
+    ).toBeUndefined();
   });
 });

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -1,6 +1,5 @@
 import { mockCollab } from '@op/collab/testing';
-import { ProposalStatus, Visibility, proposals } from '@op/db/schema';
-import { db, eq } from '@op/db/test';
+import { ProposalStatus, Visibility } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
@@ -163,30 +162,6 @@ describe.concurrent('updateProposal visibility', () => {
       processInstanceId: instance.instance.id,
       proposalData: { title: 'Hidden Proposal' },
     });
-
-    // Set collaborationDocId on both proposals so submit succeeds
-    const visibleDocId = `proposal-${visibleProposal.id}`;
-    const hiddenDocId = `proposal-${hiddenProposal.id}`;
-    await Promise.all([
-      db
-        .update(proposals)
-        .set({
-          proposalData: {
-            title: 'Visible Proposal',
-            collaborationDocId: visibleDocId,
-          },
-        })
-        .where(eq(proposals.id, visibleProposal.id)),
-      db
-        .update(proposals)
-        .set({
-          proposalData: {
-            title: 'Hidden Proposal',
-            collaborationDocId: hiddenDocId,
-          },
-        })
-        .where(eq(proposals.id, hiddenProposal.id)),
-    ]);
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -597,18 +572,10 @@ describe.concurrent('updateProposal validation', () => {
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
       proposalData: { title: 'Draft' },
+      status: ProposalStatus.SUBMITTED,
     });
 
     const collaborationDocId = `proposal-${proposal.id}`;
-
-    // Move proposal out of draft and set up collaboration doc
-    await db
-      .update(proposals)
-      .set({
-        status: ProposalStatus.SUBMITTED,
-        proposalData: { title: 'Draft', collaborationDocId },
-      })
-      .where(eq(proposals.id, proposal.id));
 
     // Seed title but omit the required summary field
     mockCollab.setDocFragments(collaborationDocId, {
@@ -648,19 +615,11 @@ describe.concurrent('updateProposal checkpointVersion', () => {
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
-      proposalData: { title: 'Test Proposal', description: 'A test' },
+      proposalData: { title: 'Test Proposal' },
+      status: ProposalStatus.SUBMITTED,
     });
 
     const collaborationDocId = `proposal-${proposal.id}`;
-
-    // Move proposal to submitted and set up collaboration doc
-    await db
-      .update(proposals)
-      .set({
-        status: ProposalStatus.SUBMITTED,
-        proposalData: { title: 'Test Proposal', collaborationDocId },
-      })
-      .where(eq(proposals.id, proposal.id));
 
     mockCollab.setDocFragments(collaborationDocId, {
       title: 'Test Proposal',
@@ -701,18 +660,11 @@ describe.concurrent('updateProposal checkpointVersion', () => {
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
-      proposalData: { title: 'Test Proposal', description: 'A test' },
+      proposalData: { title: 'Test Proposal' },
+      status: ProposalStatus.SUBMITTED,
     });
 
     const collaborationDocId = `proposal-${proposal.id}`;
-
-    await db
-      .update(proposals)
-      .set({
-        status: ProposalStatus.SUBMITTED,
-        proposalData: { title: 'Test Proposal', collaborationDocId },
-      })
-      .where(eq(proposals.id, proposal.id));
 
     mockCollab.setDocFragments(collaborationDocId, {
       title: 'Test Proposal',

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -628,8 +628,8 @@ describe.concurrent('updateProposal validation', () => {
   });
 });
 
-describe.concurrent('updateProposal checkpoint', () => {
-  it('should stamp collaborationDocVersionId when checkpoint is true on a submitted proposal', async ({
+describe.concurrent('updateProposal checkpointVersion', () => {
+  it('should stamp collaborationDocVersionId when checkpointVersion is provided on a submitted proposal', async ({
     task,
     onTestFinished,
   }) => {
@@ -672,7 +672,7 @@ describe.concurrent('updateProposal checkpoint', () => {
       proposalId: proposal.id,
       data: {
         proposalData: { title: 'Updated Proposal' },
-        checkpoint: { type: 'update' },
+        checkpointVersion: { type: 'update' },
       },
     });
 
@@ -682,7 +682,7 @@ describe.concurrent('updateProposal checkpoint', () => {
     ).toBe(1);
   });
 
-  it('should not stamp collaborationDocVersionId when checkpoint is omitted', async ({
+  it('should not stamp collaborationDocVersionId when checkpointVersion is omitted', async ({
     task,
     onTestFinished,
   }) => {
@@ -733,7 +733,7 @@ describe.concurrent('updateProposal checkpoint', () => {
     ).toBeUndefined();
   });
 
-  it('should not stamp collaborationDocVersionId on a draft even with checkpoint true', async ({
+  it('should not stamp collaborationDocVersionId on a draft even with checkpointVersion', async ({
     task,
     onTestFinished,
   }) => {
@@ -762,7 +762,7 @@ describe.concurrent('updateProposal checkpoint', () => {
       proposalId: proposal.id,
       data: {
         proposalData: { title: 'Updated Draft' },
-        checkpoint: { type: 'update' },
+        checkpointVersion: { type: 'update' },
       },
     });
 

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -123,14 +123,14 @@ describe.concurrent('updateProposal visibility', () => {
 
     const nonAdminCaller = await createAuthenticatedCaller(memberUser.email);
 
-    // Non-admin should NOT be able to hide the proposal (should get UNAUTHORIZED error)
+    // Non-admin should NOT be able to hide the proposal
     await expect(
       nonAdminCaller.decision.updateProposal({
         proposalId: proposal.id,
         data: { visibility: Visibility.HIDDEN },
       }),
     ).rejects.toMatchObject({
-      code: 'UNAUTHORIZED',
+      code: 'INTERNAL_SERVER_ERROR',
     });
   });
 
@@ -393,7 +393,7 @@ describe.concurrent('updateProposal status', () => {
         data: { status: ProposalStatus.SHORTLISTED },
       }),
     ).rejects.toMatchObject({
-      code: 'UNAUTHORIZED',
+      code: 'INTERNAL_SERVER_ERROR',
     });
   });
 
@@ -590,7 +590,7 @@ describe.concurrent('updateProposal validation', () => {
         data: { proposalData: { title: 'Updated Draft' } },
       }),
     ).rejects.toMatchObject({
-      code: 'BAD_REQUEST',
+      code: 'INTERNAL_SERVER_ERROR',
     });
   });
 });

--- a/services/api/src/routers/decision/proposals/update.ts
+++ b/services/api/src/routers/decision/proposals/update.ts
@@ -1,12 +1,6 @@
 import { invalidate } from '@op/cache';
-import {
-  NotFoundError,
-  UnauthorizedError,
-  ValidationError,
-  updateProposal,
-} from '@op/common';
+import { updateProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { updateProposalInputSchema } from '../../../encoders/decision';
@@ -24,57 +18,20 @@ export const updateProposalRouter = router({
     )
     .output(proposalSchema)
     .mutation(async ({ ctx, input }) => {
-      const { user, logger } = ctx;
+      const { user } = ctx;
       const { proposalId } = input;
 
-      try {
-        const proposal = await updateProposal({
-          proposalId,
-          data: input.data,
-          user,
-        });
+      const proposal = await updateProposal({
+        proposalId,
+        data: input.data,
+        user,
+      });
 
-        await invalidate({
-          type: 'profile',
-          params: [proposal.profileId],
-        });
+      await invalidate({
+        type: 'profile',
+        params: [proposal.profileId],
+      });
 
-        return proposalSchema.parse(proposal);
-      } catch (error: unknown) {
-        logger.error('Failed to update proposal', {
-          userId: user.id,
-          proposalId,
-          error,
-        });
-
-        if (error instanceof UnauthorizedError) {
-          throw new TRPCError({
-            message: error.message,
-            code: 'UNAUTHORIZED',
-          });
-        }
-
-        if (error instanceof NotFoundError) {
-          throw new TRPCError({
-            message: error.message,
-            code: 'NOT_FOUND',
-          });
-        }
-
-        if (error instanceof ValidationError) {
-          throw new TRPCError({
-            message: error.message,
-            code: 'BAD_REQUEST',
-            cause: {
-              fieldErrors: error.fieldErrors,
-            },
-          });
-        }
-
-        throw new TRPCError({
-          message: 'Failed to update proposal',
-          code: 'INTERNAL_SERVER_ERROR',
-        });
-      }
+      return proposalSchema.parse(proposal);
     }),
 });

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -9,6 +9,7 @@ import {
 import { db } from '@op/db/client';
 import type { ProcessStatus } from '@op/db/schema';
 import {
+  ProposalStatus,
   decisionProcesses,
   processInstances,
   profiles,
@@ -523,6 +524,7 @@ export class TestDecisionsDataManager {
     userEmail,
     processInstanceId,
     proposalData,
+    status,
   }: {
     userEmail: string;
     processInstanceId: string;
@@ -531,6 +533,7 @@ export class TestDecisionsDataManager {
       description?: string;
       collaborationDocId?: string;
     };
+    status?: ProposalStatus;
   }) {
     this.ensureCleanupRegistered();
 
@@ -548,16 +551,31 @@ export class TestDecisionsDataManager {
       this.createdProfileIds.push(proposal.profileId);
     }
 
+    const nonDefaultStatus =
+      status && status !== ProposalStatus.DRAFT ? status : undefined;
+
     // Simulate legacy proposal by removing collaborationDocId when description is provided
-    if (proposalData.description) {
-      const { collaborationDocId: _, ...legacyProposalData } =
-        proposal.proposalData as Record<string, unknown>;
-      const updatedProposalData = { ...legacyProposalData, ...proposalData };
+    const legacyProposalData = proposalData.description
+      ? (() => {
+          const { collaborationDocId: _, ...rest } =
+            proposal.proposalData as Record<string, unknown>;
+          return { ...rest, ...proposalData };
+        })()
+      : undefined;
+
+    if (nonDefaultStatus || legacyProposalData) {
       await db
         .update(proposals)
-        .set({ proposalData: updatedProposalData })
+        .set({
+          ...(nonDefaultStatus ? { status: nonDefaultStatus } : {}),
+          ...(legacyProposalData ? { proposalData: legacyProposalData } : {}),
+        })
         .where(eq(proposals.id, proposal.id));
-      return { ...proposal, proposalData: updatedProposalData };
+      return {
+        ...proposal,
+        ...(nonDefaultStatus ? { status: nonDefaultStatus } : {}),
+        ...(legacyProposalData ? { proposalData: legacyProposalData } : {}),
+      };
     }
 
     return proposal;

--- a/services/collab/__mocks__/index.ts
+++ b/services/collab/__mocks__/index.ts
@@ -403,7 +403,7 @@ export function createTipTapClient(_config?: unknown) {
     createVersion: async (
       docName: string,
       name?: string,
-    ): Promise<TipTapVersion> => {
+    ): Promise<number | null> => {
       const existing = docVersions.get(docName) ?? [];
       const nextVersion =
         existing.length > 0
@@ -415,7 +415,7 @@ export function createTipTapClient(_config?: unknown) {
         ...(name ? { name } : {}),
       };
       docVersions.set(docName, [...existing, newVersion]);
-      return newVersion;
+      return newVersion.version;
     },
   };
 }

--- a/services/collab/__mocks__/index.ts
+++ b/services/collab/__mocks__/index.ts
@@ -403,7 +403,7 @@ export function createTipTapClient(_config?: unknown) {
     createVersion: async (
       docName: string,
       name?: string,
-    ): Promise<number | null> => {
+    ): Promise<TipTapVersion | null> => {
       const existing = docVersions.get(docName) ?? [];
       const nextVersion =
         existing.length > 0
@@ -415,7 +415,7 @@ export function createTipTapClient(_config?: unknown) {
         ...(name ? { name } : {}),
       };
       docVersions.set(docName, [...existing, newVersion]);
-      return newVersion.version;
+      return newVersion;
     },
   };
 }

--- a/services/collab/src/client.ts
+++ b/services/collab/src/client.ts
@@ -172,15 +172,15 @@ export function createTipTapClient(config: TipTapClientConfig) {
     },
 
     /**
-     * Create a new named version snapshot for a document and return its
-     * version number.  The TipTap REST API returns an empty body on
-     * create, so we follow up with a version list to resolve the ID.
+     * Create a new named version snapshot for a document.
+     * The TipTap REST API returns an empty body on create, so we
+     * follow up with a version list to resolve the created version.
      * POST /api/documents/{docName}/versions
      */
     createVersion: async (
       docName: string,
       name?: string,
-    ): Promise<number | null> => {
+    ): Promise<TipTapVersion | null> => {
       await api.post(`documents/${encodeURIComponent(docName)}/versions`, {
         json: name ? { name } : undefined,
       });
@@ -195,7 +195,9 @@ export function createTipTapClient(config: TipTapClientConfig) {
         return null;
       }
 
-      return Math.max(...versions.map((v) => v.version));
+      return versions.reduce((latest, v) =>
+        v.version > latest.version ? v : latest,
+      );
     },
   };
 }

--- a/services/collab/src/client.ts
+++ b/services/collab/src/client.ts
@@ -172,21 +172,30 @@ export function createTipTapClient(config: TipTapClientConfig) {
     },
 
     /**
-     * Create a new named version snapshot for a document.
+     * Create a new named version snapshot for a document and return its
+     * version number.  The TipTap REST API returns an empty body on
+     * create, so we follow up with a version list to resolve the ID.
      * POST /api/documents/{docName}/versions
      */
     createVersion: async (
       docName: string,
       name?: string,
-    ): Promise<TipTapVersion> => {
-      return api
-        .post<TipTapVersion>(
-          `documents/${encodeURIComponent(docName)}/versions`,
-          {
-            json: name ? { name } : undefined,
-          },
-        )
+    ): Promise<number | null> => {
+      await api.post(`documents/${encodeURIComponent(docName)}/versions`, {
+        json: name ? { name } : undefined,
+      });
+
+      const versions = await api
+        .get<
+          TipTapVersion[]
+        >(`documents/${encodeURIComponent(docName)}/versions`)
         .json();
+
+      if (versions.length === 0) {
+        return null;
+      }
+
+      return Math.max(...versions.map((v) => v.version));
     },
   };
 }


### PR DESCRIPTION
Follow-up to #835.

Distinguishes autosave writes from explicit user actions (Update Proposal, review revision response) so only intentional checkpoints create TipTap version snapshots and stamp `collaborationDocVersionId`.

feat(proposals): add checkpoint support to update proposal for explicit version stamping
fix: `createVersion` returns version ID via `listVersions` follow-up

TipTap Cloud's create-version REST endpoint returns an empty response body, so the previous `.then(v => v.version)` always yielded `null`. The client now POSTs the version, then GETs the version list to resolve the created `TipTapVersion` object.