### PR TITLE
feat(reviews): generate review assignments on phase transition

### DIFF
--- a/packages/common/src/services/decision/generateReviewAssignments.ts
+++ b/packages/common/src/services/decision/generateReviewAssignments.ts
@@ -1,11 +1,15 @@
-import { db, eq, inArray } from '@op/db/client';
+import { and, db, eq, inArray, sql } from '@op/db/client';
 import {
+  accessRolePermissionsOnAccessZones,
+  profileUserToAccessRoles,
   profileUsers,
   proposalReviewAssignments,
   proposals,
   users,
 } from '@op/db/schema';
 
+import { CommonError } from '../../utils';
+import { decisionPermission } from './permissions';
 import type { DecisionInstanceData } from './schemas/instanceData';
 import type { ReviewsPolicy } from './schemas/types';
 
@@ -18,12 +22,11 @@ export interface GenerateReviewAssignmentsInput {
 /**
  * Generate review assignment rows for proposals entering a review-capable phase.
  *
- * Assignment strategy depends on the instance's `reviewsPolicy`:
- * - `full_coverage` — every eligible reviewer is assigned every proposal.
- * - `self_selection` — no upfront assignments; reviewers claim proposals themselves.
- * - `random_assignment` — a random subset of reviewers is assigned per proposal (TODO).
+ * Only members with the REVIEW capability on the `decisions` access zone are
+ * eligible. Reviewers are never assigned their own proposals.
  *
- * Reviewers are never assigned their own proposals.
+ * Currently supports the `full_coverage` policy (every eligible reviewer is
+ * assigned every proposal). Throws for unsupported policies.
  */
 export async function generateReviewAssignments({
   instanceId,
@@ -46,11 +49,13 @@ export async function generateReviewAssignments({
   }
 
   const instanceData = instance.instanceData as DecisionInstanceData;
-  const reviewsPolicy: ReviewsPolicy =
-    instanceData.config?.reviewsPolicy ?? 'full_coverage';
+  const reviewsPolicy: ReviewsPolicy | undefined =
+    instanceData.config?.reviewsPolicy;
 
-  if (reviewsPolicy === 'self_selection') {
-    return;
+  if (reviewsPolicy && reviewsPolicy !== 'full_coverage') {
+    throw new CommonError(
+      `Review assignment policy '${reviewsPolicy}' is not implemented`,
+    );
   }
 
   const decisionProfileId = instance.profileId;
@@ -62,7 +67,18 @@ export async function generateReviewAssignments({
     return;
   }
 
-  const [selectedProposals, memberPersonalProfileIds] = await Promise.all([
+  const decisionsZone = await db.query.accessZones.findFirst({
+    where: { name: 'decisions' },
+  });
+
+  if (!decisionsZone) {
+    console.error(
+      'generateReviewAssignments: decisions access zone not found',
+    );
+    return;
+  }
+
+  const [selectedProposals, reviewerProfileIds] = await Promise.all([
     db
       .select({
         id: proposals.id,
@@ -71,40 +87,62 @@ export async function generateReviewAssignments({
       .from(proposals)
       .where(inArray(proposals.id, selectedProposalIds)),
 
-    // profileUsers (decision membership) → users (via authUserId) → users.profileId (personal profile)
+    // profileUsers (decision membership)
+    //   → profileUserToAccessRoles (role assignments)
+    //   → accessRolePermissionsOnAccessZones (zone permissions)
+    //   → users (personal profileId)
+    // Filtered to members with the REVIEW bit on the decisions zone.
     db
       .selectDistinct({ profileId: users.profileId })
       .from(profileUsers)
       .innerJoin(users, eq(profileUsers.authUserId, users.authUserId))
-      .where(eq(profileUsers.profileId, decisionProfileId))
+      .innerJoin(
+        profileUserToAccessRoles,
+        eq(profileUsers.id, profileUserToAccessRoles.profileUserId),
+      )
+      .innerJoin(
+        accessRolePermissionsOnAccessZones,
+        and(
+          eq(
+            profileUserToAccessRoles.accessRoleId,
+            accessRolePermissionsOnAccessZones.accessRoleId,
+          ),
+          eq(
+            accessRolePermissionsOnAccessZones.accessZoneId,
+            decisionsZone.id,
+          ),
+        ),
+      )
+      .where(
+        and(
+          eq(profileUsers.profileId, decisionProfileId),
+          sql`(${accessRolePermissionsOnAccessZones.permission} & ${decisionPermission.REVIEW}) != 0`,
+        ),
+      )
       .then((rows) =>
         rows.map((r) => r.profileId).filter((id): id is string => id != null),
       ),
   ]);
 
-  if (memberPersonalProfileIds.length === 0 || selectedProposals.length === 0) {
+  if (reviewerProfileIds.length === 0 || selectedProposals.length === 0) {
     return;
   }
 
-  if (reviewsPolicy === 'full_coverage') {
-    const assignmentValues = selectedProposals.flatMap((proposal) =>
-      memberPersonalProfileIds
-        .filter((profileId) => profileId !== proposal.submittedByProfileId)
-        .map((profileId) => ({
-          processInstanceId: instanceId,
-          proposalId: proposal.id,
-          reviewerProfileId: profileId,
-          phaseId,
-        })),
-    );
+  const assignmentValues = selectedProposals.flatMap((proposal) =>
+    reviewerProfileIds
+      .filter((profileId) => profileId !== proposal.submittedByProfileId)
+      .map((profileId) => ({
+        processInstanceId: instanceId,
+        proposalId: proposal.id,
+        reviewerProfileId: profileId,
+        phaseId,
+      })),
+  );
 
-    if (assignmentValues.length > 0) {
-      await db
-        .insert(proposalReviewAssignments)
-        .values(assignmentValues)
-        .onConflictDoNothing();
-    }
+  if (assignmentValues.length > 0) {
+    await db
+      .insert(proposalReviewAssignments)
+      .values(assignmentValues)
+      .onConflictDoNothing();
   }
-
-  // TODO: random_assignment strategy
 }

--- a/packages/common/src/services/decision/generateReviewAssignments.ts
+++ b/packages/common/src/services/decision/generateReviewAssignments.ts
@@ -1,6 +1,7 @@
 import { and, db, eq, inArray, sql } from '@op/db/client';
 import {
   accessRolePermissionsOnAccessZones,
+  decisionTransitionProposals,
   profileUserToAccessRoles,
   profileUsers,
   proposalReviewAssignments,
@@ -17,6 +18,7 @@ export interface GenerateReviewAssignmentsInput {
   instanceId: string;
   phaseId: string;
   selectedProposalIds: string[];
+  transitionHistoryId: string;
 }
 
 /**
@@ -32,6 +34,7 @@ export async function generateReviewAssignments({
   instanceId,
   phaseId,
   selectedProposalIds,
+  transitionHistoryId,
 }: GenerateReviewAssignmentsInput): Promise<void> {
   if (selectedProposalIds.length === 0) {
     return;
@@ -72,61 +75,84 @@ export async function generateReviewAssignments({
   });
 
   if (!decisionsZone) {
-    console.error(
-      'generateReviewAssignments: decisions access zone not found',
-    );
+    console.error('generateReviewAssignments: decisions access zone not found');
     return;
   }
 
-  const [selectedProposals, reviewerProfileIds] = await Promise.all([
-    db
-      .select({
-        id: proposals.id,
-        submittedByProfileId: proposals.submittedByProfileId,
-      })
-      .from(proposals)
-      .where(inArray(proposals.id, selectedProposalIds)),
+  const [selectedProposals, reviewerProfileIds, transitionProposalRows] =
+    await Promise.all([
+      db
+        .select({
+          id: proposals.id,
+          submittedByProfileId: proposals.submittedByProfileId,
+        })
+        .from(proposals)
+        .where(inArray(proposals.id, selectedProposalIds)),
 
-    // profileUsers (decision membership)
-    //   → profileUserToAccessRoles (role assignments)
-    //   → accessRolePermissionsOnAccessZones (zone permissions)
-    //   → users (personal profileId)
-    // Filtered to members with the REVIEW bit on the decisions zone.
-    db
-      .selectDistinct({ profileId: users.profileId })
-      .from(profileUsers)
-      .innerJoin(users, eq(profileUsers.authUserId, users.authUserId))
-      .innerJoin(
-        profileUserToAccessRoles,
-        eq(profileUsers.id, profileUserToAccessRoles.profileUserId),
-      )
-      .innerJoin(
-        accessRolePermissionsOnAccessZones,
-        and(
-          eq(
-            profileUserToAccessRoles.accessRoleId,
-            accessRolePermissionsOnAccessZones.accessRoleId,
+      // profileUsers (decision membership)
+      //   → profileUserToAccessRoles (role assignments)
+      //   → accessRolePermissionsOnAccessZones (zone permissions)
+      //   → users (personal profileId)
+      // Filtered to members with the REVIEW bit on the decisions zone.
+      db
+        .selectDistinct({ profileId: users.profileId })
+        .from(profileUsers)
+        .innerJoin(users, eq(profileUsers.authUserId, users.authUserId))
+        .innerJoin(
+          profileUserToAccessRoles,
+          eq(profileUsers.id, profileUserToAccessRoles.profileUserId),
+        )
+        .innerJoin(
+          accessRolePermissionsOnAccessZones,
+          and(
+            eq(
+              profileUserToAccessRoles.accessRoleId,
+              accessRolePermissionsOnAccessZones.accessRoleId,
+            ),
+            eq(
+              accessRolePermissionsOnAccessZones.accessZoneId,
+              decisionsZone.id,
+            ),
           ),
-          eq(
-            accessRolePermissionsOnAccessZones.accessZoneId,
-            decisionsZone.id,
+        )
+        .where(
+          and(
+            eq(profileUsers.profileId, decisionProfileId),
+            sql`(${accessRolePermissionsOnAccessZones.permission} & ${decisionPermission.REVIEW}) != 0`,
+          ),
+        )
+        .then((rows) =>
+          rows.map((r) => r.profileId).filter((id): id is string => id != null),
+        ),
+
+      // Look up the proposal history snapshots captured during the phase transition.
+      db
+        .select({
+          proposalId: decisionTransitionProposals.proposalId,
+          proposalHistoryId: decisionTransitionProposals.proposalHistoryId,
+        })
+        .from(decisionTransitionProposals)
+        .where(
+          and(
+            eq(
+              decisionTransitionProposals.transitionHistoryId,
+              transitionHistoryId,
+            ),
+            inArray(
+              decisionTransitionProposals.proposalId,
+              selectedProposalIds,
+            ),
           ),
         ),
-      )
-      .where(
-        and(
-          eq(profileUsers.profileId, decisionProfileId),
-          sql`(${accessRolePermissionsOnAccessZones.permission} & ${decisionPermission.REVIEW}) != 0`,
-        ),
-      )
-      .then((rows) =>
-        rows.map((r) => r.profileId).filter((id): id is string => id != null),
-      ),
-  ]);
+    ]);
 
   if (reviewerProfileIds.length === 0 || selectedProposals.length === 0) {
     return;
   }
+
+  const historyByProposalId = new Map(
+    transitionProposalRows.map((r) => [r.proposalId, r.proposalHistoryId]),
+  );
 
   const assignmentValues = selectedProposals.flatMap((proposal) =>
     reviewerProfileIds
@@ -136,6 +162,7 @@ export async function generateReviewAssignments({
         proposalId: proposal.id,
         reviewerProfileId: profileId,
         phaseId,
+        assignedProposalHistoryId: historyByProposalId.get(proposal.id) ?? null,
       })),
   );
 

--- a/packages/common/src/services/decision/generateReviewAssignments.ts
+++ b/packages/common/src/services/decision/generateReviewAssignments.ts
@@ -12,7 +12,6 @@ import {
 import { CommonError } from '../../utils';
 import { decisionPermission } from './permissions';
 import type { DecisionInstanceData } from './schemas/instanceData';
-import type { ReviewsPolicy } from './schemas/types';
 
 export interface GenerateReviewAssignmentsInput {
   instanceId: string;
@@ -40,20 +39,19 @@ export async function generateReviewAssignments({
     return;
   }
 
-  const instance = await db.query.processInstances.findFirst({
-    where: { id: instanceId },
-  });
+  const [instance, decisionsZone] = await Promise.all([
+    db.query.processInstances.findFirst({ where: { id: instanceId } }),
+    db.query.accessZones.findFirst({ where: { name: 'decisions' } }),
+  ]);
 
   if (!instance) {
-    console.error(
+    throw new CommonError(
       `generateReviewAssignments: instance ${instanceId} not found`,
     );
-    return;
   }
 
   const instanceData = instance.instanceData as DecisionInstanceData;
-  const reviewsPolicy: ReviewsPolicy | undefined =
-    instanceData.config?.reviewsPolicy;
+  const reviewsPolicy = instanceData.config?.reviewsPolicy;
 
   if (reviewsPolicy && reviewsPolicy !== 'full_coverage') {
     throw new CommonError(
@@ -69,10 +67,6 @@ export async function generateReviewAssignments({
     );
     return;
   }
-
-  const decisionsZone = await db.query.accessZones.findFirst({
-    where: { name: 'decisions' },
-  });
 
   if (!decisionsZone) {
     console.error('generateReviewAssignments: decisions access zone not found');
@@ -156,6 +150,7 @@ export async function generateReviewAssignments({
 
   const assignmentValues = selectedProposals.flatMap((proposal) =>
     reviewerProfileIds
+      // NOTE: we should revisit this logic when we have multiple authors per proposal
       .filter((profileId) => profileId !== proposal.submittedByProfileId)
       .map((profileId) => ({
         processInstanceId: instanceId,

--- a/packages/common/src/services/decision/generateReviewAssignments.ts
+++ b/packages/common/src/services/decision/generateReviewAssignments.ts
@@ -78,9 +78,7 @@ export async function generateReviewAssignments({
       .innerJoin(users, eq(profileUsers.authUserId, users.authUserId))
       .where(eq(profileUsers.profileId, decisionProfileId))
       .then((rows) =>
-        rows
-          .map((r) => r.profileId)
-          .filter((id): id is string => id != null),
+        rows.map((r) => r.profileId).filter((id): id is string => id != null),
       ),
   ]);
 

--- a/packages/common/src/services/decision/generateReviewAssignments.ts
+++ b/packages/common/src/services/decision/generateReviewAssignments.ts
@@ -1,0 +1,112 @@
+import { db, eq, inArray } from '@op/db/client';
+import {
+  profileUsers,
+  proposalReviewAssignments,
+  proposals,
+  users,
+} from '@op/db/schema';
+
+import type { DecisionInstanceData } from './schemas/instanceData';
+import type { ReviewsPolicy } from './schemas/types';
+
+export interface GenerateReviewAssignmentsInput {
+  instanceId: string;
+  phaseId: string;
+  selectedProposalIds: string[];
+}
+
+/**
+ * Generate review assignment rows for proposals entering a review-capable phase.
+ *
+ * Assignment strategy depends on the instance's `reviewsPolicy`:
+ * - `full_coverage` — every eligible reviewer is assigned every proposal.
+ * - `self_selection` — no upfront assignments; reviewers claim proposals themselves.
+ * - `random_assignment` — a random subset of reviewers is assigned per proposal (TODO).
+ *
+ * Reviewers are never assigned their own proposals.
+ */
+export async function generateReviewAssignments({
+  instanceId,
+  phaseId,
+  selectedProposalIds,
+}: GenerateReviewAssignmentsInput): Promise<void> {
+  if (selectedProposalIds.length === 0) {
+    return;
+  }
+
+  const instance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+
+  if (!instance) {
+    console.error(
+      `generateReviewAssignments: instance ${instanceId} not found`,
+    );
+    return;
+  }
+
+  const instanceData = instance.instanceData as DecisionInstanceData;
+  const reviewsPolicy: ReviewsPolicy =
+    instanceData.config?.reviewsPolicy ?? 'full_coverage';
+
+  if (reviewsPolicy === 'self_selection') {
+    return;
+  }
+
+  const decisionProfileId = instance.profileId;
+
+  if (!decisionProfileId) {
+    console.error(
+      `generateReviewAssignments: instance ${instanceId} has no profileId`,
+    );
+    return;
+  }
+
+  const [selectedProposals, memberPersonalProfileIds] = await Promise.all([
+    db
+      .select({
+        id: proposals.id,
+        submittedByProfileId: proposals.submittedByProfileId,
+      })
+      .from(proposals)
+      .where(inArray(proposals.id, selectedProposalIds)),
+
+    // profileUsers (decision membership) → users (via authUserId) → users.profileId (personal profile)
+    db
+      .selectDistinct({ profileId: users.profileId })
+      .from(profileUsers)
+      .innerJoin(users, eq(profileUsers.authUserId, users.authUserId))
+      .where(eq(profileUsers.profileId, decisionProfileId))
+      .then((rows) =>
+        rows
+          .map((r) => r.profileId)
+          .filter((id): id is string => id != null),
+      ),
+  ]);
+
+  if (memberPersonalProfileIds.length === 0 || selectedProposals.length === 0) {
+    return;
+  }
+
+  if (reviewsPolicy === 'full_coverage') {
+    const assignmentValues = selectedProposals.flatMap((proposal) =>
+      memberPersonalProfileIds
+        .filter((profileId) => profileId !== proposal.submittedByProfileId)
+        .map((profileId) => ({
+          processInstanceId: instanceId,
+          proposalId: proposal.id,
+          reviewerProfileId: profileId,
+          phaseId,
+        })),
+    );
+
+    if (assignmentValues.length > 0) {
+      await db
+        .insert(proposalReviewAssignments)
+        .values(assignmentValues)
+        .onConflictDoNothing();
+    }
+  }
+
+  // TODO: random_assignment strategy
+}

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -18,6 +18,9 @@ export * from './getDecisionBySlug';
 // Shared phase advancement core (used by transitionFromPhase and transitionMonitor)
 export * from './advancePhase';
 
+// Post-advance hook
+export * from './onPhaseAdvanced';
+
 // Manual transition
 export * from './triggerPhaseAdvancement';
 
@@ -48,6 +51,7 @@ export * from './updateProposal';
 export * from './getProposal';
 export * from './listProposalVersions';
 export * from './listProposals';
+export * from './generateReviewAssignments';
 export * from './getReviewAssignment';
 export * from './listReviewAssignments';
 export * from './submitReview';

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -52,6 +52,7 @@ export * from './getProposal';
 export * from './listProposalVersions';
 export * from './listProposals';
 export * from './generateReviewAssignments';
+export * from './runGenerateReviewAssignments';
 export * from './getReviewAssignment';
 export * from './listReviewAssignments';
 export * from './submitReview';

--- a/packages/common/src/services/decision/onPhaseAdvanced.ts
+++ b/packages/common/src/services/decision/onPhaseAdvanced.ts
@@ -1,7 +1,7 @@
 import type { AdvancePhaseResult } from './advancePhase';
 import { runGenerateReviewAssignments } from './runGenerateReviewAssignments';
 import { runResultsProcessing } from './runResultsProcessing';
-import type { PhaseInstanceData } from './schemas/instanceData';
+import { type PhaseInstanceData, isLastPhase } from './schemas/instanceData';
 
 export interface OnPhaseAdvancedInput {
   instanceId: string;
@@ -29,9 +29,7 @@ export async function onPhaseAdvanced(
     await runGenerateReviewAssignments(input);
   }
 
-  const isNowOnFinalPhase =
-    input.phases[input.phases.length - 1]?.phaseId === input.toPhaseId;
-  if (isNowOnFinalPhase) {
+  if (isLastPhase(input.toPhaseId, input.phases)) {
     await runResultsProcessing(input);
   }
 }

--- a/packages/common/src/services/decision/onPhaseAdvanced.ts
+++ b/packages/common/src/services/decision/onPhaseAdvanced.ts
@@ -1,0 +1,49 @@
+import type { AdvancePhaseResult } from './advancePhase';
+import { generateReviewAssignments } from './generateReviewAssignments';
+import { runResultsProcessing } from './runResultsProcessing';
+import type { PhaseInstanceData } from './schemas/instanceData';
+
+export interface OnPhaseAdvancedInput {
+  instanceId: string;
+  toPhaseId: string;
+  phases: PhaseInstanceData[];
+  advanceResult: AdvancePhaseResult & { conflict: false };
+}
+
+/**
+ * Post-advance hook that runs after a successful phase transition commits.
+ *
+ * Centralises side-effects that should happen whenever a decision instance
+ * moves to a new phase — regardless of whether the advance was manual or
+ * cron-triggered — so callers of `advancePhase` don't duplicate logic.
+ *
+ * Runs outside the advance transaction on purpose: a failure here must not
+ * roll back the phase transition itself.
+ */
+export async function onPhaseAdvanced({
+  instanceId,
+  toPhaseId,
+  phases,
+  advanceResult,
+}: OnPhaseAdvancedInput): Promise<void> {
+  const targetPhase = phases.find((p) => p.phaseId === toPhaseId);
+  if (targetPhase?.rules?.proposals?.review) {
+    try {
+      await generateReviewAssignments({
+        instanceId,
+        phaseId: toPhaseId,
+        selectedProposalIds: advanceResult.selectedProposalIds,
+      });
+    } catch (error) {
+      console.error(
+        `Review assignment generation failed for instance ${instanceId}, phase ${toPhaseId}:`,
+        error,
+      );
+    }
+  }
+
+  const isNowOnFinalPhase = phases[phases.length - 1]?.phaseId === toPhaseId;
+  if (isNowOnFinalPhase) {
+    await runResultsProcessing(instanceId);
+  }
+}

--- a/packages/common/src/services/decision/onPhaseAdvanced.ts
+++ b/packages/common/src/services/decision/onPhaseAdvanced.ts
@@ -1,5 +1,5 @@
 import type { AdvancePhaseResult } from './advancePhase';
-import { generateReviewAssignments } from './generateReviewAssignments';
+import { runGenerateReviewAssignments } from './runGenerateReviewAssignments';
 import { runResultsProcessing } from './runResultsProcessing';
 import type { PhaseInstanceData } from './schemas/instanceData';
 
@@ -20,30 +20,18 @@ export interface OnPhaseAdvancedInput {
  * Runs outside the advance transaction on purpose: a failure here must not
  * roll back the phase transition itself.
  */
-export async function onPhaseAdvanced({
-  instanceId,
-  toPhaseId,
-  phases,
-  advanceResult,
-}: OnPhaseAdvancedInput): Promise<void> {
-  const targetPhase = phases.find((p) => p.phaseId === toPhaseId);
+export async function onPhaseAdvanced(
+  input: OnPhaseAdvancedInput,
+): Promise<void> {
+  const targetPhase = input.phases.find((p) => p.phaseId === input.toPhaseId);
+
   if (targetPhase?.rules?.proposals?.review) {
-    try {
-      await generateReviewAssignments({
-        instanceId,
-        phaseId: toPhaseId,
-        selectedProposalIds: advanceResult.selectedProposalIds,
-      });
-    } catch (error) {
-      console.error(
-        `Review assignment generation failed for instance ${instanceId}, phase ${toPhaseId}:`,
-        error,
-      );
-    }
+    await runGenerateReviewAssignments(input);
   }
 
-  const isNowOnFinalPhase = phases[phases.length - 1]?.phaseId === toPhaseId;
+  const isNowOnFinalPhase =
+    input.phases[input.phases.length - 1]?.phaseId === input.toPhaseId;
   if (isNowOnFinalPhase) {
-    await runResultsProcessing(instanceId);
+    await runResultsProcessing(input);
   }
 }

--- a/packages/common/src/services/decision/runGenerateReviewAssignments.ts
+++ b/packages/common/src/services/decision/runGenerateReviewAssignments.ts
@@ -1,0 +1,20 @@
+import { generateReviewAssignments } from './generateReviewAssignments';
+import type { OnPhaseAdvancedInput } from './onPhaseAdvanced';
+
+/** Run review assignment generation. Failures are logged, not thrown. */
+export async function runGenerateReviewAssignments(
+  input: OnPhaseAdvancedInput,
+): Promise<void> {
+  try {
+    await generateReviewAssignments({
+      instanceId: input.instanceId,
+      phaseId: input.toPhaseId,
+      selectedProposalIds: input.advanceResult.selectedProposalIds,
+    });
+  } catch (error) {
+    console.error(
+      `Review assignment generation failed for instance ${input.instanceId}, phase ${input.toPhaseId}:`,
+      error,
+    );
+  }
+}

--- a/packages/common/src/services/decision/runGenerateReviewAssignments.ts
+++ b/packages/common/src/services/decision/runGenerateReviewAssignments.ts
@@ -10,6 +10,7 @@ export async function runGenerateReviewAssignments(
       instanceId: input.instanceId,
       phaseId: input.toPhaseId,
       selectedProposalIds: input.advanceResult.selectedProposalIds,
+      transitionHistoryId: input.advanceResult.transitionHistoryId,
     });
   } catch (error) {
     console.error(

--- a/packages/common/src/services/decision/runResultsProcessing.ts
+++ b/packages/common/src/services/decision/runResultsProcessing.ts
@@ -1,21 +1,24 @@
+import type { OnPhaseAdvancedInput } from './onPhaseAdvanced';
 import { processResults } from './processResults';
 
 /** Run results processing for an instance that reached its final phase. Failures are logged, not thrown. */
 export async function runResultsProcessing(
-  processInstanceId: string,
+  input: OnPhaseAdvancedInput,
 ): Promise<void> {
   try {
-    const processingResult = await processResults({ processInstanceId });
+    const processingResult = await processResults({
+      processInstanceId: input.instanceId,
+    });
 
     if (!processingResult.success) {
       console.error(
-        `Results processing failed for process instance ${processInstanceId}:`,
+        `Results processing failed for process instance ${input.instanceId}:`,
         processingResult.error,
       );
     }
   } catch (error) {
     console.error(
-      `Error processing results for process instance ${processInstanceId}:`,
+      `Error processing results for process instance ${input.instanceId}:`,
       error,
     );
   }

--- a/packages/common/src/services/decision/transitionMonitor.ts
+++ b/packages/common/src/services/decision/transitionMonitor.ts
@@ -8,8 +8,11 @@ import pMap from 'p-map';
 
 import { CommonError } from '../../utils';
 import { advancePhase } from './advancePhase';
-import { runResultsProcessing } from './runResultsProcessing';
-import type { DecisionInstanceData } from './schemas/instanceData';
+import { onPhaseAdvanced } from './onPhaseAdvanced';
+import type {
+  DecisionInstanceData,
+  PhaseInstanceData,
+} from './schemas/instanceData';
 
 export interface ProcessDecisionsTransitionsResult {
   processed: number;
@@ -98,18 +101,13 @@ export async function processDecisionsTransitions(): Promise<ProcessDecisionsTra
           return;
         }
 
-        const lastPhaseId = phases[phases.length - 1]!.phaseId;
-
-        const lastSuccessfulToStateId = await advanceInstanceTransitions({
+        await advanceInstanceTransitions({
           processInstanceId,
           transitions,
+          phases,
           now,
           result,
         });
-
-        if (lastSuccessfulToStateId === lastPhaseId) {
-          await runResultsProcessing(processInstanceId);
-        }
       },
       { concurrency: 5 },
     );
@@ -148,15 +146,16 @@ function groupTransitionsByInstance(
 async function advanceInstanceTransitions({
   processInstanceId,
   transitions,
+  phases,
   now,
   result,
 }: {
   processInstanceId: string;
   transitions: DueTransition[];
+  phases: PhaseInstanceData[];
   now: string;
   result: ProcessDecisionsTransitionsResult;
-}): Promise<string | null> {
-  let lastSuccessfulToStateId: string | null = null;
+}): Promise<void> {
   let currentInstanceData = transitions[0]!.instance
     .instanceData as DecisionInstanceData;
 
@@ -194,8 +193,14 @@ async function advanceInstanceTransitions({
         break;
       }
 
-      lastSuccessfulToStateId = transition.toStateId;
       result.processed++;
+
+      await onPhaseAdvanced({
+        instanceId: processInstanceId,
+        toPhaseId: transition.toStateId,
+        phases,
+        advanceResult,
+      });
 
       // Re-fetch so the next iteration sees the committed state.
       const refreshed = await db.query.processInstances.findFirst({
@@ -216,5 +221,4 @@ async function advanceInstanceTransitions({
     }
   }
 
-  return lastSuccessfulToStateId;
 }

--- a/packages/common/src/services/decision/transitionMonitor.ts
+++ b/packages/common/src/services/decision/transitionMonitor.ts
@@ -220,5 +220,4 @@ async function advanceInstanceTransitions({
       break;
     }
   }
-
 }

--- a/packages/common/src/services/decision/triggerPhaseAdvancement.ts
+++ b/packages/common/src/services/decision/triggerPhaseAdvancement.ts
@@ -13,7 +13,7 @@ import {
 import { getProfileAccessUser } from '../access';
 import { assertUserByAuthId } from '../assert';
 import { advancePhase } from './advancePhase';
-import { runResultsProcessing } from './runResultsProcessing';
+import { onPhaseAdvanced } from './onPhaseAdvanced';
 import type { DecisionInstanceData } from './schemas/instanceData';
 
 export interface TriggerPhaseAdvancementInput {
@@ -37,9 +37,6 @@ export interface TriggerPhaseAdvancementResult {
  * Manually advance a decision instance from its current phase to the next phase.
  * Validates admin access and instance eligibility, then delegates the actual
  * phase advance to the shared `advancePhase` core function.
- *
- * When transitioning to the final phase: additionally runs processResults to
- * store final selections in the results tables and update proposal statuses.
  */
 export async function triggerPhaseAdvancement({
   instanceId,
@@ -108,10 +105,8 @@ export async function triggerPhaseAdvancement({
   }
 
   const toPhaseId = phases[currentPhaseIndex + 1]!.phaseId;
-  const isTransitioningToFinalPhase =
-    currentPhaseIndex + 1 === phases.length - 1;
 
-  await db.transaction(async (tx) => {
+  const advanceResult = await db.transaction(async (tx) => {
     const result = await advancePhase({
       tx,
       instance: {
@@ -127,14 +122,11 @@ export async function triggerPhaseAdvancement({
     if (result.conflict) {
       throw new ConflictError('Phase transition conflict');
     }
+
+    return result;
   });
 
-  // processResults runs as a separate top-level operation: the join table
-  // writes inside advancePhase are per-transition, while processResults
-  // populates decisionProcessResults + selections + proposal statuses.
-  if (isTransitioningToFinalPhase) {
-    await runResultsProcessing(instanceId);
-  }
+  await onPhaseAdvanced({ instanceId, toPhaseId, phases, advanceResult });
 
   return {
     currentPhaseId: toPhaseId,

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -8,9 +8,7 @@ import {
 import { db, eq } from '@op/db/client';
 import {
   ProcessStatus,
-  decisionProcesses,
   processInstances,
-  profileUserToAccessRoles,
   proposalReviewAssignments,
   users,
 } from '@op/db/schema';
@@ -35,7 +33,7 @@ async function createAuthenticatedCaller(email: string) {
  * Schema with a review-capable middle phase.
  * submission → review (proposals.review: true) → results
  */
-const reviewSchema = {
+const decisionSchemaWithReview = {
   id: 'review-test-schema',
   version: '1.0.0',
   name: 'Review Test Schema',
@@ -79,31 +77,22 @@ const reviewSchema = {
  * Returns the instance, its profileId, and the creating user's personal profileId.
  */
 async function createReviewInstance(testData: TestDecisionsDataManager) {
-  const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+  const setup = await testData.createDecisionSetup({
+    instanceCount: 1,
+    processSchema: decisionSchemaWithReview,
+    status: ProcessStatus.PUBLISHED,
+  });
 
   const [userRecord] = await db
     .select({ profileId: users.profileId })
     .from(users)
     .where(eq(users.authUserId, setup.user.id));
 
-  const [processRecord] = await db
-    .insert(decisionProcesses)
-    .values({
-      name: `Review Process ${setup.userEmail}`,
-      description: 'Test review process',
-      processSchema: reviewSchema,
-      createdByProfileId: userRecord!.profileId!,
-    })
-    .returning();
-
-  const created = await testData.createInstanceForProcess({
-    processId: processRecord!.id,
-    user: setup.user,
-    name: 'Review Instance',
-    status: ProcessStatus.PUBLISHED,
-  });
-
-  return { setup, instance: created, creatorProfileId: userRecord!.profileId! };
+  return {
+    setup,
+    instance: setup.instances[0]!,
+    creatorProfileId: userRecord!.profileId!,
+  };
 }
 
 /**
@@ -129,33 +118,6 @@ async function createReviewerRole(instanceProfileId: string) {
         },
       },
     },
-  });
-}
-
-/**
- * Assigns an additional role to a user on a specific decision profile.
- */
-async function assignRole(
-  authUserId: string,
-  instanceProfileId: string,
-  roleId: string,
-) {
-  const profileUser = await db.query.profileUsers.findFirst({
-    where: {
-      authUserId,
-      profileId: instanceProfileId,
-    },
-  });
-
-  if (!profileUser) {
-    throw new Error(
-      `No profileUser found for authUserId=${authUserId} on profile=${instanceProfileId}`,
-    );
-  }
-
-  await db.insert(profileUserToAccessRoles).values({
-    profileUserId: profileUser.id,
-    accessRoleId: roleId,
   });
 }
 
@@ -238,8 +200,16 @@ describe.concurrent('generateReviewAssignments', () => {
 
     // Give reviewerA and reviewerB the Reviewer role
     await Promise.all([
-      assignRole(reviewerA.authUserId, instance.profileId, reviewerRole.id),
-      assignRole(reviewerB.authUserId, instance.profileId, reviewerRole.id),
+      testData.assignRole(
+        reviewerA.authUserId,
+        instance.profileId,
+        reviewerRole.id,
+      ),
+      testData.assignRole(
+        reviewerB.authUserId,
+        instance.profileId,
+        reviewerRole.id,
+      ),
     ]);
 
     // Create and submit proposals so they have history rows
@@ -386,7 +356,11 @@ describe.concurrent('generateReviewAssignments', () => {
       organization: setup.organization,
       instanceProfileIds: [instance.profileId],
     });
-    await assignRole(reviewer.authUserId, instance.profileId, reviewerRole.id);
+    await testData.assignRole(
+      reviewer.authUserId,
+      instance.profileId,
+      reviewerRole.id,
+    );
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -8,7 +8,6 @@ import {
 import { db, eq } from '@op/db/client';
 import {
   ProcessStatus,
-  processInstances,
   proposalReviewAssignments,
   users,
 } from '@op/db/schema';
@@ -76,10 +75,16 @@ const decisionSchemaWithReview = {
  * Creates a published decision instance from the review schema.
  * Returns the instance, its profileId, and the creating user's personal profileId.
  */
-async function createReviewInstance(testData: TestDecisionsDataManager) {
+async function createReviewInstance(
+  testData: TestDecisionsDataManager,
+  { reviewsPolicy = 'full_coverage' as const } = {},
+) {
   const setup = await testData.createDecisionSetup({
     instanceCount: 1,
-    processSchema: decisionSchemaWithReview,
+    processSchema: {
+      ...decisionSchemaWithReview,
+      config: { ...decisionSchemaWithReview.config, reviewsPolicy },
+    },
     status: ProcessStatus.PUBLISHED,
   });
 
@@ -154,22 +159,6 @@ async function advanceToReviewPhase(instanceId: string) {
   return result;
 }
 
-/** Patches the reviewsPolicy on an existing instance's instanceData. */
-async function setReviewsPolicy(instanceId: string, reviewsPolicy: string) {
-  const instance = await db.query.processInstances.findFirst({
-    where: { id: instanceId },
-  });
-  const instanceData = instance!.instanceData as Record<string, unknown>;
-  await db
-    .update(processInstances)
-    .set({
-      instanceData: {
-        ...instanceData,
-        config: { ...(instanceData.config as object), reviewsPolicy },
-      },
-    })
-    .where(eq(processInstances.id, instanceId));
-}
 
 describe.concurrent('generateReviewAssignments', () => {
   it('full_coverage assigns only members with REVIEW capability, excluding self-review', async ({
@@ -330,9 +319,9 @@ describe.concurrent('generateReviewAssignments', () => {
 
   it('throws for self_selection policy', async ({ task, onTestFinished }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
-    const { instance } = await createReviewInstance(testData);
-
-    await setReviewsPolicy(instance.instance.id, 'self_selection');
+    const { instance } = await createReviewInstance(testData, {
+      reviewsPolicy: 'self_selection',
+    });
 
     await expect(
       generateReviewAssignments({
@@ -402,9 +391,9 @@ describe.concurrent('generateReviewAssignments', () => {
     onTestFinished,
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
-    const { instance } = await createReviewInstance(testData);
-
-    await setReviewsPolicy(instance.instance.id, 'random_assignment');
+    const { instance } = await createReviewInstance(testData, {
+      reviewsPolicy: 'random_assignment',
+    });
 
     await expect(
       generateReviewAssignments({

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -164,29 +164,17 @@ describe.concurrent('generateReviewAssignments', () => {
       testData.createMemberUser({
         organization: setup.organization,
         instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
       }),
       testData.createMemberUser({
         organization: setup.organization,
         instanceProfileIds: [instance.profileId],
       }),
-      testData.createMemberUser({
-        organization: setup.organization,
-        instanceProfileIds: [instance.profileId],
-      }),
-    ]);
-
-    // Give reviewerA and reviewerB the Reviewer role
-    await Promise.all([
-      testData.assignRole(
-        reviewerA.authUserId,
-        instance.profileId,
-        reviewerRole.id,
-      ),
-      testData.assignRole(
-        reviewerB.authUserId,
-        instance.profileId,
-        reviewerRole.id,
-      ),
     ]);
 
     // Create submitted proposals (DB trigger creates history rows on status change)
@@ -321,15 +309,11 @@ describe.concurrent('generateReviewAssignments', () => {
     const { setup, instance } = await createReviewInstance(testData);
 
     const reviewerRole = await createReviewerRole(instance.profileId);
-    const reviewer = await testData.createMemberUser({
+    await testData.createMemberUser({
       organization: setup.organization,
       instanceProfileIds: [instance.profileId],
+      roleIds: { [instance.profileId]: reviewerRole.id },
     });
-    await testData.assignRole(
-      reviewer.authUserId,
-      instance.profileId,
-      reviewerRole.id,
-    );
 
     await testData.createProposal({
       userEmail: setup.userEmail,

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -1,6 +1,7 @@
 import {
   type DecisionInstanceData,
   type DecisionSchemaDefinition,
+  type ReviewsPolicy,
   advancePhase,
   createDecisionRole,
   generateReviewAssignments,
@@ -8,25 +9,13 @@ import {
 import { db, eq } from '@op/db/client';
 import {
   ProcessStatus,
+  ProposalStatus,
   proposalReviewAssignments,
   users,
 } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
-import { appRouter } from '../..';
 import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
-import {
-  createIsolatedSession,
-  createTestContextWithSession,
-} from '../../../test/supabase-utils';
-import { createCallerFactory } from '../../../trpcFactory';
-
-const createCaller = createCallerFactory(appRouter);
-
-async function createAuthenticatedCaller(email: string) {
-  const { session } = await createIsolatedSession(email);
-  return createCaller(await createTestContextWithSession(session));
-}
 
 /**
  * Schema with a review-capable middle phase.
@@ -77,7 +66,7 @@ const decisionSchemaWithReview = {
  */
 async function createReviewInstance(
   testData: TestDecisionsDataManager,
-  { reviewsPolicy = 'full_coverage' as const } = {},
+  { reviewsPolicy = 'full_coverage' }: { reviewsPolicy?: ReviewsPolicy } = {},
 ) {
   const setup = await testData.createDecisionSetup({
     instanceCount: 1,
@@ -159,7 +148,6 @@ async function advanceToReviewPhase(instanceId: string) {
   return result;
 }
 
-
 describe.concurrent('generateReviewAssignments', () => {
   it('full_coverage assigns only members with REVIEW capability, excluding self-review', async ({
     task,
@@ -201,28 +189,20 @@ describe.concurrent('generateReviewAssignments', () => {
       ),
     ]);
 
-    // Create and submit proposals so they have history rows
+    // Create submitted proposals (DB trigger creates history rows on status change)
     const [proposalByA, proposalByC] = await Promise.all([
       testData.createProposal({
         userEmail: reviewerA.email,
         processInstanceId: instance.instance.id,
         proposalData: { title: 'Proposal by Reviewer A' },
+        status: ProposalStatus.SUBMITTED,
       }),
       testData.createProposal({
         userEmail: memberC.email,
         processInstanceId: instance.instance.id,
         proposalData: { title: 'Proposal by Member C' },
+        status: ProposalStatus.SUBMITTED,
       }),
-    ]);
-
-    const [callerA, callerC] = await Promise.all([
-      createAuthenticatedCaller(reviewerA.email),
-      createAuthenticatedCaller(memberC.email),
-    ]);
-
-    await Promise.all([
-      callerA.decision.submitProposal({ proposalId: proposalByA.id }),
-      callerC.decision.submitProposal({ proposalId: proposalByC.id }),
     ]);
 
     // Advance submission → review to get transitionHistoryId + transition proposal rows
@@ -351,14 +331,12 @@ describe.concurrent('generateReviewAssignments', () => {
       reviewerRole.id,
     );
 
-    const proposal = await testData.createProposal({
+    await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
       proposalData: { title: 'Idempotency proposal' },
+      status: ProposalStatus.SUBMITTED,
     });
-
-    const caller = await createAuthenticatedCaller(setup.userEmail);
-    await caller.decision.submitProposal({ proposalId: proposal.id });
 
     const advanceResult = await advanceToReviewPhase(instance.instance.id);
 

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -1,0 +1,392 @@
+import {
+  createDecisionRole,
+  generateReviewAssignments,
+  type DecisionSchemaDefinition,
+} from '@op/common';
+import { db, eq } from '@op/db/client';
+import {
+  ProcessStatus,
+  decisionProcesses,
+  processInstances,
+  profileUserToAccessRoles,
+  proposalReviewAssignments,
+  users,
+} from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+
+/**
+ * Schema with a review-capable middle phase.
+ * submission → review (proposals.review: true) → results
+ */
+const reviewSchema = {
+  id: 'review-test-schema',
+  version: '1.0.0',
+  name: 'Review Test Schema',
+  description: 'Schema with a review phase for testing',
+  config: {
+    reviewsPolicy: 'full_coverage' as const,
+  },
+  proposalTemplate: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        title: 'Title',
+        'x-format': 'short-text',
+      },
+    },
+    required: ['title'],
+    'x-field-order': ['title'],
+  },
+  phases: [
+    {
+      id: 'submission',
+      name: 'Submission',
+      description: 'Submit proposals',
+      rules: {
+        proposals: { submit: true },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'review',
+      name: 'Review',
+      description: 'Review proposals',
+      rules: {
+        proposals: { review: true },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'results',
+      name: 'Results',
+      description: 'Final results',
+      rules: {
+        proposals: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+  ],
+} satisfies DecisionSchemaDefinition;
+
+/**
+ * Creates a published decision instance from the review schema.
+ * Returns the instance, its profileId, and the creating user's personal profileId.
+ */
+async function createReviewInstance(testData: TestDecisionsDataManager) {
+  const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+  const [userRecord] = await db
+    .select({ profileId: users.profileId })
+    .from(users)
+    .where(eq(users.authUserId, setup.user.id));
+
+  const [processRecord] = await db
+    .insert(decisionProcesses)
+    .values({
+      name: `Review Process ${setup.userEmail}`,
+      description: 'Test review process',
+      processSchema: reviewSchema,
+      createdByProfileId: userRecord!.profileId!,
+    })
+    .returning();
+
+  const created = await testData.createInstanceForProcess({
+    processId: processRecord!.id,
+    user: setup.user,
+    name: 'Review Instance',
+    status: ProcessStatus.PUBLISHED,
+  });
+
+  return { setup, instance: created, creatorProfileId: userRecord!.profileId! };
+}
+
+/**
+ * Creates a "Reviewer" role on the given decision profile with the REVIEW bit set.
+ */
+async function createReviewerRole(instanceProfileId: string) {
+  return createDecisionRole({
+    name: 'Reviewer',
+    profileId: instanceProfileId,
+    permissions: {
+      decisions: {
+        type: 'decision',
+        value: {
+          create: false,
+          read: true,
+          update: false,
+          delete: false,
+          admin: false,
+          inviteMembers: false,
+          review: true,
+          submitProposals: false,
+          vote: false,
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Assigns an additional role to a user on a specific decision profile.
+ */
+async function assignRole(
+  authUserId: string,
+  instanceProfileId: string,
+  roleId: string,
+) {
+  const profileUser = await db.query.profileUsers.findFirst({
+    where: {
+      authUserId,
+      profileId: instanceProfileId,
+    },
+  });
+
+  if (!profileUser) {
+    throw new Error(
+      `No profileUser found for authUserId=${authUserId} on profile=${instanceProfileId}`,
+    );
+  }
+
+  await db.insert(profileUserToAccessRoles).values({
+    profileUserId: profileUser.id,
+    accessRoleId: roleId,
+  });
+}
+
+/** Patches the reviewsPolicy on an existing instance's instanceData. */
+async function setReviewsPolicy(
+  instanceId: string,
+  reviewsPolicy: string,
+) {
+  const instance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+  const instanceData = instance!.instanceData as Record<string, unknown>;
+  await db
+    .update(processInstances)
+    .set({
+      instanceData: {
+        ...instanceData,
+        config: { ...(instanceData.config as object), reviewsPolicy },
+      },
+    })
+    .where(eq(processInstances.id, instanceId));
+}
+
+describe.concurrent('generateReviewAssignments', () => {
+  it('full_coverage assigns only members with REVIEW capability, excluding self-review', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance, creatorProfileId } =
+      await createReviewInstance(testData);
+
+    const reviewerRole = await createReviewerRole(instance.profileId);
+
+    // Create 3 members: reviewerA, reviewerB (both with REVIEW), memberC (no REVIEW)
+    const [reviewerA, reviewerB, memberC] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+    ]);
+
+    // Give reviewerA and reviewerB the Reviewer role
+    await Promise.all([
+      assignRole(reviewerA.authUserId, instance.profileId, reviewerRole.id),
+      assignRole(reviewerB.authUserId, instance.profileId, reviewerRole.id),
+    ]);
+
+    // Create proposals: one by reviewerA, one by memberC
+    const [proposalByA, proposalByC] = await Promise.all([
+      testData.createProposal({
+        userEmail: reviewerA.email,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Proposal by Reviewer A' },
+      }),
+      testData.createProposal({
+        userEmail: memberC.email,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Proposal by Member C' },
+      }),
+    ]);
+
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: [proposalByA.id, proposalByC.id],
+    });
+
+    const assignments = await db
+      .select()
+      .from(proposalReviewAssignments)
+      .where(
+        eq(
+          proposalReviewAssignments.processInstanceId,
+          instance.instance.id,
+        ),
+      );
+
+    const assignmentsByReviewer = new Map<string, string[]>();
+    for (const a of assignments) {
+      const existing = assignmentsByReviewer.get(a.reviewerProfileId) ?? [];
+      existing.push(a.proposalId);
+      assignmentsByReviewer.set(a.reviewerProfileId, existing);
+    }
+
+    // Exact set of reviewers who should appear — and no one else.
+    // creatorAdmin has REVIEW via createDefaultDecisionRoles.
+    // reviewerA and reviewerB have REVIEW via the custom Reviewer role.
+    // memberC has only the Member role (no REVIEW) — must be absent.
+    const expectedReviewerIds = new Set([
+      creatorProfileId,
+      reviewerA.profileId,
+      reviewerB.profileId,
+    ]);
+    const excludedProfileIds = [memberC.profileId];
+
+    const actualReviewerIds = new Set(assignmentsByReviewer.keys());
+    expect(actualReviewerIds).toEqual(expectedReviewerIds);
+
+    for (const excluded of excludedProfileIds) {
+      expect(assignmentsByReviewer.has(excluded)).toBe(false);
+    }
+
+    // Per-reviewer assignment breakdown:
+    // creatorAdmin: both proposals (authored neither)
+    expect(assignmentsByReviewer.get(creatorProfileId)).toHaveLength(2);
+    expect(assignmentsByReviewer.get(creatorProfileId)).toEqual(
+      expect.arrayContaining([proposalByA.id, proposalByC.id]),
+    );
+
+    // reviewerA: only proposalByC (self-review excluded for proposalByA)
+    expect(assignmentsByReviewer.get(reviewerA.profileId)).toEqual([
+      proposalByC.id,
+    ]);
+
+    // reviewerB: both proposals
+    expect(assignmentsByReviewer.get(reviewerB.profileId)).toHaveLength(2);
+    expect(assignmentsByReviewer.get(reviewerB.profileId)).toEqual(
+      expect.arrayContaining([proposalByA.id, proposalByC.id]),
+    );
+
+    expect(assignments).toHaveLength(5);
+  });
+
+  it('does nothing when selectedProposalIds is empty', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instance } = await createReviewInstance(testData);
+
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: [],
+    });
+
+    const assignments = await db
+      .select()
+      .from(proposalReviewAssignments)
+      .where(
+        eq(
+          proposalReviewAssignments.processInstanceId,
+          instance.instance.id,
+        ),
+      );
+
+    expect(assignments).toHaveLength(0);
+  });
+
+  it('throws for self_selection policy', async ({ task, onTestFinished }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instance } = await createReviewInstance(testData);
+
+    await setReviewsPolicy(instance.instance.id, 'self_selection');
+
+    await expect(
+      generateReviewAssignments({
+        instanceId: instance.instance.id,
+        phaseId: 'review',
+        selectedProposalIds: ['any-id'],
+      }),
+    ).rejects.toThrow('not implemented');
+  });
+
+  it('is idempotent — calling twice does not duplicate rows', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(testData);
+
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const reviewer = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    await assignRole(reviewer.authUserId, instance.profileId, reviewerRole.id);
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Idempotency proposal' },
+    });
+
+    const input = {
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: [proposal.id],
+    };
+
+    await generateReviewAssignments(input);
+    await generateReviewAssignments(input);
+
+    const assignments = await db
+      .select()
+      .from(proposalReviewAssignments)
+      .where(
+        eq(
+          proposalReviewAssignments.processInstanceId,
+          instance.instance.id,
+        ),
+      );
+
+    // Each reviewer should appear exactly once per proposal, not duplicated.
+    const uniquePairs = new Set(
+      assignments.map((a) => `${a.reviewerProfileId}:${a.proposalId}`),
+    );
+    expect(assignments).toHaveLength(uniquePairs.size);
+  });
+
+  it('throws for random_assignment policy', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instance } = await createReviewInstance(testData);
+
+    await setReviewsPolicy(instance.instance.id, 'random_assignment');
+
+    await expect(
+      generateReviewAssignments({
+        instanceId: instance.instance.id,
+        phaseId: 'review',
+        selectedProposalIds: ['any-id'],
+      }),
+    ).rejects.toThrow('not implemented');
+  });
+});

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -1,7 +1,9 @@
 import {
+  type DecisionInstanceData,
+  type DecisionSchemaDefinition,
+  advancePhase,
   createDecisionRole,
   generateReviewAssignments,
-  type DecisionSchemaDefinition,
 } from '@op/common';
 import { db, eq } from '@op/db/client';
 import {
@@ -14,7 +16,20 @@ import {
 } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
+import { appRouter } from '../..';
 import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
 
 /**
  * Schema with a review-capable middle phase.
@@ -27,18 +42,6 @@ const reviewSchema = {
   description: 'Schema with a review phase for testing',
   config: {
     reviewsPolicy: 'full_coverage' as const,
-  },
-  proposalTemplate: {
-    type: 'object',
-    properties: {
-      title: {
-        type: 'string',
-        title: 'Title',
-        'x-format': 'short-text',
-      },
-    },
-    required: ['title'],
-    'x-field-order': ['title'],
   },
   phases: [
     {
@@ -156,11 +159,41 @@ async function assignRole(
   });
 }
 
+/**
+ * Advances the instance from submission → review via advancePhase inside a
+ * transaction and returns the non-conflict result.
+ */
+async function advanceToReviewPhase(instanceId: string) {
+  const dbInstance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+
+  if (!dbInstance) {
+    throw new Error('Instance not found');
+  }
+
+  const result = await db.transaction(async (tx) =>
+    advancePhase({
+      tx,
+      instance: {
+        id: dbInstance.id,
+        instanceData: dbInstance.instanceData as DecisionInstanceData,
+      },
+      fromPhaseId: 'submission',
+      toPhaseId: 'review',
+      triggeredByProfileId: null,
+    }),
+  );
+
+  if (result.conflict) {
+    throw new Error('Unexpected conflict during advance');
+  }
+
+  return result;
+}
+
 /** Patches the reviewsPolicy on an existing instance's instanceData. */
-async function setReviewsPolicy(
-  instanceId: string,
-  reviewsPolicy: string,
-) {
+async function setReviewsPolicy(instanceId: string, reviewsPolicy: string) {
   const instance = await db.query.processInstances.findFirst({
     where: { id: instanceId },
   });
@@ -209,7 +242,7 @@ describe.concurrent('generateReviewAssignments', () => {
       assignRole(reviewerB.authUserId, instance.profileId, reviewerRole.id),
     ]);
 
-    // Create proposals: one by reviewerA, one by memberC
+    // Create and submit proposals so they have history rows
     const [proposalByA, proposalByC] = await Promise.all([
       testData.createProposal({
         userEmail: reviewerA.email,
@@ -223,20 +256,31 @@ describe.concurrent('generateReviewAssignments', () => {
       }),
     ]);
 
+    const [callerA, callerC] = await Promise.all([
+      createAuthenticatedCaller(reviewerA.email),
+      createAuthenticatedCaller(memberC.email),
+    ]);
+
+    await Promise.all([
+      callerA.decision.submitProposal({ proposalId: proposalByA.id }),
+      callerC.decision.submitProposal({ proposalId: proposalByC.id }),
+    ]);
+
+    // Advance submission → review to get transitionHistoryId + transition proposal rows
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+
     await generateReviewAssignments({
       instanceId: instance.instance.id,
       phaseId: 'review',
-      selectedProposalIds: [proposalByA.id, proposalByC.id],
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
     });
 
     const assignments = await db
       .select()
       .from(proposalReviewAssignments)
       .where(
-        eq(
-          proposalReviewAssignments.processInstanceId,
-          instance.instance.id,
-        ),
+        eq(proposalReviewAssignments.processInstanceId, instance.instance.id),
       );
 
     const assignmentsByReviewer = new Map<string, string[]>();
@@ -283,6 +327,11 @@ describe.concurrent('generateReviewAssignments', () => {
     );
 
     expect(assignments).toHaveLength(5);
+
+    // Every assignment should have a pinned proposal history snapshot
+    for (const a of assignments) {
+      expect(a.assignedProposalHistoryId).not.toBeNull();
+    }
   });
 
   it('does nothing when selectedProposalIds is empty', async ({
@@ -296,16 +345,14 @@ describe.concurrent('generateReviewAssignments', () => {
       instanceId: instance.instance.id,
       phaseId: 'review',
       selectedProposalIds: [],
+      transitionHistoryId: 'irrelevant',
     });
 
     const assignments = await db
       .select()
       .from(proposalReviewAssignments)
       .where(
-        eq(
-          proposalReviewAssignments.processInstanceId,
-          instance.instance.id,
-        ),
+        eq(proposalReviewAssignments.processInstanceId, instance.instance.id),
       );
 
     expect(assignments).toHaveLength(0);
@@ -322,6 +369,7 @@ describe.concurrent('generateReviewAssignments', () => {
         instanceId: instance.instance.id,
         phaseId: 'review',
         selectedProposalIds: ['any-id'],
+        transitionHistoryId: 'irrelevant',
       }),
     ).rejects.toThrow('not implemented');
   });
@@ -346,10 +394,16 @@ describe.concurrent('generateReviewAssignments', () => {
       proposalData: { title: 'Idempotency proposal' },
     });
 
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+    await caller.decision.submitProposal({ proposalId: proposal.id });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+
     const input = {
       instanceId: instance.instance.id,
       phaseId: 'review',
-      selectedProposalIds: [proposal.id],
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
     };
 
     await generateReviewAssignments(input);
@@ -359,10 +413,7 @@ describe.concurrent('generateReviewAssignments', () => {
       .select()
       .from(proposalReviewAssignments)
       .where(
-        eq(
-          proposalReviewAssignments.processInstanceId,
-          instance.instance.id,
-        ),
+        eq(proposalReviewAssignments.processInstanceId, instance.instance.id),
       );
 
     // Each reviewer should appear exactly once per proposal, not duplicated.
@@ -386,6 +437,7 @@ describe.concurrent('generateReviewAssignments', () => {
         instanceId: instance.instance.id,
         phaseId: 'review',
         selectedProposalIds: ['any-id'],
+        transitionHistoryId: 'irrelevant',
       }),
     ).rejects.toThrow('not implemented');
   });

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -475,9 +475,12 @@ export class TestDecisionsDataManager {
   async createMemberUser({
     organization,
     instanceProfileIds = [],
+    roleIds = {},
   }: {
     organization: { id: string };
     instanceProfileIds?: string[];
+    /** Map of profileId → roleId to assign after granting profile access. */
+    roleIds?: Record<string, string>;
   }): Promise<MemberUserOutput> {
     this.ensureCleanupRegistered();
 
@@ -528,6 +531,11 @@ export class TestDecisionsDataManager {
     // Grant access to instance profiles if provided (member role, not admin)
     for (const profileId of instanceProfileIds) {
       await this.grantProfileAccess(profileId, authUser.id, email, false);
+    }
+
+    // Assign additional roles on specific profiles
+    for (const [profileId, roleId] of Object.entries(roleIds)) {
+      await this.assignRole(authUser.id, profileId, roleId);
     }
 
     const user: User = {

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -12,6 +12,7 @@ import {
   ProposalStatus,
   decisionProcesses,
   processInstances,
+  profileUserToAccessRoles,
   profiles,
   proposals,
   users,
@@ -43,6 +44,8 @@ interface CreateDecisionSetupOptions {
   status?: ProcessStatus;
   /** JSON Schema to validate proposal data against on submit/update */
   proposalTemplate?: Record<string, unknown>;
+  /** Custom process schema definition. Defaults to testMinimalSchema. */
+  processSchema?: DecisionSchemaDefinition;
 }
 
 type EncodedProcessInstance = z.infer<typeof processInstanceWithSchemaEncoder>;
@@ -163,6 +166,7 @@ export class TestDecisionsDataManager {
       grantAccess = false,
       status,
       proposalTemplate,
+      processSchema,
     } = opts || {};
 
     // 1. Create test user
@@ -226,7 +230,7 @@ export class TestDecisionsDataManager {
 
     // 3. Create decision process via direct DB insert with the new schema format
     const newProcessSchema = {
-      ...testMinimalSchema,
+      ...(processSchema ?? testMinimalSchema),
       name: processName,
       ...(proposalTemplate ? { proposalTemplate } : {}),
     };
@@ -421,6 +425,33 @@ export class TestDecisionsDataManager {
       authUserId,
       email,
       isAdmin,
+    });
+  }
+
+  /**
+   * Assigns an access role to a user on a specific decision profile.
+   */
+  async assignRole(
+    authUserId: string,
+    profileId: string,
+    roleId: string,
+  ): Promise<void> {
+    const profileUser = await db.query.profileUsers.findFirst({
+      where: {
+        authUserId,
+        profileId,
+      },
+    });
+
+    if (!profileUser) {
+      throw new Error(
+        `No profileUser found for authUserId=${authUserId} on profile=${profileId}`,
+      );
+    }
+
+    await db.insert(profileUserToAccessRoles).values({
+      profileUserId: profileUser.id,
+      accessRoleId: roleId,
     });
   }
 


### PR DESCRIPTION
Automatically generate review assignment rows when a decision instance transitions into a review-capable phase.

feat(reviews): add generateReviewAssignments with REVIEW capability filtering
refactor(decisions): extract onPhaseAdvanced hook to centralise post-advance side-effects