### PR TITLE
Implement overall recommendation in rubric template editor

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/components/ToggleRow.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/components/ToggleRow.tsx
@@ -10,10 +10,10 @@ export function ToggleRow({
 }) {
   return (
     <div className="flex items-center gap-4 rounded-xl py-2">
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div className="flex min-w-0 flex-1 flex-col">
         <p className="text-base leading-[1.5] text-neutral-black">{label}</p>
         {description && (
-          <p className="text-sm leading-[1.5] text-neutral-charcoal">
+          <p className="text-sm leading-[1.5] text-neutral-gray4">
             {description}
           </p>
         )}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -24,11 +24,11 @@ import type {
   RubricCriterionType,
 } from '@/components/decisions/rubricTemplate';
 import {
-  OVERALL_RECOMMENDATION_KEY,
   addCriterion,
-  addOverallRecommendation,
   changeCriterionType,
   createEmptyRubricTemplate,
+  disableOverallRecommendation,
+  enableOverallRecommendation,
   ensureOverallRecommendationLast,
   getCriteria,
   getCriterionErrors,
@@ -36,7 +36,6 @@ import {
   getCriterionType,
   hasOverallRecommendation,
   removeCriterion,
-  removeOverallRecommendation,
   reorderCriteria,
   setCriterionRequired,
   updateCriterionDescription,
@@ -162,11 +161,11 @@ export function RubricEditorContent({
 
   const handleReorderCriteria = useCallback((newItems: CriterionView[]) => {
     setTemplate((prev) => {
-      const newOrder = newItems.map((item) => item.id);
-      if (hasOverallRecommendation(prev)) {
-        newOrder.push(OVERALL_RECOMMENDATION_KEY);
-      }
-      return reorderCriteria(prev, newOrder);
+      const reordered = reorderCriteria(
+        prev,
+        newItems.map((item) => item.id),
+      );
+      return ensureOverallRecommendationLast(reordered);
     });
   }, []);
 
@@ -287,16 +286,13 @@ export function RubricEditorContent({
     });
   }, []);
 
-  const overallRecommendationEnabled = useMemo(
-    () => hasOverallRecommendation(template),
-    [template],
-  );
+  const overallRecommendationEnabled = hasOverallRecommendation(template);
 
   const handleOverallRecommendationToggle = useCallback((enabled: boolean) => {
     setTemplate((prev) =>
       enabled
-        ? addOverallRecommendation(prev)
-        : removeOverallRecommendation(prev),
+        ? enableOverallRecommendation(prev)
+        : disableOverallRecommendation(prev),
     );
   }, []);
 

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -6,6 +6,7 @@ import { Button } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header2 } from '@op/ui/Header';
 import { Sortable } from '@op/ui/Sortable';
+import { ToggleButton } from '@op/ui/ToggleButton';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LuLeaf, LuPlus } from 'react-icons/lu';
 
@@ -15,6 +16,7 @@ import type { TranslationKey } from '@/lib/i18n/routing';
 import { ConfirmDeleteModal } from '@/components/ConfirmDeleteModal';
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
+import { ToggleRow } from '@/components/decisions/ProcessBuilder/components/ToggleRow';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
 import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import type {
@@ -22,14 +24,19 @@ import type {
   RubricCriterionType,
 } from '@/components/decisions/rubricTemplate';
 import {
+  OVERALL_RECOMMENDATION_KEY,
   addCriterion,
+  addOverallRecommendation,
   changeCriterionType,
   createEmptyRubricTemplate,
+  ensureOverallRecommendationLast,
   getCriteria,
   getCriterionErrors,
   getCriterionSchema,
   getCriterionType,
+  hasOverallRecommendation,
   removeCriterion,
+  removeOverallRecommendation,
   reorderCriteria,
   setCriterionRequired,
   updateCriterionDescription,
@@ -117,8 +124,9 @@ export function RubricEditorContent({
     const criterionId = crypto.randomUUID().slice(0, 8);
     const label = t('Untitled field');
     setTemplate((prev) => {
-      const updated = addCriterion(prev, criterionId, 'scored', label);
-      return setCriterionRequired(updated, criterionId, true);
+      let updated = addCriterion(prev, criterionId, 'scored', label);
+      updated = setCriterionRequired(updated, criterionId, true);
+      return ensureOverallRecommendationLast(updated);
     });
     setExpandedCriterionIds((prev) => new Set(prev).add(criterionId));
     setNewCriterionIds((prev) => new Set(prev).add(criterionId));
@@ -153,12 +161,13 @@ export function RubricEditorContent({
   }, [criterionToDelete]);
 
   const handleReorderCriteria = useCallback((newItems: CriterionView[]) => {
-    setTemplate((prev) =>
-      reorderCriteria(
-        prev,
-        newItems.map((item) => item.id),
-      ),
-    );
+    setTemplate((prev) => {
+      const newOrder = newItems.map((item) => item.id);
+      if (hasOverallRecommendation(prev)) {
+        newOrder.push(OVERALL_RECOMMENDATION_KEY);
+      }
+      return reorderCriteria(prev, newOrder);
+    });
   }, []);
 
   const handleUpdateLabel = useCallback(
@@ -278,6 +287,19 @@ export function RubricEditorContent({
     });
   }, []);
 
+  const overallRecommendationEnabled = useMemo(
+    () => hasOverallRecommendation(template),
+    [template],
+  );
+
+  const handleOverallRecommendationToggle = useCallback((enabled: boolean) => {
+    setTemplate((prev) =>
+      enabled
+        ? addOverallRecommendation(prev)
+        : removeOverallRecommendation(prev),
+    );
+  }, []);
+
   return (
     <div className="flex h-full flex-col md:flex-row">
       <main className="flex-1 basis-1/2 overflow-y-auto p-4 pb-24 [scrollbar-gutter:stable] md:p-8 md:pb-8">
@@ -375,6 +397,21 @@ export function RubricEditorContent({
               </Button>
             </>
           )}
+
+          <hr className="border-neutral-gray1" />
+
+          <ToggleRow
+            label={t('Overall Recommendation')}
+            description={t(
+              'Reviewers recommend Yes, Maybe, or No per proposal',
+            )}
+          >
+            <ToggleButton
+              isSelected={overallRecommendationEnabled}
+              onChange={handleOverallRecommendationToggle}
+              size="small"
+            />
+          </ToggleRow>
         </div>
       </main>
 

--- a/apps/app/src/components/decisions/rubricTemplate.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.ts
@@ -440,9 +440,12 @@ export function hasOverallRecommendation(
   return OVERALL_RECOMMENDATION_KEY in (template.properties ?? {});
 }
 
-export function addOverallRecommendation(
+export function enableOverallRecommendation(
   template: RubricTemplateSchema,
 ): RubricTemplateSchema {
+  if (hasOverallRecommendation(template)) {
+    return template;
+  }
   const schema: XFormatPropertySchema = {
     type: 'string',
     title: 'Overall Recommendation',
@@ -458,7 +461,7 @@ export function addOverallRecommendation(
   return updated;
 }
 
-export function removeOverallRecommendation(
+export function disableOverallRecommendation(
   template: RubricTemplateSchema,
 ): RubricTemplateSchema {
   return removeProperty(template, OVERALL_RECOMMENDATION_KEY);

--- a/apps/app/src/components/decisions/rubricTemplate.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.ts
@@ -13,6 +13,10 @@ import type {
   RubricTemplateSchema,
   XFormatPropertySchema,
 } from '@op/common/client';
+import {
+  OVERALL_RECOMMENDATION_KEY,
+  isOverallRecommendationField,
+} from '@op/common/client';
 import type { JSONSchema7 } from 'json-schema';
 
 import type { TranslationKey } from '@/lib/i18n/routing';
@@ -256,6 +260,7 @@ export function getCriteria(template: RubricTemplateSchema): CriterionView[] {
   const order = getCriterionOrder(template);
   const criteria: CriterionView[] = [];
   for (const id of order) {
+    if (isOverallRecommendationField(id)) continue;
     const criterion = getCriterion(template, id);
     if (criterion) {
       criteria.push(criterion);
@@ -421,6 +426,60 @@ export function updateScoreLabel(
   });
 
   return updateProperty(template, criterionId, (s) => ({ ...s, oneOf }));
+}
+
+// ---------------------------------------------------------------------------
+// Overall Recommendation
+// ---------------------------------------------------------------------------
+
+export { OVERALL_RECOMMENDATION_KEY };
+
+export function hasOverallRecommendation(
+  template: RubricTemplateSchema,
+): boolean {
+  return OVERALL_RECOMMENDATION_KEY in (template.properties ?? {});
+}
+
+export function addOverallRecommendation(
+  template: RubricTemplateSchema,
+): RubricTemplateSchema {
+  const schema: XFormatPropertySchema = {
+    type: 'string',
+    title: 'Overall Recommendation',
+    'x-format': 'dropdown',
+    oneOf: [
+      { const: 'yes', title: 'Yes' },
+      { const: 'maybe', title: 'Maybe' },
+      { const: 'no', title: 'No' },
+    ],
+  };
+  let updated = addProperty(template, OVERALL_RECOMMENDATION_KEY, schema);
+  updated = setPropertyRequired(updated, OVERALL_RECOMMENDATION_KEY, true);
+  return updated;
+}
+
+export function removeOverallRecommendation(
+  template: RubricTemplateSchema,
+): RubricTemplateSchema {
+  return removeProperty(template, OVERALL_RECOMMENDATION_KEY);
+}
+
+/**
+ * If the overall recommendation criterion exists, move it to the end of
+ * `x-field-order`. No-op when absent.
+ */
+export function ensureOverallRecommendationLast(
+  template: RubricTemplateSchema,
+): RubricTemplateSchema {
+  const order = getPropertyOrder(template);
+  if (!order.includes(OVERALL_RECOMMENDATION_KEY)) {
+    return template;
+  }
+  const withoutRec = order.filter((id) => id !== OVERALL_RECOMMENDATION_KEY);
+  return reorderProperties(template, [
+    ...withoutRec,
+    OVERALL_RECOMMENDATION_KEY,
+  ]);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -981,6 +981,8 @@
   "Rubric criteria": "রুব্রিক মানদণ্ড",
   "Help reviewers score consistently by describing what each point value represents": "প্রতিটি পয়েন্ট মান কী বোঝায় তা বর্ণনা করে পর্যালোচকদের ধারাবাহিকভাবে স্কোর করতে সাহায্য করুন",
   "Review Criteria": "পর্যালোচনার মানদণ্ড",
+  "Overall Recommendation": "সামগ্রিক সুপারিশ",
+  "Reviewers recommend Yes, Maybe, or No per proposal": "পর্যালোচকরা প্রতিটি প্রস্তাবের জন্য হ্যাঁ, হয়তো বা না সুপারিশ করেন",
   "No review criteria yet": "এখনো কোনো পর্যালোচনার মানদণ্ড নেই",
   "Add criteria to help reviewers evaluate proposals consistently": "পর্যালোচকদের ধারাবাহিকভাবে প্রস্তাব মূল্যায়নে সহায়তার জন্য মানদণ্ড যোগ করুন",
   "Add your first criterion": "আপনার প্রথম মানদণ্ড যোগ করুন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -980,6 +980,8 @@
   "Rubric criteria": "Rubric criteria",
   "Help reviewers score consistently by describing what each point value represents": "Help reviewers score consistently by describing what each point value represents",
   "Review Criteria": "Review Criteria",
+  "Overall Recommendation": "Overall Recommendation",
+  "Reviewers recommend Yes, Maybe, or No per proposal": "Reviewers recommend Yes, Maybe, or No per proposal",
   "No review criteria yet": "No review criteria yet",
   "Add criteria to help reviewers evaluate proposals consistently": "Add criteria to help reviewers evaluate proposals consistently",
   "Add your first criterion": "Add your first criterion",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -980,6 +980,8 @@
   "Rubric criteria": "Criterios de rúbrica",
   "Help reviewers score consistently by describing what each point value represents": "Ayude a los revisores a puntuar de manera consistente describiendo lo que representa cada valor de punto",
   "Review Criteria": "Criterios de revisión",
+  "Overall Recommendation": "Recomendación general",
+  "Reviewers recommend Yes, Maybe, or No per proposal": "Los revisores recomiendan Sí, Quizás o No por propuesta",
   "No review criteria yet": "Aún no hay criterios de revisión",
   "Add criteria to help reviewers evaluate proposals consistently": "Agregue criterios para ayudar a los revisores a evaluar propuestas de manera consistente",
   "Add your first criterion": "Agregue su primer criterio",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -980,6 +980,8 @@
   "Rubric criteria": "Critères de la grille",
   "Help reviewers score consistently by describing what each point value represents": "Aidez les évaluateurs à noter de manière cohérente en décrivant ce que représente chaque valeur de point",
   "Review Criteria": "Critères d'évaluation",
+  "Overall Recommendation": "Recommandation générale",
+  "Reviewers recommend Yes, Maybe, or No per proposal": "Les évaluateurs recommandent Oui, Peut-être ou Non par proposition",
   "No review criteria yet": "Pas encore de critères d'évaluation",
   "Add criteria to help reviewers evaluate proposals consistently": "Ajoutez des critères pour aider les évaluateurs à évaluer les propositions de manière cohérente",
   "Add your first criterion": "Ajoutez votre premier critère",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -980,6 +980,8 @@
   "Rubric criteria": "Critérios da rubrica",
   "Help reviewers score consistently by describing what each point value represents": "Ajude os avaliadores a pontuar de forma consistente descrevendo o que cada valor de ponto representa",
   "Review Criteria": "Critérios de avaliação",
+  "Overall Recommendation": "Recomendação geral",
+  "Reviewers recommend Yes, Maybe, or No per proposal": "Os avaliadores recomendam Sim, Talvez ou Não por proposta",
   "No review criteria yet": "Ainda não há critérios de avaliação",
   "Add criteria to help reviewers evaluate proposals consistently": "Adicione critérios para ajudar os avaliadores a avaliar propostas de forma consistente",
   "Add your first criterion": "Adicione seu primeiro critério",

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -34,6 +34,8 @@ export { serverExtensions } from './services/decision/tiptapExtensions';
 export {
   getRubricScoringInfo,
   isRationaleField,
+  OVERALL_RECOMMENDATION_KEY,
+  isOverallRecommendationField,
 } from './services/decision/getRubricScoringInfo';
 export { REVIEWS_POLICIES } from './services/decision/schemas/types';
 export { isLastPhase } from './services/decision/schemas/instanceData';

--- a/packages/common/src/services/decision/getRubricScoringInfo.test.ts
+++ b/packages/common/src/services/decision/getRubricScoringInfo.test.ts
@@ -161,6 +161,45 @@ describe('getRubricScoringInfo', () => {
     expect(info.totalPoints).toBe(0);
   });
 
+  it('excludes __overall_recommendation field from criteria and summary', () => {
+    const schema: RubricTemplateSchema = {
+      type: 'object',
+      properties: {
+        innovation: {
+          type: 'integer',
+          title: 'Innovation',
+          'x-format': 'dropdown',
+          minimum: 1,
+          maximum: 5,
+          oneOf: [
+            { const: 1, title: 'Poor' },
+            { const: 2, title: 'Average' },
+            { const: 3, title: 'Good' },
+            { const: 4, title: 'Great' },
+            { const: 5, title: 'Excellent' },
+          ],
+        },
+        __overall_recommendation: {
+          type: 'string',
+          title: 'Overall Recommendation',
+          'x-format': 'dropdown',
+          oneOf: [
+            { const: 'yes', title: 'Yes' },
+            { const: 'maybe', title: 'Maybe' },
+            { const: 'no', title: 'No' },
+          ],
+        },
+      },
+    };
+
+    const info = getRubricScoringInfo(schema);
+
+    expect(info.criteria).toHaveLength(1);
+    expect(info.criteria[0]!.key).toBe('innovation');
+    expect(info.totalPoints).toBe(5);
+    expect(info.summary).toEqual({ dropdown: 1 });
+  });
+
   it('treats non-integer types as qualitative (0 points)', () => {
     const schema: RubricTemplateSchema = {
       type: 'object',

--- a/packages/common/src/services/decision/getRubricScoringInfo.ts
+++ b/packages/common/src/services/decision/getRubricScoringInfo.ts
@@ -10,6 +10,17 @@ export function isRationaleField(key: string): boolean {
   return key.endsWith('__rationale');
 }
 
+/**
+ * Well-known key for the optional "Overall Recommendation" criterion.
+ * When enabled, reviewers pick Yes / Maybe / No per proposal.
+ * Excluded from scoring and criteria counts.
+ */
+export const OVERALL_RECOMMENDATION_KEY = '__overall_recommendation';
+
+export function isOverallRecommendationField(key: string): boolean {
+  return key === OVERALL_RECOMMENDATION_KEY;
+}
+
 /** Scoring info for a single rubric criterion. */
 export interface RubricCriterion {
   key: string;
@@ -47,7 +58,7 @@ export function getRubricScoringInfo(
   let totalPoints = 0;
 
   for (const [key, prop] of Object.entries(properties)) {
-    if (isRationaleField(key)) continue;
+    if (isRationaleField(key) || isOverallRecommendationField(key)) continue;
 
     const scored = prop.type === 'integer';
     const maxPoints = scored


### PR DESCRIPTION
Adds the toggle for Overall Recommendation in the rubric template editor. The property will have a well-known key in the schema so as to be able to ensure it is always in the correct order (last).

Rendering the field for the review will be added in a follow up PR. 

<img width="1159" height="605" alt="Preview of the rubric editor with the new Overall Recommendation toggle in place" src="https://github.com/user-attachments/assets/195a9318-5807-452f-b6bb-1231aa745e8b" />
