### PR TITLE
fix(proposal-editor): prevent proposal updates on editor load

### DIFF
--- a/apps/app/src/components/collaboration/CollaborativeBudgetField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeBudgetField.tsx
@@ -62,11 +62,12 @@ export function CollaborativeBudgetField({
   );
 
   const budget = budgetText ? (JSON.parse(budgetText) as BudgetData) : null;
+  const budgetKey = budget ? `${budget.amount}:${budget.currency}` : null;
   const setBudget = (newBudget: BudgetData | null) =>
     setBudgetText(newBudget ? JSON.stringify(newBudget) : '');
 
   const onChangeRef = useRef(onChange);
-  const lastEmittedRef = useRef<string | undefined>(undefined);
+  const lastEmittedRef = useRef<string | null>(budgetKey);
 
   useEffect(() => {
     onChangeRef.current = onChange;
@@ -126,16 +127,13 @@ export function CollaborativeBudgetField({
   };
 
   useEffect(() => {
-    const emitted = budgetText ? (JSON.parse(budgetText) as BudgetData) : null;
-    const key = emitted ? `${emitted.amount}:${emitted.currency}` : null;
-
-    if (lastEmittedRef.current === key) {
+    if (lastEmittedRef.current === budgetKey) {
       return;
     }
 
-    lastEmittedRef.current = key ?? undefined;
-    onChangeRef.current?.(emitted);
-  }, [budgetText]);
+    lastEmittedRef.current = budgetKey;
+    onChangeRef.current?.(budget);
+  }, [budget, budgetKey]);
 
   const handleStartEditing = () => {
     setIsEditing(true);

--- a/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
@@ -46,7 +46,7 @@ export function CollaborativeDropdownField({
   const setSelectedValue = (value: string | null) => setSyncedText(value ?? '');
 
   const onChangeRef = useRef(onChange);
-  const lastEmittedValueRef = useRef<string | null | undefined>(undefined);
+  const lastEmittedValueRef = useRef<string | null>(selectedValue);
 
   useEffect(() => {
     onChangeRef.current = onChange;

--- a/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
@@ -56,7 +56,7 @@ export function CollaborativeMultiSelectField({
   );
 
   const onChangeRef = useRef(onChange);
-  const lastEmittedValueRef = useRef<string | undefined>(undefined);
+  const lastEmittedValueRef = useRef(JSON.stringify(selectedValues));
   const fieldRef = useRef<HTMLDivElement>(null);
   const [isEditing, setIsEditing] = useState(false);
 

--- a/apps/app/src/components/collaboration/CollaborativeTextField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTextField.tsx
@@ -52,6 +52,7 @@ export function CollaborativeTextField({
   onEditorBlur,
 }: CollaborativeTextFieldProps) {
   const [charCount, setCharCount] = useState(0);
+  const lastEmittedHtmlRef = useRef<string | null>(null);
 
   const extensions = useMemo(
     () => [
@@ -77,10 +78,19 @@ export function CollaborativeTextField({
 
   const handleEditorReady = useCallback((editor: Editor) => {
     setCharCount(editor.getText().length);
+    lastEmittedHtmlRef.current = editor.getHTML();
 
     editor.on('update', () => {
+      const html = editor.getHTML();
+
       setCharCount(editor.getText().length);
-      onChangeRef.current?.(editor.getHTML());
+
+      if (lastEmittedHtmlRef.current === html) {
+        return;
+      }
+
+      lastEmittedHtmlRef.current = html;
+      onChangeRef.current?.(html);
     });
     editor.on('focus', () => {
       onEditorFocusRef.current?.(editor);

--- a/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
@@ -8,7 +8,7 @@ import Paragraph from '@tiptap/extension-paragraph';
 import Placeholder from '@tiptap/extension-placeholder';
 import Text from '@tiptap/extension-text';
 import { EditorContent, useEditor } from '@tiptap/react';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { useCollaborativeDoc } from './CollaborativeDocContext';
 
@@ -25,6 +25,7 @@ export function CollaborativeTitleField({
   onChange,
 }: CollaborativeTitleFieldProps) {
   const { ydoc, provider, user } = useCollaborativeDoc();
+  const lastEmittedTextRef = useRef<string | null>(null);
 
   // Build collaborative extensions for the title field
   const extensions = useMemo(
@@ -71,8 +72,16 @@ export function CollaborativeTitleField({
       return;
     }
 
+    lastEmittedTextRef.current = editor.getText().trim();
+
     const handleUpdate = () => {
       const plainText = editor.getText().trim();
+
+      if (lastEmittedTextRef.current === plainText) {
+        return;
+      }
+
+      lastEmittedTextRef.current = plainText;
       onChange(plainText);
     };
 


### PR DESCRIPTION
Avoid unnecessary proposal updates when the editor initializes from existing collaborative state.