### PR TITLE
refactor(decisions): pass instance as prop instead of refetching

### DIFF
--- a/apps/app/src/components/decisions/DecisionStateRouter.tsx
+++ b/apps/app/src/components/decisions/DecisionStateRouter.tsx
@@ -36,21 +36,17 @@ function DecisionStateRouterNew({
   return match(currentStateId, {
     results: () => (
       <ResultsPage
-        instanceId={instanceId}
+        instance={instance}
         profileSlug={slug}
         decisionSlug={decisionSlug}
       />
     ),
     voting: () => (
-      <VotingPage
-        instanceId={instanceId}
-        slug={slug}
-        decisionSlug={decisionSlug}
-      />
+      <VotingPage instance={instance} slug={slug} decisionSlug={decisionSlug} />
     ),
     _: () => (
       <StandardDecisionPage
-        instanceId={instanceId}
+        instance={instance}
         slug={slug}
         decisionSlug={decisionSlug}
         decisionProfileId={decisionProfileId}

--- a/apps/app/src/components/decisions/DecisionStateRouter.tsx
+++ b/apps/app/src/components/decisions/DecisionStateRouter.tsx
@@ -15,10 +15,8 @@ function DecisionStateRouterLegacy({
   slug: string;
 }) {
   // Legacy instances are always in results phase
-  const [instance] = trpc.decision.getLegacyInstance.useSuspenseQuery({
-    instanceId,
-  });
-  return <ResultsPage instance={instance} profileSlug={slug} />;
+  const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
+  return <ResultsPage instance={instance} profileSlug={slug} useLegacy />;
 }
 
 function DecisionStateRouterNew({

--- a/apps/app/src/components/decisions/DecisionStateRouter.tsx
+++ b/apps/app/src/components/decisions/DecisionStateRouter.tsx
@@ -15,7 +15,10 @@ function DecisionStateRouterLegacy({
   slug: string;
 }) {
   // Legacy instances are always in results phase
-  return <ResultsPage instanceId={instanceId} profileSlug={slug} useLegacy />;
+  const [instance] = trpc.decision.getLegacyInstance.useSuspenseQuery({
+    instanceId,
+  });
+  return <ResultsPage instance={instance} profileSlug={slug} />;
 }
 
 function DecisionStateRouterNew({

--- a/apps/app/src/components/decisions/pages/ResultsPage.tsx
+++ b/apps/app/src/components/decisions/pages/ResultsPage.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
+import type { RouterOutput } from '@op/api';
+import { trpc } from '@op/api/client';
 import { ProposalFilter } from '@op/api/encoders';
 import { match } from '@op/core';
 import { EmptyState } from '@op/ui/EmptyState';
@@ -22,7 +24,9 @@ import { ProposalListSkeleton, ProposalsList } from '../ProposalsList';
 import { ResultsList } from '../ResultsList';
 import { ResultsStats } from '../ResultsStats';
 
-// Common instance fields used by ResultsPage
+type Instance = RouterOutput['decision']['getInstance'];
+
+// Common instance fields used by ResultsPageContent
 interface ResultsPageInstance {
   id: string;
   name: string;
@@ -32,17 +36,38 @@ interface ResultsPageInstance {
   } | null;
 }
 
+function ResultsPageLegacy({
+  instance,
+  profileSlug,
+}: {
+  instance: Instance;
+  profileSlug: string;
+}) {
+  const [legacyInstance] = trpc.decision.getLegacyInstance.useSuspenseQuery({
+    instanceId: instance.id,
+  });
+  return (
+    <ResultsPageContent profileSlug={profileSlug} instance={legacyInstance} />
+  );
+}
+
 export function ResultsPage({
   instance,
   profileSlug,
   decisionSlug,
+  useLegacy = false,
 }: {
-  instance: ResultsPageInstance;
+  instance: Instance;
   /** Owner profile slug (e.g. "people-powered") — used for org-specific hero content and legacy URL fallbacks */
   profileSlug: string;
   /** Decision profile slug (e.g. "pp-decides-season-5") — used for building proposal links in the new route structure */
   decisionSlug?: string;
+  /** Use legacy getInstance endpoint (for /profile/[slug]/decisions/[id] route) */
+  useLegacy?: boolean;
 }) {
+  if (useLegacy) {
+    return <ResultsPageLegacy instance={instance} profileSlug={profileSlug} />;
+  }
   return (
     <ResultsPageContent
       profileSlug={profileSlug}

--- a/apps/app/src/components/decisions/pages/ResultsPage.tsx
+++ b/apps/app/src/components/decisions/pages/ResultsPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
+import type { RouterOutput } from '@op/api';
 import { trpc } from '@op/api/client';
 import { ProposalFilter } from '@op/api/encoders';
 import { match } from '@op/core';
@@ -23,7 +24,9 @@ import { ProposalListSkeleton, ProposalsList } from '../ProposalsList';
 import { ResultsList } from '../ResultsList';
 import { ResultsStats } from '../ResultsStats';
 
-// Common instance fields used by ResultsPage
+type Instance = RouterOutput['decision']['getInstance'];
+
+// Common instance fields used by ResultsPageContent
 interface ResultsPageInstance {
   name: string;
   description: string | null;
@@ -51,32 +54,31 @@ function ResultsPageLegacy({
   );
 }
 
-export function ResultsPage({
-  instanceId,
-  profileSlug,
-  decisionSlug,
-  useLegacy = false,
-}: {
-  instanceId: string;
+type ResultsPageProps = {
   /** Owner profile slug (e.g. "people-powered") — used for org-specific hero content and legacy URL fallbacks */
   profileSlug: string;
   /** Decision profile slug (e.g. "pp-decides-season-5") — used for building proposal links in the new route structure */
   decisionSlug?: string;
-  /** Use legacy getInstance endpoint (for /profile/[slug]/decisions/[id] route) */
-  useLegacy?: boolean;
-}) {
-  if (useLegacy) {
+} & (
+  | { useLegacy: true; instanceId: string; instance?: never }
+  | { useLegacy?: false; instance: Instance; instanceId?: never }
+);
+
+export function ResultsPage(props: ResultsPageProps) {
+  if (props.useLegacy) {
     return (
-      <ResultsPageLegacy instanceId={instanceId} profileSlug={profileSlug} />
+      <ResultsPageLegacy
+        instanceId={props.instanceId}
+        profileSlug={props.profileSlug}
+      />
     );
   }
-  const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   return (
     <ResultsPageContent
-      instanceId={instanceId}
-      profileSlug={profileSlug}
-      decisionSlug={decisionSlug}
-      instance={instance}
+      instanceId={props.instance.id}
+      profileSlug={props.profileSlug}
+      decisionSlug={props.decisionSlug}
+      instance={props.instance}
     />
   );
 }

--- a/apps/app/src/components/decisions/pages/ResultsPage.tsx
+++ b/apps/app/src/components/decisions/pages/ResultsPage.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
-import type { RouterOutput } from '@op/api';
-import { trpc } from '@op/api/client';
 import { ProposalFilter } from '@op/api/encoders';
 import { match } from '@op/core';
 import { EmptyState } from '@op/ui/EmptyState';
@@ -24,9 +22,7 @@ import { ProposalListSkeleton, ProposalsList } from '../ProposalsList';
 import { ResultsList } from '../ResultsList';
 import { ResultsStats } from '../ResultsStats';
 
-type Instance = RouterOutput['decision']['getInstance'];
-
-// Common instance fields used by ResultsPageContent
+// Common instance fields used by ResultsPage
 interface ResultsPageInstance {
   id: string;
   name: string;
@@ -36,43 +32,22 @@ interface ResultsPageInstance {
   } | null;
 }
 
-function ResultsPageLegacy({
-  instanceId,
+export function ResultsPage({
+  instance,
   profileSlug,
+  decisionSlug,
 }: {
-  instanceId: string;
-  profileSlug: string;
-}) {
-  const [instance] = trpc.decision.getLegacyInstance.useSuspenseQuery({
-    instanceId,
-  });
-  return <ResultsPageContent profileSlug={profileSlug} instance={instance} />;
-}
-
-type ResultsPageProps = {
+  instance: ResultsPageInstance;
   /** Owner profile slug (e.g. "people-powered") — used for org-specific hero content and legacy URL fallbacks */
   profileSlug: string;
   /** Decision profile slug (e.g. "pp-decides-season-5") — used for building proposal links in the new route structure */
   decisionSlug?: string;
-} & (
-  | { useLegacy: true; instanceId: string; instance?: never }
-  | { useLegacy?: false; instance: Instance; instanceId?: never }
-);
-
-export function ResultsPage(props: ResultsPageProps) {
-  if (props.useLegacy) {
-    return (
-      <ResultsPageLegacy
-        instanceId={props.instanceId}
-        profileSlug={props.profileSlug}
-      />
-    );
-  }
+}) {
   return (
     <ResultsPageContent
-      profileSlug={props.profileSlug}
-      decisionSlug={props.decisionSlug}
-      instance={props.instance}
+      profileSlug={profileSlug}
+      decisionSlug={decisionSlug}
+      instance={instance}
     />
   );
 }

--- a/apps/app/src/components/decisions/pages/ResultsPage.tsx
+++ b/apps/app/src/components/decisions/pages/ResultsPage.tsx
@@ -28,6 +28,7 @@ type Instance = RouterOutput['decision']['getInstance'];
 
 // Common instance fields used by ResultsPageContent
 interface ResultsPageInstance {
+  id: string;
   name: string;
   description: string | null;
   process?: {
@@ -45,13 +46,7 @@ function ResultsPageLegacy({
   const [instance] = trpc.decision.getLegacyInstance.useSuspenseQuery({
     instanceId,
   });
-  return (
-    <ResultsPageContent
-      instanceId={instanceId}
-      profileSlug={profileSlug}
-      instance={instance}
-    />
-  );
+  return <ResultsPageContent profileSlug={profileSlug} instance={instance} />;
 }
 
 type ResultsPageProps = {
@@ -75,7 +70,6 @@ export function ResultsPage(props: ResultsPageProps) {
   }
   return (
     <ResultsPageContent
-      instanceId={props.instance.id}
       profileSlug={props.profileSlug}
       decisionSlug={props.decisionSlug}
       instance={props.instance}
@@ -84,16 +78,15 @@ export function ResultsPage(props: ResultsPageProps) {
 }
 
 function ResultsPageContent({
-  instanceId,
   profileSlug,
   decisionSlug,
   instance,
 }: {
-  instanceId: string;
   profileSlug: string;
   decisionSlug?: string;
   instance: ResultsPageInstance;
 }) {
+  const instanceId = instance.id;
   const t = useTranslations();
 
   // Organization-specific content

--- a/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
+++ b/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { getUniqueSubmitters } from '@/utils/proposalUtils';
+import type { RouterOutput } from '@op/api';
 import { trpc } from '@op/api/client';
 import { type InstancePhaseData } from '@op/api/encoders';
 import { Suspense } from 'react';
@@ -13,13 +14,15 @@ import { useDecisionTranslation } from '../DecisionTranslationContext';
 import { MemberParticipationFacePile } from '../MemberParticipationFacePile';
 import { ProposalListSkeleton, ProposalsList } from '../ProposalsList';
 
+type Instance = RouterOutput['decision']['getInstance'];
+
 export function StandardDecisionPage({
-  instanceId,
+  instance,
   slug,
   decisionSlug,
   decisionProfileId,
 }: {
-  instanceId: string;
+  instance: Instance;
   slug: string;
   /** Decision profile slug for building proposal links */
   decisionSlug?: string;
@@ -29,13 +32,10 @@ export function StandardDecisionPage({
   const t = useTranslations();
   const translation = useDecisionTranslation();
 
-  const [[{ proposals }, instance]] = trpc.useSuspenseQueries((t) => [
-    t.decision.listProposals({
-      processInstanceId: instanceId,
-      limit: 20,
-    }),
-    t.decision.getInstance({ instanceId }),
-  ]);
+  const [{ proposals }] = trpc.decision.listProposals.useSuspenseQuery({
+    processInstanceId: instance.id,
+    limit: 20,
+  });
 
   const phases = instance.instanceData?.phases ?? [];
   const currentPhaseId = instance.currentStateId;
@@ -71,7 +71,7 @@ export function StandardDecisionPage({
         <MemberParticipationFacePile submitters={uniqueSubmitters} />
 
         <DecisionActionBar
-          instanceId={instanceId}
+          instanceId={instance.id}
           description={actionBarDescription}
           markup={!!translation?.additionalInfo}
           showSubmitButton={allowProposals && canSubmitProposal}
@@ -84,7 +84,7 @@ export function StandardDecisionPage({
             <Suspense fallback={<ProposalListSkeleton />}>
               <ProposalsList
                 slug={slug}
-                instanceId={instanceId}
+                instanceId={instance.id}
                 decisionSlug={decisionSlug}
                 decisionProfileId={decisionProfileId}
                 permissions={instance.access}

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { getUniqueSubmitters } from '@/utils/proposalUtils';
+import type { RouterOutput } from '@op/api';
 import { trpc } from '@op/api/client';
 import { type InstancePhaseData } from '@op/api/encoders';
 import { Suspense } from 'react';
@@ -13,25 +14,24 @@ import { MemberParticipationFacePile } from '../MemberParticipationFacePile';
 import { MyBallot } from '../MyBallot';
 import { ProposalListSkeleton, ProposalsList } from '../ProposalsList';
 
+type Instance = RouterOutput['decision']['getInstance'];
+
 export function VotingPage({
-  instanceId,
+  instance,
   slug,
   decisionSlug,
 }: {
-  instanceId: string;
+  instance: Instance;
   slug: string;
   /** Decision profile slug for building proposal links */
   decisionSlug?: string;
 }) {
   const t = useTranslations();
 
-  const [[{ proposals }, instance]] = trpc.useSuspenseQueries((t) => [
-    t.decision.listProposals({
-      processInstanceId: instanceId,
-      limit: 20,
-    }),
-    t.decision.getInstance({ instanceId }),
-  ]);
+  const [{ proposals }] = trpc.decision.listProposals.useSuspenseQuery({
+    processInstanceId: instance.id,
+    limit: 20,
+  });
 
   const uniqueSubmitters = getUniqueSubmitters(proposals);
 
@@ -64,7 +64,7 @@ export function VotingPage({
         <MemberParticipationFacePile submitters={uniqueSubmitters} />
 
         <DecisionActionBar
-          instanceId={instanceId}
+          instanceId={instance.id}
           markup={currentPhase?.additionalInfo ? false : aboutIsMarkup}
           description={currentPhase?.additionalInfo ?? description}
           showSubmitButton={false}
@@ -77,7 +77,7 @@ export function VotingPage({
             <Suspense fallback={<ProposalListSkeleton />}>
               <ProposalsList
                 slug={slug}
-                instanceId={instanceId}
+                instanceId={instance.id}
                 decisionSlug={decisionSlug}
                 permissions={instance.access}
               />
@@ -89,7 +89,7 @@ export function VotingPage({
       {instance.access?.vote && (
         <div data-testid="my-ballot">
           <Suspense fallback={null}>
-            <MyBallot slug={slug} instanceId={instanceId} />
+            <MyBallot slug={slug} instanceId={instance.id} />
           </Suspense>
         </div>
       )}


### PR DESCRIPTION
Eliminates redundant getInstance queries in decision page components by passing the already-fetched instance from DecisionStateRouter as a prop.