### PR TITLE
feat(api): add realtime channels for proposal queries and mutations

### DIFF
--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
@@ -85,7 +85,6 @@ export function ProposalCardOwnerActions({
   editHref: string;
 }) {
   const t = useTranslations();
-  const utils = trpc.useUtils();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const deleteProposalMutation = trpc.decision.deleteProposal.useMutation({
@@ -96,13 +95,6 @@ export function ProposalCardOwnerActions({
     },
     onSuccess: () => {
       toast.success({ message: t('Proposal deleted successfully') });
-    },
-    onSettled: () => {
-      if (proposal.processInstanceId) {
-        utils.decision.listProposals.invalidate({
-          processInstanceId: proposal.processInstanceId,
-        });
-      }
     },
   });
 

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardMenu.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardMenu.tsx
@@ -92,14 +92,6 @@ export function ProposalCardMenu({
         toast.success({ message: statusMessage });
       }
     },
-    onSettled: () => {
-      // Always refetch after error or success
-      if (proposal.processInstanceId) {
-        utils.decision.listProposals.invalidate({
-          processInstanceId: proposal.processInstanceId,
-        });
-      }
-    },
   });
 
   const deleteProposalMutation = trpc.decision.deleteProposal.useMutation({
@@ -112,14 +104,6 @@ export function ProposalCardMenu({
       toast.success({
         message: t('Proposal deleted successfully'),
       });
-    },
-    onSettled: () => {
-      // Always refetch after error or success
-      if (proposal.processInstanceId) {
-        utils.decision.listProposals.invalidate({
-          processInstanceId: proposal.processInstanceId,
-        });
-      }
     },
   });
 
@@ -138,13 +122,6 @@ export function ProposalCardMenu({
           [Visibility.VISIBLE]: `${proposalTitle} ${t('is now visible in active proposals.')}`,
         });
         toast.success({ message });
-      }
-    },
-    onSettled: () => {
-      if (proposal.processInstanceId) {
-        utils.decision.listProposals.invalidate({
-          processInstanceId: proposal.processInstanceId,
-        });
       }
     },
   });

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -337,14 +337,6 @@ function ProposalEditorInner({
         });
       }
 
-      await Promise.all([
-        utils.decision.getProposal.invalidate({
-          profileId: proposal.profileId,
-        }),
-        utils.decision.listProposals.invalidate({
-          processInstanceId: instance.id,
-        }),
-      ]);
       router.push(backHref);
     } catch (error) {
       console.error('Failed to update proposal:', error);

--- a/apps/app/src/components/decisions/proposalEditor/useRestoreProposalVersion.ts
+++ b/apps/app/src/components/decisions/proposalEditor/useRestoreProposalVersion.ts
@@ -34,15 +34,11 @@ export function useRestoreProposalVersion({
 }: UseRestoreProposalVersionOptions) {
   const t = useTranslations();
   const { provider } = useCollaborativeDoc();
-  const utils = trpc.useUtils();
-
   const updateProposalMutation = trpc.decision.updateProposal.useMutation({
     onSuccess: () => {
       toast.success({
         message: t('Proposal version restored'),
       });
-      utils.decision.getProposal.invalidate();
-      utils.decision.listProposals.invalidate();
     },
     onError: (error) => {
       toast.error({

--- a/packages/common/src/realtime/channels/channels.ts
+++ b/packages/common/src/realtime/channels/channels.ts
@@ -28,6 +28,12 @@ export const Channels = {
 
   decisionInstance: (instanceId: string) =>
     `decisionInstance:${instanceId}` as const,
+
+  decisionProposals: (instanceId: string) =>
+    `decisionProposals:${instanceId}` as const,
+
+  decisionProposal: (instanceId: string, proposalId: string) =>
+    `decisionProposal:${instanceId}:${proposalId}` as const,
 } as const;
 
 export type GlobalChannel = ReturnType<typeof Channels.global>;
@@ -42,6 +48,12 @@ export type OrgRelationshipRequestChannel = ReturnType<
 export type DecisionInstanceChannel = ReturnType<
   typeof Channels.decisionInstance
 >;
+export type DecisionProposalsChannel = ReturnType<
+  typeof Channels.decisionProposals
+>;
+export type DecisionProposalChannel = ReturnType<
+  typeof Channels.decisionProposal
+>;
 
 /**
  * Union of all valid channel types
@@ -52,4 +64,6 @@ export type ChannelName =
   | UserChannel
   | ProfileJoinRequestChannel
   | OrgRelationshipRequestChannel
-  | DecisionInstanceChannel;
+  | DecisionInstanceChannel
+  | DecisionProposalsChannel
+  | DecisionProposalChannel;

--- a/packages/common/src/services/decision/deleteProposal.ts
+++ b/packages/common/src/services/decision/deleteProposal.ts
@@ -95,7 +95,11 @@ export const deleteProposal = async ({
 
     console.log('DELETED PROPOSAL', deletedProposal.id, user.id);
 
-    return { success: true, deletedId: proposalId };
+    return {
+      success: true,
+      deletedId: proposalId,
+      processInstanceId: deletedProposal.processInstanceId,
+    };
   } catch (error) {
     if (
       error instanceof UnauthorizedError ||

--- a/services/api/src/routers/decision/proposals/create.ts
+++ b/services/api/src/routers/decision/proposals/create.ts
@@ -1,4 +1,4 @@
-import { createProposal } from '@op/common';
+import { Channels, createProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 
 import { createProposalInputSchema } from '../../../encoders/decision';
@@ -16,6 +16,10 @@ export const createProposalRouter = router({
         data: input,
         user,
       });
+
+      ctx.registerMutationChannels([
+        Channels.decisionProposals(input.processInstanceId),
+      ]);
 
       return proposalSchema.parse(proposal);
     }),

--- a/services/api/src/routers/decision/proposals/delete.ts
+++ b/services/api/src/routers/decision/proposals/delete.ts
@@ -1,4 +1,5 @@
 import {
+  Channels,
   NotFoundError,
   UnauthorizedError,
   ValidationError,
@@ -32,6 +33,11 @@ export const deleteProposalRouter = router({
           proposalId: input.proposalId,
           user,
         });
+
+        ctx.registerMutationChannels([
+          Channels.decisionProposals(result.processInstanceId),
+          Channels.decisionProposal(result.processInstanceId, input.proposalId),
+        ]);
 
         logger.info('Proposal deleted', {
           userId: user.id,

--- a/services/api/src/routers/decision/proposals/get.ts
+++ b/services/api/src/routers/decision/proposals/get.ts
@@ -1,5 +1,5 @@
 import { cache } from '@op/cache';
-import { getPermissionsOnProposal, getProposal } from '@op/common';
+import { Channels, getPermissionsOnProposal, getProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 import { ProposalStatus } from '@op/db/schema';
 import { logger } from '@op/logging';
@@ -58,6 +58,10 @@ export const getProposalRouter = router({
           trackProposalViewed(ctx, proposal.processInstance.id, proposal.id),
         );
       }
+
+      ctx.registerQueryChannels([
+        Channels.decisionProposal(proposal.processInstanceId, proposal.id),
+      ]);
 
       return proposalSchema.parse({
         ...proposal,

--- a/services/api/src/routers/decision/proposals/list.ts
+++ b/services/api/src/routers/decision/proposals/list.ts
@@ -1,4 +1,4 @@
-import { listProposals } from '@op/common';
+import { Channels, listProposals } from '@op/common';
 import { proposalListSchema } from '@op/common/client';
 
 import { proposalFilterSchema } from '../../../encoders/decision';
@@ -15,6 +15,10 @@ export const listProposalsRouter = router({
         input: { ...input, authUserId: user.id },
         user,
       });
+
+      ctx.registerQueryChannels([
+        Channels.decisionProposals(input.processInstanceId),
+      ]);
 
       return proposalListSchema.parse(result);
     }),

--- a/services/api/src/routers/decision/proposals/submit.ts
+++ b/services/api/src/routers/decision/proposals/submit.ts
@@ -1,4 +1,4 @@
-import { submitProposal } from '@op/common';
+import { Channels, submitProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
@@ -22,6 +22,11 @@ export const submitProposalRouter = router({
         data: input,
         authUserId: user.id,
       });
+
+      ctx.registerMutationChannels([
+        Channels.decisionProposals(proposal.processInstanceId),
+        Channels.decisionProposal(proposal.processInstanceId, proposal.id),
+      ]);
 
       // Fire analytics after successful submission
       waitUntil(

--- a/services/api/src/routers/decision/proposals/update.ts
+++ b/services/api/src/routers/decision/proposals/update.ts
@@ -1,5 +1,5 @@
 import { invalidate } from '@op/cache';
-import { updateProposal } from '@op/common';
+import { Channels, updateProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 import { z } from 'zod';
 
@@ -31,6 +31,14 @@ export const updateProposalRouter = router({
         type: 'profile',
         params: [proposal.profileId],
       });
+
+      ctx.registerMutationChannels([
+        Channels.decisionProposals(proposal.processInstanceId),
+        Channels.decisionProposal(
+          proposal.processInstanceId,
+          input.proposalId,
+        ),
+      ]);
 
       return proposalSchema.parse(proposal);
     }),

--- a/services/api/src/routers/decision/proposals/update.ts
+++ b/services/api/src/routers/decision/proposals/update.ts
@@ -34,10 +34,7 @@ export const updateProposalRouter = router({
 
       ctx.registerMutationChannels([
         Channels.decisionProposals(proposal.processInstanceId),
-        Channels.decisionProposal(
-          proposal.processInstanceId,
-          input.proposalId,
-        ),
+        Channels.decisionProposal(proposal.processInstanceId, input.proposalId),
       ]);
 
       return proposalSchema.parse(proposal);


### PR DESCRIPTION
Adds realtime channel subscriptions for proposal endpoints so clients receive live updates when proposals are created, updated, deleted, or submitted.

### Demo
https://github.com/user-attachments/assets/80a96855-2799-4515-98b5-7c2f15e7be52


