### PR TITLE
feat(decisions): enable review on review phase in simple template

### DIFF
--- a/packages/common/src/services/decision/schemas/definitions.ts
+++ b/packages/common/src/services/decision/schemas/definitions.ts
@@ -88,7 +88,7 @@ export const simpleVoting: DecisionSchemaDefinition = {
       name: 'Review & Shortlist',
       description: 'Reviewers evaluate and shortlist proposals.',
       rules: {
-        proposals: { submit: false },
+        proposals: { submit: false, review: true },
         voting: { submit: false },
         advancement: { method: 'date', endDate: '2026-01-02' },
       },


### PR DESCRIPTION
Reviews were added after the simple voting template was written, so its review phase never opted in — instances built from it have no rules.proposals.review, so the review UI and review-assignment generation both silently skip.