### PR TITLE
fix(account): require org membership to switch organizations

### DIFF
--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -12,7 +12,7 @@ import {
 } from '@op/db/schema';
 import { type UserWithRoles, getGlobalPermissions } from 'access-zones';
 
-import { UnauthorizedError } from '../../utils/error';
+import { NotFoundError, UnauthorizedError } from '../../utils/error';
 import { getNormalizedRoles, getOrgAccessUser } from '../access';
 import { assertGlobalRole } from '../assert/assertGlobalRole';
 import { generateUniqueProfileSlug } from '../profile/utils';
@@ -493,7 +493,7 @@ export const switchUserOrganization = async (
   });
 
   if (!organization) {
-    throw new Error('Organization not found');
+    throw new NotFoundError('Organization', organizationId);
   }
 
   const orgUser = await getOrgAccessUser({
@@ -515,7 +515,7 @@ export const switchUserOrganization = async (
     .returning();
 
   if (!result.length || !result[0]) {
-    throw new Error('User not found');
+    throw new NotFoundError('User');
   }
 
   return result[0];

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -12,7 +12,8 @@ import {
 } from '@op/db/schema';
 import { type UserWithRoles, getGlobalPermissions } from 'access-zones';
 
-import { getNormalizedRoles } from '../access';
+import { UnauthorizedError } from '../../utils/error';
+import { getNormalizedRoles, getOrgAccessUser } from '../access';
 import { assertGlobalRole } from '../assert/assertGlobalRole';
 import { generateUniqueProfileSlug } from '../profile/utils';
 import { AllowListUser, allowListMetadataSchema } from './validators';
@@ -493,6 +494,15 @@ export const switchUserOrganization = async (
 
   if (!organization) {
     throw new Error('Organization not found');
+  }
+
+  const orgUser = await getOrgAccessUser({
+    user: { id: authUserId },
+    organizationId,
+  });
+
+  if (!orgUser) {
+    throw new UnauthorizedError('Not a member of this organization');
   }
 
   const result = await db

--- a/services/api/src/routers/account/switchOrganization.test.ts
+++ b/services/api/src/routers/account/switchOrganization.test.ts
@@ -1,0 +1,120 @@
+import { db } from '@op/db/client';
+import { users } from '@op/db/schema';
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { TestOrganizationDataManager } from '../../test/helpers/TestOrganizationDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../test/supabase-utils';
+import { createCallerFactory } from '../../trpcFactory';
+import accountRouter from './index';
+
+describe.concurrent('account.switchOrganization', () => {
+  const createCaller = createCallerFactory(accountRouter);
+
+  it('should successfully switch organization when caller is a member', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestOrganizationDataManager(task.id, onTestFinished);
+
+    const { organization, organizationProfile, adminUser } =
+      await testData.createOrganization({
+        users: { admin: 1 },
+        organizationName: 'Member Switch Org',
+      });
+
+    const { session } = await createIsolatedSession(adminUser.email);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    const result = await caller.switchOrganization({
+      organizationId: organization.id,
+    });
+
+    expect(result.currentProfileId).toBe(organizationProfile.id);
+
+    const [userRecord] = await db
+      .select({
+        currentProfileId: users.currentProfileId,
+        lastOrgId: users.lastOrgId,
+      })
+      .from(users)
+      .where(eq(users.authUserId, adminUser.authUserId));
+
+    expect(userRecord?.currentProfileId).toBe(organizationProfile.id);
+    expect(userRecord?.lastOrgId).toBe(organization.id);
+  });
+
+  it('should throw UNAUTHORIZED when caller is not a member of target org', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestOrganizationDataManager(task.id, onTestFinished);
+
+    // Target org the attacker is NOT a member of
+    const { organization: targetOrg, organizationProfile: targetProfile } =
+      await testData.createOrganization({
+        users: { admin: 1 },
+        organizationName: 'Target Org',
+      });
+
+    // Attacker has their own org; they are not a member of targetOrg
+    const { adminUser: attacker } = await testData.createOrganization({
+      users: { admin: 1 },
+      organizationName: 'Attacker Org',
+    });
+
+    // Snapshot the attacker's currentProfileId before the exploit attempt
+    const [before] = await db
+      .select({ currentProfileId: users.currentProfileId })
+      .from(users)
+      .where(eq(users.authUserId, attacker.authUserId));
+
+    const { session } = await createIsolatedSession(attacker.email);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    await expect(
+      caller.switchOrganization({
+        organizationId: targetOrg.id,
+      }),
+    ).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+
+    // Verify the attacker's currentProfileId was NOT changed to the victim org's profile
+    const [after] = await db
+      .select({
+        currentProfileId: users.currentProfileId,
+        lastOrgId: users.lastOrgId,
+      })
+      .from(users)
+      .where(eq(users.authUserId, attacker.authUserId));
+
+    expect(after?.currentProfileId).toBe(before?.currentProfileId);
+    expect(after?.currentProfileId).not.toBe(targetProfile.id);
+    expect(after?.lastOrgId).not.toBe(targetOrg.id);
+  });
+
+  it('should throw NOT_FOUND when organization does not exist', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestOrganizationDataManager(task.id, onTestFinished);
+    const { adminUser } = await testData.createOrganization({
+      users: { admin: 1 },
+    });
+
+    const { session } = await createIsolatedSession(adminUser.email);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    await expect(
+      caller.switchOrganization({
+        organizationId: '00000000-0000-0000-0000-000000000000',
+      }),
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+});

--- a/services/api/src/routers/account/switchOrganization.test.ts
+++ b/services/api/src/routers/account/switchOrganization.test.ts
@@ -47,7 +47,7 @@ describe.concurrent('account.switchOrganization', () => {
     expect(userRecord?.lastOrgId).toBe(organization.id);
   });
 
-  it('should throw UNAUTHORIZED when caller is not a member of target org', async ({
+  it('should throw UnauthorizedError when caller is not a member of target org', async ({
     task,
     onTestFinished,
   }) => {
@@ -80,7 +80,9 @@ describe.concurrent('account.switchOrganization', () => {
         organizationId: targetOrg.id,
       }),
     ).rejects.toMatchObject({
-      code: 'UNAUTHORIZED',
+      cause: {
+        name: 'UnauthorizedError',
+      },
     });
 
     // Verify the attacker's currentProfileId was NOT changed to the victim org's profile
@@ -97,7 +99,7 @@ describe.concurrent('account.switchOrganization', () => {
     expect(after?.lastOrgId).not.toBe(targetOrg.id);
   });
 
-  it('should throw NOT_FOUND when organization does not exist', async ({
+  it('should throw NotFoundError when organization does not exist', async ({
     task,
     onTestFinished,
   }) => {
@@ -114,7 +116,9 @@ describe.concurrent('account.switchOrganization', () => {
         organizationId: '00000000-0000-0000-0000-000000000000',
       }),
     ).rejects.toMatchObject({
-      code: 'NOT_FOUND',
+      cause: {
+        name: 'NotFoundError',
+      },
     });
   });
 });

--- a/services/api/src/routers/account/updateLastOrgId.ts
+++ b/services/api/src/routers/account/updateLastOrgId.ts
@@ -28,6 +28,12 @@ export const switchOrganization = router({
         });
 
         if (error instanceof Error) {
+          if (error.name === 'UnauthorizedError') {
+            throw new TRPCError({
+              code: 'UNAUTHORIZED',
+              message: error.message,
+            });
+          }
           if (error.message === 'Organization not found') {
             throw new TRPCError({
               code: 'NOT_FOUND',

--- a/services/api/src/routers/account/updateLastOrgId.ts
+++ b/services/api/src/routers/account/updateLastOrgId.ts
@@ -1,6 +1,4 @@
 import { switchUserOrganization } from '@op/common';
-import { logger } from '@op/logging';
-import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { userEncoder } from '../../encoders';
@@ -15,43 +13,11 @@ export const switchOrganization = router({
     .mutation(async ({ input, ctx }) => {
       const { id } = ctx.user;
 
-      try {
-        const result = await switchUserOrganization({
-          authUserId: id,
-          organizationId: input.organizationId,
-        });
-        return userEncoder.parse(result);
-      } catch (error) {
-        logger.error('Error switching organization', {
-          error,
-          organizationId: input.organizationId,
-        });
+      const result = await switchUserOrganization({
+        authUserId: id,
+        organizationId: input.organizationId,
+      });
 
-        if (error instanceof Error) {
-          if (error.name === 'UnauthorizedError') {
-            throw new TRPCError({
-              code: 'UNAUTHORIZED',
-              message: error.message,
-            });
-          }
-          if (error.message === 'Organization not found') {
-            throw new TRPCError({
-              code: 'NOT_FOUND',
-              message: 'Organization not found',
-            });
-          }
-          if (error.message === 'User not found') {
-            throw new TRPCError({
-              code: 'NOT_FOUND',
-              message: 'User not found',
-            });
-          }
-        }
-
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to update currentProfileId',
-        });
-      }
+      return userEncoder.parse(result);
     }),
 });


### PR DESCRIPTION
Fix an issue where any authenticated user could call account.switchOrganization with another org's id and have downstream post/proposal creation attribute authorship to that org.