### PR TITLE
ci: typecheck + format + migration gate on PRs to dev

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
 
 jobs:
-  typecheck:
-    name: Typecheck
+  checks:
+    name: Typecheck, format, migrations
     runs-on: blacksmith-2vcpu-ubuntu-2204
 
     env:
@@ -48,5 +48,8 @@ jobs:
       - name: Check formatting
         run: pnpm format:check
 
-      - name: Run TypeScript checks - App
+      - name: Check migrations
+        run: pnpm check-migrations
+
+      - name: Run TypeScript checks
         run: pnpm typecheck

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ _(Commands below assume usage of the `w:<workspace>` shorthand)_
 - **Running Specific Workspaces**: Use `pnpm w:<workspace> <script>` (e.g., `pnpm w:app dev`). Workspace names (`app`, `api`, `ui`, `core`, `hooks`, `db`, `emails`, `supabase`, `trpc`) correspond to the directories.
 - **Adding Dependencies**: Use `pnpm add <package-name> --filter <workspace-name>` (e.g., `pnpm add zod --filter @op/core`). For dev dependencies, use `-D`. (Note: Using `--filter` is recommended when adding dependencies from the root to ensure the `package.json` is updated correctly).
 
+### Running PR checks locally
+
+The `Checks` GitHub Actions workflow (`.github/workflows/pr-checks.yml`) gates every PR with the same commands you can run locally:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm format:check
+pnpm check-migrations
+pnpm typecheck
+```
+
+- `pnpm format:check` — verifies Prettier formatting.
+- `pnpm check-migrations` — fails if a PR modifies or deletes an existing `services/db/migrations/*.sql` file. In CI it diffs against the PR base ref (`GITHUB_BASE_REF`); locally it inspects your staged changes (`git diff --cached`), so stage the migration changes first to reproduce CI behavior.
+- `pnpm typecheck` — runs TypeScript across all workspaces via Turbo.
+
+Run these before pushing to avoid red PRs on `dev`.
+
 ## Tailwind Integration Details
 
 This monorepo utilizes a shared Tailwind configuration strategy managed primarily by the `@op/ui` package.

--- a/scripts/migrationsCheck.ts
+++ b/scripts/migrationsCheck.ts
@@ -1,19 +1,31 @@
 import { execSync } from 'child_process';
 
-try {
-  // Get the list of staged changes
-  const output = execSync('git diff --cached --name-status').toString();
+const MIGRATION_PATTERN = /^(D|M)\s+services\/db\/migrations\/.*\.sql$/m;
+const ERROR_MESSAGE =
+  'Error: You cannot remove or modify SQL migration files in the "services/db/migrations" directory.';
 
-  // Check for modifications or deletions of .sql files in the migrations directory
-  if (/^(D|M)\s+services\/db\/migrations\/.*\.sql$/m.test(output)) {
-    console.error(
-      'Error: You cannot remove or modify SQL migration files in the "services/db/migrations" directory.',
-    );
-    process.exit(1); // Exit with error code
+function getDiffCommand(): string {
+  // In GitHub Actions, compare the PR branch against its base ref so CI can
+  // detect modified/deleted migration files that never get "staged" on a runner.
+  const baseRef = process.env.GITHUB_BASE_REF;
+  if (baseRef) {
+    return `git diff --name-status origin/${baseRef}...HEAD`;
+  }
+
+  // Local/pre-commit context: fall back to the staged diff.
+  return 'git diff --cached --name-status';
+}
+
+try {
+  const output = execSync(getDiffCommand()).toString();
+
+  if (MIGRATION_PATTERN.test(output)) {
+    console.error(ERROR_MESSAGE);
+    process.exit(1);
   }
 } catch (error) {
   console.error('Error executing git command:', (error as Error).message);
-  process.exit(1); // Exit with error code if git command fails
+  process.exit(1);
 }
 
-process.exit(0); // Exit successfully if no issues found
+process.exit(0);


### PR DESCRIPTION
Adds `pnpm check-migrations` to the PR Checks workflow alongside the existing typecheck + format gate, and reworks the migration script to diff against `GITHUB_BASE_REF` so it detects changes on CI runners. README gains a short section on running the same commands locally.

Closes [COM-5](/COM/issues/COM-5).