### PR TITLE
Include timezone in phase transition scheduled date

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -89,6 +89,7 @@ export const ProcessBuilderFooter = ({
         description: storeData?.description || undefined,
         stewardProfileId: storeData?.stewardProfileId || undefined,
         phases: storeData?.phases,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         proposalTemplate: storeData?.proposalTemplate,
         rubricTemplate: storeData?.rubricTemplate,
         config: storeData?.config,

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -143,7 +143,13 @@ function PhaseDetailForm({
       setInstanceData(decisionProfileId, { phases: phasesPayload });
 
       if (isDraft) {
-        updateInstance.mutate({ instanceId, phases: phasesPayload });
+        const browserTimezone =
+          Intl.DateTimeFormat().resolvedOptions().timeZone;
+        updateInstance.mutate({
+          instanceId,
+          phases: phasesPayload,
+          timezone: browserTimezone,
+        });
       } else {
         markSaved(decisionProfileId);
       }
@@ -208,7 +214,11 @@ function PhaseDetailForm({
 
     if (isDraft) {
       updateInstance.mutate(
-        { instanceId, phases: remainingPhases },
+        {
+          instanceId,
+          phases: remainingPhases,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        },
         {
           onSuccess: () => {
             onDelete();

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
@@ -96,7 +96,11 @@ export function PhasesSectionContent({
     setInstanceData(decisionProfileId, { phases: phasesPayload });
 
     if (isDraft) {
-      updateInstance.mutate({ instanceId, phases: phasesPayload });
+      updateInstance.mutate({
+        instanceId,
+        phases: phasesPayload,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      });
     } else {
       markSaved(decisionProfileId);
     }

--- a/packages/common/src/services/decision/schemas/instanceData.ts
+++ b/packages/common/src/services/decision/schemas/instanceData.ts
@@ -39,6 +39,8 @@ export interface DecisionInstanceData {
   templateVersion?: string;
   templateName?: string;
   templateDescription?: string;
+  /** IANA timezone of the user who configured phase dates (e.g. "America/New_York"). */
+  timezone?: string;
   phases: PhaseInstanceData[];
   /** Proposal template (JSON Schema) */
   proposalTemplate?: ProposalTemplateSchema;

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -35,6 +35,7 @@ export const updateDecisionInstance = async ({
   stewardProfileId,
   config,
   phases,
+  timezone,
   proposalTemplate,
   rubricTemplate,
   user,
@@ -48,6 +49,8 @@ export const updateDecisionInstance = async ({
   config?: ProcessConfig;
   /** Optional phase overrides (dates and settings) */
   phases?: PhaseOverride[];
+  /** IANA timezone of the user who configured phase dates (e.g. "America/New_York"). */
+  timezone?: string;
   /** Proposal template (JSON Schema) */
   proposalTemplate?: Record<string, unknown>;
   /** Rubric template (JSON Schema defining evaluation criteria) */
@@ -121,12 +124,14 @@ export const updateDecisionInstance = async ({
   // Apply config, phase overrides, and/or template updates to existing instanceData
   const hasConfigUpdate = config !== undefined;
   const hasPhaseUpdates = phases && phases.length > 0;
+  const hasTimezoneUpdate = timezone !== undefined;
   const hasProposalTemplateUpdate = proposalTemplate !== undefined;
   const hasRubricTemplateUpdate = rubricTemplate !== undefined;
 
   if (
     hasConfigUpdate ||
     hasPhaseUpdates ||
+    hasTimezoneUpdate ||
     hasProposalTemplateUpdate ||
     hasRubricTemplateUpdate
   ) {
@@ -153,6 +158,11 @@ export const updateDecisionInstance = async ({
         ...config,
         ...(config?.categories ? { categories: normalizedCategories } : {}),
       };
+    }
+
+    // Store the browser timezone so scheduled transitions use the correct offset
+    if (hasTimezoneUpdate) {
+      updatedInstanceData.timezone = timezone;
     }
 
     // Apply phase updates — replaces the full phases array to accommodate

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -236,6 +236,8 @@ const instanceDataWithSchemaEncoder = z.object({
   templateVersion: z.string().optional(),
   templateName: z.string().optional(),
   templateDescription: z.string().optional(),
+  /** IANA timezone of the user who configured phase dates (e.g. "America/New_York"). */
+  timezone: z.string().optional(),
   phases: z.array(instancePhaseDataEncoder).optional(),
   proposalTemplate: jsonSchemaEncoder.optional(),
   rubricTemplate: rubricTemplateEncoder.optional(),
@@ -526,6 +528,8 @@ export const updateDecisionInstanceInputSchema = z.object({
   config: processConfigEncoder.optional(),
   /** Phase overrides for dates, rules, and settings */
   phases: z.array(instancePhaseDataInputEncoder).optional(),
+  /** IANA timezone of the user who configured phase dates (e.g. "America/New_York"). */
+  timezone: z.string().optional(),
   /** Proposal template (JSON Schema) */
   proposalTemplate: jsonSchemaEncoder.optional(),
   /**

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -862,6 +862,50 @@ describe.concurrent('updateDecisionInstance', () => {
     ).rejects.toThrow();
   });
 
+  it('should persist timezone in instanceData when sent with phases', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // Get current phases
+    const dbInstance = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instance.instance.id),
+    });
+    const currentData = dbInstance!.instanceData as DecisionInstanceData;
+
+    const endDate = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      phases: currentData.phases.map((p) => ({
+        phaseId: p.phaseId,
+        endDate,
+      })),
+      timezone: 'America/New_York',
+    });
+
+    const updatedInstance = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, instance.instance.id),
+    });
+    const updatedData = updatedInstance!.instanceData as DecisionInstanceData;
+    expect(updatedData.timezone).toBe('America/New_York');
+  });
+
   it('should allow non-owner admin to update other fields without changing steward', async ({
     task,
     onTestFinished,


### PR DESCRIPTION
Captures the user's IANA timezone from the browser when saving phase dates and persists it in instanceData.timezone so transition scheduling reflects the timezone in which dates were set.