### PR TITLE
refactor: remove valueless success: true from return types

### DIFF
--- a/apps/app/src/app/api/waitlist-signup/route.ts
+++ b/apps/app/src/app/api/waitlist-signup/route.ts
@@ -58,7 +58,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    return Response.json({ success: true }, { status: 201 });
+    return new Response(null, { status: 201 });
   } catch (error) {
     console.error(error);
     return Response.json(

--- a/packages/common/src/services/access/permissions.ts
+++ b/packages/common/src/services/access/permissions.ts
@@ -251,7 +251,7 @@ export async function deleteRole({
   // Delete the role (cascade will handle permissions)
   await db.delete(accessRoles).where(eq(accessRoles.id, roleId));
 
-  return { success: true, deletedId: roleId };
+  return { deletedId: roleId };
 }
 
 export async function assignRoleToUser(

--- a/packages/common/src/services/decision/deleteProposal.ts
+++ b/packages/common/src/services/decision/deleteProposal.ts
@@ -96,7 +96,6 @@ export const deleteProposal = async ({
     console.log('DELETED PROPOSAL', deletedProposal.id, user.id);
 
     return {
-      success: true,
       deletedId: proposalId,
       processInstanceId: deletedProposal.processInstanceId,
     };

--- a/packages/common/src/services/organization/deleteOrganization.ts
+++ b/packages/common/src/services/organization/deleteOrganization.ts
@@ -51,5 +51,5 @@ export async function deleteOrganization({
   invalidate({ type: 'organization', params: [deletedOrganization.slug] });
   invalidate({ type: 'orgUser', params: [organization.id, user.id] });
 
-  return { success: true, deletedId: organizationProfileId };
+  return { deletedId: organizationProfileId };
 }

--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -42,6 +42,4 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
   }
 
   await db.delete(posts).where(eq(posts.id, postId));
-
-  return { success: true };
 };

--- a/packages/common/src/services/reactions/toggleReaction.ts
+++ b/packages/common/src/services/reactions/toggleReaction.ts
@@ -17,15 +17,15 @@ export const toggleReaction = async (options: ToggleReactionOptions) => {
     // If user has the same reaction type, remove it
     if (existingReaction.reactionType === reactionType) {
       await removeReaction({ postId, profileId });
-      return { success: true, action: 'removed' as const };
+      return { action: 'removed' as const };
     } else {
       // If user has a different reaction type, replace it
       await addReaction({ postId, profileId, reactionType });
-      return { success: true, action: 'replaced' as const };
+      return { action: 'replaced' as const };
     }
   } else {
     // No existing reaction, add new one
     await addReaction({ postId, profileId, reactionType });
-    return { success: true, action: 'added' as const };
+    return { action: 'added' as const };
   }
 };

--- a/services/api/src/routers/decision/proposals/delete.ts
+++ b/services/api/src/routers/decision/proposals/delete.ts
@@ -21,8 +21,8 @@ export const deleteProposalRouter = router({
     )
     .output(
       z.object({
-        success: z.boolean(),
         deletedId: z.string(),
+        processInstanceId: z.string(),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/delete.ts
+++ b/services/api/src/routers/decision/proposals/delete.ts
@@ -22,7 +22,6 @@ export const deleteProposalRouter = router({
     .output(
       z.object({
         deletedId: z.string(),
-        processInstanceId: z.string(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -44,7 +43,7 @@ export const deleteProposalRouter = router({
           proposalId: input.proposalId,
         });
 
-        return result;
+        return { deletedId: result.deletedId };
       } catch (error: unknown) {
         logger.error('Failed to delete proposal', {
           userId: user.id,

--- a/services/api/src/routers/organization/addRelationship.ts
+++ b/services/api/src/routers/organization/addRelationship.ts
@@ -23,7 +23,6 @@ const inputSchema = z.object({
 export const addRelationshipRouter = router({
   addRelationship: commonAuthedProcedure()
     .input(inputSchema)
-    .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
       const { user } = ctx;
       const { to, relationships } = input;
@@ -61,8 +60,6 @@ export const addRelationshipRouter = router({
             }),
           ]),
         );
-
-        return { success: true };
       } catch (error: unknown) {
         console.log('ERROR', error);
         if (error instanceof UnauthorizedError) {

--- a/services/api/src/routers/organization/deleteOrganization.test.ts
+++ b/services/api/src/routers/organization/deleteOrganization.test.ts
@@ -36,7 +36,6 @@ describe.concurrent('organization.deleteOrganization', () => {
 
     // Verify the response contains expected profile fields
     expect(result).toBeDefined();
-    expect(result.success).toBe(true);
     expect(result.deletedId).toBe(organizationProfile.id);
 
     // Verify the organization was actually deleted from the database

--- a/services/api/src/routers/organization/deleteOrganization.ts
+++ b/services/api/src/routers/organization/deleteOrganization.ts
@@ -6,7 +6,6 @@ import { z } from 'zod';
 import { commonAuthedProcedure, router } from '../../trpcFactory';
 
 const outputSchema = z.object({
-  success: z.boolean(),
   deletedId: z.string().uuid(),
 });
 

--- a/services/api/src/routers/organization/deletePost.ts
+++ b/services/api/src/routers/organization/deletePost.ts
@@ -22,7 +22,6 @@ export const deletePost = router({
           .describe('The ID of the profile the post belongs to'),
       }),
     )
-    .output(z.object({ success: z.boolean() }))
     .mutation(async ({ input, ctx }) => {
       const { id, profileId } = input;
 
@@ -52,7 +51,7 @@ export const deletePost = router({
       }
 
       try {
-        return await deletePostById({ postId: id, organizationId });
+        await deletePostById({ postId: id, organizationId });
       } catch (error) {
         if (
           error instanceof Error &&

--- a/services/api/src/routers/organization/reactions.ts
+++ b/services/api/src/routers/organization/reactions.ts
@@ -33,7 +33,6 @@ export const reactionsRouter = router({
       try {
         const profileId = await getCurrentProfileId(user.id);
         await addReaction({ postId, profileId, reactionType });
-        return { success: true };
       } catch (error) {
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
@@ -54,8 +53,6 @@ export const reactionsRouter = router({
 
       const profileId = await getCurrentProfileId(user.id);
       await removeReaction({ postId, profileId });
-
-      return { success: true };
     }),
 
   toggleReaction: reactionProcedure

--- a/services/api/src/routers/organization/removeRelationship.ts
+++ b/services/api/src/routers/organization/removeRelationship.ts
@@ -13,7 +13,6 @@ const inputSchema = z.object({
 export const removeRelationshipRouter = router({
   removeRelationship: commonAuthedProcedure()
     .input(inputSchema)
-    .output(z.object({ success: z.boolean() }))
     .mutation(async ({ ctx, input }) => {
       const { id } = input;
 
@@ -35,8 +34,6 @@ export const removeRelationshipRouter = router({
             orgId: targetOrgId,
           }),
         ]);
-
-        return { success: true };
       } catch (error: unknown) {
         console.log('ERROR', error);
         if (error instanceof UnauthorizedError) {

--- a/services/api/src/routers/profile/deleteRole.test.ts
+++ b/services/api/src/routers/profile/deleteRole.test.ts
@@ -37,9 +37,7 @@ describe.concurrent('profile.deleteRole', () => {
     const { session } = await createIsolatedSession(adminUser.email);
     const caller = createCaller(await createTestContextWithSession(session));
 
-    const result = await caller.deleteRole({ roleId: customRole!.id });
-
-    expect(result.success).toBe(true);
+    await caller.deleteRole({ roleId: customRole!.id });
 
     // Verify role was deleted
     const deletedRole = await db.query.accessRoles.findFirst({

--- a/services/api/src/routers/profile/deleteRole.ts
+++ b/services/api/src/routers/profile/deleteRole.ts
@@ -6,7 +6,7 @@ import { commonAuthedProcedure, router } from '../../trpcFactory';
 export const deleteRoleRouter = router({
   deleteRole: commonAuthedProcedure()
     .input(z.object({ roleId: z.string().uuid() }))
-    .output(z.object({ success: z.boolean(), deletedId: z.string() }))
+    .output(z.object({ deletedId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       return deleteRole({
         roleId: input.roleId,

--- a/services/api/src/routers/profile/relationships.ts
+++ b/services/api/src/routers/profile/relationships.ts
@@ -76,7 +76,6 @@ const relationshipProcedure = commonAuthedProcedure({
 export const profileRelationshipRouter = router({
   addRelationship: relationshipProcedure
     .input(relationshipInputSchema)
-    .output(z.object({ success: z.boolean() }))
     .mutation(async ({ input, ctx }) => {
       const { targetProfileId, relationshipType, pending } = input;
 
@@ -111,8 +110,6 @@ export const profileRelationshipRouter = router({
             }
           })(),
         );
-
-        return { success: true };
       } catch (error) {
         if (error instanceof ValidationError) {
           throw new TRPCError({
@@ -135,7 +132,6 @@ export const profileRelationshipRouter = router({
 
   removeRelationship: relationshipProcedure
     .input(removeRelationshipInputSchema)
-    .output(z.object({ success: z.boolean() }))
     .mutation(async ({ input, ctx }) => {
       const { targetProfileId, relationshipType } = input;
 
@@ -145,7 +141,6 @@ export const profileRelationshipRouter = router({
           relationshipType,
           authUserId: ctx.user.id,
         });
-        return { success: true };
       } catch (error) {
         logger.error('Error removing relationship', { error, targetProfileId });
         throw new TRPCError({

--- a/services/workflows/src/functions/modules/decisions/processTransitions.ts
+++ b/services/workflows/src/functions/modules/decisions/processTransitions.ts
@@ -27,7 +27,6 @@ export const processTransitions = inngest.createFunction(
     }
 
     return {
-      success: true,
       processed: result.processed,
       failed: result.failed,
       errors: result.errors,


### PR DESCRIPTION
Functions that throw on failure don't need a success field — reaching the return already proves success. Removes it where it was the sole return value, and strips it from objects that carry meaningful data alongside it.