### PR TITLE
fix: Account for legacy stateId in phase lookup

### DIFF
--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -43,7 +43,10 @@ function getCurrentPhaseConfig(processInstance: {
   }
 
   const currentPhase = instanceData.phases.find(
-    (p) => p.phaseId === currentPhaseId,
+    (p) =>
+      p.phaseId === currentPhaseId ||
+      // @ts-expect-error  Remove p.stateId in a migration before undoing p.stateId
+      p.stateId === currentPhaseId,
   );
 
   if (!currentPhase) {


### PR DESCRIPTION
Accounts for the legacy stateId in the phase lookup. This seems to have been removed in a rebase.
