### PR TITLE
refactor(test): remove createProposalHistorySnapshot in favor of DB trigger

### DIFF
--- a/services/api/src/routers/decision/reviews/getReviewAssignment.test.ts
+++ b/services/api/src/routers/decision/reviews/getReviewAssignment.test.ts
@@ -67,7 +67,6 @@ describe.concurrent('getReviewAssignment', () => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const created = await testData.createReviewAssignment({
       title: 'Live Proposal Review',
-      withHistory: false,
     });
 
     const { collaborationDocId } = created.proposal.proposalData as {

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
@@ -67,7 +67,6 @@ describe.concurrent('listReviewAssignments', () => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const created = await testData.createReviewAssignment({
       title: 'Live Proposal Review',
-      withHistory: false,
     });
 
     const { collaborationDocId } = created.proposal.proposalData as {

--- a/services/api/src/test/helpers/TestReviewsDataManager.ts
+++ b/services/api/src/test/helpers/TestReviewsDataManager.ts
@@ -7,13 +7,14 @@ import {
   objectsInStorage,
   processInstances,
   proposalAttachments,
+  proposals,
 } from '@op/db/schema';
 import {
   configureProcessReviews,
   createProposal,
-  createProposalHistorySnapshot,
   createReviewAssignment as createReviewAssignmentRecord,
   defaultReviewSettings,
+  getLatestProposalHistoryId,
 } from '@op/test';
 import { eq } from 'drizzle-orm';
 
@@ -44,8 +45,6 @@ interface CreateReviewAssignmentOptions {
   title?: string;
   description?: string;
   status?: ProposalReviewAssignmentStatus;
-  /** When false, skips creating a proposal history snapshot. Defaults to true. */
-  withHistory?: boolean;
 }
 
 /** Creates review-focused test fixtures on top of the decision test setup. */
@@ -177,21 +176,25 @@ export class TestReviewsDataManager {
         title: opts.title ?? 'Community Garden Expansion',
         ...(opts.description ? { description: opts.description } : {}),
       },
-      status: ProposalStatus.SUBMITTED,
     });
+
+    // UPDATE to SUBMITTED so the AFTER UPDATE trigger creates a history snapshot.
+    await db
+      .update(proposals)
+      .set({ status: ProposalStatus.SUBMITTED })
+      .where(eq(proposals.id, proposal.id));
 
     this.decisions.trackProfileForCleanup(proposal.profileId);
 
-    const withHistory = opts.withHistory ?? true;
-    const proposalHistory = withHistory
-      ? await createProposalHistorySnapshot({ proposalId: proposal.id })
-      : null;
+    const assignedProposalHistoryId = await getLatestProposalHistoryId({
+      proposalId: proposal.id,
+    });
 
     const assignment = await createReviewAssignmentRecord({
       processInstanceId: context.instance.instance.id,
       proposalId: proposal.id,
       reviewerProfileId: reviewer.profileId,
-      assignedProposalHistoryId: proposalHistory?.historyId ?? null,
+      assignedProposalHistoryId,
       status: opts.status ?? ProposalReviewAssignmentStatus.PENDING,
     });
 

--- a/services/api/src/test/helpers/TestReviewsDataManager.ts
+++ b/services/api/src/test/helpers/TestReviewsDataManager.ts
@@ -183,6 +183,7 @@ export class TestReviewsDataManager {
       .update(proposals)
       .set({ status: ProposalStatus.SUBMITTED })
       .where(eq(proposals.id, proposal.id));
+    proposal.status = ProposalStatus.SUBMITTED;
 
     this.decisions.trackProfileForCleanup(proposal.profileId);
 

--- a/tests/core/src/index.ts
+++ b/tests/core/src/index.ts
@@ -32,7 +32,6 @@ export {
 
 export {
   configureProcessReviews,
-  createProposalHistorySnapshot,
   createProposalReview,
   createReviewAssignment,
   createRevisionRequest,

--- a/tests/core/src/review-data.ts
+++ b/tests/core/src/review-data.ts
@@ -3,12 +3,11 @@ import {
   ProposalReviewRequestState,
   ProposalReviewState,
   decisionProcesses,
-  proposalHistory,
   proposalReviewAssignments,
   proposalReviewRequests,
   proposalReviews,
 } from '@op/db/schema';
-import { db, eq, sql } from '@op/db/test';
+import { db, eq } from '@op/db/test';
 
 export interface ReviewSettings {
   reviewsPolicy: 'full_coverage';
@@ -77,47 +76,6 @@ export async function getLatestProposalHistoryId(opts: {
   }
 
   return latestHistory.historyId;
-}
-
-/** Creates a synthetic proposal history snapshot for test fixtures. */
-export async function createProposalHistorySnapshot(opts: {
-  proposalId: string;
-}): Promise<typeof proposalHistory.$inferSelect> {
-  const proposalRecord = await db.query.proposals.findFirst({
-    where: {
-      id: opts.proposalId,
-    },
-  });
-
-  if (!proposalRecord) {
-    throw new Error(`Proposal not found: ${opts.proposalId}`);
-  }
-
-  const [historyRecord] = await db
-    .insert(proposalHistory)
-    .values({
-      id: proposalRecord.id,
-      processInstanceId: proposalRecord.processInstanceId,
-      proposalData: proposalRecord.proposalData,
-      status: proposalRecord.status,
-      visibility: proposalRecord.visibility,
-      submittedByProfileId: proposalRecord.submittedByProfileId,
-      profileId: proposalRecord.profileId,
-      lastEditedByProfileId: proposalRecord.lastEditedByProfileId,
-      createdAt: proposalRecord.createdAt,
-      updatedAt: proposalRecord.updatedAt,
-      deletedAt: proposalRecord.deletedAt,
-      validDuring: sql`tstzrange(now(), NULL)`,
-    })
-    .returning();
-
-  if (!historyRecord) {
-    throw new Error(
-      `Failed to create proposal history snapshot for proposal: ${opts.proposalId}`,
-    );
-  }
-
-  return historyRecord;
 }
 
 export interface CreateReviewAssignmentOptions {


### PR DESCRIPTION
The AFTER UPDATE trigger from #989 now creates history snapshots automatically, so test helpers no longer need to insert them manually.