### PR TITLE
feat(rubric): redesign criterion cards to match proposal template

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -57,7 +57,7 @@ interface RubricCriterionCardProps {
  *
  * Uses CollapsibleConfigCard to match the proposal template FieldCard pattern:
  * drag handle + label in header, content with field name, description,
- * criterion type selector, and a footer with required toggle + delete.
+ * and criterion type selector.
  */
 export function RubricCriterionCard({
   criterion,
@@ -76,13 +76,12 @@ export function RubricCriterionCard({
 }: RubricCriterionCardProps) {
   const t = useTranslations();
   const cardRef = useRef<HTMLDivElement>(null);
-  const fieldNameRef = useRef<HTMLInputElement>(null);
 
   const displayLabel = criterion.label || t('Untitled field');
 
   const badgeLabel =
     criterion.criterionType === 'scored' && criterion.maxPoints
-      ? `${criterion.maxPoints}${t('pts')}`
+      ? `${criterion.maxPoints} ${t('pts')}`
       : t(CRITERION_TYPE_REGISTRY[criterion.criterionType].labelKey);
 
   // Only trigger validation when focus leaves the card entirely
@@ -96,7 +95,11 @@ export function RubricCriterionCard({
     <div
       ref={cardRef}
       onBlur={handleBlur}
-      onAnimationEnd={() => onNewComplete?.(criterion.id)}
+      onAnimationEnd={(e) => {
+        if (e.animationName === 'border-highlight') {
+          onNewComplete?.(criterion.id);
+        }
+      }}
       className="scroll-m-6"
     >
       <CollapsibleConfigCard
@@ -117,7 +120,6 @@ export function RubricCriterionCard({
         <div className="space-y-4 px-8">
           {/* Field name */}
           <TextField
-            ref={fieldNameRef}
             label={t('Field name')}
             isRequired
             value={criterion.label}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@op/ui/Button';
 import {
   CollapsibleConfigCard,
   CollapsibleConfigCardDragPreview,
@@ -10,6 +11,7 @@ import type { SortableItemControls } from '@op/ui/Sortable';
 import { TextField } from '@op/ui/TextField';
 import { cn } from '@op/ui/utils';
 import { useRef, useState } from 'react';
+import { LuTrash2 } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 import type { TranslationKey } from '@/lib/i18n/routing';
@@ -34,6 +36,7 @@ interface RubricCriterionCardProps {
   controls?: SortableItemControls;
   isExpanded?: boolean;
   onExpandedChange?: (expanded: boolean) => void;
+  onRemove?: (criterionId: string) => void;
   onBlur?: (criterionId: string) => void;
   onUpdateLabel?: (criterionId: string, label: string) => void;
   onUpdateDescription?: (criterionId: string, description: string) => void;
@@ -65,6 +68,7 @@ export function RubricCriterionCard({
   controls,
   isExpanded,
   onExpandedChange,
+  onRemove,
   onBlur,
   onUpdateLabel,
   onUpdateDescription,
@@ -175,6 +179,22 @@ export function RubricCriterionCard({
                   {t(error)}
                 </p>
               ))}
+            </div>
+          )}
+
+          {/* Footer */}
+          {onRemove && (
+            <div className="flex items-center justify-end border-t pt-4">
+              <Button
+                color="ghost"
+                size="small"
+                onPress={() => onRemove(criterion.id)}
+                aria-label={t('Delete')}
+                className="text-neutral-gray4 hover:text-functional-red"
+              >
+                <LuTrash2 className="size-4" />
+                {t('Delete')}
+              </Button>
             </div>
           )}
         </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -1,19 +1,18 @@
 'use client';
 
-import {
-  AccordionContent,
-  AccordionHeader,
-  AccordionIndicator,
-  AccordionTrigger,
-} from '@op/ui/Accordion';
 import { Button } from '@op/ui/Button';
+import {
+  CollapsibleConfigCard,
+  CollapsibleConfigCardDragPreview,
+} from '@op/ui/CollapsibleConfigCard';
 import { NumberField } from '@op/ui/NumberField';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
-import { DragHandle } from '@op/ui/Sortable';
 import type { SortableItemControls } from '@op/ui/Sortable';
 import { TextField } from '@op/ui/TextField';
-import { useState } from 'react';
-import { LuChevronRight, LuGripVertical, LuTrash2 } from 'react-icons/lu';
+import { ToggleButton } from '@op/ui/ToggleButton';
+import { cn } from '@op/ui/utils';
+import { useRef, useState } from 'react';
+import { LuTrash2 } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 import type { TranslationKey } from '@/lib/i18n/routing';
@@ -34,11 +33,12 @@ import {
 
 interface RubricCriterionCardProps {
   criterion: CriterionView;
-  /** 1-based display index for the header (e.g. "Criterion 1") */
-  index: number;
   errors?: TranslationKey[];
   controls?: SortableItemControls;
+  isExpanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
   onRemove?: (criterionId: string) => void;
+  onBlur?: (criterionId: string) => void;
   onUpdateLabel?: (criterionId: string, label: string) => void;
   onUpdateDescription?: (criterionId: string, description: string) => void;
   onChangeType?: (criterionId: string, newType: RubricCriterionType) => void;
@@ -48,6 +48,9 @@ interface RubricCriterionCardProps {
     scoreValue: number,
     label: string,
   ) => void;
+  onUpdateRequired?: (criterionId: string, required: boolean) => void;
+  isNew?: boolean;
+  onNewComplete?: (criterionId: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,93 +58,94 @@ interface RubricCriterionCardProps {
 // ---------------------------------------------------------------------------
 
 /**
- * A collapsible accordion card for a single rubric criterion.
+ * A collapsible card for a single rubric criterion.
  *
- * Built directly with Accordion primitives (not FieldConfigCard) to match
- * the mockup: static "Criterion N" header, separate name/description fields
- * in the body, and a criterion type radio selector.
- *
- * Must be rendered inside an `<AccordionItem>` which is inside an `<Accordion>`.
+ * Uses CollapsibleConfigCard to match the proposal template FieldCard pattern:
+ * drag handle + label in header, content with field name, description,
+ * criterion type selector, and a footer with required toggle + delete.
  */
 export function RubricCriterionCard({
   criterion,
-  index,
   errors = [],
   controls,
+  isExpanded,
+  onExpandedChange,
   onRemove,
+  onBlur,
   onUpdateLabel,
   onUpdateDescription,
   onChangeType,
   onUpdateMaxPoints,
   onUpdateScoreLabel,
+  onUpdateRequired,
+  isNew,
+  onNewComplete,
 }: RubricCriterionCardProps) {
   const t = useTranslations();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const fieldNameRef = useRef<HTMLInputElement>(null);
+
+  const displayLabel = criterion.label || t('Untitled field');
+
+  const badgeLabel =
+    criterion.criterionType === 'scored' && criterion.maxPoints
+      ? `${criterion.maxPoints}${t('pts')}`
+      : t(CRITERION_TYPE_REGISTRY[criterion.criterionType].labelKey);
+
+  // Only trigger validation when focus leaves the card entirely
+  const handleBlur = (e: React.FocusEvent) => {
+    if (cardRef.current && !cardRef.current.contains(e.relatedTarget as Node)) {
+      onBlur?.(criterion.id);
+    }
+  };
 
   return (
-    <>
-      {/* Header: drag handle + chevron + "Criterion N" + delete button */}
-      <AccordionHeader className="flex items-center gap-2 px-3 py-2">
-        {controls && (
-          <DragHandle
-            {...controls.dragHandleProps}
-            aria-label={t('Drag to reorder criterion')}
-          />
+    <div
+      ref={cardRef}
+      onBlur={handleBlur}
+      onAnimationEnd={() => onNewComplete?.(criterion.id)}
+      className="scroll-m-6"
+    >
+      <CollapsibleConfigCard
+        label={displayLabel}
+        badgeLabel={badgeLabel}
+        badgeClassName="group-data-[expanded]/accordion-item:hidden"
+        isCollapsible
+        isExpanded={isExpanded}
+        onExpandedChange={onExpandedChange}
+        controls={controls}
+        dragHandleAriaLabel={t('Drag to reorder criterion')}
+        className={cn(
+          'data-[expanded]:bg-neutral-offWhite',
+          isNew && 'animate-border-highlight',
+          errors.length > 0 && 'border-functional-red',
         )}
-        <AccordionTrigger className="flex flex-1 cursor-pointer items-center gap-2 overflow-hidden">
-          <AccordionIndicator />
-          <span className="shrink-0 text-left font-serif text-neutral-charcoal">
-            {t('Criterion {number}', { number: index })}
-          </span>
-          <span className="truncate text-left text-neutral-gray4">
-            {criterion.label || t('New criterion')}
-          </span>
-          <CriterionBadges criterion={criterion} />
-        </AccordionTrigger>
-        {onRemove && (
-          <Button
-            color="ghost"
-            size="small"
-            aria-label={t('Remove criterion')}
-            onPress={() => onRemove(criterion.id)}
-            className="p-2 text-neutral-gray4 hover:text-functional-red"
-          >
-            <LuTrash2 className="size-4" />
-          </Button>
-        )}
-      </AccordionHeader>
-
-      {/* Collapsible body */}
-      <AccordionContent>
-        <hr className="border-neutral-gray1" />
-        <div className="space-y-4 p-4">
-          {/* Criterion name */}
+      >
+        <div className="space-y-4 px-8">
+          {/* Field name */}
           <TextField
-            label={t('Criterion name')}
+            ref={fieldNameRef}
+            label={t('Field name')}
             isRequired
             value={criterion.label}
             onChange={(value) => onUpdateLabel?.(criterion.id, value)}
+            maxLength={50}
             inputProps={{
-              placeholder: t('e.g., Goal Alignment'),
+              className: 'bg-white',
             }}
-            description={t(
-              'Add a short, clear name for this evaluation criterion',
-            )}
+            className="min-w-0 flex-1"
           />
 
           {/* Description */}
           <TextField
             label={t('Description')}
-            isRequired
             useTextArea
             value={criterion.description ?? ''}
             onChange={(value) => onUpdateDescription?.(criterion.id, value)}
             textareaProps={{
-              placeholder: t(
-                "What should reviewers evaluate? Be specific about what you're looking for.",
-              ),
-              className: 'min-h-24 resize-none',
+              placeholder: t('Provide additional guidance for participants...'),
+              className: 'min-h-24 resize-none bg-white',
             }}
-            description={t('Help reviewers understand what to assess')}
           />
 
           <hr />
@@ -178,9 +182,36 @@ export function RubricCriterionCard({
               ))}
             </div>
           )}
+
+          {/* Footer: Required toggle + Delete button */}
+          <div className="flex items-center justify-between border-t pt-4">
+            <div className="flex items-center gap-2">
+              <span className="text-neutral-charcoal">{t('Required?')}</span>
+              <ToggleButton
+                size="small"
+                isSelected={criterion.required}
+                onChange={(isSelected) =>
+                  onUpdateRequired?.(criterion.id, isSelected)
+                }
+                aria-label={t('Required')}
+              />
+            </div>
+            {onRemove && (
+              <Button
+                color="ghost"
+                size="small"
+                onPress={() => onRemove(criterion.id)}
+                aria-label={t('Delete')}
+                className="text-neutral-gray4 hover:text-functional-red"
+              >
+                <LuTrash2 className="size-4" />
+                {t('Delete')}
+              </Button>
+            )}
+          </div>
         </div>
-      </AccordionContent>
-    </>
+      </CollapsibleConfigCard>
+    </div>
   );
 }
 
@@ -243,8 +274,6 @@ function ScoredCriterionConfig({
   const max = criterion.maxPoints ?? 5;
 
   // Cache descriptions that would be lost when maxPoints decreases.
-  // Key is 1-based score value, value is the description text.
-  // Cache persists until user navigates away from this criterion card.
   const [cachedDescriptions, setCachedDescriptions] = useState<
     Record<number, string>
   >({});
@@ -257,17 +286,15 @@ function ScoredCriterionConfig({
     const newMax = value;
 
     if (newMax < max) {
-      // Decreasing - cache descriptions that will be removed
       const toCache: Record<number, string> = { ...cachedDescriptions };
       for (let i = newMax + 1; i <= max; i++) {
-        const label = criterion.scoreLabels[i - 1]; // scoreLabels is 0-indexed
+        const label = criterion.scoreLabels[i - 1];
         if (label) {
           toCache[i] = label;
         }
       }
       setCachedDescriptions(toCache);
     } else if (newMax > max) {
-      // Increasing - restore cached descriptions after update
       const labelsToRestore: Array<{ score: number; label: string }> = [];
       for (let i = max + 1; i <= newMax; i++) {
         const cached = cachedDescriptions[i];
@@ -276,13 +303,11 @@ function ScoredCriterionConfig({
         }
       }
 
-      // Clear restored items from cache
       if (labelsToRestore.length > 0) {
         const newCache = { ...cachedDescriptions };
         labelsToRestore.forEach(({ score }) => delete newCache[score]);
         setCachedDescriptions(newCache);
 
-        // Restore labels after state update
         setTimeout(() => {
           labelsToRestore.forEach(({ score, label }) => {
             onUpdateScoreLabel(score, label);
@@ -344,59 +369,22 @@ function ScoredCriterionConfig({
 }
 
 // ---------------------------------------------------------------------------
-// Shared criterion badges (type + points)
-// ---------------------------------------------------------------------------
-
-function CriterionBadges({ criterion }: { criterion: CriterionView }) {
-  const t = useTranslations();
-  return (
-    <span className="ml-auto flex shrink-0 items-center gap-1.5">
-      <span className="rounded-md bg-neutral-gray1 px-1.5 py-0.5 text-xs text-neutral-charcoal">
-        {t(CRITERION_TYPE_REGISTRY[criterion.criterionType].labelKey)}
-      </span>
-      {criterion.criterionType === 'scored' && criterion.maxPoints && (
-        <span className="bg-primary-mint/20 text-primary-tealDark rounded-md px-1.5 py-0.5 text-xs">
-          {criterion.maxPoints} {t('pts')}
-        </span>
-      )}
-    </span>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Drag preview
 // ---------------------------------------------------------------------------
 
 export function RubricCriterionDragPreview({
   criterion,
-  index,
 }: {
   criterion: CriterionView;
-  index: number;
 }) {
   const t = useTranslations();
   return (
-    <div className="flex items-center gap-2 rounded-lg border bg-white p-3 shadow-lg">
-      <div className="grid size-6 place-items-center rounded bg-neutral-offWhite">
-        <LuGripVertical className="size-4 shrink-0 text-neutral-gray4" />
-      </div>
-      <LuChevronRight className="size-4 shrink-0 text-neutral-gray4" />
-      <span className="shrink-0 font-serif text-neutral-charcoal">
-        {t('Criterion {number}', { number: index })}
-      </span>
-      <span className="truncate text-neutral-gray4">
-        {criterion.label || t('New criterion')}
-      </span>
-      <CriterionBadges criterion={criterion} />
-      <div className="grid w-8 place-items-center rounded">
-        <LuTrash2 className="size-4 shrink-0 text-neutral-gray3" />
-      </div>
-    </div>
+    <CollapsibleConfigCardDragPreview
+      label={criterion.label || t('Untitled field')}
+    />
   );
 }
 
 export function RubricCriterionDropIndicator() {
-  return (
-    <div className="flex h-12 items-center gap-2 rounded-lg border bg-neutral-offWhite" />
-  );
+  return <div className="h-16 rounded-lg border bg-neutral-offWhite" />;
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -121,7 +121,7 @@ export function RubricCriterionCard({
           errors.length > 0 && 'border-functional-red',
         )}
       >
-        <div className="space-y-4 px-8">
+        <div className="space-y-2.5 px-8">
           {/* Field name */}
           <TextField
             label={t('Field name')}
@@ -190,7 +190,7 @@ export function RubricCriterionCard({
                 size="small"
                 onPress={() => onRemove(criterion.id)}
                 aria-label={t('Delete')}
-                className="text-neutral-gray4 hover:text-functional-red"
+                className="text-neutral-charcoal hover:text-functional-red"
               >
                 <LuTrash2 className="size-4" />
                 {t('Delete')}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -349,6 +349,11 @@ export function RubricCriterionDragPreview({
   return (
     <CollapsibleConfigCardDragPreview
       label={criterion.label || t('Untitled field')}
+      badgeLabel={
+        criterion.criterionType === 'scored' && criterion.maxPoints
+          ? `${criterion.maxPoints} ${t('pts')}`
+          : t(CRITERION_TYPE_REGISTRY[criterion.criterionType].labelKey)
+      }
     />
   );
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Button } from '@op/ui/Button';
 import {
   CollapsibleConfigCard,
   CollapsibleConfigCardDragPreview,
@@ -9,10 +8,8 @@ import { NumberField } from '@op/ui/NumberField';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import type { SortableItemControls } from '@op/ui/Sortable';
 import { TextField } from '@op/ui/TextField';
-import { ToggleButton } from '@op/ui/ToggleButton';
 import { cn } from '@op/ui/utils';
 import { useRef, useState } from 'react';
-import { LuTrash2 } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 import type { TranslationKey } from '@/lib/i18n/routing';
@@ -37,7 +34,6 @@ interface RubricCriterionCardProps {
   controls?: SortableItemControls;
   isExpanded?: boolean;
   onExpandedChange?: (expanded: boolean) => void;
-  onRemove?: (criterionId: string) => void;
   onBlur?: (criterionId: string) => void;
   onUpdateLabel?: (criterionId: string, label: string) => void;
   onUpdateDescription?: (criterionId: string, description: string) => void;
@@ -48,7 +44,6 @@ interface RubricCriterionCardProps {
     scoreValue: number,
     label: string,
   ) => void;
-  onUpdateRequired?: (criterionId: string, required: boolean) => void;
   isNew?: boolean;
   onNewComplete?: (criterionId: string) => void;
 }
@@ -70,14 +65,12 @@ export function RubricCriterionCard({
   controls,
   isExpanded,
   onExpandedChange,
-  onRemove,
   onBlur,
   onUpdateLabel,
   onUpdateDescription,
   onChangeType,
   onUpdateMaxPoints,
   onUpdateScoreLabel,
-  onUpdateRequired,
   isNew,
   onNewComplete,
 }: RubricCriterionCardProps) {
@@ -182,33 +175,6 @@ export function RubricCriterionCard({
               ))}
             </div>
           )}
-
-          {/* Footer: Required toggle + Delete button */}
-          <div className="flex items-center justify-between border-t pt-4">
-            <div className="flex items-center gap-2">
-              <span className="text-neutral-charcoal">{t('Required?')}</span>
-              <ToggleButton
-                size="small"
-                isSelected={criterion.required}
-                onChange={(isSelected) =>
-                  onUpdateRequired?.(criterion.id, isSelected)
-                }
-                aria-label={t('Required')}
-              />
-            </div>
-            {onRemove && (
-              <Button
-                color="ghost"
-                size="small"
-                onPress={() => onRemove(criterion.id)}
-                aria-label={t('Delete')}
-                className="text-neutral-gray4 hover:text-functional-red"
-              >
-                <LuTrash2 className="size-4" />
-                {t('Delete')}
-              </Button>
-            )}
-          </div>
         </div>
       </CollapsibleConfigCard>
     </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -209,6 +209,21 @@ export function RubricEditorContent({
     [criteria],
   );
 
+  const handleExpandedChange = useCallback(
+    (criterionId: string, expanded: boolean) => {
+      setExpandedCriterionIds((prev) => {
+        const next = new Set(prev);
+        if (expanded) {
+          next.add(criterionId);
+        } else {
+          next.delete(criterionId);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
   const handleNewComplete = useCallback((criterionId: string) => {
     setNewCriterionIds((prev) => {
       const next = new Set(prev);
@@ -287,15 +302,7 @@ export function RubricEditorContent({
                       controls={controls}
                       isExpanded={expandedCriterionIds.has(criterion.id)}
                       onExpandedChange={(expanded) =>
-                        setExpandedCriterionIds((prev) => {
-                          const next = new Set(prev);
-                          if (expanded) {
-                            next.add(criterion.id);
-                          } else {
-                            next.delete(criterion.id);
-                          }
-                          return next;
-                        })
+                        handleExpandedChange(criterion.id, expanded)
                       }
                       isNew={newCriterionIds.has(criterion.id)}
                       onNewComplete={handleNewComplete}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -12,7 +12,6 @@ import { LuLeaf, LuPlus } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 import type { TranslationKey } from '@/lib/i18n/routing';
 
-import { ConfirmDeleteModal } from '@/components/ConfirmDeleteModal';
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
@@ -29,9 +28,7 @@ import {
   getCriterionErrors,
   getCriterionSchema,
   getCriterionType,
-  removeCriterion,
   reorderCriteria,
-  setCriterionRequired,
   updateCriterionDescription,
   updateCriterionJsonSchema,
   updateCriterionLabel,
@@ -87,11 +84,6 @@ export function RubricEditorContent({
     new Set(),
   );
 
-  // Delete confirmation modal
-  const [criterionToDelete, setCriterionToDelete] = useState<string | null>(
-    null,
-  );
-
   // Cache scored config so switching type and back doesn't lose score labels
   const scoredConfigCacheRef = useRef<
     Map<string, { maximum: number; oneOf: { const: number; title: string }[] }>
@@ -120,34 +112,6 @@ export function RubricEditorContent({
     setExpandedCriterionIds((prev) => new Set(prev).add(criterionId));
     setNewCriterionIds((prev) => new Set(prev).add(criterionId));
   }, [t]);
-
-  const handleRemoveCriterion = useCallback((criterionId: string) => {
-    setCriterionToDelete(criterionId);
-  }, []);
-
-  const confirmRemoveCriterion = useCallback(() => {
-    if (!criterionToDelete) {
-      return;
-    }
-    setTemplate((prev) => removeCriterion(prev, criterionToDelete));
-    setCriterionErrors((prev) => {
-      const next = new Map(prev);
-      next.delete(criterionToDelete);
-      return next;
-    });
-    setExpandedCriterionIds((prev) => {
-      const next = new Set(prev);
-      next.delete(criterionToDelete);
-      return next;
-    });
-    setNewCriterionIds((prev) => {
-      const next = new Set(prev);
-      next.delete(criterionToDelete);
-      return next;
-    });
-    scoredConfigCacheRef.current.delete(criterionToDelete);
-    setCriterionToDelete(null);
-  }, [criterionToDelete]);
 
   const handleReorderCriteria = useCallback((newItems: CriterionView[]) => {
     setTemplate((prev) =>
@@ -229,13 +193,6 @@ export function RubricEditorContent({
       setTemplate((prev) =>
         updateScoreLabel(prev, criterionId, scoreValue, label),
       );
-    },
-    [],
-  );
-
-  const handleUpdateRequired = useCallback(
-    (criterionId: string, required: boolean) => {
-      setTemplate((prev) => setCriterionRequired(prev, criterionId, required));
     },
     [],
   );
@@ -342,11 +299,9 @@ export function RubricEditorContent({
                       }
                       isNew={newCriterionIds.has(criterion.id)}
                       onNewComplete={handleNewComplete}
-                      onRemove={handleRemoveCriterion}
                       onBlur={handleCriterionBlur}
                       onUpdateLabel={handleUpdateLabel}
                       onUpdateDescription={handleUpdateDescription}
-                      onUpdateRequired={handleUpdateRequired}
                       onChangeType={handleChangeType}
                       onUpdateMaxPoints={handleUpdateMaxPoints}
                       onUpdateScoreLabel={handleUpdateScoreLabel}
@@ -369,16 +324,6 @@ export function RubricEditorContent({
       </main>
 
       <RubricParticipantPreview template={template} />
-
-      <ConfirmDeleteModal
-        isOpen={criterionToDelete !== null}
-        title={t('Delete criterion')}
-        message={t(
-          'Are you sure you want to delete this criterion? This action cannot be undone.',
-        )}
-        onConfirm={confirmRemoveCriterion}
-        onCancel={() => setCriterionToDelete(null)}
-      />
     </div>
   );
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -12,6 +12,7 @@ import { LuLeaf, LuPlus } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 import type { TranslationKey } from '@/lib/i18n/routing';
 
+import { ConfirmDeleteModal } from '@/components/ConfirmDeleteModal';
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
@@ -28,6 +29,7 @@ import {
   getCriterionErrors,
   getCriterionSchema,
   getCriterionType,
+  removeCriterion,
   reorderCriteria,
   updateCriterionDescription,
   updateCriterionJsonSchema,
@@ -84,6 +86,11 @@ export function RubricEditorContent({
     new Set(),
   );
 
+  // Delete confirmation modal
+  const [criterionToDelete, setCriterionToDelete] = useState<string | null>(
+    null,
+  );
+
   // Cache scored config so switching type and back doesn't lose score labels
   const scoredConfigCacheRef = useRef<
     Map<string, { maximum: number; oneOf: { const: number; title: string }[] }>
@@ -112,6 +119,34 @@ export function RubricEditorContent({
     setExpandedCriterionIds((prev) => new Set(prev).add(criterionId));
     setNewCriterionIds((prev) => new Set(prev).add(criterionId));
   }, [t]);
+
+  const handleRemoveCriterion = useCallback((criterionId: string) => {
+    setCriterionToDelete(criterionId);
+  }, []);
+
+  const confirmRemoveCriterion = useCallback(() => {
+    if (!criterionToDelete) {
+      return;
+    }
+    setTemplate((prev) => removeCriterion(prev, criterionToDelete));
+    setCriterionErrors((prev) => {
+      const next = new Map(prev);
+      next.delete(criterionToDelete);
+      return next;
+    });
+    setExpandedCriterionIds((prev) => {
+      const next = new Set(prev);
+      next.delete(criterionToDelete);
+      return next;
+    });
+    setNewCriterionIds((prev) => {
+      const next = new Set(prev);
+      next.delete(criterionToDelete);
+      return next;
+    });
+    scoredConfigCacheRef.current.delete(criterionToDelete);
+    setCriterionToDelete(null);
+  }, [criterionToDelete]);
 
   const handleReorderCriteria = useCallback((newItems: CriterionView[]) => {
     setTemplate((prev) =>
@@ -306,6 +341,7 @@ export function RubricEditorContent({
                       }
                       isNew={newCriterionIds.has(criterion.id)}
                       onNewComplete={handleNewComplete}
+                      onRemove={handleRemoveCriterion}
                       onBlur={handleCriterionBlur}
                       onUpdateLabel={handleUpdateLabel}
                       onUpdateDescription={handleUpdateDescription}
@@ -331,6 +367,16 @@ export function RubricEditorContent({
       </main>
 
       <RubricParticipantPreview template={template} />
+
+      <ConfirmDeleteModal
+        isOpen={criterionToDelete !== null}
+        title={t('Delete criterion')}
+        message={t(
+          'Are you sure you want to delete this criterion? This action cannot be undone.',
+        )}
+        onConfirm={confirmRemoveCriterion}
+        onCancel={() => setCriterionToDelete(null)}
+      />
     </div>
   );
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -2,13 +2,10 @@
 
 import { trpc } from '@op/api/client';
 import type { RubricTemplateSchema } from '@op/common/client';
-import { Accordion, AccordionItem } from '@op/ui/Accordion';
 import { Button } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header2 } from '@op/ui/Header';
-import type { Key } from '@op/ui/RAC';
 import { Sortable } from '@op/ui/Sortable';
-import { cn } from '@op/ui/utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LuLeaf, LuPlus } from 'react-icons/lu';
 
@@ -34,6 +31,7 @@ import {
   getCriterionType,
   removeCriterion,
   reorderCriteria,
+  setCriterionRequired,
   updateCriterionDescription,
   updateCriterionJsonSchema,
   updateCriterionLabel,
@@ -79,8 +77,15 @@ export function RubricEditorContent({
     Map<string, TranslationKey[]>
   >(new Map());
 
-  // Accordion expansion state
-  const [expandedKeys, setExpandedKeys] = useState<Set<Key>>(new Set());
+  // Track which criteria are expanded — multiple can be open simultaneously
+  const [expandedCriterionIds, setExpandedCriterionIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  // Track newly added criteria for highlight animation
+  const [newCriterionIds, setNewCriterionIds] = useState<Set<string>>(
+    new Set(),
+  );
 
   // Delete confirmation modal
   const [criterionToDelete, setCriterionToDelete] = useState<string | null>(
@@ -96,10 +101,6 @@ export function RubricEditorContent({
 
   // Derive criterion views from the template
   const criteria = useMemo(() => getCriteria(template), [template]);
-  const criteriaIndexMap = useMemo(
-    () => new Map(criteria.map((c, i) => [c.id, i])),
-    [criteria],
-  );
 
   // Save rubric changes via the shared autosave context (skip initial load)
   useEffect(() => {
@@ -114,9 +115,10 @@ export function RubricEditorContent({
 
   const handleAddCriterion = useCallback(() => {
     const criterionId = crypto.randomUUID().slice(0, 8);
-    const label = t('New criterion');
+    const label = t('Untitled field');
     setTemplate((prev) => addCriterion(prev, criterionId, 'scored', label));
-    setExpandedKeys((prev) => new Set([...prev, criterionId]));
+    setExpandedCriterionIds((prev) => new Set(prev).add(criterionId));
+    setNewCriterionIds((prev) => new Set(prev).add(criterionId));
   }, [t]);
 
   const handleRemoveCriterion = useCallback((criterionId: string) => {
@@ -130,6 +132,16 @@ export function RubricEditorContent({
     setTemplate((prev) => removeCriterion(prev, criterionToDelete));
     setCriterionErrors((prev) => {
       const next = new Map(prev);
+      next.delete(criterionToDelete);
+      return next;
+    });
+    setExpandedCriterionIds((prev) => {
+      const next = new Set(prev);
+      next.delete(criterionToDelete);
+      return next;
+    });
+    setNewCriterionIds((prev) => {
+      const next = new Set(prev);
       next.delete(criterionToDelete);
       return next;
     });
@@ -221,6 +233,33 @@ export function RubricEditorContent({
     [],
   );
 
+  const handleUpdateRequired = useCallback(
+    (criterionId: string, required: boolean) => {
+      setTemplate((prev) => setCriterionRequired(prev, criterionId, required));
+    },
+    [],
+  );
+
+  const handleCriterionBlur = useCallback(
+    (criterionId: string) => {
+      const criterion = criteria.find((c) => c.id === criterionId);
+      if (criterion) {
+        setCriterionErrors((prev) =>
+          new Map(prev).set(criterionId, getCriterionErrors(criterion)),
+        );
+      }
+    },
+    [criteria],
+  );
+
+  const handleNewComplete = useCallback((criterionId: string) => {
+    setNewCriterionIds((prev) => {
+      const next = new Set(prev);
+      next.delete(criterionId);
+      return next;
+    });
+  }, []);
+
   return (
     <div className="flex h-full flex-col md:flex-row">
       <main className="flex-1 basis-1/2 overflow-y-auto p-4 pb-24 [scrollbar-gutter:stable] md:p-8 md:pb-8">
@@ -260,68 +299,61 @@ export function RubricEditorContent({
             </div>
           ) : (
             <>
-              <Accordion
-                allowsMultipleExpanded
-                expandedKeys={expandedKeys}
-                onExpandedChange={setExpandedKeys}
+              <Sortable
+                items={criteria}
+                onChange={handleReorderCriteria}
+                dragTrigger="handle"
+                getItemLabel={(criterion) => criterion.label}
+                className="gap-3"
+                renderDragPreview={(items) => {
+                  const item = items[0];
+                  if (!item) {
+                    return null;
+                  }
+                  return <RubricCriterionDragPreview criterion={item} />;
+                }}
+                renderDropIndicator={RubricCriterionDropIndicator}
+                aria-label={t('Rubric criteria')}
               >
-                <Sortable
-                  items={criteria}
-                  onChange={handleReorderCriteria}
-                  dragTrigger="handle"
-                  getItemLabel={(criterion) => criterion.label}
-                  className="gap-3"
-                  renderDragPreview={(items) => {
-                    const item = items[0];
-                    if (!item) {
-                      return null;
-                    }
-                    const idx = criteriaIndexMap.get(item.id) ?? 0;
-                    return (
-                      <RubricCriterionDragPreview
-                        criterion={item}
-                        index={idx + 1}
-                      />
-                    );
-                  }}
-                  renderDropIndicator={RubricCriterionDropIndicator}
-                  aria-label={t('Rubric criteria')}
-                >
-                  {(criterion, controls) => {
-                    const idx = criteriaIndexMap.get(criterion.id) ?? 0;
-                    const snapshotErrors =
-                      criterionErrors.get(criterion.id) ?? [];
-                    const liveErrors = getCriterionErrors(criterion);
-                    const displayedErrors = snapshotErrors.filter((e) =>
-                      liveErrors.includes(e),
-                    );
+                {(criterion, controls) => {
+                  const snapshotErrors =
+                    criterionErrors.get(criterion.id) ?? [];
+                  const liveErrors = getCriterionErrors(criterion);
+                  const displayedErrors = snapshotErrors.filter((e) =>
+                    liveErrors.includes(e),
+                  );
 
-                    return (
-                      <AccordionItem
-                        id={criterion.id}
-                        variant="unstyled"
-                        className={cn(
-                          'rounded-lg border bg-white',
-                          controls.isDragging && 'opacity-50',
-                        )}
-                      >
-                        <RubricCriterionCard
-                          criterion={criterion}
-                          index={idx + 1}
-                          errors={displayedErrors}
-                          controls={controls}
-                          onRemove={handleRemoveCriterion}
-                          onUpdateLabel={handleUpdateLabel}
-                          onUpdateDescription={handleUpdateDescription}
-                          onChangeType={handleChangeType}
-                          onUpdateMaxPoints={handleUpdateMaxPoints}
-                          onUpdateScoreLabel={handleUpdateScoreLabel}
-                        />
-                      </AccordionItem>
-                    );
-                  }}
-                </Sortable>
-              </Accordion>
+                  return (
+                    <RubricCriterionCard
+                      criterion={criterion}
+                      errors={displayedErrors}
+                      controls={controls}
+                      isExpanded={expandedCriterionIds.has(criterion.id)}
+                      onExpandedChange={(expanded) =>
+                        setExpandedCriterionIds((prev) => {
+                          const next = new Set(prev);
+                          if (expanded) {
+                            next.add(criterion.id);
+                          } else {
+                            next.delete(criterion.id);
+                          }
+                          return next;
+                        })
+                      }
+                      isNew={newCriterionIds.has(criterion.id)}
+                      onNewComplete={handleNewComplete}
+                      onRemove={handleRemoveCriterion}
+                      onBlur={handleCriterionBlur}
+                      onUpdateLabel={handleUpdateLabel}
+                      onUpdateDescription={handleUpdateDescription}
+                      onUpdateRequired={handleUpdateRequired}
+                      onChangeType={handleChangeType}
+                      onUpdateMaxPoints={handleUpdateMaxPoints}
+                      onUpdateScoreLabel={handleUpdateScoreLabel}
+                    />
+                  );
+                }}
+              </Sortable>
 
               <Button
                 color="secondary"

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
@@ -226,6 +226,21 @@ export function TemplateEditorContent({
     [t],
   );
 
+  const handleExpandedChange = useCallback(
+    (fieldId: string, expanded: boolean) => {
+      setExpandedFieldIds((prev) => {
+        const next = new Set(prev);
+        if (expanded) {
+          next.add(fieldId);
+        } else {
+          next.delete(fieldId);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
   const handleNewComplete = useCallback((fieldId: string) => {
     setNewFieldIds((prev) => {
       const next = new Set(prev);
@@ -348,15 +363,7 @@ export function TemplateEditorContent({
         controls={controls}
         isExpanded={expandedFieldIds.has(field.id)}
         onExpandedChange={(expanded) =>
-          setExpandedFieldIds((prev) => {
-            const next = new Set(prev);
-            if (expanded) {
-              next.add(field.id);
-            } else {
-              next.delete(field.id);
-            }
-            return next;
-          })
+          handleExpandedChange(field.id, expanded)
         }
         isNew={newFieldIds.has(field.id)}
         onNewComplete={handleNewComplete}

--- a/apps/app/src/components/decisions/rubricTemplate.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.ts
@@ -279,10 +279,6 @@ export function getCriterionErrors(criterion: CriterionView): TranslationKey[] {
     errors.push('Criterion label is required');
   }
 
-  if (!criterion.description?.trim()) {
-    errors.push('Criterion description is required');
-  }
-
   return errors;
 }
 

--- a/packages/ui/src/components/CollapsibleConfigCard.tsx
+++ b/packages/ui/src/components/CollapsibleConfigCard.tsx
@@ -88,26 +88,24 @@ export function CollapsibleConfigCard({
       ) : Icon ? (
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <div className="flex min-w-0 items-center gap-2 rounded bg-neutral-gray1 px-2 py-1">
-            <Icon className="size-4 shrink-0 text-neutral-gray4" />
-            <span className="truncate text-neutral-charcoal">{label}</span>
+            <Icon className="size-4 shrink-0 text-neutral-charcoal" />
+            <span className="truncate text-neutral-black">{label}</span>
           </div>
         </div>
       ) : (
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="truncate text-neutral-charcoal">{label}</span>
+          <span className="truncate text-neutral-black">{label}</span>
         </div>
       )}
 
       {/* Badge chip */}
       {badgeLabel && (
-        <Chip className={cn('shrink-0 text-neutral-gray4', badgeClassName)}>
-          {badgeLabel}
-        </Chip>
+        <Chip className={cn('shrink-0', badgeClassName)}>{badgeLabel}</Chip>
       )}
 
       {/* Chevron (only when collapsible) */}
       {isCollapsible && (
-        <LuChevronDown className="size-4 shrink-0 text-neutral-gray4 transition-transform duration-200 group-data-[expanded]/accordion-item:rotate-180" />
+        <LuChevronDown className="size-4 shrink-0 text-neutral-charcoal transition-transform duration-200 group-data-[expanded]/accordion-item:rotate-180" />
       )}
     </>
   );

--- a/packages/ui/src/components/CollapsibleConfigCard.tsx
+++ b/packages/ui/src/components/CollapsibleConfigCard.tsx
@@ -192,20 +192,22 @@ export function CollapsibleConfigCardDragPreview({
 
   return (
     <div className={cn('rounded-lg border bg-white p-4 shadow-lg', className)}>
-      <div className="flex items-center gap-3">
-        <div className="flex items-center justify-center text-neutral-gray4">
+      <div className="flex items-center gap-2 pr-1">
+        <div className="mr-1 flex items-center justify-center text-neutral-gray4">
           <LuGripVertical className="size-4" />
         </div>
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          {Icon ? (
-            <div className="flex min-w-0 items-center gap-2 rounded bg-neutral-gray1 px-2 py-1">
+        {Icon ? (
+          <div className="w-full grow">
+            <div className="flex w-fit shrink items-center gap-2 rounded bg-neutral-gray1 px-2 py-1">
               <Icon className="size-4 text-neutral-gray4" />
               <span className="truncate text-neutral-charcoal">{label}</span>
             </div>
-          ) : (
-            <span className="truncate text-neutral-charcoal">{label}</span>
-          )}
-        </div>
+          </div>
+        ) : (
+          <span className="w-full grow truncate text-neutral-charcoal">
+            {label}
+          </span>
+        )}
         {badgeLabel && (
           <Chip className="shrink-0 text-neutral-gray4">{badgeLabel}</Chip>
         )}

--- a/packages/ui/src/components/CollapsibleConfigCard.tsx
+++ b/packages/ui/src/components/CollapsibleConfigCard.tsx
@@ -15,12 +15,14 @@ import {
 } from './ui/accordion';
 
 export interface CollapsibleConfigCardProps {
-  /** Icon component to display in the header */
-  icon: React.ComponentType<{ className?: string }>;
-  /** Label text shown in the header pill */
+  /** Icon component to display in the header. When omitted, label renders as plain text (no pill). */
+  icon?: React.ComponentType<{ className?: string }>;
+  /** Label text shown in the header pill (or plain text when no icon) */
   label: string;
   /** Badge text shown as a chip (e.g. "Required" / "Optional") */
   badgeLabel?: string;
+  /** Additional class name for the badge chip */
+  badgeClassName?: string;
   /** Whether this card is collapsible. Default: false */
   isCollapsible?: boolean;
   /** Controlled expansion state */
@@ -45,6 +47,7 @@ export function CollapsibleConfigCard({
   icon: Icon,
   label,
   badgeLabel,
+  badgeClassName,
   isCollapsible = false,
   isExpanded,
   defaultExpanded,
@@ -76,24 +79,30 @@ export function CollapsibleConfigCard({
   // [Icon + Label pill] ... [Badge chip] [Chevron]
   const headerContent = (
     <>
-      {/* Icon + Label pill (or plain for locked) */}
+      {/* Icon + Label pill (or plain text when no icon) */}
       {locked ? (
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <Icon className="size-4 shrink-0 text-neutral-gray4" />
+          {Icon && <Icon className="size-4 shrink-0 text-neutral-gray4" />}
           <span className="truncate text-neutral-charcoal">{label}</span>
         </div>
-      ) : (
+      ) : Icon ? (
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <div className="flex min-w-0 items-center gap-2 rounded bg-neutral-gray1 px-2 py-1">
             <Icon className="size-4 shrink-0 text-neutral-gray4" />
             <span className="truncate text-neutral-charcoal">{label}</span>
           </div>
         </div>
+      ) : (
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="truncate text-neutral-charcoal">{label}</span>
+        </div>
       )}
 
       {/* Badge chip */}
       {badgeLabel && (
-        <Chip className="shrink-0 text-neutral-gray4">{badgeLabel}</Chip>
+        <Chip className={cn('shrink-0 text-neutral-gray4', badgeClassName)}>
+          {badgeLabel}
+        </Chip>
       )}
 
       {/* Chevron (only when collapsible) */}
@@ -140,7 +149,7 @@ export function CollapsibleConfigCard({
     >
       <div className="flex w-full items-center gap-2">
         {leadingElement}
-        <AccordionTrigger className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1">
+        <AccordionTrigger className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 pr-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1">
           {headerContent}
         </AccordionTrigger>
       </div>
@@ -152,8 +161,8 @@ export function CollapsibleConfigCard({
 }
 
 export interface CollapsibleConfigCardDragPreviewProps {
-  /** Icon component to display next to the label */
-  icon: React.ComponentType<{ className?: string }>;
+  /** Icon component to display next to the label. When omitted, label renders as plain text. */
+  icon?: React.ComponentType<{ className?: string }>;
   /** The label text */
   label: string;
   /** Badge text shown as a chip (e.g. "Required" / "Optional") */
@@ -188,10 +197,14 @@ export function CollapsibleConfigCardDragPreview({
           <LuGripVertical className="size-4" />
         </div>
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <div className="flex min-w-0 items-center gap-2 rounded bg-neutral-gray1 px-2 py-1">
-            <Icon className="size-4 text-neutral-gray4" />
+          {Icon ? (
+            <div className="flex min-w-0 items-center gap-2 rounded bg-neutral-gray1 px-2 py-1">
+              <Icon className="size-4 text-neutral-gray4" />
+              <span className="truncate text-neutral-charcoal">{label}</span>
+            </div>
+          ) : (
             <span className="truncate text-neutral-charcoal">{label}</span>
-          </div>
+          )}
         </div>
         {badgeLabel && (
           <Chip className="shrink-0 text-neutral-gray4">{badgeLabel}</Chip>

--- a/tests/e2e/tests/edit-published-process.spec.ts
+++ b/tests/e2e/tests/edit-published-process.spec.ts
@@ -80,7 +80,7 @@ test.describe('Edit Published Process', () => {
 
     // 9. Verify the criterion was added
     await expect(
-      authenticatedPage.getByRole('heading', { name: 'New criterion' }),
+      authenticatedPage.getByText('Untitled field', { exact: true }).first(),
     ).toBeVisible({ timeout: 6_000 });
 
     // 10. Navigate away to Overview
@@ -103,7 +103,7 @@ test.describe('Edit Published Process', () => {
 
     // 13. Verify the criterion is still there
     await expect(
-      authenticatedPage.getByRole('heading', { name: 'New criterion' }),
+      authenticatedPage.getByText('Untitled field', { exact: true }).first(),
     ).toBeVisible({ timeout: 6_000 });
   });
 


### PR DESCRIPTION
- Criterion cards use `CollapsibleConfigCard` (matching FieldCard pattern)
- `CollapsibleConfigCard`: `icon` optional, new `badgeClassName` prop
- Header badge shows points or type, hides when expanded
- Delete button in card footer with confirmation modal
- OffWhite bg when expanded

### Stack
1. **#961** ← this PR
2. [#962](https://github.com/oneprojectorg/common/pull/962) — Required? toggle