### PR TITLE
feat: Add email notifications for decision process phase transitions

### DIFF
--- a/packages/common/src/services/decision/onPhaseAdvanced.ts
+++ b/packages/common/src/services/decision/onPhaseAdvanced.ts
@@ -1,3 +1,5 @@
+import { Events, event } from '@op/events';
+
 import type { AdvancePhaseResult } from './advancePhase';
 import { runGenerateReviewAssignments } from './runGenerateReviewAssignments';
 import { runResultsProcessing } from './runResultsProcessing';
@@ -5,6 +7,7 @@ import { type PhaseInstanceData, isLastPhase } from './schemas/instanceData';
 
 export interface OnPhaseAdvancedInput {
   instanceId: string;
+  fromPhaseId: string;
   toPhaseId: string;
   phases: PhaseInstanceData[];
   advanceResult: AdvancePhaseResult & { conflict: false };
@@ -24,6 +27,23 @@ export async function onPhaseAdvanced(
   input: OnPhaseAdvancedInput,
 ): Promise<void> {
   const targetPhase = input.phases.find((p) => p.phaseId === input.toPhaseId);
+
+  // Notify participants about the phase transition (fire-and-forget)
+  event
+    .send({
+      name: Events.phaseTransitioned.name,
+      data: {
+        processInstanceId: input.instanceId,
+        fromPhaseId: input.fromPhaseId,
+        toPhaseId: input.toPhaseId,
+      },
+    })
+    .catch((err) => {
+      console.error(
+        `Failed to send phase transition event for instance ${input.instanceId}:`,
+        err,
+      );
+    });
 
   if (targetPhase?.rules?.proposals?.review) {
     await runGenerateReviewAssignments(input);

--- a/packages/common/src/services/decision/transitionMonitor.ts
+++ b/packages/common/src/services/decision/transitionMonitor.ts
@@ -197,6 +197,7 @@ async function advanceInstanceTransitions({
 
       await onPhaseAdvanced({
         instanceId: processInstanceId,
+        fromPhaseId,
         toPhaseId: transition.toStateId,
         phases,
         advanceResult,

--- a/packages/common/src/services/decision/triggerPhaseAdvancement.ts
+++ b/packages/common/src/services/decision/triggerPhaseAdvancement.ts
@@ -126,7 +126,7 @@ export async function triggerPhaseAdvancement({
     return result;
   });
 
-  await onPhaseAdvanced({ instanceId, toPhaseId, phases, advanceResult });
+  await onPhaseAdvanced({ instanceId, fromPhaseId, toPhaseId, phases, advanceResult });
 
   return {
     currentPhaseId: toPhaseId,

--- a/packages/common/src/services/decision/triggerPhaseAdvancement.ts
+++ b/packages/common/src/services/decision/triggerPhaseAdvancement.ts
@@ -126,7 +126,13 @@ export async function triggerPhaseAdvancement({
     return result;
   });
 
-  await onPhaseAdvanced({ instanceId, fromPhaseId, toPhaseId, phases, advanceResult });
+  await onPhaseAdvanced({
+    instanceId,
+    fromPhaseId,
+    toPhaseId,
+    phases,
+    advanceResult,
+  });
 
   return {
     currentPhaseId: toPhaseId,

--- a/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
@@ -6,7 +6,8 @@ import {
   processInstances,
   stateTransitionHistory,
 } from '@op/db/schema';
-import { describe, expect, it } from 'vitest';
+import { event } from '@op/events';
+import { type MockInstance, describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
 import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
@@ -52,6 +53,9 @@ describe.concurrent('transitionFromPhase', () => {
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
+    const mockSend = event.send as MockInstance;
+    mockSend.mockClear();
+
     const result = await caller.decision.transitionFromPhase({
       instanceId: instance.instance.id,
     });
@@ -65,6 +69,18 @@ describe.concurrent('transitionFromPhase', () => {
     });
 
     expect(dbInstance!.currentStateId).toBe('final');
+
+    // Verify phase transition event was dispatched
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'decision/phase-transitioned',
+        data: {
+          processInstanceId: instance.instance.id,
+          fromPhaseId: 'initial',
+          toPhaseId: 'final',
+        },
+      }),
+    );
   });
 
   it('should record transition in history with manual flag', async ({
@@ -110,11 +126,17 @@ describe.concurrent('transitionFromPhase', () => {
     // Instance is DRAFT by default — do not publish
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
+    const mockSend = event.send as MockInstance;
+    mockSend.mockClear();
+
     await expect(
       caller.decision.transitionFromPhase({
         instanceId: instance.instance.id,
       }),
     ).rejects.toThrow('Instance must be published');
+
+    // No phase transition event should have been dispatched
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('should reject transition when already on final phase', async ({

--- a/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
@@ -53,7 +53,7 @@ describe.concurrent('transitionFromPhase', () => {
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
-    const mockSend = event.send as MockInstance;
+    const mockSend = event.send as unknown as MockInstance;
     mockSend.mockClear();
 
     const result = await caller.decision.transitionFromPhase({
@@ -126,7 +126,7 @@ describe.concurrent('transitionFromPhase', () => {
     // Instance is DRAFT by default — do not publish
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
-    const mockSend = event.send as MockInstance;
+    const mockSend = event.send as unknown as MockInstance;
     mockSend.mockClear();
 
     await expect(

--- a/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
@@ -54,7 +54,6 @@ describe.concurrent('transitionFromPhase', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const mockSend = event.send as unknown as MockInstance;
-    mockSend.mockClear();
 
     const result = await caller.decision.transitionFromPhase({
       instanceId: instance.instance.id,
@@ -70,17 +69,24 @@ describe.concurrent('transitionFromPhase', () => {
 
     expect(dbInstance!.currentStateId).toBe('final');
 
-    // Verify phase transition event was dispatched
-    expect(mockSend).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'decision/phase-transitioned',
-        data: {
-          processInstanceId: instance.instance.id,
-          fromPhaseId: 'initial',
-          toPhaseId: 'final',
-        },
-      }),
+    // Verify phase transition event was dispatched (filter by this instance
+    // to avoid interference from concurrent tests sharing the mock)
+    const transitionCalls = mockSend.mock.calls.filter(
+      (call: unknown[]) =>
+        (call[0] as { name: string; data: { processInstanceId: string } })
+          .name === 'decision/phase-transitioned' &&
+        (call[0] as { data: { processInstanceId: string } }).data
+          .processInstanceId === instance.instance.id,
     );
+    expect(transitionCalls).toHaveLength(1);
+    expect(transitionCalls[0][0]).toMatchObject({
+      name: 'decision/phase-transitioned',
+      data: {
+        processInstanceId: instance.instance.id,
+        fromPhaseId: 'initial',
+        toPhaseId: 'final',
+      },
+    });
   });
 
   it('should record transition in history with manual flag', async ({
@@ -127,7 +133,6 @@ describe.concurrent('transitionFromPhase', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const mockSend = event.send as unknown as MockInstance;
-    mockSend.mockClear();
 
     await expect(
       caller.decision.transitionFromPhase({
@@ -135,8 +140,16 @@ describe.concurrent('transitionFromPhase', () => {
       }),
     ).rejects.toThrow('Instance must be published');
 
-    // No phase transition event should have been dispatched
-    expect(mockSend).not.toHaveBeenCalled();
+    // No phase transition event should have been dispatched for this instance
+    // (filter by instanceId to avoid interference from concurrent tests)
+    const transitionCalls = mockSend.mock.calls.filter(
+      (call: unknown[]) =>
+        (call[0] as { name: string; data: { processInstanceId: string } })
+          .name === 'decision/phase-transitioned' &&
+        (call[0] as { data: { processInstanceId: string } }).data
+          .processInstanceId === instance.instance.id,
+    );
+    expect(transitionCalls).toHaveLength(0);
   });
 
   it('should reject transition when already on final phase', async ({

--- a/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
@@ -79,7 +79,7 @@ describe.concurrent('transitionFromPhase', () => {
           .processInstanceId === instance.instance.id,
     );
     expect(transitionCalls).toHaveLength(1);
-    expect(transitionCalls[0][0]).toMatchObject({
+    expect(transitionCalls[0]![0]).toMatchObject({
       name: 'decision/phase-transitioned',
       data: {
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/instances/transitionMonitor.test.ts
+++ b/services/api/src/routers/decision/instances/transitionMonitor.test.ts
@@ -11,7 +11,8 @@ import {
   stateTransitionHistory,
   users,
 } from '@op/db/schema';
-import { describe, expect, it } from 'vitest';
+import { event } from '@op/events';
+import { type MockInstance, describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
 import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
@@ -212,6 +213,9 @@ describe('processDecisionsTransitions', () => {
     });
     const updatedAtBefore = beforeInstance!.updatedAt;
 
+    const mockSend = event.send as MockInstance;
+    mockSend.mockClear();
+
     const result = await processDecisionsTransitions();
 
     expect(result.processed).toBeGreaterThanOrEqual(1);
@@ -254,6 +258,15 @@ describe('processDecisionsTransitions', () => {
     expect(historyRows.length).toBe(3);
     const fromStates = historyRows.map((h) => h.fromStateId).sort();
     expect(fromStates).toEqual(['review', 'submission', 'voting']);
+
+    // Verify phase transition events were dispatched for each advance
+    expect(mockSend).toHaveBeenCalledTimes(3);
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'decision/phase-transitioned',
+        data: expect.objectContaining({ processInstanceId: instanceId }),
+      }),
+    );
   });
 
   it('should NOT process transitions for DRAFT instances', async ({
@@ -288,6 +301,9 @@ describe('processDecisionsTransitions', () => {
       scheduledDate: pastDate.toISOString(),
     });
 
+    const mockSend = event.send as MockInstance;
+    mockSend.mockClear();
+
     await processDecisionsTransitions();
 
     // The transition should NOT have been processed because the instance is DRAFT
@@ -301,6 +317,9 @@ describe('processDecisionsTransitions', () => {
     for (const transition of transitions) {
       expect(transition.completedAt).toBeNull();
     }
+
+    // No phase transition events should have been dispatched
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('should NOT process future-dated transitions', async ({

--- a/services/api/src/routers/decision/instances/transitionMonitor.test.ts
+++ b/services/api/src/routers/decision/instances/transitionMonitor.test.ts
@@ -213,7 +213,7 @@ describe('processDecisionsTransitions', () => {
     });
     const updatedAtBefore = beforeInstance!.updatedAt;
 
-    const mockSend = event.send as MockInstance;
+    const mockSend = event.send as unknown as MockInstance;
     mockSend.mockClear();
 
     const result = await processDecisionsTransitions();
@@ -301,7 +301,7 @@ describe('processDecisionsTransitions', () => {
       scheduledDate: pastDate.toISOString(),
     });
 
-    const mockSend = event.send as MockInstance;
+    const mockSend = event.send as unknown as MockInstance;
     mockSend.mockClear();
 
     await processDecisionsTransitions();

--- a/services/emails/emails/PhaseTransitionEmail.tsx
+++ b/services/emails/emails/PhaseTransitionEmail.tsx
@@ -1,0 +1,46 @@
+import { Button, Heading, Section, Text } from '@react-email/components';
+
+import EmailTemplate from '../components/EmailTemplate';
+
+export const PhaseTransitionEmail = ({
+  processTitle,
+  fromPhaseName,
+  toPhaseName,
+  processUrl = 'https://common.oneproject.org/',
+}: {
+  processTitle: string;
+  fromPhaseName: string;
+  toPhaseName: string;
+  processUrl: string;
+}) => {
+  return (
+    <EmailTemplate previewText={`${processTitle} has moved to ${toPhaseName}`}>
+      <Heading className="mx-0 !my-0 p-0 text-left font-serif text-[28px] font-light tracking-[-0.02625rem] text-[#222D38]">
+        Phase Update
+      </Heading>
+      <Text className="my-8 text-lg">
+        <strong>{processTitle}</strong> has moved from{' '}
+        <strong>{fromPhaseName}</strong> to <strong>{toPhaseName}</strong>.
+      </Text>
+
+      <Section className="pb-0">
+        <Button
+          href={processUrl}
+          className="rounded-lg bg-primary-teal px-4 py-3 text-white no-underline hover:bg-primary-teal/90"
+          style={{
+            fontSize: '0.875rem',
+            textAlign: 'center',
+            textDecoration: 'none',
+          }}
+        >
+          View process
+        </Button>
+      </Section>
+    </EmailTemplate>
+  );
+};
+
+PhaseTransitionEmail.subject = (processTitle: string, toPhaseName: string) =>
+  `Phase update: ${processTitle} has moved to ${toPhaseName}`;
+
+export default PhaseTransitionEmail;

--- a/services/emails/emails/PhaseTransitionEmail.tsx
+++ b/services/emails/emails/PhaseTransitionEmail.tsx
@@ -16,7 +16,9 @@ export const PhaseTransitionEmail = ({
   processUrl: string;
 }) => {
   return (
-    <EmailTemplate previewText={`${processTitle} — now in ${toPhaseName}`}>
+    <EmailTemplate
+      previewText={`${processTitle} has moved to phase ${phaseNumber} of ${totalPhases}: ${toPhaseName}.`}
+    >
       <Text className="my-8 text-lg">
         <strong>{processTitle}</strong> has moved to phase {phaseNumber} of{' '}
         {totalPhases}: <strong>{toPhaseName}</strong>.

--- a/services/emails/emails/PhaseTransitionEmail.tsx
+++ b/services/emails/emails/PhaseTransitionEmail.tsx
@@ -1,26 +1,25 @@
-import { Button, Heading, Section, Text } from '@react-email/components';
+import { Button, Section, Text } from '@react-email/components';
 
 import EmailTemplate from '../components/EmailTemplate';
 
 export const PhaseTransitionEmail = ({
   processTitle,
-  fromPhaseName,
   toPhaseName,
+  phaseNumber,
+  totalPhases,
   processUrl = 'https://common.oneproject.org/',
 }: {
   processTitle: string;
-  fromPhaseName: string;
   toPhaseName: string;
+  phaseNumber: number;
+  totalPhases: number;
   processUrl: string;
 }) => {
   return (
-    <EmailTemplate previewText={`${processTitle} has moved to ${toPhaseName}`}>
-      <Heading className="mx-0 !my-0 p-0 text-left font-serif text-[28px] font-light tracking-[-0.02625rem] text-[#222D38]">
-        Phase Update
-      </Heading>
+    <EmailTemplate previewText={`${processTitle} — now in ${toPhaseName}`}>
       <Text className="my-8 text-lg">
-        <strong>{processTitle}</strong> has moved from{' '}
-        <strong>{fromPhaseName}</strong> to <strong>{toPhaseName}</strong>.
+        <strong>{processTitle}</strong> has moved to phase {phaseNumber} of{' '}
+        {totalPhases}: <strong>{toPhaseName}</strong>.
       </Text>
 
       <Section className="pb-0">
@@ -36,11 +35,15 @@ export const PhaseTransitionEmail = ({
           View process
         </Button>
       </Section>
+
+      <Text className="mt-8 mb-0 text-xs text-neutral-gray4">
+        You're receiving this because you're a participant in {processTitle}.
+      </Text>
     </EmailTemplate>
   );
 };
 
 PhaseTransitionEmail.subject = (processTitle: string, toPhaseName: string) =>
-  `Phase update: ${processTitle} has moved to ${toPhaseName}`;
+  `${processTitle} — now in ${toPhaseName}`;
 
 export default PhaseTransitionEmail;

--- a/services/emails/index.tsx
+++ b/services/emails/index.tsx
@@ -116,3 +116,4 @@ export * from './emails/OPRelationshipRequestEmail';
 export * from './emails/CommentNotificationEmail';
 export * from './emails/ReactionNotificationEmail';
 export * from './emails/ProposalSubmittedEmail';
+export * from './emails/PhaseTransitionEmail';

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -49,4 +49,12 @@ export const Events = {
       proposalId: z.string().uuid(),
     }),
   },
+  phaseTransitioned: {
+    name: 'decision/phase-transitioned' as const,
+    schema: z.object({
+      processInstanceId: z.string().uuid(),
+      fromPhaseId: z.string(),
+      toPhaseId: z.string(),
+    }),
+  },
 } as const;

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -53,8 +53,8 @@ export const Events = {
     name: 'decision/phase-transitioned' as const,
     schema: z.object({
       processInstanceId: z.string().uuid(),
-      fromPhaseId: z.string(),
-      toPhaseId: z.string(),
+      fromPhaseId: z.string().min(1),
+      toPhaseId: z.string().min(1),
     }),
   },
 } as const;

--- a/services/workflows/src/functions/notifications/index.ts
+++ b/services/workflows/src/functions/notifications/index.ts
@@ -1,3 +1,4 @@
 export * from './sendReactionNotification';
 export * from './sendProfileInviteEmails';
 export * from './sendProposalSubmittedNotification';
+export * from './sendPhaseTransitionNotification';

--- a/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
+++ b/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
@@ -1,0 +1,109 @@
+import { OPURLConfig } from '@op/core';
+import { db, eq } from '@op/db/client';
+import { processInstances, profileUsers, profiles } from '@op/db/schema';
+import { OPBatchSend, PhaseTransitionEmail } from '@op/emails';
+import { Events, inngest } from '@op/events';
+
+const { phaseTransitioned } = Events;
+
+export const sendPhaseTransitionNotification = inngest.createFunction(
+  {
+    id: 'sendPhaseTransitionNotification',
+    debounce: {
+      key: 'event.data.processInstanceId',
+      period: '1m',
+      timeout: '3m',
+    },
+  },
+  { event: phaseTransitioned.name },
+  async ({ event, step }) => {
+    const { processInstanceId, fromPhaseId, toPhaseId } =
+      phaseTransitioned.schema.parse(event.data);
+
+    // Step 1: Get process instance with its profile and instance data
+    const processData = await step.run('get-process-data', async () => {
+      const instance = await db
+        .select({
+          id: processInstances.id,
+          name: processInstances.name,
+          profileId: processInstances.profileId,
+          instanceData: processInstances.instanceData,
+          profileSlug: profiles.slug,
+        })
+        .from(processInstances)
+        .innerJoin(profiles, eq(processInstances.profileId, profiles.id))
+        .where(eq(processInstances.id, processInstanceId))
+        .limit(1);
+
+      return instance[0];
+    });
+
+    if (!processData) {
+      console.log('No process instance found for id:', processInstanceId);
+      return;
+    }
+
+    // Resolve phase names from instance data
+    const instanceData = processData.instanceData as {
+      phases?: Array<{ phaseId: string; name?: string }>;
+    };
+    const phases = instanceData?.phases ?? [];
+    const fromPhaseName =
+      phases.find((p) => p.phaseId === fromPhaseId)?.name ?? fromPhaseId;
+    const toPhaseName =
+      phases.find((p) => p.phaseId === toPhaseId)?.name ?? toPhaseId;
+
+    // Step 2: Get all participant emails (profileUsers linked to the process's profile)
+    const participants = await step.run('get-participants', async () => {
+      if (!processData.profileId) {
+        return [];
+      }
+
+      return db
+        .select({
+          email: profileUsers.email,
+        })
+        .from(profileUsers)
+        .where(eq(profileUsers.profileId, processData.profileId));
+    });
+
+    if (participants.length === 0) {
+      console.log(
+        'No participants found for process instance:',
+        processInstanceId,
+      );
+      return;
+    }
+
+    const processUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processData.profileSlug}`;
+
+    // Step 3: Send notification emails to all participants
+    const result = await step.run('send-emails', async () => {
+      const emails = participants.map(({ email }) => ({
+        to: email,
+        subject: PhaseTransitionEmail.subject(processData.name, toPhaseName),
+        component: () =>
+          PhaseTransitionEmail({
+            processTitle: processData.name,
+            fromPhaseName,
+            toPhaseName,
+            processUrl,
+          }),
+      }));
+
+      const { data, errors } = await OPBatchSend(emails);
+
+      if (errors.length > 0) {
+        throw Error(`Email batch failed: ${JSON.stringify(errors)}`);
+      }
+
+      return {
+        sent: data.length,
+      };
+    });
+
+    return {
+      message: `${result.sent} phase transition notification(s) sent`,
+    };
+  },
+);

--- a/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
+++ b/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
@@ -19,8 +19,9 @@ export const sendPhaseTransitionNotification = inngest.createFunction(
   },
   { event: phaseTransitioned.name },
   async ({ event, step }) => {
-    const { processInstanceId, fromPhaseId, toPhaseId } =
-      phaseTransitioned.schema.parse(event.data);
+    const { processInstanceId, toPhaseId } = phaseTransitioned.schema.parse(
+      event.data,
+    );
 
     const processData = await step.run('get-process-data', async () => {
       const instance = await db
@@ -51,13 +52,13 @@ export const sendPhaseTransitionNotification = inngest.createFunction(
       return;
     }
 
-    // Resolve phase names from instance data
+    // Resolve phase name and position from instance data
     const instanceData = processData.instanceData as DecisionInstanceData;
     const phases = instanceData?.phases ?? [];
-    const fromPhaseName =
-      phases.find((p) => p.phaseId === fromPhaseId)?.name ?? fromPhaseId;
-    const toPhaseName =
-      phases.find((p) => p.phaseId === toPhaseId)?.name ?? toPhaseId;
+    const toPhaseIndex = phases.findIndex((p) => p.phaseId === toPhaseId);
+    const toPhaseName = phases[toPhaseIndex]?.name ?? toPhaseId;
+    const phaseNumber = toPhaseIndex !== -1 ? toPhaseIndex + 1 : 1;
+    const totalPhases = phases.length;
 
     const participants = await step.run('get-participants', async () => {
       return db
@@ -88,8 +89,9 @@ export const sendPhaseTransitionNotification = inngest.createFunction(
           component: () =>
             PhaseTransitionEmail({
               processTitle: processData.name,
-              fromPhaseName,
               toPhaseName,
+              phaseNumber,
+              totalPhases,
               processUrl,
             }),
         }));

--- a/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
+++ b/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
@@ -1,8 +1,10 @@
+import type { DecisionInstanceData } from '@op/common';
 import { OPURLConfig } from '@op/core';
-import { db, eq } from '@op/db/client';
+import { db } from '@op/db/client';
 import { processInstances, profileUsers, profiles } from '@op/db/schema';
 import { OPBatchSend, PhaseTransitionEmail } from '@op/emails';
 import { Events, inngest } from '@op/events';
+import { eq } from 'drizzle-orm';
 
 const { phaseTransitioned } = Events;
 
@@ -10,7 +12,7 @@ export const sendPhaseTransitionNotification = inngest.createFunction(
   {
     id: 'sendPhaseTransitionNotification',
     debounce: {
-      key: 'event.data.processInstanceId',
+      key: 'event.data.processInstanceId + "-" + event.data.fromPhaseId + "-" + event.data.toPhaseId',
       period: '1m',
       timeout: '3m',
     },
@@ -20,18 +22,16 @@ export const sendPhaseTransitionNotification = inngest.createFunction(
     const { processInstanceId, fromPhaseId, toPhaseId } =
       phaseTransitioned.schema.parse(event.data);
 
-    // Step 1: Get process instance with its profile and instance data
     const processData = await step.run('get-process-data', async () => {
       const instance = await db
         .select({
-          id: processInstances.id,
           name: processInstances.name,
           profileId: processInstances.profileId,
           instanceData: processInstances.instanceData,
           profileSlug: profiles.slug,
         })
         .from(processInstances)
-        .innerJoin(profiles, eq(processInstances.profileId, profiles.id))
+        .leftJoin(profiles, eq(processInstances.profileId, profiles.id))
         .where(eq(processInstances.id, processInstanceId))
         .limit(1);
 
@@ -39,67 +39,77 @@ export const sendPhaseTransitionNotification = inngest.createFunction(
     });
 
     if (!processData) {
-      console.log('No process instance found for id:', processInstanceId);
+      console.error('No process instance found for id:', processInstanceId);
+      return;
+    }
+
+    if (!processData.profileId) {
+      console.error(
+        'Process instance has no associated profile:',
+        processInstanceId,
+      );
       return;
     }
 
     // Resolve phase names from instance data
-    const instanceData = processData.instanceData as {
-      phases?: Array<{ phaseId: string; name?: string }>;
-    };
+    const instanceData = processData.instanceData as DecisionInstanceData;
     const phases = instanceData?.phases ?? [];
     const fromPhaseName =
       phases.find((p) => p.phaseId === fromPhaseId)?.name ?? fromPhaseId;
     const toPhaseName =
       phases.find((p) => p.phaseId === toPhaseId)?.name ?? toPhaseId;
 
-    // Step 2: Get all participant emails (profileUsers linked to the process's profile)
     const participants = await step.run('get-participants', async () => {
-      if (!processData.profileId) {
-        return [];
-      }
-
       return db
         .select({
           email: profileUsers.email,
         })
         .from(profileUsers)
-        .where(eq(profileUsers.profileId, processData.profileId));
+        .where(eq(profileUsers.profileId, processData.profileId!));
     });
 
     if (participants.length === 0) {
-      console.log(
+      console.warn(
         'No participants found for process instance:',
         processInstanceId,
+        'profileId:',
+        processData.profileId,
       );
       return;
     }
 
     const processUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processData.profileSlug}`;
 
-    // Step 3: Send notification emails to all participants
     const result = await step.run('send-emails', async () => {
-      const emails = participants.map(({ email }) => ({
-        to: email,
-        subject: PhaseTransitionEmail.subject(processData.name, toPhaseName),
-        component: () =>
-          PhaseTransitionEmail({
-            processTitle: processData.name,
-            fromPhaseName,
-            toPhaseName,
-            processUrl,
-          }),
-      }));
+      try {
+        const emails = participants.map(({ email }) => ({
+          to: email,
+          subject: PhaseTransitionEmail.subject(processData.name, toPhaseName),
+          component: () =>
+            PhaseTransitionEmail({
+              processTitle: processData.name,
+              fromPhaseName,
+              toPhaseName,
+              processUrl,
+            }),
+        }));
 
-      const { data, errors } = await OPBatchSend(emails);
+        const { data, errors } = await OPBatchSend(emails);
 
-      if (errors.length > 0) {
-        throw Error(`Email batch failed: ${JSON.stringify(errors)}`);
+        if (errors.length > 0) {
+          throw Error(`Email batch failed: ${JSON.stringify(errors)}`);
+        }
+
+        return {
+          sent: data.length,
+        };
+      } catch (error) {
+        console.error('Failed to send phase transition notifications:', {
+          error,
+          processInstanceId,
+        });
+        throw error;
       }
-
-      return {
-        sent: data.length,
-      };
     });
 
     return {


### PR DESCRIPTION
Adds a new `phaseTransitioned` Inngest event dispatched whenever a decision process moves between phases that send an email to all participants.
