### PR TITLE
fix(decisions): fix categories not duplicating

### DIFF
--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -7,6 +7,7 @@ import { CommonError, NotFoundError, UnauthorizedError } from '../../utils';
 import { getProfileAccessUser } from '../access';
 import { assertUserByAuthId } from '../assert';
 import { createDecisionInstance } from './createInstanceFromTemplate';
+import { ensureProposalTaxonomyTerms } from './proposalTaxonomy';
 import type {
   DecisionInstanceData,
   PhaseInstanceData,
@@ -91,6 +92,13 @@ export const duplicateInstance = async ({
 
   // Build new instance data based on include flags
   const newInstanceData = buildInstanceData(sourceData, include);
+
+  // Ensure taxonomy terms exist for copied categories so getProcessCategories
+  // can resolve them on the new instance
+  const copiedCategories = newInstanceData.config?.categories;
+  if (copiedCategories && copiedCategories.length > 0) {
+    await ensureProposalTaxonomyTerms(copiedCategories.map((c) => c.label));
+  }
 
   // Delegate core creation (profile, instance, default roles, profile user)
   const profile = await createDecisionInstance({

--- a/packages/common/src/services/decision/getProcessCategories.ts
+++ b/packages/common/src/services/decision/getProcessCategories.ts
@@ -5,6 +5,7 @@ import { permission } from 'access-zones';
 import { UnauthorizedError } from '../../utils';
 import { assertInstanceProfileAccess } from '../access';
 import type { DecisionInstanceData } from './schemas';
+import { toTermUri } from './utils/taxonomy';
 
 export interface ProcessCategory {
   id: string;
@@ -66,15 +67,18 @@ export const getProcessCategories = async ({
     // Find matching taxonomy terms for the categories
     const categories: ProcessCategory[] = [];
 
-    for (const category of instanceCategories) {
-      const expectedTermUri = category.label
-        .toLowerCase()
-        .replace(/\s+/g, '-')
-        .replace(/[^a-z0-9-]/g, '');
+    type TaxonomyTerm = { id: string; label: string; termUri: string };
+    const termsByUri = new Map<string, TaxonomyTerm>(
+      proposalTaxonomy.taxonomyTerms.map((term: TaxonomyTerm) => [
+        term.termUri,
+        term,
+      ]),
+    );
 
-      const taxonomyTerm = proposalTaxonomy.taxonomyTerms.find(
-        (term: { termUri: string }) => term.termUri === expectedTermUri,
-      );
+    for (const category of instanceCategories) {
+      const expectedTermUri = toTermUri(category.label);
+
+      const taxonomyTerm = termsByUri.get(expectedTermUri);
 
       if (taxonomyTerm) {
         categories.push({

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -82,6 +82,9 @@ export type { VoteData } from '@op/db/schema';
 // Schema validation
 export { schemaValidator } from './schemaValidator';
 
+// Taxonomy utilities
+export { toTermUri } from './utils/taxonomy';
+
 // Types
 export * from './types';
 export type {

--- a/packages/common/src/services/decision/proposalTaxonomy.ts
+++ b/packages/common/src/services/decision/proposalTaxonomy.ts
@@ -1,8 +1,8 @@
 import { db, eq } from '@op/db/client';
 import { taxonomies, taxonomyTerms } from '@op/db/schema';
-import slugify from 'slugify';
 
 import { CommonError } from '../../utils';
+import { toTermUri } from './utils/taxonomy';
 
 /**
  * Ensures the proposal taxonomy exists and that each category label has a
@@ -44,11 +44,7 @@ export async function ensureProposalTaxonomyTerms(
     }
 
     const categoryLabel = categoryName.trim();
-    const termUri = slugify(categoryLabel, {
-      lower: true,
-      strict: true,
-      trim: true,
-    });
+    const termUri = toTermUri(categoryLabel);
 
     // taxonomyTerms V2 types are broken due to self-referential parentId
     let existingTerm = await db._query.taxonomyTerms.findFirst({

--- a/packages/common/src/services/decision/utils/taxonomy.ts
+++ b/packages/common/src/services/decision/utils/taxonomy.ts
@@ -1,0 +1,10 @@
+import slugify from 'slugify';
+
+/**
+ * Converts a category label to a taxonomy term URI.
+ * Must be used consistently across all write (ensureProposalTaxonomyTerms)
+ * and read (getProcessCategories) paths.
+ */
+export function toTermUri(label: string): string {
+  return slugify(label, { lower: true, strict: true, trim: true });
+}

--- a/services/api/src/routers/decision/instances/duplicateInstance.test.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.test.ts
@@ -1,10 +1,11 @@
-import { type DecisionInstanceData, simpleVoting } from '@op/common';
+import { type DecisionInstanceData, simpleVoting, toTermUri } from '@op/common';
 import type { DecisionSchemaDefinition } from '@op/common';
-import { db, eq } from '@op/db/client';
+import { db, eq, inArray } from '@op/db/client';
 import {
   accessRoles,
   decisionProcesses,
   processInstances,
+  taxonomyTerms,
   users,
 } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
@@ -506,5 +507,122 @@ describe.concurrent('duplicateInstance', () => {
     expect(instanceData.config).toBeUndefined();
     expect(instanceData.proposalTemplate).toBeUndefined();
     expect(instanceData.rubricTemplate).toBeUndefined();
+  });
+
+  it('should duplicate categories when proposalCategories is included', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { result: source, caller } = await createSourceInstance(
+      testData,
+      task.id,
+    );
+
+    // Add categories to the source instance
+    const testCategories = [
+      {
+        id: crypto.randomUUID(),
+        label: 'Education',
+        description: 'Education programs',
+      },
+      {
+        id: crypto.randomUUID(),
+        label: 'Health',
+        description: 'Health initiatives',
+      },
+    ];
+    await caller.decision.updateDecisionInstance({
+      instanceId: source.processInstance.id,
+      config: {
+        categories: testCategories,
+        requireCategorySelection: true,
+        allowMultipleCategories: false,
+        organizeByCategories: true,
+      },
+    });
+
+    // Clean up taxonomy terms created by ensureProposalTaxonomyTerms
+    const termUris = testCategories.map((c) => toTermUri(c.label));
+    onTestFinished(async () => {
+      await db
+        .delete(taxonomyTerms)
+        .where(inArray(taxonomyTerms.termUri, termUris));
+    });
+
+    const duplicate = await caller.decision.duplicateInstance({
+      instanceId: source.processInstance.id,
+      name: 'Categories Test',
+      include: ALL_INCLUDED,
+    });
+
+    testData.trackProfileForCleanup(duplicate.id);
+
+    const instance = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, duplicate.processInstance.id),
+    });
+    const instanceData = instance!.instanceData as DecisionInstanceData;
+
+    // Categories should be copied to the duplicate
+    expect(instanceData.config?.categories).toBeDefined();
+    expect(instanceData.config!.categories!.length).toBe(2);
+    expect(instanceData.config!.categories!.map((c) => c.label).sort()).toEqual(
+      ['Education', 'Health'],
+    );
+    expect(instanceData.config!.requireCategorySelection).toBe(true);
+    expect(instanceData.config!.allowMultipleCategories).toBe(false);
+    expect(instanceData.config!.organizeByCategories).toBe(true);
+  });
+
+  it('should not duplicate categories when proposalCategories is excluded', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { result: source, caller } = await createSourceInstance(
+      testData,
+      task.id,
+    );
+
+    // Add categories to the source instance
+    await caller.decision.updateDecisionInstance({
+      instanceId: source.processInstance.id,
+      config: {
+        categories: [
+          {
+            id: crypto.randomUUID(),
+            label: 'Test',
+            description: 'Test category',
+          },
+        ],
+        organizeByCategories: true,
+      },
+    });
+
+    // Clean up taxonomy terms created by ensureProposalTaxonomyTerms
+    onTestFinished(async () => {
+      await db
+        .delete(taxonomyTerms)
+        .where(inArray(taxonomyTerms.termUri, [toTermUri('Test')]));
+    });
+
+    const duplicate = await caller.decision.duplicateInstance({
+      instanceId: source.processInstance.id,
+      name: 'No Categories Test',
+      include: { ...ALL_INCLUDED, proposalCategories: false },
+    });
+
+    testData.trackProfileForCleanup(duplicate.id);
+
+    const instance = await db._query.processInstances.findFirst({
+      where: eq(processInstances.id, duplicate.processInstance.id),
+    });
+    const instanceData = instance!.instanceData as DecisionInstanceData;
+
+    // Categories should be stripped when proposalCategories is false
+    expect(instanceData.config?.categories).toBeUndefined();
+    expect(instanceData.config?.requireCategorySelection).toBeUndefined();
+    expect(instanceData.config?.allowMultipleCategories).toBeUndefined();
+    expect(instanceData.config?.organizeByCategories).toBeUndefined();
   });
 });

--- a/services/api/src/routers/decision/instances/getCategories.test.ts
+++ b/services/api/src/routers/decision/instances/getCategories.test.ts
@@ -1,3 +1,4 @@
+import { toTermUri } from '@op/common';
 import { db, eq, inArray } from '@op/db/client';
 import {
   organizationUsers,
@@ -60,10 +61,7 @@ async function seedProposalTaxonomy(
   const termRecords = termLabels.map((label) => ({
     id: randomUUID(),
     taxonomyId: resolvedTaxonomyId,
-    termUri: label
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(/[^a-z0-9-]/g, ''),
+    termUri: toTermUri(label),
     label,
   }));
 
@@ -464,13 +462,12 @@ describe.concurrent('getCategories category matching', () => {
       throw new Error('No instance created');
     }
 
-    // The termUri for "Health & Wellness" after conversion:
-    // "health & wellness" -> "health--wellness" (& removed, spaces become -)
+    // slugify converts "Health & Wellness" → "health-and-wellness"
     const { termRecords } = await seedProposalTaxonomy(
       ['Health & Wellness'],
       onTestFinished,
     );
-    const expectedTermUri = 'health--wellness';
+    const expectedTermUri = 'health-and-wellness';
 
     await injectInstanceCategories(instance.instance.id, [
       {


### PR DESCRIPTION
Fixes category duplication by aligning URI generation between write (ensureProposalTaxonomyTerms) and read (getProcessCategories) paths, and ensuring taxonomy terms are created when duplicating a process instance.