### PR TITLE
feat(rubric): add required toggle to criterion card footer

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -48,7 +48,7 @@ interface RubricCriterionCardProps {
     scoreValue: number,
     label: string,
   ) => void;
-  onUpdateRequired?: (criterionId: string, required: boolean) => void;
+  onUpdateRequired: (criterionId: string, required: boolean) => void;
   isNew?: boolean;
   onNewComplete?: (criterionId: string) => void;
 }
@@ -193,7 +193,7 @@ export function RubricCriterionCard({
                 size="small"
                 isSelected={criterion.required}
                 onChange={(isSelected) =>
-                  onUpdateRequired?.(criterion.id, isSelected)
+                  onUpdateRequired(criterion.id, isSelected)
                 }
                 aria-label={t('Required')}
               />

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -9,6 +9,7 @@ import { NumberField } from '@op/ui/NumberField';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import type { SortableItemControls } from '@op/ui/Sortable';
 import { TextField } from '@op/ui/TextField';
+import { ToggleButton } from '@op/ui/ToggleButton';
 import { cn } from '@op/ui/utils';
 import { useRef, useState } from 'react';
 import { LuTrash2 } from 'react-icons/lu';
@@ -47,6 +48,7 @@ interface RubricCriterionCardProps {
     scoreValue: number,
     label: string,
   ) => void;
+  onUpdateRequired?: (criterionId: string, required: boolean) => void;
   isNew?: boolean;
   onNewComplete?: (criterionId: string) => void;
 }
@@ -75,6 +77,7 @@ export function RubricCriterionCard({
   onChangeType,
   onUpdateMaxPoints,
   onUpdateScoreLabel,
+  onUpdateRequired,
   isNew,
   onNewComplete,
 }: RubricCriterionCardProps) {
@@ -182,9 +185,20 @@ export function RubricCriterionCard({
             </div>
           )}
 
-          {/* Footer */}
-          {onRemove && (
-            <div className="flex items-center justify-end border-t pt-4">
+          {/* Footer: Required toggle + Delete button */}
+          <div className="flex items-center justify-between border-t pt-4">
+            <div className="flex items-center gap-2">
+              <span className="text-neutral-charcoal">{t('Required?')}</span>
+              <ToggleButton
+                size="small"
+                isSelected={criterion.required}
+                onChange={(isSelected) =>
+                  onUpdateRequired?.(criterion.id, isSelected)
+                }
+                aria-label={t('Required')}
+              />
+            </div>
+            {onRemove && (
               <Button
                 color="ghost"
                 size="small"
@@ -195,8 +209,8 @@ export function RubricCriterionCard({
                 <LuTrash2 className="size-4" />
                 {t('Delete')}
               </Button>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </CollapsibleConfigCard>
     </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -31,6 +31,7 @@ import {
   getCriterionType,
   removeCriterion,
   reorderCriteria,
+  setCriterionRequired,
   updateCriterionDescription,
   updateCriterionJsonSchema,
   updateCriterionLabel,
@@ -115,7 +116,10 @@ export function RubricEditorContent({
   const handleAddCriterion = useCallback(() => {
     const criterionId = crypto.randomUUID().slice(0, 8);
     const label = t('Untitled field');
-    setTemplate((prev) => addCriterion(prev, criterionId, 'scored', label));
+    setTemplate((prev) => {
+      const updated = addCriterion(prev, criterionId, 'scored', label);
+      return setCriterionRequired(updated, criterionId, true);
+    });
     setExpandedCriterionIds((prev) => new Set(prev).add(criterionId));
     setNewCriterionIds((prev) => new Set(prev).add(criterionId));
   }, [t]);
@@ -228,6 +232,13 @@ export function RubricEditorContent({
       setTemplate((prev) =>
         updateScoreLabel(prev, criterionId, scoreValue, label),
       );
+    },
+    [],
+  );
+
+  const handleUpdateRequired = useCallback(
+    (criterionId: string, required: boolean) => {
+      setTemplate((prev) => setCriterionRequired(prev, criterionId, required));
     },
     [],
   );
@@ -345,6 +356,7 @@ export function RubricEditorContent({
                       onBlur={handleCriterionBlur}
                       onUpdateLabel={handleUpdateLabel}
                       onUpdateDescription={handleUpdateDescription}
+                      onUpdateRequired={handleUpdateRequired}
                       onChangeType={handleChangeType}
                       onUpdateMaxPoints={handleUpdateMaxPoints}
                       onUpdateScoreLabel={handleUpdateScoreLabel}

--- a/tests/core/src/decision-data.ts
+++ b/tests/core/src/decision-data.ts
@@ -406,6 +406,23 @@ export async function getSeededTemplate(): Promise<{
   };
 }
 
+/**
+ * Fetches a decision instance by ID from the database.
+ * Returns the full instance record including instanceData.
+ */
+export async function getDecisionInstance(instanceId: string) {
+  const [instance] = await db
+    .select()
+    .from(processInstances)
+    .where(eq(processInstances.id, instanceId));
+
+  if (!instance) {
+    throw new Error(`Decision instance "${instanceId}" not found`);
+  }
+
+  return instance;
+}
+
 export interface CreateProposalOptions {
   /** Process instance ID this proposal belongs to */
   processInstanceId: string;

--- a/tests/core/src/decision-data.ts
+++ b/tests/core/src/decision-data.ts
@@ -410,7 +410,9 @@ export async function getSeededTemplate(): Promise<{
  * Fetches a decision instance by ID from the database.
  * Returns the full instance record including instanceData.
  */
-export async function getDecisionInstance(instanceId: string) {
+export async function getDecisionInstance(
+  instanceId: string,
+): Promise<typeof processInstances.$inferSelect> {
   const [instance] = await db
     .select()
     .from(processInstances)

--- a/tests/core/src/index.ts
+++ b/tests/core/src/index.ts
@@ -14,6 +14,7 @@ export {
   createDecisionInstance,
   createDecisionProcess,
   createProposal,
+  getDecisionInstance,
   getSeededTemplate,
   grantDecisionProfileAccess,
   SEEDED_SIMPLE_VOTING_TEMPLATE_NAME,

--- a/tests/e2e/tests/edit-published-process.spec.ts
+++ b/tests/e2e/tests/edit-published-process.spec.ts
@@ -1,4 +1,8 @@
-import { createDecisionInstance, getSeededTemplate } from '@op/test';
+import {
+  createDecisionInstance,
+  getDecisionInstance,
+  getSeededTemplate,
+} from '@op/test';
 
 import { expect, test } from '../fixtures/index.js';
 
@@ -71,55 +75,97 @@ test.describe('Edit Published Process', () => {
       authenticatedPage.getByRole('heading', { name: 'Review Criteria' }),
     ).toBeVisible({ timeout: 12_000 });
 
-    // 8. Add a rubric criterion
-    const addButton = authenticatedPage.getByRole('button', {
+    // 8. Add the first rubric criterion (defaults to required=true)
+    const addFirstButton = authenticatedPage.getByRole('button', {
       name: 'Add your first criterion',
     });
-    await expect(addButton).toBeVisible({ timeout: 6_000 });
-    await addButton.click();
-
-    // 9. Verify the criterion was added
+    await expect(addFirstButton).toBeVisible({ timeout: 6_000 });
+    await addFirstButton.click();
     await expect(
       authenticatedPage.getByText('Untitled field', { exact: true }).first(),
     ).toBeVisible({ timeout: 6_000 });
 
-    // 9b. Toggle Required off (new criteria default to required=true)
-    const requiredToggle = authenticatedPage.getByRole('button', {
+    // 9. Toggle Required off on the first criterion
+    const firstRequiredToggle = authenticatedPage.getByRole('button', {
       name: 'Required',
     });
-    await requiredToggle.click();
+    await firstRequiredToggle.click();
 
-    // 10. Navigate away to Overview
-    const overviewButton = sidebarNav.getByRole('button', {
-      name: 'Overview',
+    // 10. Add a second criterion (keep it required)
+    const addMoreButton = authenticatedPage.getByRole('button', {
+      name: 'Add criterion',
     });
-    await overviewButton.click();
-    await expect(authenticatedPage.getByText('Process Overview')).toBeVisible({
-      timeout: 12_000,
+    await addMoreButton.click();
+
+    // Wait for the second criterion to appear in the UI
+    const criterionLabels = authenticatedPage.getByText('Untitled field', {
+      exact: true,
+    });
+    await expect(criterionLabels.nth(1)).toBeVisible({ timeout: 6_000 });
+
+    // 11. Click "Update Process" to persist all changes to the DB
+    const footer = authenticatedPage.getByRole('contentinfo');
+    const updateButton = footer.getByRole('button', {
+      name: 'Update Process',
     });
 
-    // 11. Verify Review Rubric is still in the sidebar
-    await expect(reviewRubricButton).toBeVisible({ timeout: 6_000 });
+    // Set up response listener before clicking to avoid race condition
+    const saveResponse = authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes('decision.updateDecisionInstance') && resp.ok(),
+      { timeout: 12_000 },
+    );
+    await updateButton.click();
+    await saveResponse;
 
-    // 12. Navigate back to Review Rubric
-    await reviewRubricButton.click();
+    // 12. Verify the rubric template was persisted correctly
+    await expect
+      .poll(
+        async () => {
+          const saved = await getDecisionInstance(instance.instance.id);
+          const data = saved.instanceData as Record<string, unknown>;
+          return data.rubricTemplate as Record<string, unknown> | undefined;
+        },
+        { timeout: 6_000 },
+      )
+      .toBeDefined();
+
+    const saved = await getDecisionInstance(instance.instance.id);
+    const rubric = (saved.instanceData as Record<string, unknown>)
+      .rubricTemplate as {
+      properties: Record<string, unknown>;
+      'x-field-order': string[];
+      required?: string[];
+    };
+
+    // Two criteria in the template
+    expect(Object.keys(rubric.properties)).toHaveLength(2);
+    expect(rubric['x-field-order']).toHaveLength(2);
+
+    // Only one is required (the second one — first was toggled off)
+    expect(rubric.required ?? []).toHaveLength(1);
+
+    // 13. "Update Process" navigates to the published view — go back to editor
+    const settingsButton = authenticatedPage.getByRole('link', {
+      name: 'Settings',
+    });
+    await expect(settingsButton).toBeVisible({ timeout: 12_000 });
+    await settingsButton.click();
+
+    // 14. Navigate to Review Rubric and verify both criteria survived
+    const rubricButton = authenticatedPage
+      .getByRole('navigation', { name: 'Section navigation' })
+      .getByRole('button', { name: 'Review Rubric' });
+    await expect(rubricButton).toBeVisible({ timeout: 6_000 });
+    await rubricButton.click();
     await expect(authenticatedPage.getByText('Review Criteria')).toBeVisible({
       timeout: 12_000,
     });
 
-    // 13. Verify the criterion is still there
+    // Verify at least one criterion card is visible (DB already verified count=2)
     await expect(
       authenticatedPage.getByText('Untitled field', { exact: true }).first(),
     ).toBeVisible({ timeout: 6_000 });
-
-    // 14. Expand the criterion card and verify Required toggle persisted as off
-    await authenticatedPage
-      .getByText('Untitled field', { exact: true })
-      .first()
-      .click();
-    await expect(
-      authenticatedPage.getByRole('button', { name: 'Required' }),
-    ).toHaveAttribute('aria-pressed', 'false', { timeout: 6_000 });
   });
 
   test('proposal template fields survive section navigation', async ({

--- a/tests/e2e/tests/edit-published-process.spec.ts
+++ b/tests/e2e/tests/edit-published-process.spec.ts
@@ -83,6 +83,16 @@ test.describe('Edit Published Process', () => {
       authenticatedPage.getByText('Untitled field', { exact: true }).first(),
     ).toBeVisible({ timeout: 6_000 });
 
+    // 9b. Toggle Required off (new criteria default to required=true)
+    const requiredToggle = authenticatedPage.getByRole('button', {
+      name: 'Required',
+    });
+    await expect(requiredToggle).toHaveAttribute('aria-pressed', 'true', {
+      timeout: 3_000,
+    });
+    await requiredToggle.click();
+    await expect(requiredToggle).toHaveAttribute('aria-pressed', 'false');
+
     // 10. Navigate away to Overview
     const overviewButton = sidebarNav.getByRole('button', {
       name: 'Overview',
@@ -105,6 +115,15 @@ test.describe('Edit Published Process', () => {
     await expect(
       authenticatedPage.getByText('Untitled field', { exact: true }).first(),
     ).toBeVisible({ timeout: 6_000 });
+
+    // 14. Expand the criterion card and verify Required toggle persisted as off
+    await authenticatedPage
+      .getByText('Untitled field', { exact: true })
+      .first()
+      .click();
+    await expect(
+      authenticatedPage.getByRole('button', { name: 'Required' }),
+    ).toHaveAttribute('aria-pressed', 'false', { timeout: 6_000 });
   });
 
   test('proposal template fields survive section navigation', async ({

--- a/tests/e2e/tests/edit-published-process.spec.ts
+++ b/tests/e2e/tests/edit-published-process.spec.ts
@@ -85,13 +85,38 @@ test.describe('Edit Published Process', () => {
       authenticatedPage.getByText('Untitled field', { exact: true }).first(),
     ).toBeVisible({ timeout: 6_000 });
 
-    // 9. Toggle Required off on the first criterion
+    // 9. Navigate away to Overview and back to verify criterion survives
+    const overviewButton = sidebarNav.getByRole('button', {
+      name: 'Overview',
+    });
+    await overviewButton.click();
+    await expect(authenticatedPage.getByText('Process Overview')).toBeVisible({
+      timeout: 12_000,
+    });
+
+    await expect(reviewRubricButton).toBeVisible({ timeout: 6_000 });
+    await reviewRubricButton.click();
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Review Criteria' }),
+    ).toBeVisible({ timeout: 12_000 });
+
+    // Verify the criterion survived navigation
+    await expect(
+      authenticatedPage.getByText('Untitled field', { exact: true }).first(),
+    ).toBeVisible({ timeout: 6_000 });
+
+    // 10. Expand the first criterion and toggle Required off
+    await authenticatedPage
+      .getByText('Untitled field', { exact: true })
+      .first()
+      .click();
     const firstRequiredToggle = authenticatedPage.getByRole('button', {
       name: 'Required',
     });
+    await expect(firstRequiredToggle).toBeVisible({ timeout: 3_000 });
     await firstRequiredToggle.click();
 
-    // 10. Add a second criterion (keep it required)
+    // 11. Add a second criterion (keep it required)
     const addMoreButton = authenticatedPage.getByRole('button', {
       name: 'Add criterion',
     });
@@ -103,7 +128,7 @@ test.describe('Edit Published Process', () => {
     });
     await expect(criterionLabels.nth(1)).toBeVisible({ timeout: 6_000 });
 
-    // 11. Click "Update Process" to persist all changes to the DB
+    // 12. Click "Update Process" to persist all changes to the DB
     const footer = authenticatedPage.getByRole('contentinfo');
     const updateButton = footer.getByRole('button', {
       name: 'Update Process',
@@ -118,7 +143,7 @@ test.describe('Edit Published Process', () => {
     await updateButton.click();
     await saveResponse;
 
-    // 12. Verify the rubric template was persisted correctly
+    // 13. Verify the rubric template was persisted correctly
     await expect
       .poll(
         async () => {
@@ -145,14 +170,14 @@ test.describe('Edit Published Process', () => {
     // Only one is required (the second one — first was toggled off)
     expect(rubric.required ?? []).toHaveLength(1);
 
-    // 13. "Update Process" navigates to the published view — go back to editor
+    // 14. "Update Process" navigates to the published view — go back to editor
     const settingsButton = authenticatedPage.getByRole('link', {
       name: 'Settings',
     });
     await expect(settingsButton).toBeVisible({ timeout: 12_000 });
     await settingsButton.click();
 
-    // 14. Navigate to Review Rubric and verify both criteria survived
+    // 15. Navigate to Review Rubric and verify both criteria survived
     const rubricButton = authenticatedPage
       .getByRole('navigation', { name: 'Section navigation' })
       .getByRole('button', { name: 'Review Rubric' });

--- a/tests/e2e/tests/edit-published-process.spec.ts
+++ b/tests/e2e/tests/edit-published-process.spec.ts
@@ -87,11 +87,7 @@ test.describe('Edit Published Process', () => {
     const requiredToggle = authenticatedPage.getByRole('button', {
       name: 'Required',
     });
-    await expect(requiredToggle).toHaveAttribute('aria-pressed', 'true', {
-      timeout: 3_000,
-    });
     await requiredToggle.click();
-    await expect(requiredToggle).toHaveAttribute('aria-pressed', 'false');
 
     // 10. Navigate away to Overview
     const overviewButton = sidebarNav.getByRole('button', {


### PR DESCRIPTION
- Required? toggle in criterion card footer
- New criteria default to required=true

### Stack
1. [#961](https://github.com/oneprojectorg/common/pull/961) — Card redesign + delete
2. **#962** ← this PR