### PR TITLE
test(reviews): add e2e test for full review lifecycle

### DIFF
--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -45,6 +45,7 @@ const config = {
     NEXT_PUBLIC_DEPLOY_ENV: DEPLOY_ENV,
     NEXT_PUBLIC_PREVIEW_BRANCH_URL:
       DEPLOY_ENV === 'preview' ? PREVIEW_BRANCH_URL : undefined,
+    NEXT_PUBLIC_E2E: process.env.E2E,
   },
   images: {
     minimumCacheTTL: 31536000, // 1 year — assets are content-addressed
@@ -130,8 +131,7 @@ const getGitInfo = () => ({
   branch:
     process.env.VERCEL_GIT_COMMIT_REF ??
     tryGit('git rev-parse --abbrev-ref HEAD'),
-  sha:
-    process.env.VERCEL_GIT_COMMIT_SHA ?? tryGit('git rev-parse HEAD'),
+  sha: process.env.VERCEL_GIT_COMMIT_SHA ?? tryGit('git rev-parse HEAD'),
 });
 
 const { branch: currentBranch, sha: commitSha } = getGitInfo();

--- a/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
@@ -42,7 +42,7 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
           <Button
             color="secondary"
             size="small"
-            isDisabled={isSubmitted || isPausedForRevision}
+            isDisabled={isSubmitted}
             onPress={() => {
               if (isPausedForRevision) {
                 setIsViewModalOpen(true);

--- a/apps/app/src/hooks/useFeatureFlag.ts
+++ b/apps/app/src/hooks/useFeatureFlag.ts
@@ -1,8 +1,11 @@
 import { useFeatureFlagEnabled } from 'posthog-js/react';
 
 export const useFeatureFlag = (key: string) => {
-  // enable flags for development environments
-  if (process.env.NODE_ENV === 'development') {
+  // enable flags for development and e2e environments
+  if (
+    process.env.NODE_ENV === 'development' ||
+    process.env.NEXT_PUBLIC_E2E === 'true'
+  ) {
     return true;
   }
 

--- a/tests/e2e/tests/review-submit.spec.ts
+++ b/tests/e2e/tests/review-submit.spec.ts
@@ -1,0 +1,229 @@
+import type { RubricTemplateSchema } from '@op/common';
+import { ProposalStatus, processInstances } from '@op/db/schema';
+import { db, eq } from '@op/db/test';
+import {
+  createDecisionInstance,
+  createProposal,
+  createProposalHistorySnapshot,
+  createReviewAssignment,
+  getSeededTemplate,
+} from '@op/test';
+
+import { expect, test } from '../fixtures/index.js';
+
+/**
+ * Rubric template with three criterion types:
+ *  - innovation: scored integer dropdown (1–5)
+ *  - compliance: yes/no toggle
+ *  - feedback:   long-text textarea
+ *
+ * All three are required so the submit button stays disabled until every
+ * criterion has a value.
+ */
+const RUBRIC_TEMPLATE = {
+  type: 'object',
+  required: ['innovation', 'compliance', 'feedback'],
+  'x-field-order': ['innovation', 'compliance', 'feedback'],
+  properties: {
+    innovation: {
+      type: 'integer',
+      title: 'Innovation',
+      description: 'How innovative is this proposal?',
+      'x-format': 'dropdown',
+      minimum: 1,
+      maximum: 5,
+      oneOf: [
+        { const: 1, title: '1 — Poor' },
+        { const: 2, title: '2 — Fair' },
+        { const: 3, title: '3 — Good' },
+        { const: 4, title: '4 — Very Good' },
+        { const: 5, title: '5 — Excellent' },
+      ],
+    },
+    compliance: {
+      type: 'string',
+      title: 'Compliance',
+      description: 'Does the proposal meet compliance requirements?',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 'yes', title: 'Yes' },
+        { const: 'no', title: 'No' },
+      ],
+    },
+    feedback: {
+      type: 'string',
+      title: 'Qualitative Feedback',
+      description: 'Provide written feedback on the proposal.',
+      'x-format': 'long-text',
+      minLength: 1,
+    },
+  },
+} as const satisfies RubricTemplateSchema;
+
+test.describe('Review Submit', () => {
+  test('reviewer can fill rubric form and submit review', async ({
+    authenticatedPage,
+    org,
+  }) => {
+    // -- Setup ---------------------------------------------------------------
+
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: template.processSchema,
+    });
+
+    // Inject rubricTemplate into instanceData and set current phase to "review"
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...(instance.instance.instanceData as Record<string, unknown>),
+          rubricTemplate: RUBRIC_TEMPLATE,
+        },
+        currentStateId: 'review',
+      })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    // Create a submitted proposal for the reviewer to evaluate
+    const proposal = await createProposal({
+      processInstanceId: instance.instance.id,
+      submittedByProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      proposalData: {
+        title: 'Proposal Under Review',
+        collaborationDocId: 'test-proposal-doc',
+      },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    // History snapshot is needed by the review assignment lookup
+    await createProposalHistorySnapshot({ proposalId: proposal.id });
+
+    // Assign the authenticated user as the reviewer
+    const assignment = await createReviewAssignment({
+      processInstanceId: instance.instance.id,
+      proposalId: proposal.id,
+      reviewerProfileId: org.adminUser.profileId,
+    });
+
+    // Small delay for DB propagation
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    // -- Navigate to review page ---------------------------------------------
+
+    await authenticatedPage.goto(
+      `/en/decisions/${instance.slug}/reviews/${assignment.id}`,
+      { waitUntil: 'domcontentloaded' },
+    );
+
+    // Verify the rubric form rendered (heading appears in both desktop and
+    // mobile layouts — pick the first visible one).
+    await expect(
+      authenticatedPage.getByText('Review Proposal', { exact: true }).first(),
+    ).toBeVisible({ timeout: 36_000 });
+
+    const submitButton = authenticatedPage.getByRole('button', {
+      name: 'Submit review',
+    });
+    await expect(submitButton).toBeVisible();
+
+    // Submit should be disabled — no criteria filled yet
+    await expect(submitButton).toBeDisabled();
+
+    // -- Open "Request revision" modal then cancel ----------------------------
+
+    const requestRevisionButton = authenticatedPage.getByRole('button', {
+      name: 'Request revision',
+    });
+    await requestRevisionButton.click();
+
+    // Modal should be visible with its header and form
+    const revisionModal = authenticatedPage.getByRole('dialog');
+    await expect(revisionModal).toBeVisible();
+    await expect(
+      revisionModal.getByRole('heading', { name: 'Request revision' }),
+    ).toBeVisible();
+    await expect(
+      revisionModal.getByText('Feedback for proposal author'),
+    ).toBeVisible();
+
+    // The submit button inside the modal should be disabled (empty comment)
+    const modalSubmitButton = revisionModal.getByRole('button', {
+      name: 'Request revision',
+    });
+    await expect(modalSubmitButton).toBeDisabled();
+
+    // Type a comment — button should become enabled
+    const commentTextarea = revisionModal.getByRole('textbox', {
+      name: 'Feedback for proposal author',
+    });
+    await commentTextarea.fill('Please add more detail to the budget section.');
+    await expect(modalSubmitButton).toBeEnabled();
+
+    // Cancel instead of submitting
+    await revisionModal.getByRole('button', { name: 'Cancel' }).click();
+    await expect(revisionModal).toBeHidden();
+
+    // -- Fill in scored criterion (Innovation) --------------------------------
+
+    const innovationSelect = authenticatedPage.getByRole('button', {
+      name: 'Innovation',
+    });
+    await innovationSelect.click();
+    await authenticatedPage
+      .getByRole('option', { name: '4 — Very Good' })
+      .click();
+
+    // -- Fill in yes/no criterion (Compliance) --------------------------------
+
+    // The yes/no toggle has no accessible name — locate via its parent section.
+    const complianceSection = authenticatedPage
+      .locator('section')
+      .filter({ hasText: 'Compliance' });
+    await complianceSection.getByRole('button').click();
+
+    // -- Fill in long-text criterion (Qualitative Feedback) -------------------
+
+    const feedbackTextarea = authenticatedPage.getByRole('textbox', {
+      name: 'Qualitative Feedback',
+    });
+    await feedbackTextarea.fill('The proposal is well-structured and feasible.');
+
+    // -- Verify total score updated -------------------------------------------
+
+    // Only "Innovation" contributes to the score (integer criterion = 4 pts).
+    // The component renders in both desktop and mobile layouts — use .first().
+    const totalScoreContainer = authenticatedPage
+      .getByText('Total Score')
+      .first()
+      .locator('..');
+    await expect(
+      totalScoreContainer.locator('span').filter({ hasText: /^4$/ }),
+    ).toBeVisible();
+
+    // -- Submit the review ----------------------------------------------------
+
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    // -- Assert success -------------------------------------------------------
+
+    // Success toast
+    const successToast = authenticatedPage
+      .locator('[data-sonner-toast]')
+      .filter({ hasText: 'Review submitted successfully' });
+    await expect(successToast).toBeVisible({ timeout: 10_000 });
+
+    // Redirected back to the decision page
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/decisions/${instance.slug}`),
+      { timeout: 10_000 },
+    );
+  });
+});

--- a/tests/e2e/tests/review-submit.spec.ts
+++ b/tests/e2e/tests/review-submit.spec.ts
@@ -70,18 +70,32 @@ const REVIEW_SCHEMA = {
 } satisfies DecisionSchemaDefinition;
 
 /**
- * Rubric template with three criterion types:
- *  - innovation: scored integer dropdown (1–5)
- *  - compliance: yes/no toggle
- *  - feedback:   long-text textarea
+ * Rubric template with five criteria — three required and two optional.
  *
- * All three are required so the submit button stays disabled until every
- * criterion has a value.
+ * Required:
+ *  - innovation:  scored integer dropdown (1–5)
+ *  - compliance:  yes/no toggle
+ *  - feasibility: scored integer dropdown (1–3)
+ *
+ * Optional:
+ *  - feedback:    long-text textarea
+ *  - methodology: string dropdown (multiple choice)
+ *
+ * This lets us verify that:
+ *  - Submit is disabled until all *required* criteria are filled
+ *  - Submit is enabled even when optional criteria are left empty
+ *  - Total score sums only scored criteria that have values
  */
 const RUBRIC_TEMPLATE = {
   type: 'object',
-  required: ['innovation', 'compliance', 'feedback'],
-  'x-field-order': ['innovation', 'compliance', 'feedback'],
+  required: ['innovation', 'compliance', 'feasibility'],
+  'x-field-order': [
+    'innovation',
+    'feasibility',
+    'compliance',
+    'methodology',
+    'feedback',
+  ],
   properties: {
     innovation: {
       type: 'integer',
@@ -98,6 +112,19 @@ const RUBRIC_TEMPLATE = {
         { const: 5, title: '5 — Excellent' },
       ],
     },
+    feasibility: {
+      type: 'integer',
+      title: 'Feasibility',
+      description: 'How feasible is the proposed plan?',
+      'x-format': 'dropdown',
+      minimum: 1,
+      maximum: 3,
+      oneOf: [
+        { const: 1, title: '1 — Unlikely' },
+        { const: 2, title: '2 — Possible' },
+        { const: 3, title: '3 — Very Likely' },
+      ],
+    },
     compliance: {
       type: 'string',
       title: 'Compliance',
@@ -108,12 +135,22 @@ const RUBRIC_TEMPLATE = {
         { const: 'no', title: 'No' },
       ],
     },
+    methodology: {
+      type: 'string',
+      title: 'Methodology',
+      description: 'What methodology does the proposal follow?',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 'quantitative', title: 'Quantitative' },
+        { const: 'qualitative', title: 'Qualitative' },
+        { const: 'mixed', title: 'Mixed Methods' },
+      ],
+    },
     feedback: {
       type: 'string',
       title: 'Qualitative Feedback',
       description: 'Provide written feedback on the proposal.',
       'x-format': 'long-text',
-      minLength: 1,
     },
   },
 } as const satisfies RubricTemplateSchema;
@@ -289,33 +326,43 @@ test.describe('Review Submit', () => {
       page.getByText('Review Proposal', { exact: true }).first(),
     ).toBeVisible({ timeout: 36_000 });
 
-    // Scored criterion (Innovation)
+    const submitButton = page.getByRole('button', { name: 'Submit review' });
+    await expect(submitButton).toBeDisabled();
+
+    // Fill first required criterion: Innovation (scored, 4 pts)
     await page.getByRole('button', { name: 'Innovation' }).click();
     await page.getByRole('option', { name: '4 — Very Good' }).click();
 
-    // Yes/no criterion (Compliance)
+    // Still disabled — two more required criteria (Feasibility, Compliance)
+    await expect(submitButton).toBeDisabled();
+
+    // Fill second required criterion: Feasibility (scored, 2 pts)
+    await page.getByRole('button', { name: 'Feasibility' }).click();
+    await page.getByRole('option', { name: '2 — Possible' }).click();
+
+    // Still disabled — Compliance is still missing
+    await expect(submitButton).toBeDisabled();
+
+    // Fill third required criterion: Compliance (yes/no toggle)
     await page
       .locator('section')
       .filter({ hasText: 'Compliance' })
       .getByRole('button')
       .click();
 
-    // Long-text criterion (Qualitative Feedback)
-    await page
-      .getByRole('textbox', { name: 'Qualitative Feedback' })
-      .fill('The proposal is well-structured and feasible.');
+    // All required criteria are filled — submit should be enabled even though
+    // the optional criteria (Methodology, Qualitative Feedback) are empty.
+    await expect(submitButton).toBeEnabled();
 
-    // Total score
+    // Total score = Innovation (4) + Feasibility (2) = 6
     const totalScoreContainer = page
       .getByText('Total Score')
       .first()
       .locator('..');
     await expect(
-      totalScoreContainer.locator('span').filter({ hasText: /^4$/ }),
+      totalScoreContainer.locator('span').filter({ hasText: /^6$/ }),
     ).toBeVisible();
 
-    const submitButton = page.getByRole('button', { name: 'Submit review' });
-    await expect(submitButton).toBeEnabled();
     await submitButton.click();
 
     await expect(
@@ -328,7 +375,10 @@ test.describe('Review Submit', () => {
     // Step 7: Redirected to list — status is "Completed"
     // ========================================================================
 
-    await expect(page).toHaveURL(new RegExp(decisionUrl), { timeout: 10_000 });
+    // router.push may drop the locale prefix, so match just the slug
+    await expect(page).toHaveURL(new RegExp(`/decisions/${instance.slug}`), {
+      timeout: 10_000,
+    });
 
     await expect(page.getByText('Proposals to review')).toBeVisible({
       timeout: 10_000,

--- a/tests/e2e/tests/review-submit.spec.ts
+++ b/tests/e2e/tests/review-submit.spec.ts
@@ -1,4 +1,7 @@
-import type { RubricTemplateSchema } from '@op/common';
+import type {
+  DecisionSchemaDefinition,
+  RubricTemplateSchema,
+} from '@op/common';
 import { ProposalStatus, processInstances } from '@op/db/schema';
 import { db, eq } from '@op/db/test';
 import {
@@ -10,6 +13,61 @@ import {
 } from '@op/test';
 
 import { expect, test } from '../fixtures/index.js';
+
+/**
+ * Schema with a review phase that has `proposals.review: true` so the
+ * DecisionStateRouter renders the ReviewPage with the assignments list.
+ */
+const REVIEW_SCHEMA = {
+  id: 'review-e2e',
+  version: '1.0.0',
+  name: 'Review E2E',
+  description: 'Schema for review e2e tests.',
+  proposalTemplate: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        title: 'Proposal title',
+        'x-format': 'short-text',
+      },
+    },
+    'x-field-order': ['title'],
+    required: ['title'],
+  },
+  phases: [
+    {
+      id: 'submission',
+      name: 'Proposal Submission',
+      description: 'Members submit proposals.',
+      rules: {
+        proposals: { submit: true },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'review',
+      name: 'Review',
+      description: 'Reviewers evaluate proposals.',
+      rules: {
+        proposals: { submit: false, review: true },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'results',
+      name: 'Results',
+      description: 'Final results.',
+      rules: {
+        proposals: { submit: false },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+  ],
+} satisfies DecisionSchemaDefinition;
 
 /**
  * Rubric template with three criterion types:
@@ -60,12 +118,19 @@ const RUBRIC_TEMPLATE = {
   },
 } as const satisfies RubricTemplateSchema;
 
+/**
+ * The proposal title displayed on cards is resolved from the collab doc
+ * fragment, not `proposalData.title`. The `test-proposal-view-doc` mock
+ * returns 'Community Solar Initiative' for the title fragment.
+ */
+const PROPOSAL_TITLE = 'Community Solar Initiative';
+
 test.describe('Review Submit', () => {
-  test('reviewer can fill rubric form and submit review', async ({
-    authenticatedPage,
+  test('full review journey: request revision → cancel → submit review', async ({
+    authenticatedPage: page,
     org,
   }) => {
-    // -- Setup ---------------------------------------------------------------
+    // -- Setup: decision in review phase with one assignment ------------------
 
     const template = await getSeededTemplate();
 
@@ -74,10 +139,10 @@ test.describe('Review Submit', () => {
       ownerProfileId: org.organizationProfile.id,
       authUserId: org.adminUser.authUserId,
       email: org.adminUser.email,
-      schema: template.processSchema,
+      schema: REVIEW_SCHEMA,
     });
 
-    // Inject rubricTemplate into instanceData and set current phase to "review"
+    // Inject rubricTemplate and set current phase to "review"
     await db
       .update(processInstances)
       .set({
@@ -89,117 +154,159 @@ test.describe('Review Submit', () => {
       })
       .where(eq(processInstances.id, instance.instance.id));
 
-    // Create a submitted proposal for the reviewer to evaluate
     const proposal = await createProposal({
       processInstanceId: instance.instance.id,
       submittedByProfileId: org.organizationProfile.id,
       authUserId: org.adminUser.authUserId,
       email: org.adminUser.email,
       proposalData: {
-        title: 'Proposal Under Review',
-        collaborationDocId: 'test-proposal-doc',
+        title: PROPOSAL_TITLE,
+        collaborationDocId: 'test-proposal-view-doc',
       },
       status: ProposalStatus.SUBMITTED,
     });
 
-    // History snapshot is needed by the review assignment lookup
     await createProposalHistorySnapshot({ proposalId: proposal.id });
 
-    // Assign the authenticated user as the reviewer
-    const assignment = await createReviewAssignment({
+    await createReviewAssignment({
       processInstanceId: instance.instance.id,
       proposalId: proposal.id,
       reviewerProfileId: org.adminUser.profileId,
     });
 
-    // Small delay for DB propagation
     await new Promise((resolve) => setTimeout(resolve, 600));
 
-    // -- Navigate to review page ---------------------------------------------
+    const decisionUrl = `/en/decisions/${instance.slug}`;
 
-    await authenticatedPage.goto(
-      `/en/decisions/${instance.slug}/reviews/${assignment.id}`,
-      { waitUntil: 'domcontentloaded' },
-    );
+    /** Locate the status badge <span> on the assignments list. */
+    const statusBadge = page.locator('span').filter({
+      hasText:
+        /^(Not Started|In Progress|Completed|Revision Requested|Needs Review)$/,
+    });
 
-    // Verify the rubric form rendered (heading appears in both desktop and
-    // mobile layouts — pick the first visible one).
+    // ========================================================================
+    // Step 1: Decision page — assignments list shows "Not Started"
+    // ========================================================================
+
+    await page.goto(decisionUrl, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByText('Proposals to review')).toBeVisible({
+      timeout: 36_000,
+    });
+    await expect(page.getByText(PROPOSAL_TITLE).first()).toBeVisible();
+    await expect(statusBadge).toHaveText('Not Started');
+
+    // ========================================================================
+    // Step 2: Click into review and request a revision
+    // ========================================================================
+
+    await page.getByText(PROPOSAL_TITLE).first().click();
+    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
     await expect(
-      authenticatedPage.getByText('Review Proposal', { exact: true }).first(),
+      page.getByText('Review Proposal', { exact: true }).first(),
     ).toBeVisible({ timeout: 36_000 });
 
-    const submitButton = authenticatedPage.getByRole('button', {
-      name: 'Submit review',
-    });
-    await expect(submitButton).toBeVisible();
+    await page.getByRole('button', { name: 'Request revision' }).click();
 
-    // Submit should be disabled — no criteria filled yet
-    await expect(submitButton).toBeDisabled();
+    const requestModal = page.getByRole('dialog');
+    await expect(requestModal).toBeVisible();
 
-    // -- Open "Request revision" modal then cancel ----------------------------
+    await requestModal
+      .getByRole('textbox', { name: 'Feedback for proposal author' })
+      .fill('Please add more detail to the budget section.');
 
-    const requestRevisionButton = authenticatedPage.getByRole('button', {
-      name: 'Request revision',
-    });
-    await requestRevisionButton.click();
-
-    // Modal should be visible with its header and form
-    const revisionModal = authenticatedPage.getByRole('dialog');
-    await expect(revisionModal).toBeVisible();
-    await expect(
-      revisionModal.getByRole('heading', { name: 'Request revision' }),
-    ).toBeVisible();
-    await expect(
-      revisionModal.getByText('Feedback for proposal author'),
-    ).toBeVisible();
-
-    // The submit button inside the modal should be disabled (empty comment)
-    const modalSubmitButton = revisionModal.getByRole('button', {
-      name: 'Request revision',
-    });
-    await expect(modalSubmitButton).toBeDisabled();
-
-    // Type a comment — button should become enabled
-    const commentTextarea = revisionModal.getByRole('textbox', {
-      name: 'Feedback for proposal author',
-    });
-    await commentTextarea.fill('Please add more detail to the budget section.');
-    await expect(modalSubmitButton).toBeEnabled();
-
-    // Cancel instead of submitting
-    await revisionModal.getByRole('button', { name: 'Cancel' }).click();
-    await expect(revisionModal).toBeHidden();
-
-    // -- Fill in scored criterion (Innovation) --------------------------------
-
-    const innovationSelect = authenticatedPage.getByRole('button', {
-      name: 'Innovation',
-    });
-    await innovationSelect.click();
-    await authenticatedPage
-      .getByRole('option', { name: '4 — Very Good' })
+    await requestModal
+      .getByRole('button', { name: 'Request revision' })
       .click();
 
-    // -- Fill in yes/no criterion (Compliance) --------------------------------
+    await expect(
+      page
+        .locator('[data-sonner-toast]')
+        .filter({ hasText: 'Revision requested' }),
+    ).toBeVisible({ timeout: 10_000 });
 
-    // The yes/no toggle has no accessible name — locate via its parent section.
-    const complianceSection = authenticatedPage
-      .locator('section')
-      .filter({ hasText: 'Compliance' });
-    await complianceSection.getByRole('button').click();
+    // ========================================================================
+    // Step 3: Back to list — status is "Revision Requested"
+    // ========================================================================
 
-    // -- Fill in long-text criterion (Qualitative Feedback) -------------------
+    await page.getByText('Back to proposals').click();
+    await expect(page).toHaveURL(new RegExp(decisionUrl), { timeout: 10_000 });
 
-    const feedbackTextarea = authenticatedPage.getByRole('textbox', {
-      name: 'Qualitative Feedback',
+    await expect(page.getByText('Proposals to review')).toBeVisible({
+      timeout: 10_000,
     });
-    await feedbackTextarea.fill('The proposal is well-structured and feasible.');
+    await expect(statusBadge).toHaveText('Revision Requested');
 
-    // -- Verify total score updated -------------------------------------------
+    // ========================================================================
+    // Step 4: Click back into review and cancel the revision
+    // ========================================================================
 
-    // Only "Innovation" contributes to the score (integer criterion = 4 pts).
-    // The component renders in both desktop and mobile layouts — use .first().
-    const totalScoreContainer = authenticatedPage
+    await page.getByText(PROPOSAL_TITLE).first().click();
+    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
+    await expect(
+      page.getByText('Review Proposal', { exact: true }).first(),
+    ).toBeVisible({ timeout: 36_000 });
+
+    // Button still says "Request revision" but now opens the view modal
+    await page.getByRole('button', { name: 'Request revision' }).click();
+
+    const viewModal = page.getByRole('dialog');
+    await expect(viewModal).toBeVisible();
+    await expect(
+      viewModal.getByRole('heading', { name: 'Revision request' }),
+    ).toBeVisible();
+    await expect(
+      viewModal.getByText('Please add more detail to the budget section.'),
+    ).toBeVisible();
+
+    await viewModal.getByRole('button', { name: 'Cancel request' }).click();
+
+    await expect(
+      page
+        .locator('[data-sonner-toast]')
+        .filter({ hasText: 'Revision request cancelled' }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // ========================================================================
+    // Step 5: Back to list — status is "In Progress"
+    // ========================================================================
+
+    await page.getByText('Back to proposals').click();
+    await expect(page).toHaveURL(new RegExp(decisionUrl), { timeout: 10_000 });
+
+    await expect(page.getByText('Proposals to review')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(statusBadge).toHaveText('In Progress');
+
+    // ========================================================================
+    // Step 6: Click back into review, fill rubric, and submit
+    // ========================================================================
+
+    await page.getByText(PROPOSAL_TITLE).first().click();
+    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
+    await expect(
+      page.getByText('Review Proposal', { exact: true }).first(),
+    ).toBeVisible({ timeout: 36_000 });
+
+    // Scored criterion (Innovation)
+    await page.getByRole('button', { name: 'Innovation' }).click();
+    await page.getByRole('option', { name: '4 — Very Good' }).click();
+
+    // Yes/no criterion (Compliance)
+    await page
+      .locator('section')
+      .filter({ hasText: 'Compliance' })
+      .getByRole('button')
+      .click();
+
+    // Long-text criterion (Qualitative Feedback)
+    await page
+      .getByRole('textbox', { name: 'Qualitative Feedback' })
+      .fill('The proposal is well-structured and feasible.');
+
+    // Total score
+    const totalScoreContainer = page
       .getByText('Total Score')
       .first()
       .locator('..');
@@ -207,23 +314,26 @@ test.describe('Review Submit', () => {
       totalScoreContainer.locator('span').filter({ hasText: /^4$/ }),
     ).toBeVisible();
 
-    // -- Submit the review ----------------------------------------------------
-
+    const submitButton = page.getByRole('button', { name: 'Submit review' });
     await expect(submitButton).toBeEnabled();
     await submitButton.click();
 
-    // -- Assert success -------------------------------------------------------
+    await expect(
+      page
+        .locator('[data-sonner-toast]')
+        .filter({ hasText: 'Review submitted successfully' }),
+    ).toBeVisible({ timeout: 10_000 });
 
-    // Success toast
-    const successToast = authenticatedPage
-      .locator('[data-sonner-toast]')
-      .filter({ hasText: 'Review submitted successfully' });
-    await expect(successToast).toBeVisible({ timeout: 10_000 });
+    // ========================================================================
+    // Step 7: Redirected to list — status is "Completed"
+    // ========================================================================
 
-    // Redirected back to the decision page
-    await expect(authenticatedPage).toHaveURL(
-      new RegExp(`/decisions/${instance.slug}`),
-      { timeout: 10_000 },
-    );
+    await expect(page).toHaveURL(new RegExp(decisionUrl), { timeout: 10_000 });
+
+    await expect(page.getByText('Proposals to review')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByText(PROPOSAL_TITLE)).toBeVisible();
+    await expect(statusBadge).toHaveText('Completed');
   });
 });


### PR DESCRIPTION
Covers the complete reviewer journey end-to-end: assignments list → request revision → cancel revision → fill rubric → submit review, verifying status transitions at each step.

fix(reviews): remove isPausedForRevision from Request revision button isDisabled so the view/cancel revision modal is reachable