### PR TITLE
feat(reviews): add email notification when revision is requested

### DIFF
--- a/services/api/src/routers/decision/reviews/requestRevision.ts
+++ b/services/api/src/routers/decision/reviews/requestRevision.ts
@@ -1,5 +1,7 @@
 import { Channels, requestRevision } from '@op/common';
 import { proposalReviewRequestSchema } from '@op/common/client';
+import { Events, inngest } from '@op/events';
+import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
 import { commonAuthedProcedure, router } from '../../../trpcFactory';
@@ -24,6 +26,17 @@ export const requestRevisionRouter = router({
         Channels.reviewAssignment(input.assignmentId),
         Channels.reviewAssignments(result.processInstanceId),
       ]);
+
+      // Send revision requested event for notification workflow
+      waitUntil(
+        inngest.send({
+          name: Events.reviewRevisionRequested.name,
+          data: {
+            assignmentId: input.assignmentId,
+            revisionRequestId: result.id,
+          },
+        }),
+      );
 
       return proposalReviewRequestSchema.parse(result);
     }),

--- a/services/emails/emails/RevisionRequestedEmail.tsx
+++ b/services/emails/emails/RevisionRequestedEmail.tsx
@@ -1,0 +1,51 @@
+import { Button, Heading, Section, Text } from '@react-email/components';
+
+import EmailTemplate from '../components/EmailTemplate';
+
+export const RevisionRequestedEmail = ({
+  proposalName,
+  processTitle,
+  proposalUrl = 'https://common.oneproject.org/',
+}: {
+  proposalName: string;
+  processTitle: string;
+  proposalUrl: string;
+}) => {
+  return (
+    <EmailTemplate
+      previewText={`A reviewer has requested changes to "${proposalName}"`}
+    >
+      <Heading className="mx-0 !my-0 p-0 text-left font-serif text-[28px] font-light tracking-[-0.02625rem] text-[#222D38]">
+        Revision Requested
+      </Heading>
+      <Text className="my-8 text-lg">
+        A reviewer has requested changes to your proposal{' '}
+        <strong>{proposalName}</strong> in <strong>{processTitle}</strong>.
+        Review their feedback and submit your revision.
+      </Text>
+
+      <Section className="pb-0">
+        <Button
+          href={proposalUrl}
+          className="rounded-lg bg-primary-teal px-4 py-3 text-white no-underline hover:bg-primary-teal/90"
+          style={{
+            fontSize: '0.875rem',
+            textAlign: 'center',
+            textDecoration: 'none',
+          }}
+        >
+          Revise proposal
+        </Button>
+      </Section>
+
+      <Text className="mt-8 mb-0 text-xs text-neutral-gray4">
+        You're receiving this because you're the author of this proposal.
+      </Text>
+    </EmailTemplate>
+  );
+};
+
+RevisionRequestedEmail.subject = (proposalName: string) =>
+  `A reviewer has requested changes to "${proposalName}"`;
+
+export default RevisionRequestedEmail;

--- a/services/emails/index.tsx
+++ b/services/emails/index.tsx
@@ -119,3 +119,4 @@ export * from './emails/ProposalSubmittedEmail';
 export * from './emails/PhaseTransitionEmail';
 export * from './emails/VoteSubmittedEmail';
 export * from './emails/RevisionResubmittedEmail';
+export * from './emails/RevisionRequestedEmail';

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -71,4 +71,11 @@ export const Events = {
       revisionRequestId: z.string().uuid(),
     }),
   },
+  reviewRevisionRequested: {
+    name: 'review/revision-requested' as const,
+    schema: z.object({
+      assignmentId: z.string().uuid(),
+      revisionRequestId: z.string().uuid(),
+    }),
+  },
 } as const;

--- a/services/workflows/src/functions/notifications/index.ts
+++ b/services/workflows/src/functions/notifications/index.ts
@@ -4,3 +4,4 @@ export * from './sendProposalSubmittedNotification';
 export * from './sendPhaseTransitionNotification';
 export * from './sendVoteSubmittedNotification';
 export * from './sendRevisionResubmittedNotification';
+export * from './sendRevisionRequestedNotification';

--- a/services/workflows/src/functions/notifications/sendRevisionRequestedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionRequestedNotification.ts
@@ -1,0 +1,146 @@
+import { OPURLConfig } from '@op/core';
+import { db } from '@op/db/client';
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+} from '@op/db/schema';
+import { OPBatchSend, RevisionRequestedEmail } from '@op/emails';
+import { Events, inngest } from '@op/events';
+
+const { reviewRevisionRequested } = Events;
+
+export const sendRevisionRequestedNotification = inngest.createFunction(
+  {
+    id: 'sendRevisionRequestedNotification',
+    debounce: {
+      key: 'event.data.revisionRequestId',
+      period: '1m',
+      timeout: '3m',
+    },
+  },
+  { event: reviewRevisionRequested.name },
+  async ({ event, step }) => {
+    const { assignmentId, revisionRequestId } =
+      reviewRevisionRequested.schema.parse(event.data);
+
+    const assignment = await step.run('get-assignment-data', async () => {
+      return db.query.proposalReviewAssignments.findFirst({
+        where: { id: assignmentId },
+        with: {
+          proposal: {
+            with: {
+              profile: {
+                with: {
+                  profileUsers: true,
+                },
+              },
+            },
+          },
+          processInstance: {
+            with: {
+              profile: true,
+            },
+          },
+          requests: true,
+        },
+      });
+    });
+
+    if (!assignment) {
+      console.error('No assignment data found for assignment:', assignmentId);
+      return;
+    }
+
+    // Verify the revision request is still active before sending
+    const revisionRequest = assignment.requests.find(
+      (r) => r.id === revisionRequestId,
+    );
+
+    if (!revisionRequest) {
+      console.warn('Revision request not found:', revisionRequestId);
+      return;
+    }
+
+    if (revisionRequest.state !== ProposalReviewRequestState.REQUESTED) {
+      console.log(
+        'Revision request is no longer active:',
+        revisionRequestId,
+        'state:',
+        revisionRequest.state,
+      );
+      return;
+    }
+
+    if (
+      assignment.status !==
+      ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION
+    ) {
+      console.log(
+        'Assignment is no longer awaiting revision:',
+        assignmentId,
+        'status:',
+        assignment.status,
+      );
+      return;
+    }
+
+    const { proposal, processInstance } = assignment;
+    const authorProfileUsers = proposal.profile.profileUsers;
+
+    if (authorProfileUsers.length === 0) {
+      console.warn(
+        'No author profile users found for proposal profile:',
+        proposal.profileId,
+      );
+      return;
+    }
+
+    const processProfile = processInstance.profile;
+    if (!processProfile) {
+      console.error(
+        'No profile found for process instance:',
+        processInstance.id,
+      );
+      return;
+    }
+
+    const proposalName = proposal.profile.name;
+    const processTitle = processProfile.name;
+    const proposalUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processProfile.slug}/proposal/${proposal.profileId}/edit?reviewRevision=${revisionRequestId}`;
+
+    const result = await step.run('send-emails', async () => {
+      try {
+        const emails = authorProfileUsers.map(({ email }) => ({
+          to: email,
+          subject: RevisionRequestedEmail.subject(proposalName),
+          component: () =>
+            RevisionRequestedEmail({
+              proposalName,
+              processTitle,
+              proposalUrl,
+            }),
+        }));
+
+        const { data, errors } = await OPBatchSend(emails);
+
+        if (errors.length > 0) {
+          throw Error(`Email batch failed: ${JSON.stringify(errors)}`);
+        }
+
+        return {
+          sent: data.length,
+        };
+      } catch (error) {
+        console.error('Failed to send revision requested notifications:', {
+          error,
+          assignmentId,
+        });
+        throw error;
+      }
+    });
+
+    return {
+      message: `${result.sent} revision requested notification(s) sent`,
+    };
+  },
+);


### PR DESCRIPTION
Notify proposal authors via email when a reviewer requests changes, so they can review feedback and submit a revision promptly.