### PR TITLE
feat(reviews): add create and cancel revision mutations

### DIFF
--- a/packages/common/src/services/decision/cancelRevisionRequest.ts
+++ b/packages/common/src/services/decision/cancelRevisionRequest.ts
@@ -10,10 +10,6 @@ import { eq } from 'drizzle-orm';
 
 import { CommonError, NotFoundError, ValidationError } from '../../utils';
 import { assertReviewAssignmentContext } from './reviewHelpers';
-import {
-  type ProposalReviewRequest,
-  proposalReviewRequestSchema,
-} from './schemas/reviews';
 
 /** Cancels an active revision request and resumes the assignment. */
 export async function cancelRevisionRequest({
@@ -24,7 +20,7 @@ export async function cancelRevisionRequest({
   assignmentId: string;
   revisionRequestId: string;
   user: User;
-}): Promise<ProposalReviewRequest & { processInstanceId: string }> {
+}) {
   const context = await assertReviewAssignmentContext({
     assignmentId,
     user,
@@ -64,7 +60,7 @@ export async function cancelRevisionRequest({
   });
 
   return {
-    ...proposalReviewRequestSchema.parse(request),
+    ...request,
     processInstanceId: context.assignment.processInstanceId,
   };
 }

--- a/packages/common/src/services/decision/cancelRevisionRequest.ts
+++ b/packages/common/src/services/decision/cancelRevisionRequest.ts
@@ -1,6 +1,7 @@
 import { db } from '@op/db/client';
 import {
   ProposalReviewAssignmentStatus,
+  type ProposalReviewRequest,
   ProposalReviewRequestState,
   proposalReviewAssignments,
   proposalReviewRequests,
@@ -20,7 +21,7 @@ export async function cancelRevisionRequest({
   assignmentId: string;
   revisionRequestId: string;
   user: User;
-}) {
+}): Promise<ProposalReviewRequest & { processInstanceId: string }> {
   const context = await assertReviewAssignmentContext({
     assignmentId,
     user,

--- a/packages/common/src/services/decision/cancelRevisionRequest.ts
+++ b/packages/common/src/services/decision/cancelRevisionRequest.ts
@@ -1,0 +1,70 @@
+import { db } from '@op/db/client';
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+  proposalReviewAssignments,
+  proposalReviewRequests,
+} from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+import { eq } from 'drizzle-orm';
+
+import { CommonError, NotFoundError, ValidationError } from '../../utils';
+import { assertReviewAssignmentContext } from './reviewHelpers';
+import {
+  type ProposalReviewRequest,
+  proposalReviewRequestSchema,
+} from './schemas/reviews';
+
+/** Cancels an active revision request and resumes the assignment. */
+export async function cancelRevisionRequest({
+  assignmentId,
+  revisionRequestId,
+  user,
+}: {
+  assignmentId: string;
+  revisionRequestId: string;
+  user: User;
+}): Promise<ProposalReviewRequest & { processInstanceId: string }> {
+  const context = await assertReviewAssignmentContext({
+    assignmentId,
+    user,
+  });
+
+  const existingRequest = context.revisionRequest;
+
+  if (!existingRequest || existingRequest.id !== revisionRequestId) {
+    throw new NotFoundError('Revision request');
+  }
+
+  if (existingRequest.state !== ProposalReviewRequestState.REQUESTED) {
+    throw new ValidationError('Only active revision requests can be cancelled');
+  }
+
+  const request = await db.transaction(async (tx) => {
+    const [cancelledRequest] = await tx
+      .update(proposalReviewRequests)
+      .set({
+        state: ProposalReviewRequestState.CANCELLED,
+      })
+      .where(eq(proposalReviewRequests.id, revisionRequestId))
+      .returning();
+
+    if (!cancelledRequest) {
+      throw new CommonError('Failed to cancel revision request');
+    }
+
+    await tx
+      .update(proposalReviewAssignments)
+      .set({
+        status: ProposalReviewAssignmentStatus.IN_PROGRESS,
+      })
+      .where(eq(proposalReviewAssignments.id, assignmentId));
+
+    return cancelledRequest;
+  });
+
+  return {
+    ...proposalReviewRequestSchema.parse(request),
+    processInstanceId: context.assignment.processInstanceId,
+  };
+}

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -56,6 +56,8 @@ export * from './runGenerateReviewAssignments';
 export * from './getReviewAssignment';
 export * from './listReviewAssignments';
 export * from './submitReview';
+export * from './requestRevision';
+export * from './cancelRevisionRequest';
 export * from './deleteProposal';
 export * from './deleteDecision';
 export * from './getProcessCategories';

--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -1,5 +1,4 @@
 import { db } from '@op/db/client';
-import { ProposalReviewRequestState } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 
 import { UnauthorizedError } from '../../utils';
@@ -8,7 +7,11 @@ import { generateProposalHtml } from './generateProposalHtml';
 import { getInstance } from './getInstance';
 import { getProposalDocumentsContent } from './getProposalDocumentsContent';
 import { resolveProposalTemplate } from './resolveProposalTemplate';
-import { resolveAssignmentProposal } from './reviewHelpers';
+import {
+  getActiveRevisionRequest,
+  resolveAssignmentProposal,
+  reviewAssignmentWithConfig,
+} from './reviewHelpers';
 import {
   type ReviewAssignmentList,
   reviewAssignmentListSchema,
@@ -45,34 +48,7 @@ export async function listReviewAssignments({
       reviewerProfileId: dbUser.profileId,
       ...(status && { status }),
     },
-    with: {
-      assignedProposalHistory: {
-        with: {
-          submittedBy: {
-            with: {
-              avatarImage: true,
-            },
-          },
-          profile: true,
-        },
-      },
-      proposal: {
-        with: {
-          submittedBy: {
-            with: {
-              avatarImage: true,
-            },
-          },
-          profile: true,
-        },
-      },
-      reviews: true,
-      requests: {
-        orderBy: {
-          createdAt: 'desc',
-        },
-      },
-    },
+    with: reviewAssignmentWithConfig,
     orderBy: {
       assignedAt: dir,
     },
@@ -130,12 +106,7 @@ export async function listReviewAssignments({
       },
       rubricTemplate,
       review: assignment.reviews[0] ?? null,
-      revisionRequest:
-        assignment.requests.find(
-          (r) => r.state === ProposalReviewRequestState.REQUESTED,
-        ) ??
-        assignment.requests[0] ??
-        null,
+      revisionRequest: getActiveRevisionRequest(assignment.requests),
     };
   });
 

--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -1,4 +1,5 @@
 import { db } from '@op/db/client';
+import { ProposalReviewRequestState } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 
 import { UnauthorizedError } from '../../utils';
@@ -66,7 +67,11 @@ export async function listReviewAssignments({
         },
       },
       reviews: true,
-      requests: true,
+      requests: {
+        orderBy: {
+          createdAt: 'desc',
+        },
+      },
     },
     orderBy: {
       assignedAt: dir,
@@ -124,9 +129,13 @@ export async function listReviewAssignments({
         },
       },
       rubricTemplate,
-      // NOTE: We currently support only one review/revision cycle per assignment.
       review: assignment.reviews[0] ?? null,
-      revisionRequest: assignment.requests[0] ?? null,
+      revisionRequest:
+        assignment.requests.find(
+          (r) => r.state === ProposalReviewRequestState.REQUESTED,
+        ) ??
+        assignment.requests[0] ??
+        null,
     };
   });
 

--- a/packages/common/src/services/decision/requestRevision.ts
+++ b/packages/common/src/services/decision/requestRevision.ts
@@ -10,10 +10,6 @@ import { eq } from 'drizzle-orm';
 
 import { CommonError, ValidationError } from '../../utils';
 import { assertReviewAssignmentContext } from './reviewHelpers';
-import {
-  type ProposalReviewRequest,
-  proposalReviewRequestSchema,
-} from './schemas/reviews';
 
 /** Creates a revision request and pauses the assignment until the author revises. */
 export async function requestRevision({
@@ -24,7 +20,7 @@ export async function requestRevision({
   assignmentId: string;
   requestComment: string;
   user: User;
-}): Promise<ProposalReviewRequest & { processInstanceId: string }> {
+}) {
   const context = await assertReviewAssignmentContext({
     assignmentId,
     user,
@@ -52,6 +48,8 @@ export async function requestRevision({
         assignmentId,
         state: ProposalReviewRequestState.REQUESTED,
         requestComment,
+        requestedProposalHistoryId:
+          context.assignment.assignedProposalHistoryId,
       })
       .returning();
 
@@ -70,7 +68,7 @@ export async function requestRevision({
   });
 
   return {
-    ...proposalReviewRequestSchema.parse(request),
+    ...request,
     processInstanceId: context.assignment.processInstanceId,
   };
 }

--- a/packages/common/src/services/decision/requestRevision.ts
+++ b/packages/common/src/services/decision/requestRevision.ts
@@ -1,6 +1,7 @@
 import { db } from '@op/db/client';
 import {
   ProposalReviewAssignmentStatus,
+  type ProposalReviewRequest,
   ProposalReviewRequestState,
   proposalReviewAssignments,
   proposalReviewRequests,
@@ -20,7 +21,7 @@ export async function requestRevision({
   assignmentId: string;
   requestComment: string;
   user: User;
-}) {
+}): Promise<ProposalReviewRequest & { processInstanceId: string }> {
   const context = await assertReviewAssignmentContext({
     assignmentId,
     user,

--- a/packages/common/src/services/decision/requestRevision.ts
+++ b/packages/common/src/services/decision/requestRevision.ts
@@ -1,0 +1,76 @@
+import { db } from '@op/db/client';
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+  proposalReviewAssignments,
+  proposalReviewRequests,
+} from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+import { eq } from 'drizzle-orm';
+
+import { CommonError, ValidationError } from '../../utils';
+import { assertReviewAssignmentContext } from './reviewHelpers';
+import {
+  type ProposalReviewRequest,
+  proposalReviewRequestSchema,
+} from './schemas/reviews';
+
+/** Creates a revision request and pauses the assignment until the author revises. */
+export async function requestRevision({
+  assignmentId,
+  requestComment,
+  user,
+}: {
+  assignmentId: string;
+  requestComment: string;
+  user: User;
+}): Promise<ProposalReviewRequest & { processInstanceId: string }> {
+  const context = await assertReviewAssignmentContext({
+    assignmentId,
+    user,
+  });
+
+  if (
+    context.assignment.status ===
+    ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION
+  ) {
+    throw new ValidationError(
+      'A revision has already been requested for this assignment',
+    );
+  }
+
+  if (context.assignment.status === ProposalReviewAssignmentStatus.COMPLETED) {
+    throw new ValidationError(
+      'Cannot request a revision for a completed assignment',
+    );
+  }
+
+  const request = await db.transaction(async (tx) => {
+    const [revisionRequest] = await tx
+      .insert(proposalReviewRequests)
+      .values({
+        assignmentId,
+        state: ProposalReviewRequestState.REQUESTED,
+        requestComment,
+      })
+      .returning();
+
+    if (!revisionRequest) {
+      throw new CommonError('Failed to create revision request');
+    }
+
+    await tx
+      .update(proposalReviewAssignments)
+      .set({
+        status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+      })
+      .where(eq(proposalReviewAssignments.id, assignmentId));
+
+    return revisionRequest;
+  });
+
+  return {
+    ...proposalReviewRequestSchema.parse(request),
+    processInstanceId: context.assignment.processInstanceId,
+  };
+}

--- a/packages/common/src/services/decision/requestRevision.ts
+++ b/packages/common/src/services/decision/requestRevision.ts
@@ -27,19 +27,18 @@ export async function requestRevision({
     user,
   });
 
-  if (
-    context.assignment.status ===
-    ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION
-  ) {
-    throw new ValidationError(
-      'A revision has already been requested for this assignment',
-    );
-  }
-
-  if (context.assignment.status === ProposalReviewAssignmentStatus.COMPLETED) {
-    throw new ValidationError(
-      'Cannot request a revision for a completed assignment',
-    );
+  switch (context.assignment.status) {
+    case ProposalReviewAssignmentStatus.PENDING:
+    case ProposalReviewAssignmentStatus.IN_PROGRESS:
+      break;
+    case ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION:
+      throw new ValidationError(
+        'A revision has already been requested for this assignment',
+      );
+    case ProposalReviewAssignmentStatus.COMPLETED:
+      throw new ValidationError(
+        'Cannot request a revision for a completed assignment',
+      );
   }
 
   const request = await db.transaction(async (tx) => {

--- a/packages/common/src/services/decision/reviewHelpers.ts
+++ b/packages/common/src/services/decision/reviewHelpers.ts
@@ -1,4 +1,5 @@
 import { db } from '@op/db/client';
+import { ProposalReviewRequestState } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 
 import { NotFoundError, UnauthorizedError, ValidationError } from '../../utils';
@@ -41,7 +42,11 @@ export async function assertReviewAssignmentContext({
           },
         },
         reviews: true,
-        requests: true,
+        requests: {
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
     }),
     assertUserByAuthId(user.id),
@@ -74,9 +79,13 @@ export async function assertReviewAssignmentContext({
   return {
     assignment,
     instance,
-    // NOTE: We currently support only one review/revision cycle per assignment.
     review: assignment.reviews[0] ?? null,
-    revisionRequest: assignment.requests[0] ?? null,
+    revisionRequest:
+      assignment.requests.find(
+        (r) => r.state === ProposalReviewRequestState.REQUESTED,
+      ) ??
+      assignment.requests[0] ??
+      null,
     rubricTemplate: instance.instanceData.rubricTemplate ?? null,
   };
 }

--- a/packages/common/src/services/decision/reviewHelpers.ts
+++ b/packages/common/src/services/decision/reviewHelpers.ts
@@ -1,11 +1,55 @@
 import { db } from '@op/db/client';
-import { ProposalReviewRequestState } from '@op/db/schema';
+import {
+  type ProposalReviewRequest,
+  ProposalReviewRequestState,
+} from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 
 import { NotFoundError, UnauthorizedError, ValidationError } from '../../utils';
 import { assertUserByAuthId } from '../assert';
 import { getInstance } from './getInstance';
 import { type ProposalData, parseProposalData } from './proposalDataSchema';
+
+/** Shared `with` config for review assignment queries. */
+export const reviewAssignmentWithConfig = {
+  assignedProposalHistory: {
+    with: {
+      submittedBy: {
+        with: {
+          avatarImage: true,
+        },
+      },
+      profile: true,
+    },
+  },
+  proposal: {
+    with: {
+      submittedBy: {
+        with: {
+          avatarImage: true,
+        },
+      },
+      profile: true,
+    },
+  },
+  reviews: true,
+  requests: {
+    orderBy: {
+      createdAt: 'desc' as const,
+    },
+  },
+} as const;
+
+/** Returns the active (REQUESTED) revision request, falling back to the most recent one. */
+export function getActiveRevisionRequest(
+  requests: ProposalReviewRequest[],
+): ProposalReviewRequest | null {
+  return (
+    requests.find((r) => r.state === ProposalReviewRequestState.REQUESTED) ??
+    requests[0] ??
+    null
+  );
+}
 
 /** Loads and authorizes access to a single review assignment for the current reviewer. */
 export async function assertReviewAssignmentContext({
@@ -20,34 +64,7 @@ export async function assertReviewAssignmentContext({
       where: {
         id: assignmentId,
       },
-      with: {
-        assignedProposalHistory: {
-          with: {
-            submittedBy: {
-              with: {
-                avatarImage: true,
-              },
-            },
-            profile: true,
-          },
-        },
-        proposal: {
-          with: {
-            submittedBy: {
-              with: {
-                avatarImage: true,
-              },
-            },
-            profile: true,
-          },
-        },
-        reviews: true,
-        requests: {
-          orderBy: {
-            createdAt: 'desc',
-          },
-        },
-      },
+      with: reviewAssignmentWithConfig,
     }),
     assertUserByAuthId(user.id),
   ]);
@@ -80,12 +97,7 @@ export async function assertReviewAssignmentContext({
     assignment,
     instance,
     review: assignment.reviews[0] ?? null,
-    revisionRequest:
-      assignment.requests.find(
-        (r) => r.state === ProposalReviewRequestState.REQUESTED,
-      ) ??
-      assignment.requests[0] ??
-      null,
+    revisionRequest: getActiveRevisionRequest(assignment.requests),
     rubricTemplate: instance.instanceData.rubricTemplate ?? null,
   };
 }

--- a/services/api/src/routers/decision/reviews/cancelRevisionRequest.test.ts
+++ b/services/api/src/routers/decision/reviews/cancelRevisionRequest.test.ts
@@ -82,7 +82,9 @@ describe.concurrent('cancelRevisionRequest', () => {
         assignmentId: created.assignment.id,
         revisionRequestId: revisionRequest.id,
       }),
-    ).rejects.toThrow('Only active revision requests can be cancelled');
+    ).rejects.toMatchObject({
+      cause: { name: 'ValidationError' },
+    });
   });
 
   it('rejects when the revision request does not exist', async ({

--- a/services/api/src/routers/decision/reviews/cancelRevisionRequest.test.ts
+++ b/services/api/src/routers/decision/reviews/cancelRevisionRequest.test.ts
@@ -1,0 +1,138 @@
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+} from '@op/db/schema';
+import { db } from '@op/db/test';
+import { createRevisionRequest } from '@op/test';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestReviewsDataManager } from '../../../test/helpers/TestReviewsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+describe.concurrent('cancelRevisionRequest', () => {
+  it('cancels a revision request and resumes the assignment', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Cancel This Revision',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    const revisionRequest = await createRevisionRequest({
+      assignmentId: created.assignment.id,
+      requestComment: 'Please revise.',
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.cancelRevisionRequest({
+      assignmentId: created.assignment.id,
+      revisionRequestId: revisionRequest.id,
+    });
+
+    expect(result).toMatchObject({
+      id: revisionRequest.id,
+      assignmentId: created.assignment.id,
+      state: ProposalReviewRequestState.CANCELLED,
+    });
+
+    const assignment = await db.query.proposalReviewAssignments.findFirst({
+      where: { id: created.assignment.id },
+    });
+    expect(assignment?.status).toBe(ProposalReviewAssignmentStatus.IN_PROGRESS);
+  });
+
+  it('rejects when the revision request is not in requested state', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Already Cancelled',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    const revisionRequest = await createRevisionRequest({
+      assignmentId: created.assignment.id,
+      state: ProposalReviewRequestState.CANCELLED,
+      requestComment: 'Already cancelled.',
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.cancelRevisionRequest({
+        assignmentId: created.assignment.id,
+        revisionRequestId: revisionRequest.id,
+      }),
+    ).rejects.toThrow('Only active revision requests can be cancelled');
+  });
+
+  it('rejects when the revision request does not exist', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'No Request',
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.cancelRevisionRequest({
+        assignmentId: created.assignment.id,
+        revisionRequestId: '00000000-0000-0000-0000-000000000000',
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'NotFoundError' },
+    });
+  });
+
+  it('rejects access for a different reviewer', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Not My Assignment',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    const revisionRequest = await createRevisionRequest({
+      assignmentId: created.assignment.id,
+      requestComment: 'Please revise.',
+    });
+
+    const otherReviewer = await testData.createReviewer(created.context);
+    const otherCaller = await createAuthenticatedCaller(otherReviewer.email);
+
+    await expect(
+      otherCaller.decision.cancelRevisionRequest({
+        assignmentId: created.assignment.id,
+        revisionRequestId: revisionRequest.id,
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
+  });
+});

--- a/services/api/src/routers/decision/reviews/cancelRevisionRequest.ts
+++ b/services/api/src/routers/decision/reviews/cancelRevisionRequest.ts
@@ -1,0 +1,30 @@
+import { Channels, cancelRevisionRequest } from '@op/common';
+import { proposalReviewRequestSchema } from '@op/common/client';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const cancelRevisionRequestRouter = router({
+  cancelRevisionRequest: commonAuthedProcedure()
+    .input(
+      z.object({
+        assignmentId: z.uuid(),
+        revisionRequestId: z.uuid(),
+      }),
+    )
+    .output(proposalReviewRequestSchema)
+    .mutation(async ({ ctx, input }) => {
+      const result = await cancelRevisionRequest({
+        assignmentId: input.assignmentId,
+        revisionRequestId: input.revisionRequestId,
+        user: ctx.user,
+      });
+
+      ctx.registerMutationChannels([
+        Channels.reviewAssignment(input.assignmentId),
+        Channels.reviewAssignments(result.processInstanceId),
+      ]);
+
+      return proposalReviewRequestSchema.parse(result);
+    }),
+});

--- a/services/api/src/routers/decision/reviews/index.ts
+++ b/services/api/src/routers/decision/reviews/index.ts
@@ -1,10 +1,14 @@
 import { mergeRouters } from '../../../trpcFactory';
+import { cancelRevisionRequestRouter } from './cancelRevisionRequest';
 import { getReviewAssignmentRouter } from './getReviewAssignment';
 import { listReviewAssignmentsRouter } from './listReviewAssignments';
+import { requestRevisionRouter } from './requestRevision';
 import { submitReviewRouter } from './submitReview';
 
 export const reviewsRouter = mergeRouters(
+  cancelRevisionRequestRouter,
   getReviewAssignmentRouter,
   listReviewAssignmentsRouter,
+  requestRevisionRouter,
   submitReviewRouter,
 );

--- a/services/api/src/routers/decision/reviews/requestRevision.test.ts
+++ b/services/api/src/routers/decision/reviews/requestRevision.test.ts
@@ -1,0 +1,128 @@
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+} from '@op/db/schema';
+import { db } from '@op/db/test';
+import { createRevisionRequest } from '@op/test';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestReviewsDataManager } from '../../../test/helpers/TestReviewsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+describe.concurrent('requestRevision', () => {
+  it('creates a revision request and sets assignment to awaiting revision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Needs Budget Detail',
+      status: ProposalReviewAssignmentStatus.IN_PROGRESS,
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.requestRevision({
+      assignmentId: created.assignment.id,
+      requestComment: 'Please add a detailed budget breakdown.',
+    });
+
+    expect(result).toMatchObject({
+      assignmentId: created.assignment.id,
+      state: ProposalReviewRequestState.REQUESTED,
+      requestComment: 'Please add a detailed budget breakdown.',
+    });
+    expect(result.requestedAt).toBeTruthy();
+
+    const assignment = await db.query.proposalReviewAssignments.findFirst({
+      where: { id: created.assignment.id },
+    });
+    expect(assignment?.status).toBe(
+      ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    );
+  });
+
+  it('rejects when a revision is already pending', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Already Awaiting',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    await createRevisionRequest({
+      assignmentId: created.assignment.id,
+      requestComment: 'First request',
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.requestRevision({
+        assignmentId: created.assignment.id,
+        requestComment: 'Second request',
+      }),
+    ).rejects.toThrow('A revision has already been requested');
+  });
+
+  it('rejects when the assignment is already completed', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Already Done',
+      status: ProposalReviewAssignmentStatus.COMPLETED,
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.requestRevision({
+        assignmentId: created.assignment.id,
+        requestComment: 'Too late',
+      }),
+    ).rejects.toThrow('Cannot request a revision for a completed assignment');
+  });
+
+  it('rejects access for a different reviewer', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Not My Assignment',
+    });
+    const otherReviewer = await testData.createReviewer(created.context);
+
+    const otherCaller = await createAuthenticatedCaller(otherReviewer.email);
+
+    await expect(
+      otherCaller.decision.requestRevision({
+        assignmentId: created.assignment.id,
+        requestComment: 'Should not work',
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
+  });
+});

--- a/services/api/src/routers/decision/reviews/requestRevision.test.ts
+++ b/services/api/src/routers/decision/reviews/requestRevision.test.ts
@@ -104,6 +104,51 @@ describe.concurrent('requestRevision', () => {
     ).rejects.toThrow('Cannot request a revision for a completed assignment');
   });
 
+  it('allows a new revision request after cancelling a previous one', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Cancel Then Re-request',
+      status: ProposalReviewAssignmentStatus.IN_PROGRESS,
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    const firstRequest = await reviewerCaller.decision.requestRevision({
+      assignmentId: created.assignment.id,
+      requestComment: 'Please add budget details.',
+    });
+    expect(firstRequest.state).toBe(ProposalReviewRequestState.REQUESTED);
+
+    await reviewerCaller.decision.cancelRevisionRequest({
+      assignmentId: created.assignment.id,
+      revisionRequestId: firstRequest.id,
+    });
+
+    const secondRequest = await reviewerCaller.decision.requestRevision({
+      assignmentId: created.assignment.id,
+      requestComment: 'Actually, please also add a timeline.',
+    });
+
+    expect(secondRequest).toMatchObject({
+      assignmentId: created.assignment.id,
+      state: ProposalReviewRequestState.REQUESTED,
+      requestComment: 'Actually, please also add a timeline.',
+    });
+    expect(secondRequest.id).not.toBe(firstRequest.id);
+
+    const assignment = await db.query.proposalReviewAssignments.findFirst({
+      where: { id: created.assignment.id },
+    });
+    expect(assignment?.status).toBe(
+      ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    );
+  });
+
   it('rejects access for a different reviewer', async ({
     task,
     onTestFinished,

--- a/services/api/src/routers/decision/reviews/requestRevision.test.ts
+++ b/services/api/src/routers/decision/reviews/requestRevision.test.ts
@@ -79,7 +79,9 @@ describe.concurrent('requestRevision', () => {
         assignmentId: created.assignment.id,
         requestComment: 'Second request',
       }),
-    ).rejects.toThrow('A revision has already been requested');
+    ).rejects.toMatchObject({
+      cause: { name: 'ValidationError' },
+    });
   });
 
   it('rejects when the assignment is already completed', async ({
@@ -101,7 +103,9 @@ describe.concurrent('requestRevision', () => {
         assignmentId: created.assignment.id,
         requestComment: 'Too late',
       }),
-    ).rejects.toThrow('Cannot request a revision for a completed assignment');
+    ).rejects.toMatchObject({
+      cause: { name: 'ValidationError' },
+    });
   });
 
   it('allows a new revision request after cancelling a previous one', async ({

--- a/services/api/src/routers/decision/reviews/requestRevision.ts
+++ b/services/api/src/routers/decision/reviews/requestRevision.ts
@@ -1,0 +1,30 @@
+import { Channels, requestRevision } from '@op/common';
+import { proposalReviewRequestSchema } from '@op/common/client';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const requestRevisionRouter = router({
+  requestRevision: commonAuthedProcedure()
+    .input(
+      z.object({
+        assignmentId: z.uuid(),
+        requestComment: z.string().min(1),
+      }),
+    )
+    .output(proposalReviewRequestSchema)
+    .mutation(async ({ ctx, input }) => {
+      const result = await requestRevision({
+        assignmentId: input.assignmentId,
+        requestComment: input.requestComment,
+        user: ctx.user,
+      });
+
+      ctx.registerMutationChannels([
+        Channels.reviewAssignment(input.assignmentId),
+        Channels.reviewAssignments(result.processInstanceId),
+      ]);
+
+      return proposalReviewRequestSchema.parse(result);
+    }),
+});


### PR DESCRIPTION
Adds the two mutation endpoints needed for the reviewer revision flow: requesting the author revise their proposal, and cancelling that request to resume reviewing.