### PR TITLE
feat(reviews): add list proposal revision requested endpoint and homepage notifications

### DIFF
--- a/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
+++ b/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
@@ -114,6 +114,7 @@ const RevisionRequestRow = ({
 
   const { proposal } = item;
   const title = proposal.profile.name;
+  // TODO: link to revision editor view — will be addressed in a coming PR
   const editHref = `/decisions/${item.decisionProfileSlug}/proposal/${proposal.profileId}/edit`;
 
   return (

--- a/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
+++ b/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
@@ -112,8 +112,8 @@ const RevisionRequestRow = ({
   }
 
   const { proposal } = item;
-  const title = proposal.proposalData.title ?? '';
-  const editHref = `/profile/${item.decisionProfileSlug}/decisions/${proposal.processInstanceId}/proposal/${proposal.profileId}/edit`;
+  const title = proposal.profile.name;
+  const editHref = `/decisions/${item.decisionProfileSlug}/proposal/${proposal.profileId}/edit`;
 
   return (
     <NotificationPanelItem>

--- a/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
+++ b/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
@@ -2,8 +2,9 @@
 
 import { trpc } from '@op/api/client';
 import { ProcessStatus } from '@op/api/encoders';
+import type { ProposalRevisionRequestItem } from '@op/common/client';
 import { getTextPreview } from '@op/core';
-import { ButtonLink } from '@op/ui/Button';
+import { Button, ButtonLink } from '@op/ui/Button';
 import {
   NotificationPanel,
   NotificationPanelActions,
@@ -13,6 +14,7 @@ import {
 } from '@op/ui/NotificationPanel';
 import { ProfileItem } from '@op/ui/ProfileItem';
 import { Suspense, useState } from 'react';
+import { LuPenLine } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -29,7 +31,10 @@ const ActiveDecisionsNotificationsSuspense = () => {
       limit: 10,
     });
 
-  const count = decisions.length;
+  const [{ revisionRequests }] =
+    trpc.decision.listProposalsRevisionRequests.useSuspenseQuery({});
+
+  const count = decisions.length + revisionRequests.length;
 
   if (count === 0) {
     return null;
@@ -39,6 +44,9 @@ const ActiveDecisionsNotificationsSuspense = () => {
     <NotificationPanel>
       <NotificationPanelHeader title={t('Active Decisions')} count={count} />
       <NotificationPanelList>
+        {revisionRequests.map((item) => (
+          <RevisionRequestRow key={item.revisionRequest.id} item={item} />
+        ))}
         {decisions.map((decision) => {
           const instance = decision.processInstance;
           const description = instance?.description;
@@ -81,5 +89,60 @@ export const ActiveDecisionsNotifications = () => {
         <ActiveDecisionsNotificationsSuspense />
       </Suspense>
     </ErrorBoundary>
+  );
+};
+
+const RevisionRequestIcon = () => (
+  <div className="flex size-12 shrink-0 items-center justify-center rounded-full bg-primary-orange2/10 text-primary-orange2">
+    <LuPenLine className="size-6" />
+  </div>
+);
+
+const RevisionRequestRow = ({
+  item,
+}: {
+  item: ProposalRevisionRequestItem;
+}) => {
+  const t = useTranslations();
+  const [dismissed, setDismissed] = useState(false);
+  const [navigating, setNavigating] = useState(false);
+
+  if (dismissed) {
+    return null;
+  }
+
+  const { proposal } = item;
+  const title = proposal.proposalData.title ?? '';
+  const editHref = `/profile/${item.decisionProfileSlug}/decisions/${proposal.processInstanceId}/proposal/${proposal.profileId}/edit`;
+
+  return (
+    <NotificationPanelItem>
+      <ProfileItem
+        avatar={<RevisionRequestIcon />}
+        title={t('Revision Request')}
+        description={t('A reviewer has requested changes to {proposalName}', {
+          proposalName: title,
+        })}
+      />
+      <NotificationPanelActions>
+        <Button
+          size="small"
+          color="secondary"
+          className="w-full sm:w-auto"
+          onPress={() => setDismissed(true)}
+        >
+          {t('Ignore')}
+        </Button>
+        <ButtonLink
+          size="small"
+          className="w-full sm:w-auto"
+          href={editHref}
+          onPress={() => setNavigating(true)}
+          isLoading={navigating}
+        >
+          {t('Revise proposal')}
+        </ButtonLink>
+      </NotificationPanelActions>
+    </NotificationPanelItem>
   );
 };

--- a/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
+++ b/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
@@ -25,14 +25,14 @@ const ActiveDecisionsNotificationsSuspense = () => {
   const t = useTranslations();
   const [navigatingId, setNavigatingId] = useState<string | null>(null);
 
-  const [{ items: decisions }] =
-    trpc.decision.listDecisionProfiles.useSuspenseQuery({
-      status: [ProcessStatus.PUBLISHED],
-      limit: 10,
-    });
-
-  const [{ revisionRequests }] =
-    trpc.decision.listProposalsRevisionRequests.useSuspenseQuery({});
+  const [[{ items: decisions }, { revisionRequests }]] =
+    trpc.useSuspenseQueries((t) => [
+      t.decision.listDecisionProfiles({
+        status: [ProcessStatus.PUBLISHED],
+        limit: 10,
+      }),
+      t.decision.listProposalsRevisionRequests({}),
+    ]);
 
   const count = decisions.length + revisionRequests.length;
 

--- a/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
+++ b/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
@@ -107,6 +107,7 @@ const RevisionRequestRow = ({
   const [dismissed, setDismissed] = useState(false);
   const [navigating, setNavigating] = useState(false);
 
+  // TODO: persist dismiss state and navigate to proposal edit — will be addressed in a coming PR
   if (dismissed) {
     return null;
   }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1097,5 +1097,9 @@
   "Filter by status": "স্ট্যাটাস অনুযায়ী ফিল্টার",
   "Sort order": "সাজানোর ক্রম",
   "{count} Reviewed": "{count} পর্যালোচিত",
-  "{count} of {total} completed": "{count} / {total} সম্পন্ন"
+  "{count} of {total} completed": "{count} / {total} সম্পন্ন",
+  "Revision Request": "সংশোধনের অনুরোধ",
+  "A reviewer has requested changes to {proposalName}": "একজন পর্যালোচক {proposalName}-এ পরিবর্তনের অনুরোধ করেছেন",
+  "Revise proposal": "প্রস্তাব সংশোধন করুন",
+  "Ignore": "উপেক্ষা করুন"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1126,5 +1126,9 @@
   "Filter by status": "Filter by status",
   "Sort order": "Sort order",
   "{count} Reviewed": "{count} Reviewed",
-  "{count} of {total} completed": "{count} of {total} completed"
+  "{count} of {total} completed": "{count} of {total} completed",
+  "Revision Request": "Revision Request",
+  "A reviewer has requested changes to {proposalName}": "A reviewer has requested changes to {proposalName}",
+  "Revise proposal": "Revise proposal",
+  "Ignore": "Ignore"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1096,5 +1096,9 @@
   "Filter by status": "Filtrar por estado",
   "Sort order": "Orden",
   "{count} Reviewed": "{count} Revisados",
-  "{count} of {total} completed": "{count} de {total} completados"
+  "{count} of {total} completed": "{count} de {total} completados",
+  "Revision Request": "Solicitud de revisión",
+  "A reviewer has requested changes to {proposalName}": "Un revisor ha solicitado cambios en {proposalName}",
+  "Revise proposal": "Revisar propuesta",
+  "Ignore": "Ignorar"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1096,5 +1096,9 @@
   "Filter by status": "Filtrer par statut",
   "Sort order": "Ordre de tri",
   "{count} Reviewed": "{count} Examinés",
-  "{count} of {total} completed": "{count} sur {total} terminés"
+  "{count} of {total} completed": "{count} sur {total} terminés",
+  "Revision Request": "Demande de révision",
+  "A reviewer has requested changes to {proposalName}": "Un examinateur a demandé des modifications à {proposalName}",
+  "Revise proposal": "Réviser la proposition",
+  "Ignore": "Ignorer"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1096,5 +1096,9 @@
   "Filter by status": "Filtrar por status",
   "Sort order": "Ordenar",
   "{count} Reviewed": "{count} Revisados",
-  "{count} of {total} completed": "{count} de {total} concluídos"
+  "{count} of {total} completed": "{count} de {total} concluídos",
+  "Revision Request": "Solicitação de revisão",
+  "A reviewer has requested changes to {proposalName}": "Um revisor solicitou alterações em {proposalName}",
+  "Revise proposal": "Revisar proposta",
+  "Ignore": "Ignorar"
 }

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -58,6 +58,7 @@ export * from './listReviewAssignments';
 export * from './submitReview';
 export * from './requestRevision';
 export * from './cancelRevisionRequest';
+export * from './listProposalsRevisionRequests';
 export * from './deleteProposal';
 export * from './deleteDecision';
 export * from './getProcessCategories';

--- a/packages/common/src/services/decision/listProposalsRevisionRequests.ts
+++ b/packages/common/src/services/decision/listProposalsRevisionRequests.ts
@@ -18,15 +18,15 @@ export async function listProposalsRevisionRequests({
   proposalId?: string;
   user: User;
 }) {
-  const dbUser = await assertUserByAuthId(user.id);
+  const commonUser = await assertUserByAuthId(user.id);
 
-  if (!dbUser.profileId) {
+  if (!commonUser.profileId) {
     throw new UnauthorizedError('User must have an active profile');
   }
 
   const proposals = await db.query.proposals.findMany({
     where: {
-      submittedByProfileId: dbUser.profileId,
+      submittedByProfileId: commonUser.profileId,
       ...(proposalId && { id: proposalId }),
     },
     with: {

--- a/packages/common/src/services/decision/listProposalsRevisionRequests.ts
+++ b/packages/common/src/services/decision/listProposalsRevisionRequests.ts
@@ -1,0 +1,75 @@
+import { db } from '@op/db/client';
+import { ProposalReviewRequestState } from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+
+import { UnauthorizedError } from '../../utils';
+import { assertUserByAuthId } from '../assert';
+import {
+  type ProposalRevisionRequestList,
+  proposalRevisionRequestListSchema,
+} from './schemas/reviews';
+
+/**
+ * Lists all pending revision requests across proposals authored by the current user.
+ * Optionally filters to a single proposal when `proposalId` is provided.
+ */
+export async function listProposalsRevisionRequests({
+  proposalId,
+  user,
+}: {
+  proposalId?: string;
+  user: User;
+}): Promise<ProposalRevisionRequestList> {
+  const dbUser = await assertUserByAuthId(user.id);
+
+  if (!dbUser.profileId) {
+    throw new UnauthorizedError('User must have an active profile');
+  }
+
+  const proposals = await db.query.proposals.findMany({
+    where: {
+      submittedByProfileId: dbUser.profileId,
+      ...(proposalId && { id: proposalId }),
+    },
+    with: {
+      submittedBy: {
+        with: {
+          avatarImage: true,
+        },
+      },
+      profile: true,
+      processInstance: {
+        columns: {},
+        with: {
+          profile: {
+            columns: { slug: true },
+          },
+        },
+      },
+      reviewAssignments: {
+        columns: {},
+        with: {
+          requests: {
+            where: {
+              state: ProposalReviewRequestState.REQUESTED,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const revisionRequests = proposals.flatMap((proposal) => {
+    const decisionProfileSlug = proposal.processInstance.profile?.slug ?? '';
+
+    return proposal.reviewAssignments.flatMap((assignment) =>
+      assignment.requests.map((request) => ({
+        revisionRequest: request,
+        proposal,
+        decisionProfileSlug,
+      })),
+    );
+  });
+
+  return proposalRevisionRequestListSchema.parse({ revisionRequests });
+}

--- a/packages/common/src/services/decision/listProposalsRevisionRequests.ts
+++ b/packages/common/src/services/decision/listProposalsRevisionRequests.ts
@@ -4,14 +4,12 @@ import type { User } from '@op/supabase/lib';
 
 import { UnauthorizedError } from '../../utils';
 import { assertUserByAuthId } from '../assert';
-import {
-  type ProposalRevisionRequestList,
-  proposalRevisionRequestListSchema,
-} from './schemas/reviews';
 
 /**
  * Lists all pending revision requests across proposals authored by the current user.
  * Optionally filters to a single proposal when `proposalId` is provided.
+ *
+ * Returns raw data — encoding is handled by the API router.
  */
 export async function listProposalsRevisionRequests({
   proposalId,
@@ -19,7 +17,7 @@ export async function listProposalsRevisionRequests({
 }: {
   proposalId?: string;
   user: User;
-}): Promise<ProposalRevisionRequestList> {
+}) {
   const dbUser = await assertUserByAuthId(user.id);
 
   if (!dbUser.profileId) {
@@ -47,7 +45,7 @@ export async function listProposalsRevisionRequests({
         },
       },
       reviewAssignments: {
-        columns: {},
+        columns: { id: true },
         with: {
           requests: {
             where: {
@@ -71,5 +69,9 @@ export async function listProposalsRevisionRequests({
     );
   });
 
-  return proposalRevisionRequestListSchema.parse({ revisionRequests });
+  const assignmentIds = revisionRequests.map(
+    (r) => r.revisionRequest.assignmentId,
+  );
+
+  return { revisionRequests, assignmentIds };
 }

--- a/packages/common/src/services/decision/listProposalsRevisionRequests.ts
+++ b/packages/common/src/services/decision/listProposalsRevisionRequests.ts
@@ -69,9 +69,9 @@ export async function listProposalsRevisionRequests({
     );
   });
 
-  const assignmentIds = revisionRequests.map(
-    (r) => r.revisionRequest.assignmentId,
+  const processInstanceIds = Array.from(
+    new Set(proposals.map((proposal) => proposal.processInstanceId)),
   );
 
-  return { revisionRequests, assignmentIds };
+  return { revisionRequests, processInstanceIds };
 }

--- a/packages/common/src/services/decision/schemas/reviews.ts
+++ b/packages/common/src/services/decision/schemas/reviews.ts
@@ -64,6 +64,18 @@ export const reviewAssignmentListSchema = z.object({
   assignments: z.array(reviewAssignmentExtendedSchema),
 });
 
+// ── Proposal-scoped revision request schemas ──────────────────────────
+
+export const proposalRevisionRequestItemSchema = z.object({
+  revisionRequest: proposalReviewRequestSchema,
+  proposal: proposalSchema,
+  decisionProfileSlug: z.string(),
+});
+
+export const proposalRevisionRequestListSchema = z.object({
+  revisionRequests: z.array(proposalRevisionRequestItemSchema),
+});
+
 // ── Types ───────────────────────────────────────────────────────────────
 
 export type ProposalReviewAssignment = z.infer<
@@ -75,3 +87,9 @@ export type ReviewAssignmentExtended = z.infer<
   typeof reviewAssignmentExtendedSchema
 >;
 export type ReviewAssignmentList = z.infer<typeof reviewAssignmentListSchema>;
+export type ProposalRevisionRequestItem = z.infer<
+  typeof proposalRevisionRequestItemSchema
+>;
+export type ProposalRevisionRequestList = z.infer<
+  typeof proposalRevisionRequestListSchema
+>;

--- a/services/api/src/routers/decision/reviews/index.ts
+++ b/services/api/src/routers/decision/reviews/index.ts
@@ -1,6 +1,7 @@
 import { mergeRouters } from '../../../trpcFactory';
 import { cancelRevisionRequestRouter } from './cancelRevisionRequest';
 import { getReviewAssignmentRouter } from './getReviewAssignment';
+import { listProposalsRevisionRequestsRouter } from './listProposalsRevisionRequests';
 import { listReviewAssignmentsRouter } from './listReviewAssignments';
 import { requestRevisionRouter } from './requestRevision';
 import { submitReviewRouter } from './submitReview';
@@ -8,6 +9,7 @@ import { submitReviewRouter } from './submitReview';
 export const reviewsRouter = mergeRouters(
   cancelRevisionRequestRouter,
   getReviewAssignmentRouter,
+  listProposalsRevisionRequestsRouter,
   listReviewAssignmentsRouter,
   requestRevisionRouter,
   submitReviewRouter,

--- a/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.test.ts
+++ b/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.test.ts
@@ -1,0 +1,183 @@
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+} from '@op/db/schema';
+import { createRevisionRequest } from '@op/test';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestReviewsDataManager } from '../../../test/helpers/TestReviewsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+describe.concurrent('listProposalsRevisionRequests', () => {
+  it('returns pending revision requests for the proposal author', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Budget Proposal',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    const revisionRequest = await createRevisionRequest({
+      assignmentId: created.assignment.id,
+      requestComment: 'Please add a detailed budget breakdown.',
+    });
+
+    const authorCaller = await createAuthenticatedCaller(created.author.email);
+    const result = await authorCaller.decision.listProposalsRevisionRequests(
+      {},
+    );
+
+    expect(result.revisionRequests).toHaveLength(1);
+    expect(result.revisionRequests[0]).toMatchObject({
+      revisionRequest: {
+        id: revisionRequest.id,
+        assignmentId: created.assignment.id,
+        state: ProposalReviewRequestState.REQUESTED,
+        requestComment: 'Please add a detailed budget breakdown.',
+      },
+      proposal: {
+        id: created.proposal.id,
+        processInstanceId: created.context.instance.instance.id,
+        profileId: created.proposal.profileId,
+      },
+    });
+    expect(result.revisionRequests[0]?.proposal.proposalData.title).toBe(
+      'Budget Proposal',
+    );
+    expect(result.revisionRequests[0]?.decisionProfileSlug).toBeTruthy();
+  });
+
+  it('filters by proposalId when provided', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const first = await testData.createReviewAssignment({
+      title: 'First Proposal',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    const second = await testData.createReviewAssignment({
+      context: first.context,
+      author: first.author,
+      title: 'Second Proposal',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    await Promise.all([
+      createRevisionRequest({
+        assignmentId: first.assignment.id,
+        requestComment: 'Fix first proposal',
+      }),
+      createRevisionRequest({
+        assignmentId: second.assignment.id,
+        requestComment: 'Fix second proposal',
+      }),
+    ]);
+
+    const authorCaller = await createAuthenticatedCaller(first.author.email);
+    const result = await authorCaller.decision.listProposalsRevisionRequests({
+      proposalId: first.proposal.id,
+    });
+
+    expect(result.revisionRequests).toHaveLength(1);
+    expect(result.revisionRequests[0]?.proposal.id).toBe(first.proposal.id);
+    expect(result.revisionRequests[0]?.proposal.proposalData.title).toBe(
+      'First Proposal',
+    );
+  });
+
+  it('returns empty list when no revision requests exist', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'No Revisions Needed',
+    });
+
+    const authorCaller = await createAuthenticatedCaller(created.author.email);
+    const result = await authorCaller.decision.listProposalsRevisionRequests(
+      {},
+    );
+
+    expect(result.revisionRequests).toHaveLength(0);
+  });
+
+  it('excludes cancelled and resolved revision requests', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Mixed States',
+      status: ProposalReviewAssignmentStatus.IN_PROGRESS,
+    });
+
+    // Create a revision request then cancel it via the reviewer
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    const request = await reviewerCaller.decision.requestRevision({
+      assignmentId: created.assignment.id,
+      requestComment: 'Will be cancelled',
+    });
+
+    await reviewerCaller.decision.cancelRevisionRequest({
+      assignmentId: created.assignment.id,
+      revisionRequestId: request.id,
+    });
+
+    const authorCaller = await createAuthenticatedCaller(created.author.email);
+    const result = await authorCaller.decision.listProposalsRevisionRequests(
+      {},
+    );
+
+    expect(result.revisionRequests).toHaveLength(0);
+  });
+
+  it('does not return revision requests for proposals by other authors', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Not My Proposal',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    await createRevisionRequest({
+      assignmentId: created.assignment.id,
+      requestComment: 'Please revise.',
+    });
+
+    // A different author should see nothing
+    const otherAuthor = await testData.createReviewAssignment({
+      context: created.context,
+      title: 'Other Proposal',
+    });
+
+    const otherCaller = await createAuthenticatedCaller(
+      otherAuthor.author.email,
+    );
+    const result = await otherCaller.decision.listProposalsRevisionRequests({});
+
+    // Should only see their own proposals (which have no revision requests)
+    expect(result.revisionRequests).toHaveLength(0);
+  });
+});

--- a/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
+++ b/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
@@ -1,0 +1,23 @@
+import {
+  listProposalsRevisionRequests,
+  proposalRevisionRequestListSchema,
+} from '@op/common';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const listProposalsRevisionRequestsRouter = router({
+  listProposalsRevisionRequests: commonAuthedProcedure()
+    .input(
+      z.object({
+        proposalId: z.uuid().optional(),
+      }),
+    )
+    .output(proposalRevisionRequestListSchema)
+    .query(async ({ ctx, input }) => {
+      return await listProposalsRevisionRequests({
+        proposalId: input.proposalId,
+        user: ctx.user,
+      });
+    }),
+});

--- a/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
+++ b/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
@@ -22,7 +22,7 @@ export const listProposalsRevisionRequestsRouter = router({
       });
 
       ctx.registerQueryChannels(
-        result.assignmentIds.map(Channels.reviewAssignment),
+        result.processInstanceIds.map(Channels.reviewAssignments),
       );
 
       return proposalRevisionRequestListSchema.parse(result);

--- a/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
+++ b/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
@@ -1,4 +1,5 @@
 import {
+  Channels,
   listProposalsRevisionRequests,
   proposalRevisionRequestListSchema,
 } from '@op/common';
@@ -15,9 +16,15 @@ export const listProposalsRevisionRequestsRouter = router({
     )
     .output(proposalRevisionRequestListSchema)
     .query(async ({ ctx, input }) => {
-      return await listProposalsRevisionRequests({
+      const result = await listProposalsRevisionRequests({
         proposalId: input.proposalId,
         user: ctx.user,
       });
+
+      ctx.registerQueryChannels(
+        result.assignmentIds.map(Channels.reviewAssignment),
+      );
+
+      return proposalRevisionRequestListSchema.parse(result);
     }),
 });


### PR DESCRIPTION
Author-scoped endpoint to list pending revision requests across submitted proposals, rendered as notification rows inside the Active Decisions panel on the homepage.

## Demo

https://github.com/user-attachments/assets/05a6bf01-1833-476b-87b1-37ce284063e2


