### PR TITLE
fix(admin): resolve platform admin query timeouts

### DIFF
--- a/packages/common/src/services/platform/stats.ts
+++ b/packages/common/src/services/platform/stats.ts
@@ -7,37 +7,33 @@ export const getPlatformStats = async ({ user }: { user: User }) => {
   const newOrgThreshold = new Date(lastLogin.setDate(lastLogin.getDate() - 7));
 
   const [orgCount, usersCount, relationshipCount, newOrganizationsCount] =
-    await db.transaction(async (tx) => {
-      const results = await Promise.all([
-        tx
-          .select({
-            count: sql<number>`count(*)::int`,
-          })
-          .from(organizations),
+    await Promise.all([
+      db
+        .select({
+          count: sql<number>`count(*)::int`,
+        })
+        .from(organizations),
 
-        tx
-          .select({
-            count: sql<number>`count(*)::int`,
-          })
-          .from(users),
+      db
+        .select({
+          count: sql<number>`count(*)::int`,
+        })
+        .from(users),
 
-        tx
-          .select({
-            count: sql<number>`count(*)::int`,
-          })
-          .from(organizationRelationships)
-          .where(() => eq(organizationRelationships.pending, false)),
+      db
+        .select({
+          count: sql<number>`count(*)::int`,
+        })
+        .from(organizationRelationships)
+        .where(() => eq(organizationRelationships.pending, false)),
 
-        tx
-          .select({
-            count: sql<number>`count(*)::int`,
-          })
-          .from(organizations)
-          .where(gte(organizations.createdAt, newOrgThreshold.toISOString())),
-      ]);
-
-      return results;
-    });
+      db
+        .select({
+          count: sql<number>`count(*)::int`,
+        })
+        .from(organizations)
+        .where(gte(organizations.createdAt, newOrgThreshold.toISOString())),
+    ]);
 
   const totalOrganizations = orgCount[0]?.count ?? 0;
   const totalUsers = usersCount[0]?.count ?? 0;

--- a/services/api/src/routers/platform/admin/listAllOrganizations.ts
+++ b/services/api/src/routers/platform/admin/listAllOrganizations.ts
@@ -1,5 +1,5 @@
 import { decodeCursor, encodeCursor } from '@op/common';
-import { count, db, ilike, inArray } from '@op/db/client';
+import { and, count, db, eq, ilike, inArray, lt, or } from '@op/db/client';
 import { organizations, profiles } from '@op/db/schema';
 import { z } from 'zod';
 
@@ -61,28 +61,29 @@ export const listAllOrganizationsRouter = router({
             ).map((p) => p.id)
           : null;
 
-      // Build V2 relational query filters
-      const cursorFilter = cursorValue
-        ? {
-            OR: [
-              { createdAt: { lt: cursorValue.date } },
-              { createdAt: cursorValue.date, id: { lt: cursorValue.id } },
-            ],
-          }
+      // Build cursor condition for keyset pagination
+      const cursorCondition = cursorValue
+        ? or(
+            lt(organizations.createdAt, cursorValue.date),
+            and(
+              eq(organizations.createdAt, cursorValue.date),
+              lt(organizations.id, cursorValue.id),
+            ),
+          )
         : undefined;
 
-      const searchFilter = matchingProfileIds
-        ? { profileId: { in: matchingProfileIds } }
+      const searchCondition = matchingProfileIds
+        ? inArray(organizations.profileId, matchingProfileIds)
         : undefined;
 
-      const whereFilter =
-        cursorFilter && searchFilter
-          ? { AND: [cursorFilter, searchFilter] }
-          : cursorFilter || searchFilter;
+      const whereCondition =
+        cursorCondition && searchCondition
+          ? and(cursorCondition, searchCondition)
+          : cursorCondition || searchCondition;
 
       const [allOrgs, totalCount] = await Promise.all([
-        db.query.organizations.findMany({
-          where: whereFilter,
+        db._query.organizations.findMany({
+          where: whereCondition,
           with: {
             profile: {
               columns: {
@@ -124,7 +125,10 @@ export const listAllOrganizationsRouter = router({
               },
             },
           },
-          orderBy: { createdAt: dir === 'asc' ? 'asc' : 'desc' },
+          orderBy: (_, { asc, desc }) =>
+            dir === 'asc'
+              ? asc(organizations.createdAt)
+              : desc(organizations.createdAt),
           ...(limit !== undefined && { limit: limit + 1 }),
         }),
         db


### PR DESCRIPTION
V2 relational query API (db.query) generates a single SQL with deeply nested lateral joins that causes PostgreSQL's query planner to time out during PARSE — visible as consistent 120s timeouts on listAllOrganizations in production Axiom logs.

fix(admin): switch listAllOrganizations to legacy relational API (db._query) matching listAllUsers
perf(admin): remove unnecessary db.transaction() from getPlatformStats count queries