### PR TITLE
Add error boundary around platform highlights component

### DIFF
--- a/apps/app/src/components/screens/LandingScreen/index.tsx
+++ b/apps/app/src/components/screens/LandingScreen/index.tsx
@@ -37,15 +37,17 @@ export const LandingScreen = () => {
       <Suspense fallback={<WelcomeSkeleton />}>
         <WelcomeSection />
       </Suspense>
-      <Suspense
-        fallback={
-          <Surface>
-            <Skeleton className="h-52 w-full" />
-          </Surface>
-        }
-      >
-        <PlatformHighlights />
-      </Suspense>
+      <ErrorBoundary fallback={null}>
+        <Suspense
+          fallback={
+            <Surface>
+              <Skeleton className="h-52 w-full" />
+            </Surface>
+          }
+        >
+          <PlatformHighlights />
+        </Suspense>
+      </ErrorBoundary>
       <Suspense fallback={<UserContentSkeleton />}>
         <UserContent />
       </Suspense>


### PR DESCRIPTION
Add an error boundary to prevent the whole page from crashing