### PR TITLE
chore: Remove last state from json blob

### DIFF
--- a/apps/app/src/components/Profile/ProfileDecisions/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDecisions/index.tsx
@@ -52,7 +52,7 @@ const LegacyDecisionProcessList = ({ profileId }: { profileId: string }) => {
           (s) => s.id === instance.currentStateId,
         );
         const currentPhase = instance.instanceData?.phases?.find(
-          (p) => p.phaseId === instance.instanceData?.currentPhaseId,
+          (p) => p.phaseId === instance.currentStateId,
         );
 
         return (

--- a/apps/app/src/components/decisions/VoteSuccessModal.tsx
+++ b/apps/app/src/components/decisions/VoteSuccessModal.tsx
@@ -31,23 +31,9 @@ const VoteSuccessModalSuspense = ({
     instanceId,
   });
 
-  // Read phases directly from instanceData
-  const instancePhases = processInstance.instanceData?.phases ?? [];
+  const phases = processInstance.instanceData?.phases ?? [];
 
-  // Transform to format expected by getNextSteps
-  const phasesForNextSteps = instancePhases.map((phase) => ({
-    id: phase.phaseId,
-    name: phase.name ?? '',
-    description: phase.description,
-    phase: phase.startDate
-      ? { startDate: phase.startDate, endDate: phase.endDate }
-      : undefined,
-  }));
-
-  const nextSteps = getNextSteps(
-    phasesForNextSteps,
-    processInstance.currentStateId,
-  );
+  const nextSteps = getNextSteps(phases, processInstance.currentStateId);
 
   const processTitle = processInstance.name;
 

--- a/apps/app/src/components/decisions/VoteSuccessModal.tsx
+++ b/apps/app/src/components/decisions/VoteSuccessModal.tsx
@@ -46,7 +46,7 @@ const VoteSuccessModalSuspense = ({
 
   const nextSteps = getNextSteps(
     phasesForNextSteps,
-    processInstance.instanceData,
+    processInstance.currentStateId,
   );
 
   const processTitle = processInstance.name;

--- a/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
+++ b/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
@@ -38,7 +38,7 @@ export function StandardDecisionPage({
   ]);
 
   const phases = instance.instanceData?.phases ?? [];
-  const currentPhaseId = instance.instanceData?.currentPhaseId;
+  const currentPhaseId = instance.currentStateId;
   const currentPhase = phases.find(
     (phase): phase is InstancePhaseData => phase.phaseId === currentPhaseId,
   );

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -36,7 +36,7 @@ export function VotingPage({
   const uniqueSubmitters = getUniqueSubmitters(proposals);
 
   const phases = instance.instanceData?.phases ?? [];
-  const currentPhaseId = instance.instanceData?.currentPhaseId;
+  const currentPhaseId = instance.currentStateId;
   const currentPhase = phases.find(
     (phase): phase is InstancePhaseData => phase.phaseId === currentPhaseId,
   );

--- a/apps/app/src/components/decisions/utils/processSteps.ts
+++ b/apps/app/src/components/decisions/utils/processSteps.ts
@@ -1,4 +1,4 @@
-import type { InstanceData, StateDefinition } from '@op/common';
+import type { StateDefinition } from '@op/common';
 
 export interface NextStep {
   id: string;
@@ -10,9 +10,8 @@ export interface NextStep {
 
 export function getNextSteps(
   states: StateDefinition[],
-  instanceData: InstanceData,
+  currentStateId: string | null,
 ): NextStep[] {
-  const currentStateId = instanceData.currentPhaseId;
 
   // Find current state index
   const currentStateIndex = states.findIndex(

--- a/apps/app/src/components/decisions/utils/processSteps.ts
+++ b/apps/app/src/components/decisions/utils/processSteps.ts
@@ -1,5 +1,3 @@
-import type { StateDefinition } from '@op/common';
-
 export interface NextStep {
   id: string;
   name: string;
@@ -8,32 +6,40 @@ export interface NextStep {
   endDate?: string;
 }
 
+interface PhaseWithDates {
+  phaseId: string;
+  name?: string;
+  description?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
 export function getNextSteps(
-  states: StateDefinition[],
+  phases: PhaseWithDates[],
   currentStateId: string | null,
 ): NextStep[] {
-  // Find current state index
-  const currentStateIndex = states.findIndex(
-    (state) => state.id === currentStateId,
+  // Find current phase index
+  const currentPhaseIndex = phases.findIndex(
+    (phase) => phase.phaseId === currentStateId,
   );
 
-  if (currentStateIndex === -1) {
+  if (currentPhaseIndex === -1) {
     return [];
   }
 
-  // Get upcoming states (states after current one)
-  const upcomingStates = states
-    .slice(currentStateIndex + 1)
-    .filter((state) => state.phase?.startDate) // Only include states with dates
-    .map((state) => ({
-      id: state.id,
-      name: state.name,
-      description: state.description,
-      startDate: state.phase?.startDate,
-      endDate: state.phase?.endDate,
+  // Get upcoming phases (phases after current one)
+  const upcomingPhases = phases
+    .slice(currentPhaseIndex + 1)
+    .filter((phase) => phase.startDate) // Only include phases with dates
+    .map((phase) => ({
+      id: phase.phaseId,
+      name: phase.name ?? '',
+      description: phase.description,
+      startDate: phase.startDate,
+      endDate: phase.endDate,
     }));
 
-  return upcomingStates;
+  return upcomingPhases;
 }
 
 export function formatStepForDisplay(step: NextStep): string {

--- a/apps/app/src/components/decisions/utils/processSteps.ts
+++ b/apps/app/src/components/decisions/utils/processSteps.ts
@@ -12,7 +12,6 @@ export function getNextSteps(
   states: StateDefinition[],
   currentStateId: string | null,
 ): NextStep[] {
-
   // Find current state index
   const currentStateIndex = states.findIndex(
     (state) => state.id === currentStateId,

--- a/packages/common/src/services/decision/advancePhase.ts
+++ b/packages/common/src/services/decision/advancePhase.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNull, sql } from '@op/db/client';
+import { and, desc, eq, inArray, isNull } from '@op/db/client';
 import type { DbClient } from '@op/db/client';
 import {
   ProcessStatus,
@@ -116,11 +116,6 @@ export async function advancePhase(
     .set({
       currentStateId: toPhaseId,
       updatedAt: now,
-      instanceData: sql`jsonb_set(
-        coalesce(${processInstances.instanceData}, '{}'::jsonb),
-        '{currentPhaseId}',
-        to_jsonb(${toPhaseId}::text)
-      )`,
     })
     .where(
       and(

--- a/packages/common/src/services/decision/createInstanceFromTemplate.ts
+++ b/packages/common/src/services/decision/createInstanceFromTemplate.ts
@@ -67,7 +67,7 @@ export const createDecisionInstance = async ({
         name,
         description,
         instanceData,
-        currentStateId: instanceData.currentPhaseId, // DB column is currentStateId but stores phaseId
+        currentStateId: instanceData.phases[0]?.phaseId ?? null,
         ownerProfileId,
         stewardProfileId,
         profileId: instanceProfile.id,

--- a/packages/common/src/services/decision/createProposal.ts
+++ b/packages/common/src/services/decision/createProposal.ts
@@ -78,7 +78,7 @@ export const createProposal = async ({
     );
 
     const instanceData = instance.instanceData as DecisionInstanceData;
-    const currentPhaseId = instanceData.currentPhaseId;
+    const currentPhaseId = instance.currentStateId;
 
     if (!currentPhaseId) {
       throw new ValidationError('Invalid phase in process instance');

--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -134,7 +134,6 @@ function buildInstanceData(
 ): DecisionInstanceData {
   // Always copy template reference metadata
   const base: DecisionInstanceData = {
-    currentPhaseId: '',
     templateId: source.templateId,
     templateVersion: source.templateVersion,
     templateName: source.templateName,
@@ -188,20 +187,15 @@ function buildInstanceData(
 
       return copied;
     });
-    base.currentPhaseId = base.phases[0]!.phaseId;
-  } else {
-    // Even without phases, we need at least a reference from source
-    // to have a valid currentPhaseId
-    if (source.phases.length > 0) {
-      base.phases = source.phases.map(
-        (phase): PhaseInstanceData => ({
-          phaseId: phase.phaseId,
-          name: phase.name,
-          // Minimal phase - just identity
-        }),
-      );
-      base.currentPhaseId = base.phases[0]!.phaseId;
-    }
+  } else if (source.phases.length > 0) {
+    // Even without phase details, we need at least minimal phase references
+    base.phases = source.phases.map(
+      (phase): PhaseInstanceData => ({
+        phaseId: phase.phaseId,
+        name: phase.name,
+        // Minimal phase - just identity
+      }),
+    );
   }
 
   // Proposal template

--- a/packages/common/src/services/decision/getProposalsForPhase.ts
+++ b/packages/common/src/services/decision/getProposalsForPhase.ts
@@ -71,9 +71,12 @@ function allActiveProposals(instanceId: string, dbClient: DbClient) {
 async function getInstanceContext(
   instanceId: string,
   dbClient: DbClient,
-): Promise<{ isLegacy: boolean; currentPhaseId?: string } | null> {
+): Promise<{ isLegacy: boolean; currentPhaseId?: string | null } | null> {
   const [row] = await dbClient
-    .select({ instanceData: processInstances.instanceData })
+    .select({
+      instanceData: processInstances.instanceData,
+      currentStateId: processInstances.currentStateId,
+    })
     .from(processInstances)
     .where(eq(processInstances.id, instanceId))
     .limit(1);
@@ -82,11 +85,9 @@ async function getInstanceContext(
     return null;
   }
 
-  const data = row.instanceData as { currentPhaseId?: string } | null;
-
   return {
     isLegacy: isLegacyInstanceData(row.instanceData),
-    currentPhaseId: data?.currentPhaseId,
+    currentPhaseId: row.currentStateId,
   };
 }
 
@@ -94,7 +95,7 @@ async function getInstanceContext(
  * Returns IDs of proposals visible in the given phase. Lean variant for
  * callers that only need IDs (e.g. to pass as a filter to listProposals).
  *
- * - Legacy instances (instanceData.currentStateId without currentPhaseId): always returns
+ * - Legacy instances (no phases array in instanceData): always returns
  *   all non-draft, non-deleted proposals — phase scoping does not apply.
  * - If a transition into the requested phase exists: returns the proposals that survived
  *   that transition (empty means empty — no fallback).
@@ -157,7 +158,7 @@ export async function getProposalIdsForPhase({
 /**
  * Returns the proposals visible in the given phase.
  *
- * - Legacy instances (instanceData.currentStateId without currentPhaseId): always returns
+ * - Legacy instances (no phases array in instanceData): always returns
  *   all non-draft, non-deleted proposals — phase scoping does not apply.
  * - If a transition into the requested phase exists: returns the proposals that survived
  *   that transition (empty means empty — no fallback).

--- a/packages/common/src/services/decision/isLegacyInstance.ts
+++ b/packages/common/src/services/decision/isLegacyInstance.ts
@@ -5,17 +5,17 @@ import { processInstances } from '@op/db/schema';
 /**
  * Pure predicate over an `instanceData` JSON value.
  *
- * A process instance is "legacy" if its `instanceData` JSON does not have a
- * `phases` array. New instances (created from DecisionSchemaDefinition
- * templates) always store `phases`; old instances predate that structure.
+ * A process instance is "legacy" if its `instanceData` JSON contains a
+ * `currentStateId` field. Legacy instances stored current state in the JSON
+ * blob; new instances never write it there (they use the row column instead).
  */
 export function isLegacyInstanceData(instanceData: unknown): boolean {
   if (instanceData == null || typeof instanceData !== 'object') {
     return false;
   }
 
-  const data = instanceData as { phases?: unknown[] };
-  return !Array.isArray(data.phases);
+  const data = instanceData as { currentStateId?: string };
+  return data.currentStateId != null;
 }
 
 /**

--- a/packages/common/src/services/decision/isLegacyInstance.ts
+++ b/packages/common/src/services/decision/isLegacyInstance.ts
@@ -3,29 +3,19 @@ import type { DbClient } from '@op/db/client';
 import { processInstances } from '@op/db/schema';
 
 /**
- * Shape of the legacy/new fields inside `processInstances.instanceData`.
- * Legacy instances store `currentStateId`; new instances store `currentPhaseId`.
- */
-type InstanceDataLegacyFields = {
-  currentPhaseId?: string;
-  currentStateId?: string;
-};
-
-/**
  * Pure predicate over an `instanceData` JSON value.
  *
- * A process instance is "legacy" if its `instanceData` JSON has `currentStateId`
- * but no `currentPhaseId`. New instances always write `currentPhaseId`; old
- * instances (predating the join-table-backed phase scoping) only have
- * `currentStateId`. Use this when you already have the JSON in hand.
+ * A process instance is "legacy" if its `instanceData` JSON does not have a
+ * `phases` array. New instances (created from DecisionSchemaDefinition
+ * templates) always store `phases`; old instances predate that structure.
  */
 export function isLegacyInstanceData(instanceData: unknown): boolean {
   if (instanceData == null || typeof instanceData !== 'object') {
     return false;
   }
 
-  const data = instanceData as InstanceDataLegacyFields;
-  return data.currentPhaseId == null && data.currentStateId != null;
+  const data = instanceData as { phases?: unknown[] };
+  return !Array.isArray(data.phases);
 }
 
 /**

--- a/packages/common/src/services/decision/processResults.ts
+++ b/packages/common/src/services/decision/processResults.ts
@@ -47,7 +47,7 @@ export async function processResults({
     }
 
     const instanceData = processInstance.instanceData as DecisionInstanceData;
-    const currentPhaseId = instanceData.currentPhaseId;
+    const currentPhaseId = processInstance.currentStateId;
 
     const processProposals = await getProposalsForPhase({
       instanceId: processInstanceId,

--- a/packages/common/src/services/decision/schemas/instanceData.ts
+++ b/packages/common/src/services/decision/schemas/instanceData.ts
@@ -33,7 +33,6 @@ export interface PhaseInstanceData {
  * This structure must match instanceDataNewEncoder in the API encoders.
  */
 export interface DecisionInstanceData {
-  currentPhaseId: string;
   config?: ProcessConfig;
   fieldValues?: Record<string, unknown>;
   templateId?: string;
@@ -80,7 +79,6 @@ export function createInstanceDataFromTemplate(input: {
   );
 
   return {
-    currentPhaseId: firstPhase.id,
     config: template.config,
     templateId: template.id,
     templateVersion: template.version,

--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -67,7 +67,7 @@ export const submitProposal = async ({
   );
 
   const instanceData = instance.instanceData as DecisionInstanceData;
-  const currentPhaseId = instanceData.currentPhaseId;
+  const currentPhaseId = instance.currentStateId;
 
   if (!currentPhaseId) {
     throw new ValidationError('Invalid phase in process instance');

--- a/packages/common/src/services/decision/types.ts
+++ b/packages/common/src/services/decision/types.ts
@@ -135,7 +135,6 @@ export interface InstanceData {
   budget?: number;
   hideBudget?: boolean; // Whether to hide the budget from non-owners
   fieldValues?: Record<string, unknown>; // Values for process fields schema
-  currentPhaseId: string;
   phases?: PhaseConfiguration[];
 }
 

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -26,24 +26,27 @@ import { validateVoteSelection } from './schemaValidators';
 import type { DecisionInstanceData } from './schemas/instanceData';
 
 /** Extract proposal/voting permissions from the current phase. */
-function getCurrentPhaseConfig(processInstance: { instanceData: unknown }):
+function getCurrentPhaseConfig(processInstance: {
+  instanceData: unknown;
+  currentStateId: string | null;
+}):
   | {
       allowProposals: boolean;
       allowDecisions: boolean;
     }
   | undefined {
   const instanceData = processInstance.instanceData as DecisionInstanceData;
+  const currentPhaseId = processInstance.currentStateId;
 
-  // @ts-expect-error  Remove instanceData,currentStateId in a migration before undoing
-  if (!instanceData?.currentPhaseId && !instanceData?.currentStateId) {
+  if (!currentPhaseId) {
     return undefined;
   }
 
   const currentPhase = instanceData.phases.find(
     (p) =>
-      p.phaseId === instanceData.currentPhaseId ||
+      p.phaseId === currentPhaseId ||
       // @ts-expect-error  Remove p.stateId in a migration before undoing p.stateId
-      p.stateId === instanceData.currentStateId,
+      p.stateId === currentPhaseId,
   );
 
   if (!currentPhase) {
@@ -153,6 +156,7 @@ export const submitVote = async ({
         profileId: true,
         ownerProfileId: true,
         instanceData: true,
+        currentStateId: true,
       },
     });
 
@@ -349,6 +353,7 @@ export const getVotingStatus = async ({
         profileId: true,
         ownerProfileId: true,
         instanceData: true,
+        currentStateId: true,
       },
     });
 

--- a/packages/common/src/services/translation/translateDecision.ts
+++ b/packages/common/src/services/translation/translateDecision.ts
@@ -41,6 +41,7 @@ export async function translateDecision({
     .select({
       description: processInstances.description,
       instanceData: processInstances.instanceData,
+      currentStateId: processInstances.currentStateId,
       profileId: processInstances.profileId,
       ownerProfileId: processInstances.ownerProfileId,
     })
@@ -76,6 +77,7 @@ export async function translateDecision({
   const entries = buildEntries(
     decisionProfileId,
     instanceData,
+    processInstance.currentStateId,
     processInstance.description,
   );
 
@@ -110,14 +112,14 @@ function renderTipTapToHtml(content: string): string {
 function buildEntries(
   decisionProfileId: string,
   instanceData: DecisionInstanceData | null,
+  currentStateId: string | null,
   processDescription: string | null,
 ): TranslatableEntry[] {
   const prefix = `decision:${decisionProfileId}`;
   const entries: TranslatableEntry[] = [];
 
-  const currentPhaseId = instanceData?.currentPhaseId;
-  const currentPhase = currentPhaseId
-    ? instanceData?.phases?.find((p) => p.phaseId === currentPhaseId)
+  const currentPhase = currentStateId
+    ? instanceData?.phases?.find((p) => p.phaseId === currentStateId)
     : undefined;
 
   if (currentPhase?.headline) {

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -232,7 +232,6 @@ export const instancePhaseDataEncoder = z.object({
 const instanceDataWithSchemaEncoder = z.object({
   config: processConfigEncoder.optional(),
   fieldValues: z.record(z.string(), z.unknown()).optional(),
-  currentPhaseId: z.string(),
   templateId: z.string().optional(),
   templateVersion: z.string().optional(),
   templateName: z.string().optional(),
@@ -373,7 +372,6 @@ const instanceDataEncoder = z.preprocess(
       : obj.phases;
     return {
       ...obj,
-      currentPhaseId: obj.currentPhaseId ?? obj.currentStateId,
       phases,
     };
   },
@@ -381,7 +379,6 @@ const instanceDataEncoder = z.preprocess(
     budget: z.number().optional(),
     hideBudget: z.boolean().optional(),
     fieldValues: z.record(z.string(), z.unknown()).optional(),
-    currentPhaseId: z.string(),
     phases: z
       .array(
         z.object({

--- a/services/api/src/encoders/legacyDecision.ts
+++ b/services/api/src/encoders/legacyDecision.ts
@@ -127,7 +127,6 @@ const legacyInstanceDataEncoder = z.preprocess(
       : obj.phases;
     return {
       ...obj,
-      currentPhaseId: obj.currentPhaseId ?? obj.currentStateId,
       phases,
     };
   },
@@ -135,7 +134,6 @@ const legacyInstanceDataEncoder = z.preprocess(
     budget: z.number().optional(),
     hideBudget: z.boolean().optional(),
     fieldValues: z.record(z.string(), z.unknown()).optional(),
-    currentPhaseId: z.string(),
     phases: z
       .array(
         z.object({

--- a/services/api/src/routers/decision/instances/advancePhase.test.ts
+++ b/services/api/src/routers/decision/instances/advancePhase.test.ts
@@ -100,8 +100,7 @@ describe.concurrent('advancePhase', () => {
     });
     expect(reloaded!.currentStateId).toBe('final');
 
-    const instanceData = reloaded!.instanceData as { currentPhaseId?: string };
-    expect(instanceData.currentPhaseId).toBe('final');
+    expect(reloaded!.currentStateId).toBe('final');
 
     const history = await db._query.stateTransitionHistory.findFirst({
       where: eq(stateTransitionHistory.processInstanceId, loaded.dbInstance.id),

--- a/services/api/src/routers/decision/instances/buildExpectedTransitions.test.ts
+++ b/services/api/src/routers/decision/instances/buildExpectedTransitions.test.ts
@@ -120,8 +120,7 @@ describe('buildExpectedTransitions', () => {
   });
 
   it('should throw when phases is undefined', () => {
-    const instance = stubInstance({
-    });
+    const instance = stubInstance({});
 
     expect(() => buildExpectedTransitions(instance)).toThrow(
       'Process instance must have at least one phase configured',

--- a/services/api/src/routers/decision/instances/buildExpectedTransitions.test.ts
+++ b/services/api/src/routers/decision/instances/buildExpectedTransitions.test.ts
@@ -16,7 +16,6 @@ function stubInstance(
 describe('buildExpectedTransitions', () => {
   it('should create transitions for date-based phases', () => {
     const instance = stubInstance({
-      currentPhaseId: 'phase-a',
       phases: [
         {
           phaseId: 'phase-a',
@@ -53,7 +52,6 @@ describe('buildExpectedTransitions', () => {
 
   it('should skip phases without date-based advancement', () => {
     const instance = stubInstance({
-      currentPhaseId: 'phase-a',
       phases: [
         {
           phaseId: 'phase-a',
@@ -81,7 +79,6 @@ describe('buildExpectedTransitions', () => {
 
   it('should return empty array when no phases use date advancement', () => {
     const instance = stubInstance({
-      currentPhaseId: 'phase-a',
       phases: [
         {
           phaseId: 'phase-a',
@@ -99,7 +96,6 @@ describe('buildExpectedTransitions', () => {
 
   it('should return empty array for single phase (no next phase to transition to)', () => {
     const instance = stubInstance({
-      currentPhaseId: 'only-phase',
       phases: [
         {
           phaseId: 'only-phase',
@@ -115,7 +111,6 @@ describe('buildExpectedTransitions', () => {
 
   it('should throw when phases array is empty', () => {
     const instance = stubInstance({
-      currentPhaseId: 'x',
       phases: [],
     });
 
@@ -126,7 +121,6 @@ describe('buildExpectedTransitions', () => {
 
   it('should throw when phases is undefined', () => {
     const instance = stubInstance({
-      currentPhaseId: 'x',
     });
 
     expect(() => buildExpectedTransitions(instance)).toThrow(
@@ -137,7 +131,6 @@ describe('buildExpectedTransitions', () => {
   it('should throw when date-based phase has no endDate', () => {
     const instance = stubInstance(
       {
-        currentPhaseId: 'phase-a',
         phases: [
           {
             phaseId: 'phase-a',

--- a/services/api/src/routers/decision/instances/createInstanceFromTemplate.test.ts
+++ b/services/api/src/routers/decision/instances/createInstanceFromTemplate.test.ts
@@ -108,7 +108,7 @@ describe.concurrent('createInstanceFromTemplate', () => {
     const instanceData = instance!.instanceData as DecisionInstanceData;
     expect(instanceData.phases).toBeDefined();
     expect(instanceData.phases.length).toBeGreaterThan(0);
-    expect(instanceData.currentPhaseId).toBe('submission');
+    expect(instance!.currentStateId).toBe('submission');
   });
 
   it('should NOT create transitions for DRAFT instances (transitions are created on publish)', async ({

--- a/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
+++ b/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
@@ -270,12 +270,12 @@ describe.concurrent('getProposalsForPhase', () => {
       }),
     ]);
 
-    // Mutate instanceData to look like a legacy instance: drop currentPhaseId,
-    // add currentStateId. This is the signal getProposalsForPhase keys off of.
+    // Mutate instanceData to look like a legacy instance: remove the phases
+    // array. This is the signal getProposalsForPhase keys off of.
     await db
       .update(processInstances)
       .set({
-        instanceData: sql`(${processInstances.instanceData} - 'currentPhaseId') || jsonb_build_object('currentStateId', 'review')`,
+        instanceData: sql`${processInstances.instanceData} - 'phases'`,
       })
       .where(eq(processInstances.id, instanceId));
 

--- a/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
+++ b/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
@@ -270,12 +270,12 @@ describe.concurrent('getProposalsForPhase', () => {
       }),
     ]);
 
-    // Mutate instanceData to look like a legacy instance: remove the phases
-    // array. This is the signal getProposalsForPhase keys off of.
+    // Mutate instanceData to look like a legacy instance: add currentStateId
+    // to the JSON blob. Legacy instances stored state in the JSON; new ones don't.
     await db
       .update(processInstances)
       .set({
-        instanceData: sql`${processInstances.instanceData} - 'phases'`,
+        instanceData: sql`${processInstances.instanceData} || jsonb_build_object('currentStateId', 'review')`,
       })
       .where(eq(processInstances.id, instanceId));
 

--- a/services/api/src/routers/decision/instances/listLegacyInstances.test.ts
+++ b/services/api/src/routers/decision/instances/listLegacyInstances.test.ts
@@ -67,7 +67,6 @@ const legacyProcessSchema = {
 
 /** Legacy instance data matching the encoder's expected shape */
 const legacyInstanceData = {
-  currentPhaseId: 'submission',
   phases: [
     {
       phaseId: 'submission',

--- a/services/api/src/routers/decision/instances/transitionMonitor.test.ts
+++ b/services/api/src/routers/decision/instances/transitionMonitor.test.ts
@@ -1,8 +1,4 @@
-import {
-  type DecisionInstanceData,
-  processDecisionsTransitions,
-  simpleVoting,
-} from '@op/common';
+import { processDecisionsTransitions, simpleVoting } from '@op/common';
 import { db, eq } from '@op/db/client';
 import {
   ProcessStatus,
@@ -230,8 +226,6 @@ describe('processDecisionsTransitions', () => {
 
     // All 3 transitions (submission→review, review→voting, voting→results) were due
     // so the instance should have advanced to the final state
-    const instanceData = instance!.instanceData as DecisionInstanceData;
-    expect(instanceData.currentPhaseId).toBe('results');
     expect(instance!.currentStateId).toBe('results');
 
     // Verify updatedAt was set by the monitor
@@ -341,8 +335,7 @@ describe('processDecisionsTransitions', () => {
       where: eq(processInstances.id, instanceId),
     });
 
-    const instanceData = instance!.instanceData as DecisionInstanceData;
-    expect(instanceData.currentPhaseId).toBe('submission');
+    expect(instance!.currentStateId).toBe('submission');
   });
 
   it('should process multiple due transitions sequentially for same instance', async ({
@@ -368,8 +361,6 @@ describe('processDecisionsTransitions', () => {
       where: eq(processInstances.id, instanceId),
     });
 
-    const instanceData = instance!.instanceData as DecisionInstanceData;
-    expect(instanceData.currentPhaseId).toBe('results');
     expect(instance!.currentStateId).toBe('results');
 
     // All transitions should be completed
@@ -593,7 +584,7 @@ describe('processDecisionsTransitions', () => {
     await db
       .update(processInstances)
       .set({
-        instanceData: { currentPhaseId: 'submission', phases: [] },
+        instanceData: { phases: [] },
       })
       .where(eq(processInstances.id, badInstanceId));
 
@@ -640,8 +631,6 @@ describe('processDecisionsTransitions', () => {
     const instance = await db._query.processInstances.findFirst({
       where: eq(processInstances.id, instanceId),
     });
-    const instanceData = instance!.instanceData as DecisionInstanceData;
-    expect(instanceData.currentPhaseId).toBe('results');
     expect(instance!.currentStateId).toBe('results');
 
     // Each transition should have completedAt set exactly once

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -113,23 +113,10 @@ describe.concurrent('submitProposal', () => {
 
     // Advance instance to the 'final' phase which has proposals.submit = false
     // (testMinimalSchema: initial = submit:true, final = submit:false)
-    const instanceRecord = await db.query.processInstances.findFirst({
-      where: { id: instance.instance.id },
-    });
-
-    if (!instanceRecord) {
-      throw new Error('Instance record not found');
-    }
-
-    const instanceData = instanceRecord.instanceData as Record<string, unknown>;
     await db
       .update(processInstances)
       .set({
         currentStateId: 'final',
-        instanceData: {
-          ...instanceData,
-          currentPhaseId: 'final',
-        },
       })
       .where(eq(processInstances.id, instance.instance.id));
 

--- a/services/api/src/test/helpers/pipelineTestFixtures.ts
+++ b/services/api/src/test/helpers/pipelineTestFixtures.ts
@@ -212,7 +212,6 @@ export async function createInstanceWithSchema(
       currentStateId: 'submission',
       status: ProcessStatus.PUBLISHED,
       instanceData: {
-        currentPhaseId: 'submission',
         phases: instancePhases,
       },
     })

--- a/services/db/schema/tables/processInstances.sql.ts
+++ b/services/db/schema/tables/processInstances.sql.ts
@@ -56,7 +56,6 @@ export const processInstances = pgTable(
         "budget": number,
         "fieldValues": { ...based on process fields schema },
         "phases": [ ...configured phases with dates ],
-        "currentStateId": string,
       }
     */
 

--- a/tests/core/src/decision-data.ts
+++ b/tests/core/src/decision-data.ts
@@ -267,7 +267,6 @@ export async function createDecisionInstance(
     templateVersion: schema.version,
     templateName: schema.name,
     templateDescription: schema.description,
-    currentPhaseId: firstPhaseId,
     phases: schema.phases.map((phase, index) => ({
       phaseId: phase.id,
       name: phase.name,

--- a/tests/e2e/tests/proposal-listing.spec.ts
+++ b/tests/e2e/tests/proposal-listing.spec.ts
@@ -74,8 +74,8 @@ async function createProcessAndInstance({
       profileId: profile.id,
       instanceData,
       currentStateId:
-        (instanceData as { currentPhaseId?: string }).currentPhaseId ??
-        'proposalSubmission',
+        (instanceData as { phases?: { phaseId: string }[] }).phases?.[0]
+          ?.phaseId ?? 'proposalSubmission',
       status: ProcessStatus.PUBLISHED,
       ownerProfileId: org.organizationProfile.id,
     })
@@ -182,7 +182,6 @@ test.describe('Proposal Listing', () => {
 
     // instanceData includes the proposalTemplate (new-schema path)
     const newInstanceData = {
-      currentPhaseId: 'proposalSubmission',
       budget: 50000,
       hideBudget: false,
       proposalTemplate: newProcessSchema.proposalTemplate,
@@ -337,7 +336,6 @@ test.describe('Proposal Listing', () => {
 
     // COWOP-style instanceData — no proposalTemplate, has fieldValues
     const cowopInstanceData = {
-      currentPhaseId: 'ideaCollection',
       budget: 100000,
       hideBudget: false,
       phases: [

--- a/tests/e2e/tests/proposal-view.spec.ts
+++ b/tests/e2e/tests/proposal-view.spec.ts
@@ -500,9 +500,7 @@ test.describe('Proposal View', () => {
     }
 
     // COWOP-style instanceData — no proposalTemplate, has fieldValues.
-    // Must include currentPhaseId for the instanceDataWithSchemaEncoder.
     const cowopInstanceData = {
-      currentPhaseId: 'ideaCollection',
       budget: 100000,
       hideBudget: false,
       phases: [


### PR DESCRIPTION
Removes the last remaining state from the JSON blob. This makes sure that all state exists on the row and it leaves the JSON blob to simply be configuration of the process.

A follow-up PR should migrate the column name from currentStateId to currentPhaseId.