### PR TITLE
feat(reviews): surface author revision note on review proposal pane

### DIFF
--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -12,6 +12,7 @@ import { AlertBanner } from '@op/ui/AlertBanner';
 import { Header1, Header3 } from '@op/ui/Header';
 import { Link } from '@op/ui/Link';
 import { Tag, TagGroup } from '@op/ui/TagGroup';
+import type { ReactNode } from 'react';
 import { LuBookmark, LuHeart, LuMessageCircle } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
@@ -34,11 +35,17 @@ export type ProposalPreviewProps = {
   proposal: Proposal;
   /** When set, overrides proposal content with translated HTML and shows attribution */
   translation?: ProposalTranslation;
+  /** Rendered inline after the "Submitted on {date}" line, separated by a bullet. */
+  submissionMetaSuffix?: ReactNode;
+  /** Rendered between the header section and the proposal body. */
+  headerBanner?: ReactNode;
 };
 
 export function ProposalPreview({
   proposal,
   translation,
+  submissionMetaSuffix,
+  headerBanner,
 }: ProposalPreviewProps) {
   const t = useTranslations();
 
@@ -145,9 +152,17 @@ export function ProposalPreview({
                     {proposal.submittedBy.name || proposal.submittedBy.slug}
                   </NavLink>
                   {!isDraft && (
-                    <span className="text-sm text-neutral-charcoal">
-                      {t('Submitted on')} {formatDate(proposal.createdAt)}
-                    </span>
+                    <div className="flex flex-wrap items-center gap-2 text-sm text-neutral-charcoal">
+                      <span>
+                        {t('Submitted on')} {formatDate(proposal.createdAt)}
+                      </span>
+                      {submissionMetaSuffix && (
+                        <>
+                          <span className="text-neutral-gray4">•</span>
+                          {submissionMetaSuffix}
+                        </>
+                      )}
+                    </div>
                   )}
                 </div>
               </>
@@ -183,6 +198,8 @@ export function ProposalPreview({
           </div>
         </div>
       </div>
+
+      {headerBanner}
 
       {/* Proposal Content */}
       {legacyHtml ? (

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -83,7 +83,7 @@ export function ProposalPreview({
   const legacyHtml = htmlContent?.default as string | undefined;
 
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-4">
       {/* Draft mode banner */}
       {isDraft && (
         <AlertBanner intent="default" variant="banner">

--- a/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
+++ b/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { formatDate } from '@/utils/formatting';
+import { Link } from '@op/ui/Link';
+import { useState } from 'react';
+import { LuRotateCw } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
+
+export function RevisedOnBadge({ respondedAt }: { respondedAt: string }) {
+  const t = useTranslations();
+  return (
+    <span className="flex items-center gap-1">
+      <LuRotateCw className="size-4 text-primary-orange2" />
+      {t('Revised on')} {formatDate(respondedAt)}
+    </span>
+  );
+}
+
+export function AuthorRevisionNote({ comment }: { comment: string }) {
+  const t = useTranslations();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <>
+      <div className="flex flex-col gap-3 rounded-lg border border-neutral-gray1 bg-neutral-offWhite p-4">
+        <span className="font-serif text-title-sm14 text-neutral-black">
+          {t("Author's revision note")}
+        </span>
+        <p className="text-base whitespace-pre-wrap text-neutral-charcoal">
+          {comment}
+        </p>
+        <Link
+          variant="secondary"
+          onPress={() => setIsModalOpen(true)}
+          className="self-start text-sm"
+        >
+          {t('View revision request')}
+        </Link>
+      </div>
+      <ViewRevisionRequestModal
+        isOpen={isModalOpen}
+        onOpenChange={setIsModalOpen}
+      />
+    </>
+  );
+}

--- a/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
+++ b/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
@@ -36,7 +36,7 @@ export function AuthorRevisionNote({ comment }: { comment: string }) {
           <Link
             variant="secondary"
             onPress={() => setIsModalOpen(true)}
-            className="self-start text-sm"
+            className="cursor-pointer self-start text-sm"
           >
             {t('View revision request')}
           </Link>

--- a/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
+++ b/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
@@ -3,7 +3,7 @@
 import { formatDate } from '@/utils/formatting';
 import { Link } from '@op/ui/Link';
 import { useState } from 'react';
-import { LuRotateCw } from 'react-icons/lu';
+import { LuRefreshCw } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -13,7 +13,7 @@ export function RevisedOnBadge({ respondedAt }: { respondedAt: string }) {
   const t = useTranslations();
   return (
     <span className="flex items-center gap-1">
-      <LuRotateCw className="size-4 text-primary-orange2" />
+      <LuRefreshCw className="size-4 text-primary-orange2" />
       {t('Revised on')} {formatDate(respondedAt)}
     </span>
   );
@@ -29,16 +29,18 @@ export function AuthorRevisionNote({ comment }: { comment: string }) {
         <span className="font-serif text-title-sm14 text-neutral-black">
           {t("Author's revision note")}
         </span>
-        <p className="text-base whitespace-pre-wrap text-neutral-charcoal">
-          {comment}
-        </p>
-        <Link
-          variant="secondary"
-          onPress={() => setIsModalOpen(true)}
-          className="self-start text-sm"
-        >
-          {t('View revision request')}
-        </Link>
+        <div className="flex flex-col gap-2">
+          <p className="text-base whitespace-pre-wrap text-neutral-charcoal">
+            {comment}
+          </p>
+          <Link
+            variant="secondary"
+            onPress={() => setIsModalOpen(true)}
+            className="self-start text-sm"
+          >
+            {t('View revision request')}
+          </Link>
+        </div>
       </div>
       <ViewRevisionRequestModal
         isOpen={isModalOpen}

--- a/apps/app/src/components/decisions/Review/ReviewLayoutClient.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayoutClient.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-import type { ReviewAssignmentExtended } from '@op/common/client';
+import {
+  ProposalReviewRequestState,
+  type ReviewAssignmentExtended,
+} from '@op/common/client';
 import { Tab, TabList, TabPanel, Tabs } from '@op/ui/Tabs';
 import { cn } from '@op/ui/utils';
 import { notFound } from 'next/navigation';
@@ -9,6 +12,7 @@ import { notFound } from 'next/navigation';
 import { useTranslations } from '@/lib/i18n';
 
 import { ProposalPreview } from '../ProposalPreview';
+import { AuthorRevisionNote, RevisedOnBadge } from './AuthorRevisionNote';
 import { ReviewFormProvider } from './ReviewFormContext';
 import { ReviewNavbar } from './ReviewNavbar';
 import { ReviewRubricForm } from './ReviewRubricForm';
@@ -50,6 +54,7 @@ export function ReviewLayoutClient({
         <div className="mx-auto hidden min-h-0 max-w-5xl flex-1 sm:flex">
           <ReviewProposalPane
             proposal={assignment.proposal}
+            revisionRequest={revisionRequest}
             className="border-r p-12"
           />
           <div className="min-w-0 flex-1 overflow-y-auto px-12 pt-12 pb-4">
@@ -70,7 +75,10 @@ export function ReviewLayoutClient({
             id="proposal"
             className="min-h-0 overflow-y-auto px-6 pt-8 pb-4"
           >
-            <ReviewProposalPane proposal={assignment.proposal} />
+            <ReviewProposalPane
+              proposal={assignment.proposal}
+              revisionRequest={revisionRequest}
+            />
           </TabPanel>
 
           <TabPanel
@@ -87,14 +95,32 @@ export function ReviewLayoutClient({
 
 function ReviewProposalPane({
   proposal,
+  revisionRequest,
   className,
 }: {
   proposal: Parameters<typeof ProposalPreview>[0]['proposal'];
+  revisionRequest: ReviewAssignmentExtended['revisionRequest'];
   className?: string;
 }) {
+  const respondedAt =
+    revisionRequest?.state === ProposalReviewRequestState.RESUBMITTED
+      ? revisionRequest.respondedAt
+      : null;
+  const responseComment = respondedAt ? revisionRequest?.responseComment : null;
+
   return (
     <div className={cn('min-w-0 flex-1 overflow-y-auto', className)}>
-      <ProposalPreview proposal={proposal} />
+      <ProposalPreview
+        proposal={proposal}
+        submissionMetaSuffix={
+          respondedAt ? <RevisedOnBadge respondedAt={respondedAt} /> : undefined
+        }
+        headerBanner={
+          responseComment ? (
+            <AuthorRevisionNote comment={responseComment} />
+          ) : undefined
+        }
+      />
     </div>
   );
 }

--- a/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
@@ -30,8 +30,13 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
   const [isViewModalOpen, setIsViewModalOpen] = useState(false);
 
-  const hasBeenResubmitted =
-    revisionRequest?.state === ProposalReviewRequestState.RESUBMITTED;
+  // Show the button when no request exists, the current one is still active,
+  // or the last one was cancelled (reviewer can start a fresh request). Hide
+  // for terminal post-author states (resubmitted, resolved).
+  const canRequestRevision =
+    !revisionRequest ||
+    revisionRequest.state === ProposalReviewRequestState.REQUESTED ||
+    revisionRequest.state === ProposalReviewRequestState.CANCELLED;
 
   return (
     <>
@@ -44,7 +49,7 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
           {t('Back to proposals')}
         </Link>
         <div className="flex items-center gap-4">
-          {!hasBeenResubmitted && (
+          {canRequestRevision && (
             <Button
               color="secondary"
               size="small"

--- a/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
@@ -10,7 +10,6 @@ import { Link, useTranslations } from '@/lib/i18n';
 
 import { RequestRevisionModal } from './RequestRevisionModal';
 import { useReviewForm } from './ReviewFormContext';
-import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
 interface ReviewNavbarProps {
   decisionSlug: string;
@@ -22,20 +21,17 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
     canSubmit,
     isSubmitting,
     isSubmitted,
-    isPausedForRevision,
     revisionRequest,
     handleSubmit,
   } = useReviewForm();
 
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
-  const [isViewModalOpen, setIsViewModalOpen] = useState(false);
 
-  // Show the button when no request exists, the current one is still active,
-  // or the last one was cancelled (reviewer can start a fresh request). Hide
-  // for terminal post-author states (resubmitted, resolved).
+  // Only show when pressing the button would start a new request: no request
+  // yet, or the last one was cancelled. While REQUESTED, the rubric pane
+  // already surfaces the pending request via its alert banner.
   const canRequestRevision =
     !revisionRequest ||
-    revisionRequest.state === ProposalReviewRequestState.REQUESTED ||
     revisionRequest.state === ProposalReviewRequestState.CANCELLED;
 
   return (
@@ -54,13 +50,7 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
               color="secondary"
               size="small"
               isDisabled={isSubmitted}
-              onPress={() => {
-                if (isPausedForRevision) {
-                  setIsViewModalOpen(true);
-                } else {
-                  setIsRequestModalOpen(true);
-                }
-              }}
+              onPress={() => setIsRequestModalOpen(true)}
             >
               {t('Request revision')}
             </Button>
@@ -84,10 +74,6 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
       <RequestRevisionModal
         isOpen={isRequestModalOpen}
         onOpenChange={setIsRequestModalOpen}
-      />
-      <ViewRevisionRequestModal
-        isOpen={isViewModalOpen}
-        onOpenChange={setIsViewModalOpen}
       />
     </>
   );

--- a/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ProposalReviewRequestState } from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { useState } from 'react';
@@ -22,11 +23,15 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
     isSubmitting,
     isSubmitted,
     isPausedForRevision,
+    revisionRequest,
     handleSubmit,
   } = useReviewForm();
 
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
   const [isViewModalOpen, setIsViewModalOpen] = useState(false);
+
+  const hasBeenResubmitted =
+    revisionRequest?.state === ProposalReviewRequestState.RESUBMITTED;
 
   return (
     <>
@@ -39,20 +44,22 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
           {t('Back to proposals')}
         </Link>
         <div className="flex items-center gap-4">
-          <Button
-            color="secondary"
-            size="small"
-            isDisabled={isSubmitted}
-            onPress={() => {
-              if (isPausedForRevision) {
-                setIsViewModalOpen(true);
-              } else {
-                setIsRequestModalOpen(true);
-              }
-            }}
-          >
-            {t('Request revision')}
-          </Button>
+          {!hasBeenResubmitted && (
+            <Button
+              color="secondary"
+              size="small"
+              isDisabled={isSubmitted}
+              onPress={() => {
+                if (isPausedForRevision) {
+                  setIsViewModalOpen(true);
+                } else {
+                  setIsRequestModalOpen(true);
+                }
+              }}
+            >
+              {t('Request revision')}
+            </Button>
+          )}
           <Button
             color="primary"
             size="small"

--- a/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
+++ b/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ProposalReviewRequestState } from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
@@ -33,6 +34,8 @@ export function ViewRevisionRequestModal({
   const sentDate = revisionRequest.requestedAt
     ? new Date(revisionRequest.requestedAt)
     : null;
+  const canCancel =
+    revisionRequest.state === ProposalReviewRequestState.REQUESTED;
 
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable>
@@ -62,14 +65,18 @@ export function ViewRevisionRequestModal({
         </div>
       </ModalBody>
       <ModalFooter>
-        <Button
-          color="secondary"
-          onPress={handleCancelRequest}
-          isDisabled={isCancellingRevision}
-        >
-          {isCancellingRevision ? <LoadingSpinner className="size-4" /> : null}
-          {t('Cancel request')}
-        </Button>
+        {canCancel && (
+          <Button
+            color="secondary"
+            onPress={handleCancelRequest}
+            isDisabled={isCancellingRevision}
+          >
+            {isCancellingRevision ? (
+              <LoadingSpinner className="size-4" />
+            ) : null}
+            {t('Cancel request')}
+          </Button>
+        )}
         <Button color="primary" onPress={() => onOpenChange(false)}>
           {t('Close')}
         </Button>

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1115,5 +1115,8 @@
   "Briefly describe your revisions so reviewers know what to look for.": "আপনার সংশোধনগুলো সংক্ষেপে বর্ণনা করুন যাতে পর্যালোচকরা জানেন কী খুঁজতে হবে।",
   "A reviewer has requested changes to your proposal. Edit your proposal and resubmit when ready.": "একজন পর্যালোচক আপনার প্রস্তাবে পরিবর্তনের অনুরোধ করেছেন। আপনার প্রস্তাব সম্পাদনা করুন এবং প্রস্তুত হলে পুনরায় জমা দিন।",
   "When resubmitting, address each point in the feedback above. When you click Resubmit, you'll be asked to briefly describe what you changed so the reviewers know where to look.": "পুনরায় জমা দেওয়ার সময়, উপরের প্রতিক্রিয়ার প্রতিটি বিষয় সম্বোধন করুন। আপনি যখন পুনরায় জমা দিন ক্লিক করবেন, তখন আপনাকে সংক্ষেপে বর্ণনা করতে বলা হবে যে আপনি কী পরিবর্তন করেছেন যাতে পর্যালোচকরা জানতে পারেন কোথায় দেখতে হবে।",
-  "Describe what you changed…": "আপনি কী পরিবর্তন করেছেন তা বর্ণনা করুন…"
+  "Describe what you changed…": "আপনি কী পরিবর্তন করেছেন তা বর্ণনা করুন…",
+  "Revised on": "সংশোধিত",
+  "Author's revision note": "লেখকের সংশোধন নোট",
+  "View revision request": "সংশোধনের অনুরোধ দেখুন"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1144,5 +1144,8 @@
   "Briefly describe your revisions so reviewers know what to look for.": "Briefly describe your revisions so reviewers know what to look for.",
   "A reviewer has requested changes to your proposal. Edit your proposal and resubmit when ready.": "A reviewer has requested changes to your proposal. Edit your proposal and resubmit when ready.",
   "When resubmitting, address each point in the feedback above. When you click Resubmit, you'll be asked to briefly describe what you changed so the reviewers know where to look.": "When resubmitting, address each point in the feedback above. When you click Resubmit, you'll be asked to briefly describe what you changed so the reviewers know where to look.",
-  "Describe what you changed…": "Describe what you changed…"
+  "Describe what you changed…": "Describe what you changed…",
+  "Revised on": "Revised on",
+  "Author's revision note": "Author's revision note",
+  "View revision request": "View revision request"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1114,5 +1114,8 @@
   "Briefly describe your revisions so reviewers know what to look for.": "Describe brevemente tus cambios para que los revisores sepan qué buscar.",
   "A reviewer has requested changes to your proposal. Edit your proposal and resubmit when ready.": "Un revisor ha solicitado cambios en tu propuesta. Edita tu propuesta y reenvíala cuando esté lista.",
   "When resubmitting, address each point in the feedback above. When you click Resubmit, you'll be asked to briefly describe what you changed so the reviewers know where to look.": "Al reenviar, aborda cada punto de los comentarios anteriores. Cuando hagas clic en Reenviar, se te pedirá que describas brevemente lo que cambiaste para que los revisores sepan dónde mirar.",
-  "Describe what you changed…": "Describe lo que cambiaste…"
+  "Describe what you changed…": "Describe lo que cambiaste…",
+  "Revised on": "Revisado el",
+  "Author's revision note": "Nota de revisión del autor",
+  "View revision request": "Ver solicitud de revisión"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1114,5 +1114,8 @@
   "Briefly describe your revisions so reviewers know what to look for.": "Décrivez brièvement vos révisions pour que les examinateurs sachent quoi rechercher.",
   "A reviewer has requested changes to your proposal. Edit your proposal and resubmit when ready.": "Un examinateur a demandé des modifications à votre proposition. Modifiez-la et soumettez-la à nouveau lorsque vous êtes prêt.",
   "When resubmitting, address each point in the feedback above. When you click Resubmit, you'll be asked to briefly describe what you changed so the reviewers know where to look.": "Lors de la soumission, répondez à chaque point des commentaires ci-dessus. Lorsque vous cliquerez sur Soumettre à nouveau, il vous sera demandé de décrire brièvement ce que vous avez modifié afin que les examinateurs sachent où regarder.",
-  "Describe what you changed…": "Décrivez ce que vous avez modifié…"
+  "Describe what you changed…": "Décrivez ce que vous avez modifié…",
+  "Revised on": "Révisé le",
+  "Author's revision note": "Note de révision de l'auteur",
+  "View revision request": "Voir la demande de révision"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1114,5 +1114,8 @@
   "Briefly describe your revisions so reviewers know what to look for.": "Descreva brevemente suas alterações para que os revisores saibam o que procurar.",
   "A reviewer has requested changes to your proposal. Edit your proposal and resubmit when ready.": "Um revisor solicitou alterações na sua proposta. Edite sua proposta e reenvie quando estiver pronta.",
   "When resubmitting, address each point in the feedback above. When you click Resubmit, you'll be asked to briefly describe what you changed so the reviewers know where to look.": "Ao reenviar, aborde cada ponto dos comentários acima. Quando você clicar em Reenviar, será solicitado que descreva brevemente o que alterou para que os revisores saibam onde procurar.",
-  "Describe what you changed…": "Descreva o que você alterou…"
+  "Describe what you changed…": "Descreva o que você alterou…",
+  "Revised on": "Revisado em",
+  "Author's revision note": "Nota de revisão do autor",
+  "View revision request": "Ver solicitação de revisão"
 }

--- a/tests/e2e/tests/review-submit.spec.ts
+++ b/tests/e2e/tests/review-submit.spec.ts
@@ -286,8 +286,9 @@ test.describe('Review Submit', () => {
       page.getByText('Review Proposal', { exact: true }).first(),
     ).toBeVisible({ timeout: 36_000 });
 
-    // Button still says "Request revision" but now opens the view modal
-    await page.getByRole('button', { name: 'Request revision' }).click();
+    // While a request is active, the navbar "Request revision" button is
+    // hidden and the rubric pane's alert banner exposes "View feedback".
+    await page.getByRole('button', { name: 'View feedback' }).click();
 
     const viewModal = page.getByRole('dialog');
     await expect(viewModal).toBeVisible();


### PR DESCRIPTION
So reviewers revisiting a resubmitted proposal can immediately see when it was revised and the author's description of what changed.

## Demo
<img width="2950" height="1710" alt="CleanShot 2026-04-16 at 22 26 25@2x" src="https://github.com/user-attachments/assets/692b6192-c225-4666-9e31-05c429b0f974" />
