### PR TITLE
fix(translation): decode HTML entities in DeepL responses

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,7 +631,7 @@ importers:
         version: 16.2.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1)
       next-intl:
         specifier: ^4.8.3
-        version: 4.8.3(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3)
+        version: 4.8.3(next@16.2.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3)
       nuqs:
         specifier: ^2.8.5
         version: 2.8.6(next@16.2.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)
@@ -892,7 +892,7 @@ importers:
         version: 3.0.5
       next-intl:
         specifier: ^4.8.3
-        version: 4.8.3(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3)
+        version: 4.8.3(next@16.2.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3)
       react:
         specifier: ^19.0.1
         version: 19.2.1
@@ -1469,10 +1469,16 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 1.0.0-beta.11-05230d9(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9)(@types/pg@8.11.11)(gel@2.0.0)(mssql@11.0.1)(pg@8.16.0)(postgres@3.4.5)
+      he:
+        specifier: ^1.2.0
+        version: 1.2.0
     devDependencies:
       '@op/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config
+      '@types/he':
+        specifier: ^1.2.3
+        version: 1.2.3
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -16598,7 +16604,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.8.3: {}
 
-  next-intl@4.8.3(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3):
+  next-intl@4.8.3(next@16.2.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.1

--- a/services/translation/package.json
+++ b/services/translation/package.json
@@ -14,10 +14,12 @@
   "dependencies": {
     "@op/db": "workspace:*",
     "deepl-node": "^1.24.0",
-    "drizzle-orm": "catalog:"
+    "drizzle-orm": "catalog:",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "@op/typescript-config": "workspace:*",
+    "@types/he": "^1.2.3",
     "typescript": "5.7.3"
   }
 }

--- a/services/translation/src/translateBatch.ts
+++ b/services/translation/src/translateBatch.ts
@@ -1,6 +1,7 @@
 import { and, db, eq, or, sql } from '@op/db/client';
 import { contentTranslations } from '@op/db/schema';
 import type { DeepLClient, TargetLanguageCode } from 'deepl-node';
+import he from 'he';
 
 import { hashContent } from './hashContent';
 
@@ -136,7 +137,7 @@ async function translateCacheMisses(
       contentHash: miss.hash,
       sourceLocale: result.detectedSourceLang.toUpperCase(),
       targetLocale,
-      translatedText: result.text,
+      translatedText: he.decode(result.text),
     };
   });
 }


### PR DESCRIPTION
DeepL returns HTML entities (e.g. &#x27; for apostrophes) when tagHandling is set to 'html', which causes characters like ñ to produce garbled output in on-demand translations. This decodes entities with he.decode() before caching so all consumers receive clean Unicode text.