### PR TITLE
fix: accept iframely embeds as valid content in required proposal fields

### DIFF
--- a/apps/app/src/components/decisions/proposalEditor/useProposalValidation.ts
+++ b/apps/app/src/components/decisions/proposalEditor/useProposalValidation.ts
@@ -32,8 +32,11 @@ function getBlockText(element: Y.XmlElement): string {
 }
 
 /**
- * Extracts plain text from a Yjs XmlFragment, matching the output of
- * TipTap Cloud REST API with `format=text`.
+ * Extracts plain text from a Yjs XmlFragment.
+ *
+ * This is the client-side counterpart to `extractTextFromTipTapDoc`
+ * (which operates on the REST API JSON format). Both produce equivalent
+ * plain-text output, including handling of atom nodes like iframely.
  *
  * All fragment content (both TipTap editor fields and scalar values from
  * `useCollaborativeFragment`) is stored as paragraph-wrapped `XmlElement`

--- a/apps/app/src/components/decisions/proposalEditor/useProposalValidation.ts
+++ b/apps/app/src/components/decisions/proposalEditor/useProposalValidation.ts
@@ -14,6 +14,12 @@ import type { Doc } from 'yjs';
  * concatenating all nested XmlText children (ignoring markup).
  */
 function getBlockText(element: Y.XmlElement): string {
+  // Atom nodes (e.g. iframely) carry content in attributes, not text children.
+  // Return the src URL so the field is treated as non-empty by the validator.
+  if (element.nodeName === 'iframely') {
+    return element.getAttribute('src') ?? '';
+  }
+
   const parts: string[] = [];
   element.forEach((child) => {
     if (child instanceof Y.XmlText) {

--- a/packages/common/src/services/decision/extractTextFromTipTapDoc.test.ts
+++ b/packages/common/src/services/decision/extractTextFromTipTapDoc.test.ts
@@ -78,4 +78,22 @@ describe('extractTextFromTipTapDoc', () => {
     };
     expect(extractTextFromTipTapDoc(doc)).toBe('');
   });
+
+  it('returns empty string for iframely with non-string src', () => {
+    const doc = {
+      content: [{ type: 'iframely', attrs: { src: 123 } }],
+    };
+    expect(extractTextFromTipTapDoc(doc)).toBe('');
+  });
+
+  it('skips non-object entries in content array', () => {
+    const doc = {
+      content: [
+        'not a node',
+        null,
+        { type: 'paragraph', content: [{ type: 'text', text: 'valid' }] },
+      ],
+    };
+    expect(extractTextFromTipTapDoc(doc)).toBe('valid');
+  });
 });

--- a/packages/common/src/services/decision/extractTextFromTipTapDoc.test.ts
+++ b/packages/common/src/services/decision/extractTextFromTipTapDoc.test.ts
@@ -71,4 +71,11 @@ describe('extractTextFromTipTapDoc', () => {
     };
     expect(extractTextFromTipTapDoc(doc)).toBe('');
   });
+
+  it('returns empty string for iframely with no attrs', () => {
+    const doc = {
+      content: [{ type: 'iframely' }],
+    };
+    expect(extractTextFromTipTapDoc(doc)).toBe('');
+  });
 });

--- a/packages/common/src/services/decision/extractTextFromTipTapDoc.test.ts
+++ b/packages/common/src/services/decision/extractTextFromTipTapDoc.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractTextFromTipTapDoc } from './extractTextFromTipTapDoc';
+
+describe('extractTextFromTipTapDoc', () => {
+  it('returns empty string for empty doc', () => {
+    expect(extractTextFromTipTapDoc({ content: [] })).toBe('');
+  });
+
+  it('returns empty string for doc with no content key', () => {
+    expect(extractTextFromTipTapDoc({})).toBe('');
+  });
+
+  it('extracts plain text from paragraph nodes', () => {
+    const doc = {
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello world' }],
+        },
+      ],
+    };
+    expect(extractTextFromTipTapDoc(doc)).toBe('Hello world');
+  });
+
+  it('returns src URL for iframely atom nodes', () => {
+    const doc = {
+      content: [
+        {
+          type: 'iframely',
+          attrs: { src: 'https://youtu.be/abc123' },
+        },
+      ],
+    };
+    expect(extractTextFromTipTapDoc(doc)).toBe('https://youtu.be/abc123');
+  });
+
+  it('treats doc with only iframely node as non-empty', () => {
+    const doc = {
+      content: [
+        {
+          type: 'iframely',
+          attrs: { src: 'https://vimeo.com/123' },
+        },
+      ],
+    };
+    expect(extractTextFromTipTapDoc(doc).length).toBeGreaterThan(0);
+  });
+
+  it('handles mixed content: text + iframely', () => {
+    const doc = {
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Check this out:' }],
+        },
+        {
+          type: 'iframely',
+          attrs: { src: 'https://youtu.be/abc123' },
+        },
+      ],
+    };
+    expect(extractTextFromTipTapDoc(doc)).toBe(
+      'Check this out:\nhttps://youtu.be/abc123',
+    );
+  });
+
+  it('returns empty string for iframely with missing src', () => {
+    const doc = {
+      content: [{ type: 'iframely', attrs: {} }],
+    };
+    expect(extractTextFromTipTapDoc(doc)).toBe('');
+  });
+});

--- a/packages/common/src/services/decision/extractTextFromTipTapDoc.ts
+++ b/packages/common/src/services/decision/extractTextFromTipTapDoc.ts
@@ -6,6 +6,15 @@ type TipTapNode = {
   content?: TipTapNode[];
 };
 
+function isTipTapNode(value: unknown): value is TipTapNode {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'type' in value &&
+    typeof value.type === 'string'
+  );
+}
+
 /**
  * Extracts plain text from a TipTap JSON document (format=json),
  * mirroring `getBlockText` in useProposalValidation but operating on
@@ -26,7 +35,7 @@ export function extractTextFromTipTapDoc(doc: { content?: unknown[] }): string {
     return (node.content ?? []).map(nodeText).join('');
   }
 
-  const blocks = (doc.content ?? []) as TipTapNode[];
+  const blocks = (doc.content ?? []).filter(isTipTapNode);
   return blocks
     .map((block) => nodeText(block))
     .join('\n')

--- a/packages/common/src/services/decision/extractTextFromTipTapDoc.ts
+++ b/packages/common/src/services/decision/extractTextFromTipTapDoc.ts
@@ -1,0 +1,35 @@
+/** Minimal TipTap JSON node shape returned by format=json */
+type TipTapNode = {
+  type: string;
+  text?: string;
+  attrs?: Record<string, unknown>;
+  content?: TipTapNode[];
+};
+
+/**
+ * Extracts plain text from a TipTap JSON document (format=json),
+ * mirroring `getBlockText` in useProposalValidation but operating on
+ * the REST API JSON format instead of Yjs XmlElements.
+ *
+ * Handles iframely atom nodes by returning their src URL so required-field
+ * validation treats them as non-empty.
+ */
+export function extractTextFromTipTapDoc(doc: {
+  content?: unknown[];
+}): string {
+  function nodeText(node: TipTapNode): string {
+    if (node.type === 'iframely') {
+      return (node.attrs?.src as string | undefined) ?? '';
+    }
+    if (node.type === 'text') {
+      return node.text ?? '';
+    }
+    return (node.content ?? []).map(nodeText).join('');
+  }
+
+  const blocks = (doc.content ?? []) as TipTapNode[];
+  return blocks
+    .map((block) => nodeText(block))
+    .join('\n')
+    .trim();
+}

--- a/packages/common/src/services/decision/extractTextFromTipTapDoc.ts
+++ b/packages/common/src/services/decision/extractTextFromTipTapDoc.ts
@@ -14,9 +14,7 @@ type TipTapNode = {
  * Handles iframely atom nodes by returning their src URL so required-field
  * validation treats them as non-empty.
  */
-export function extractTextFromTipTapDoc(doc: {
-  content?: unknown[];
-}): string {
+export function extractTextFromTipTapDoc(doc: { content?: unknown[] }): string {
   function nodeText(node: TipTapNode): string {
     if (node.type === 'iframely') {
       return (node.attrs?.src as string | undefined) ?? '';

--- a/packages/common/src/services/decision/extractTextFromTipTapDoc.ts
+++ b/packages/common/src/services/decision/extractTextFromTipTapDoc.ts
@@ -17,7 +17,8 @@ type TipTapNode = {
 export function extractTextFromTipTapDoc(doc: { content?: unknown[] }): string {
   function nodeText(node: TipTapNode): string {
     if (node.type === 'iframely') {
-      return (node.attrs?.src as string | undefined) ?? '';
+      const src = node.attrs?.src;
+      return typeof src === 'string' ? src : '';
     }
     if (node.type === 'text') {
       return node.text ?? '';

--- a/packages/common/src/services/decision/validateProposalAgainstTemplate.ts
+++ b/packages/common/src/services/decision/validateProposalAgainstTemplate.ts
@@ -1,6 +1,7 @@
 import { getTipTapClient } from '@op/collab';
 
 import { assembleProposalData } from './assembleProposalData';
+import { extractTextFromTipTapDoc } from './extractTextFromTipTapDoc';
 import { getProposalFragmentNames } from './getProposalFragmentNames';
 import { parseProposalData } from './proposalDataSchema';
 import { schemaValidator } from './schemaValidator';
@@ -33,11 +34,20 @@ export async function validateProposalAgainstTemplate(
     const client = getTipTapClient();
 
     const fragmentNames = getProposalFragmentNames(proposalTemplate);
-    const fragmentTexts = await client.getDocumentFragments(
+    // Use format=json so we can handle atom nodes (e.g. iframely) that produce
+    // empty string with format=text but carry content in their attrs.
+    const fragmentDocs = await client.getDocumentFragments(
       parsed.collaborationDocId,
       fragmentNames,
-      { format: 'text' },
+      { format: 'json' },
     );
+    const fragmentTexts: Record<string, string> = {};
+    for (const [name, doc] of Object.entries(fragmentDocs)) {
+      const text = extractTextFromTipTapDoc(doc as { content?: unknown[] });
+      if (text) {
+        fragmentTexts[name] = text;
+      }
+    }
     const validationData = {
       ...assembleProposalData(proposalTemplate, fragmentTexts),
       ...(storedProposalData.category !== undefined

--- a/packages/common/src/services/decision/validateProposalAgainstTemplate.ts
+++ b/packages/common/src/services/decision/validateProposalAgainstTemplate.ts
@@ -43,7 +43,7 @@ export async function validateProposalAgainstTemplate(
     );
     const fragmentTexts: Record<string, string> = {};
     for (const [name, doc] of Object.entries(fragmentDocs)) {
-      const text = extractTextFromTipTapDoc(doc as { content?: unknown[] });
+      const text = extractTextFromTipTapDoc(doc);
       if (text) {
         fragmentTexts[name] = text;
       }

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -1,4 +1,4 @@
-import { mockCollab } from '@op/collab/testing';
+import { mockCollab, textFragment } from '@op/collab/testing';
 import { ProposalStatus, processInstances, proposals } from '@op/db/schema';
 import { db, eq } from '@op/db/test';
 import { describe, expect, it } from 'vitest';
@@ -235,11 +235,12 @@ describe.concurrent('submitProposal', () => {
       .where(eq(proposals.id, proposal.id));
 
     // Seed the collaboration doc fragments so validation reads from TipTap
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'Proposal with vendor extensions',
-      budget: JSON.stringify({ amount: 5000, currency: 'USD' }),
-      summary:
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('Proposal with vendor extensions'),
+      budget: textFragment(JSON.stringify({ amount: 5000, currency: 'USD' })),
+      summary: textFragment(
         'Testing that x-field-order and x-format do not break validation',
+      ),
     });
 
     // Seed version history so submit can stamp the latest version
@@ -291,6 +292,11 @@ describe.concurrent('submitProposal', () => {
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
       proposalData: { title: '' },
+    });
+
+    // Seed the collaboration doc with an empty title fragment
+    mockCollab.setDocFragmentResponses(`proposal-${proposal.id}`, {
+      title: textFragment(''),
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -353,8 +359,8 @@ describe.concurrent('submitProposal', () => {
       })
       .where(eq(proposals.id, proposal.id));
 
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'A title that is too long',
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('A title that is too long'),
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -419,6 +425,11 @@ describe.concurrent('submitProposal', () => {
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
       proposalData: { title: 'Incomplete Proposal' },
+    });
+
+    // Seed only the title fragment — a1b2c3d4 and e5f6a7b8 are deliberately omitted
+    mockCollab.setDocFragmentResponses(`proposal-${proposal.id}`, {
+      title: textFragment('Incomplete Proposal'),
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -494,9 +505,9 @@ describe.concurrent('submitProposal', () => {
       .where(eq(proposals.id, proposal.id));
 
     // Seed the collaboration doc fragments with the over-budget value
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'Over Budget Proposal',
-      budget: JSON.stringify({ amount: 99999, currency: 'USD' }),
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('Over Budget Proposal'),
+      budget: textFragment(JSON.stringify({ amount: 99999, currency: 'USD' })),
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -563,8 +574,8 @@ describe.concurrent('submitProposal', () => {
       .where(eq(proposals.id, proposal.id));
 
     // Seed title but leave summary empty — simulates user never filling it in
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'Has Title',
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('Has Title'),
       // summary deliberately omitted
     });
 
@@ -630,8 +641,8 @@ describe.concurrent('submitProposal', () => {
       .where(eq(proposals.id, proposal.id));
 
     // Seed title but no budget fragment
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'No Budget',
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('No Budget'),
       // budget deliberately omitted
     });
 
@@ -704,9 +715,9 @@ describe.concurrent('submitProposal', () => {
       })
       .where(eq(proposals.id, proposal.id));
 
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'OneOf Category Test',
-      category: JSON.stringify(['Infrastructure']),
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('OneOf Category Test'),
+      category: textFragment(JSON.stringify(['Infrastructure'])),
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -777,8 +788,82 @@ describe.concurrent('submitProposal', () => {
       })
       .where(eq(proposals.id, proposal.id));
 
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'Legacy Template Array Data',
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('Legacy Template Array Data'),
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.submitProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result.status).toBe(ProposalStatus.SUBMITTED);
+  });
+
+  it('should submit successfully when a required long-text field contains only an iframely embed', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+      proposalTemplate: {
+        type: 'object',
+        required: ['title', 'summary'],
+        'x-field-order': ['title', 'summary'],
+        properties: {
+          title: {
+            type: 'string',
+            title: 'Title',
+            'x-format': 'short-text',
+          },
+          summary: {
+            type: 'string',
+            title: 'Summary',
+            minLength: 1,
+            'x-format': 'long-text',
+          },
+        },
+      },
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Embed Only Proposal' },
+    });
+
+    const collaborationDocId = `proposal-${proposal.id}`;
+
+    await db
+      .update(proposals)
+      .set({
+        proposalData: { title: 'Embed Only Proposal', collaborationDocId },
+      })
+      .where(eq(proposals.id, proposal.id));
+
+    // Summary contains only an iframely embed — no text content.
+    // Before the fix, this would fail validation because format=text
+    // returned empty string for iframely atom nodes.
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('Embed Only Proposal'),
+      summary: {
+        type: 'doc',
+        content: [
+          {
+            type: 'iframely',
+            attrs: { src: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+          },
+        ],
+      },
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -1,4 +1,4 @@
-import { mockCollab } from '@op/collab/testing';
+import { mockCollab, textFragment } from '@op/collab/testing';
 import { ProposalStatus, Visibility } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
@@ -578,8 +578,8 @@ describe.concurrent('updateProposal validation', () => {
     const collaborationDocId = `proposal-${proposal.id}`;
 
     // Seed title but omit the required summary field
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'Draft',
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('Draft'),
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -621,8 +621,8 @@ describe.concurrent('updateProposal checkpointVersion', () => {
 
     const collaborationDocId = `proposal-${proposal.id}`;
 
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'Test Proposal',
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('Test Proposal'),
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -666,8 +666,8 @@ describe.concurrent('updateProposal checkpointVersion', () => {
 
     const collaborationDocId = `proposal-${proposal.id}`;
 
-    mockCollab.setDocFragments(collaborationDocId, {
-      title: 'Test Proposal',
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('Test Proposal'),
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);


### PR DESCRIPTION
## Problem

Required `long-text` proposal fields report "is required" when the only content is an iframely embed (e.g. a pasted YouTube/Vimeo URL that auto-converts). The embed is an atom node with no text children, so the existing text-extraction logic returns an empty string and the field is excluded from validation data.

## Root Cause

Two separate extraction paths both miss iframely atoms:

1. **Client** (`useProposalValidation.ts`): `getBlockText` iterates child `XmlText`/`XmlElement` nodes — iframely atoms have no children, so the function returns `""`.
2. **Server** (`validateProposalAgainstTemplate.ts`): TipTap Cloud called with `format: 'text'`, which also yields `""` for atom nodes.

## Changes

- **`apps/app/src/components/decisions/proposalEditor/useProposalValidation.ts`** — Early-return in `getBlockText` when `element.nodeName === 'iframely'`, returning `attrs.src` so the field is treated as non-empty.
- **`packages/common/src/services/decision/extractTextFromTipTapDoc.ts`** (new) — Pure helper that walks TipTap JSON, handles iframely atoms via `attrs.src`, mirrors the client fix.
- **`packages/common/src/services/decision/validateProposalAgainstTemplate.ts`** — Switch to `format: 'json'` and use the new extractor instead of relying on TipTap Cloud plain-text serialisation.
- **`packages/common/src/services/decision/extractTextFromTipTapDoc.test.ts`** (new) — Unit tests covering empty doc, plain text, iframely-only, and mixed content cases.

## Testing

- All 7 unit tests pass.
- Full typecheck (21 packages) clean.
- Manual: paste embeddable URL into a required field, embed renders, proposal submits without "is required" error. Truly empty required field still blocks submission.

Refs: https://app.asana.com/1/1108348036672214/project/1213315744811204/task/1213980804074933
