### PR TITLE
feat(reviews): surface revision request in review assignment endpoints

### DIFF
--- a/packages/common/src/services/decision/getReviewAssignment.ts
+++ b/packages/common/src/services/decision/getReviewAssignment.ts
@@ -30,7 +30,7 @@ export async function getReviewAssignment({
   assignmentId: string;
   user: User;
 }): Promise<ReviewAssignmentExtended> {
-  const { assignment, instance, review, rubricTemplate } =
+  const { assignment, instance, review, revisionRequest, rubricTemplate } =
     await assertReviewAssignmentContext({
       assignmentId,
       user,
@@ -88,6 +88,7 @@ export async function getReviewAssignment({
     },
     rubricTemplate,
     review,
+    revisionRequest,
   });
 }
 

--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -61,6 +61,7 @@ export async function listReviewAssignments({
         },
       },
       reviews: true,
+      requests: true,
     },
     orderBy: {
       assignedAt: 'asc',
@@ -118,7 +119,9 @@ export async function listReviewAssignments({
         },
       },
       rubricTemplate,
+      // NOTE: We currently support only one review/revision cycle per assignment.
       review: assignment.reviews[0] ?? null,
+      revisionRequest: assignment.requests[0] ?? null,
     };
   });
 

--- a/packages/common/src/services/decision/reviewHelpers.ts
+++ b/packages/common/src/services/decision/reviewHelpers.ts
@@ -41,6 +41,7 @@ export async function assertReviewAssignmentContext({
           },
         },
         reviews: true,
+        requests: true,
       },
     }),
     assertUserByAuthId(user.id),
@@ -73,7 +74,9 @@ export async function assertReviewAssignmentContext({
   return {
     assignment,
     instance,
+    // NOTE: We currently support only one review/revision cycle per assignment.
     review: assignment.reviews[0] ?? null,
+    revisionRequest: assignment.requests[0] ?? null,
     rubricTemplate: instance.instanceData.rubricTemplate ?? null,
   };
 }

--- a/packages/common/src/services/decision/schemas/reviews.ts
+++ b/packages/common/src/services/decision/schemas/reviews.ts
@@ -1,5 +1,6 @@
 import {
   ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
   ProposalReviewState,
 } from '@op/db/schema';
 import { z } from 'zod';
@@ -23,6 +24,20 @@ export const proposalReviewAssignmentSchema = z.object({
   proposal: proposalSchema,
 });
 
+// ── Revision request schemas ───────────────────────────────────────────
+
+export const proposalReviewRequestSchema = z.object({
+  id: z.uuid(),
+  assignmentId: z.uuid(),
+  state: z.enum(ProposalReviewRequestState),
+  requestComment: z.string(),
+  requestedAt: z.string().nullable(),
+  respondedAt: z.string().nullable(),
+  resolvedAt: z.string().nullable(),
+  createdAt: z.string().nullable(),
+  updatedAt: z.string().nullable(),
+});
+
 // ── Review schemas ──────────────────────────────────────────────────────
 
 export const proposalReviewSchema = z.object({
@@ -40,6 +55,7 @@ export const reviewAssignmentExtendedSchema = z.object({
   assignment: proposalReviewAssignmentSchema,
   rubricTemplate: rubricTemplateSchema.nullable(),
   review: proposalReviewSchema.nullable(),
+  revisionRequest: proposalReviewRequestSchema.nullable(),
 });
 
 export const reviewAssignmentListSchema = z.object({
@@ -51,6 +67,7 @@ export const reviewAssignmentListSchema = z.object({
 export type ProposalReviewAssignment = z.infer<
   typeof proposalReviewAssignmentSchema
 >;
+export type ProposalReviewRequest = z.infer<typeof proposalReviewRequestSchema>;
 export type ProposalReview = z.infer<typeof proposalReviewSchema>;
 export type ReviewAssignmentExtended = z.infer<
   typeof reviewAssignmentExtendedSchema

--- a/services/api/src/routers/decision/reviews/getReviewAssignment.test.ts
+++ b/services/api/src/routers/decision/reviews/getReviewAssignment.test.ts
@@ -2,9 +2,10 @@ import { mockCollab } from '@op/collab/testing';
 import type { RubricTemplateSchema } from '@op/common';
 import {
   ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
   ProposalReviewState,
 } from '@op/db/schema';
-import { createProposalReview } from '@op/test';
+import { createProposalReview, createRevisionRequest } from '@op/test';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
@@ -89,6 +90,7 @@ describe.concurrent('getReviewAssignment', () => {
         },
       },
       review: null,
+      revisionRequest: null,
     });
   });
 
@@ -190,6 +192,49 @@ describe.concurrent('getReviewAssignment', () => {
         },
       },
       review: null,
+      revisionRequest: null,
+    });
+  });
+
+  it('returns the revision request when one exists', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Proposal Needing Revision',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    const { collaborationDocId } = created.proposal.proposalData as {
+      collaborationDocId: string;
+    };
+    seedMockCollab(collaborationDocId);
+
+    const revisionRequest = await createRevisionRequest({
+      assignmentId: created.assignment.id,
+      requestComment: 'Please add more budget detail.',
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.getReviewAssignment({
+      assignmentId: created.assignment.id,
+    });
+
+    expect(result).toMatchObject({
+      assignment: {
+        id: created.assignment.id,
+        status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+      },
+      review: null,
+      revisionRequest: {
+        id: revisionRequest.id,
+        assignmentId: created.assignment.id,
+        state: ProposalReviewRequestState.REQUESTED,
+        requestComment: 'Please add more budget detail.',
+      },
     });
   });
 

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
@@ -2,9 +2,10 @@ import { mockCollab } from '@op/collab/testing';
 import type { RubricTemplateSchema } from '@op/common';
 import {
   ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
   ProposalReviewState,
 } from '@op/db/schema';
-import { createProposalReview } from '@op/test';
+import { createProposalReview, createRevisionRequest } from '@op/test';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
@@ -181,6 +182,49 @@ describe.concurrent('listReviewAssignments', () => {
           impact__rationale: 'Strong fit',
         },
         overallComment: 'Promising proposal',
+      },
+      revisionRequest: null,
+    });
+  });
+
+  it('includes revision request when one exists for an assignment', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Needs Revision',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    const { collaborationDocId } = created.proposal.proposalData as {
+      collaborationDocId: string;
+    };
+    seedMockCollab(collaborationDocId);
+
+    const revisionRequest = await createRevisionRequest({
+      assignmentId: created.assignment.id,
+      requestComment: 'Missing budget breakdown.',
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: created.context.instance.instance.id,
+    });
+
+    expect(result.assignments).toHaveLength(1);
+    expect(result.assignments[0]).toMatchObject({
+      assignment: {
+        id: created.assignment.id,
+        status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+      },
+      revisionRequest: {
+        id: revisionRequest.id,
+        assignmentId: created.assignment.id,
+        state: ProposalReviewRequestState.REQUESTED,
+        requestComment: 'Missing budget breakdown.',
       },
     });
   });

--- a/tests/core/src/index.ts
+++ b/tests/core/src/index.ts
@@ -34,10 +34,12 @@ export {
   createProposalHistorySnapshot,
   createProposalReview,
   createReviewAssignment,
+  createRevisionRequest,
   defaultReviewSettings,
   getLatestProposalHistoryId,
   type CreateProposalReviewOptions,
   type CreateReviewAssignmentOptions,
+  type CreateRevisionRequestOptions,
   type ReviewSettings,
 } from './review-data';
 

--- a/tests/core/src/review-data.ts
+++ b/tests/core/src/review-data.ts
@@ -1,9 +1,11 @@
 import {
   ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
   ProposalReviewState,
   decisionProcesses,
   proposalHistory,
   proposalReviewAssignments,
+  proposalReviewRequests,
   proposalReviews,
 } from '@op/db/schema';
 import { db, eq, sql } from '@op/db/test';
@@ -135,6 +137,14 @@ export interface CreateProposalReviewOptions {
   submittedAt?: string | null;
 }
 
+export interface CreateRevisionRequestOptions {
+  assignmentId: string;
+  state?: ProposalReviewRequestState;
+  requestComment?: string;
+  requestedProposalHistoryId?: string | null;
+  respondedProposalHistoryId?: string | null;
+}
+
 /** Creates a review assignment row for a proposal within a review phase. */
 export async function createReviewAssignment(
   opts: CreateReviewAssignmentOptions,
@@ -199,4 +209,36 @@ export async function createProposalReview(
   }
 
   return review;
+}
+
+/** Creates a revision request row for a review assignment. */
+export async function createRevisionRequest(
+  opts: CreateRevisionRequestOptions,
+): Promise<typeof proposalReviewRequests.$inferSelect> {
+  const {
+    assignmentId,
+    state = ProposalReviewRequestState.REQUESTED,
+    requestComment = 'Please revise your proposal.',
+    requestedProposalHistoryId = null,
+    respondedProposalHistoryId = null,
+  } = opts;
+
+  const [request] = await db
+    .insert(proposalReviewRequests)
+    .values({
+      assignmentId,
+      state,
+      requestComment,
+      requestedProposalHistoryId,
+      respondedProposalHistoryId,
+    })
+    .returning();
+
+  if (!request) {
+    throw new Error(
+      `Failed to create revision request for assignment: ${assignmentId}`,
+    );
+  }
+
+  return request;
 }


### PR DESCRIPTION
Add revisionRequest (nullable) to getReviewAssignment and listReviewAssignments responses so the frontend can render the revision request flow. Only one review/revision cycle per assignment is supported for now.

test(reviews): add revision request coverage for get and list assignment endpoints