### PR TITLE
feat(reviews): add email notification when revision is addressed

### DIFF
--- a/services/api/src/routers/decision/reviews/submitRevisionResponse.ts
+++ b/services/api/src/routers/decision/reviews/submitRevisionResponse.ts
@@ -27,10 +27,14 @@ export const submitRevisionResponseRouter = router({
         Channels.reviewAssignments(result.processInstanceId),
       ]);
 
+      // Send revision resubmitted event for notification workflow
       waitUntil(
         inngest.send({
           name: Events.reviewRevisionResubmitted.name,
-          data: { revisionRequestId: result.id },
+          data: {
+            assignmentId: result.assignmentId,
+            revisionRequestId: result.id,
+          },
         }),
       );
 

--- a/services/api/src/routers/decision/reviews/submitRevisionResponse.ts
+++ b/services/api/src/routers/decision/reviews/submitRevisionResponse.ts
@@ -1,5 +1,7 @@
 import { Channels, submitRevisionResponse } from '@op/common';
 import { proposalReviewRequestSchema } from '@op/common/client';
+import { Events, inngest } from '@op/events';
+import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
 import { commonAuthedProcedure, router } from '../../../trpcFactory';
@@ -24,6 +26,13 @@ export const submitRevisionResponseRouter = router({
         Channels.reviewAssignment(result.assignmentId),
         Channels.reviewAssignments(result.processInstanceId),
       ]);
+
+      waitUntil(
+        inngest.send({
+          name: Events.reviewRevisionResubmitted.name,
+          data: { revisionRequestId: result.id },
+        }),
+      );
 
       return proposalReviewRequestSchema.parse(result);
     }),

--- a/services/emails/emails/RevisionResubmittedEmail.tsx
+++ b/services/emails/emails/RevisionResubmittedEmail.tsx
@@ -1,0 +1,51 @@
+import { Button, Heading, Section, Text } from '@react-email/components';
+
+import EmailTemplate from '../components/EmailTemplate';
+
+export const RevisionResubmittedEmail = ({
+  proposalName,
+  processTitle,
+  proposalUrl = 'https://common.oneproject.org/',
+}: {
+  proposalName: string;
+  processTitle: string;
+  proposalUrl: string;
+}) => {
+  return (
+    <EmailTemplate
+      previewText={`Your revision for "${proposalName}" has been resubmitted for review`}
+    >
+      <Heading className="mx-0 !my-0 p-0 text-left font-serif text-[28px] font-light tracking-[-0.02625rem] text-[#222D38]">
+        Revision Resubmitted
+      </Heading>
+      <Text className="my-8 text-lg">
+        Your revision for <strong>{proposalName}</strong> in{' '}
+        <strong>{processTitle}</strong> has been resubmitted. Reviewers will
+        take another look and follow up with their decision.
+      </Text>
+
+      <Section className="pb-0">
+        <Button
+          href={proposalUrl}
+          className="rounded-lg bg-primary-teal px-4 py-3 text-white no-underline hover:bg-primary-teal/90"
+          style={{
+            fontSize: '0.875rem',
+            textAlign: 'center',
+            textDecoration: 'none',
+          }}
+        >
+          View proposal
+        </Button>
+      </Section>
+
+      <Text className="mt-8 mb-0 text-xs text-neutral-gray4">
+        You're receiving this because you're the author of this proposal.
+      </Text>
+    </EmailTemplate>
+  );
+};
+
+RevisionResubmittedEmail.subject = (proposalName: string) =>
+  `Your revision for "${proposalName}" has been resubmitted`;
+
+export default RevisionResubmittedEmail;

--- a/services/emails/emails/RevisionResubmittedEmail.tsx
+++ b/services/emails/emails/RevisionResubmittedEmail.tsx
@@ -13,15 +13,15 @@ export const RevisionResubmittedEmail = ({
 }) => {
   return (
     <EmailTemplate
-      previewText={`Your revision for "${proposalName}" has been resubmitted for review`}
+      previewText={`A revision to "${proposalName}" is ready for your review`}
     >
       <Heading className="mx-0 !my-0 p-0 text-left font-serif text-[28px] font-light tracking-[-0.02625rem] text-[#222D38]">
         Revision Resubmitted
       </Heading>
       <Text className="my-8 text-lg">
-        Your revision for <strong>{proposalName}</strong> in{' '}
-        <strong>{processTitle}</strong> has been resubmitted. Reviewers will
-        take another look and follow up with their decision.
+        The author of <strong>{proposalName}</strong> in{' '}
+        <strong>{processTitle}</strong> has resubmitted their revision
+        addressing your feedback. Take another look at the proposal.
       </Text>
 
       <Section className="pb-0">
@@ -34,18 +34,18 @@ export const RevisionResubmittedEmail = ({
             textDecoration: 'none',
           }}
         >
-          View proposal
+          View revised proposal
         </Button>
       </Section>
 
       <Text className="mt-8 mb-0 text-xs text-neutral-gray4">
-        You're receiving this because you're the author of this proposal.
+        You're receiving this because you requested changes to this proposal.
       </Text>
     </EmailTemplate>
   );
 };
 
 RevisionResubmittedEmail.subject = (proposalName: string) =>
-  `Your revision for "${proposalName}" has been resubmitted`;
+  `A revision to "${proposalName}" is ready for your review`;
 
 export default RevisionResubmittedEmail;

--- a/services/emails/index.tsx
+++ b/services/emails/index.tsx
@@ -118,3 +118,4 @@ export * from './emails/ReactionNotificationEmail';
 export * from './emails/ProposalSubmittedEmail';
 export * from './emails/PhaseTransitionEmail';
 export * from './emails/VoteSubmittedEmail';
+export * from './emails/RevisionResubmittedEmail';

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -64,4 +64,10 @@ export const Events = {
       processInstanceId: z.string().uuid(),
     }),
   },
+  reviewRevisionResubmitted: {
+    name: 'review/revision-resubmitted' as const,
+    schema: z.object({
+      revisionRequestId: z.string().uuid(),
+    }),
+  },
 } as const;

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -67,6 +67,7 @@ export const Events = {
   reviewRevisionResubmitted: {
     name: 'review/revision-resubmitted' as const,
     schema: z.object({
+      assignmentId: z.string().uuid(),
       revisionRequestId: z.string().uuid(),
     }),
   },

--- a/services/workflows/src/functions/notifications/index.ts
+++ b/services/workflows/src/functions/notifications/index.ts
@@ -3,3 +3,4 @@ export * from './sendProfileInviteEmails';
 export * from './sendProposalSubmittedNotification';
 export * from './sendPhaseTransitionNotification';
 export * from './sendVoteSubmittedNotification';
+export * from './sendRevisionResubmittedNotification';

--- a/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
@@ -29,16 +29,17 @@ export const sendRevisionResubmittedNotification = inngest.createFunction(
         with: {
           proposal: {
             with: {
-              profile: {
-                with: {
-                  profileUsers: true,
-                },
-              },
+              profile: true,
             },
           },
           processInstance: {
             with: {
               profile: true,
+            },
+          },
+          reviewer: {
+            with: {
+              profileUsers: true,
             },
           },
           requests: true,
@@ -83,13 +84,13 @@ export const sendRevisionResubmittedNotification = inngest.createFunction(
       return;
     }
 
-    const { proposal, processInstance } = assignment;
-    const authorEmails = proposal.profile.profileUsers;
+    const { proposal, processInstance, reviewer } = assignment;
+    const reviewerEmails = reviewer.profileUsers;
 
-    if (authorEmails.length === 0) {
+    if (reviewerEmails.length === 0) {
       console.warn(
-        'No author emails found for proposal profile:',
-        proposal.profileId,
+        'No reviewer emails found for reviewer profile:',
+        assignment.reviewerProfileId,
       );
       return;
     }
@@ -109,7 +110,7 @@ export const sendRevisionResubmittedNotification = inngest.createFunction(
 
     const result = await step.run('send-emails', async () => {
       try {
-        const emails = authorEmails.map(({ email }) => ({
+        const emails = reviewerEmails.map(({ email }) => ({
           to: email,
           subject: RevisionResubmittedEmail.subject(proposalName),
           component: () =>

--- a/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
@@ -105,7 +105,7 @@ export const sendRevisionResubmittedNotification = inngest.createFunction(
 
     const proposalName = proposal.profile.name;
     const processTitle = processProfile.name;
-    const proposalUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processProfile.slug}/proposal/${proposal.profileId}`;
+    const proposalUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processProfile.slug}/reviews/${assignmentId}`;
 
     const result = await step.run('send-emails', async () => {
       try {

--- a/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
@@ -1,17 +1,11 @@
 import { OPURLConfig } from '@op/core';
 import { db } from '@op/db/client';
 import {
-  processInstances,
-  profileUsers,
-  profiles,
-  proposalReviewAssignments,
-  proposalReviewRequests,
-  proposals,
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
 } from '@op/db/schema';
 import { OPBatchSend, RevisionResubmittedEmail } from '@op/emails';
 import { Events, inngest } from '@op/events';
-import { eq } from 'drizzle-orm';
-import { alias } from 'drizzle-orm/pg-core';
 
 const { reviewRevisionResubmitted } = Events;
 
@@ -26,86 +20,102 @@ export const sendRevisionResubmittedNotification = inngest.createFunction(
   },
   { event: reviewRevisionResubmitted.name },
   async ({ event, step }) => {
-    const { revisionRequestId } = reviewRevisionResubmitted.schema.parse(
-      event.data,
+    const { assignmentId, revisionRequestId } =
+      reviewRevisionResubmitted.schema.parse(event.data);
+
+    const assignment = await step.run('get-assignment-data', async () => {
+      return db.query.proposalReviewAssignments.findFirst({
+        where: { id: assignmentId },
+        with: {
+          proposal: {
+            with: {
+              profile: {
+                with: {
+                  profileUsers: true,
+                },
+              },
+            },
+          },
+          processInstance: {
+            with: {
+              profile: true,
+            },
+          },
+          requests: true,
+        },
+      });
+    });
+
+    if (!assignment) {
+      console.error('No assignment data found for assignment:', assignmentId);
+      return;
+    }
+
+    // Verify the revision request has been resubmitted before sending
+    const revisionRequest = assignment.requests.find(
+      (r) => r.id === revisionRequestId,
     );
 
-    const proposalProfile = alias(profiles, 'proposal_profile');
-    const processProfile = alias(profiles, 'process_profile');
+    if (!revisionRequest) {
+      console.warn('Revision request not found:', revisionRequestId);
+      return;
+    }
 
-    // Step 1: Get revision request context: proposal + process profile info
-    const context = await step.run('get-revision-context', async () => {
-      const result = await db
-        .select({
-          proposalProfileId: proposals.profileId,
-          proposalProfileName: proposalProfile.name,
-          processProfileName: processProfile.name,
-          processProfileSlug: processProfile.slug,
-        })
-        .from(proposalReviewRequests)
-        .innerJoin(
-          proposalReviewAssignments,
-          eq(proposalReviewRequests.assignmentId, proposalReviewAssignments.id),
-        )
-        .innerJoin(
-          proposals,
-          eq(proposalReviewAssignments.proposalId, proposals.id),
-        )
-        .innerJoin(proposalProfile, eq(proposals.profileId, proposalProfile.id))
-        .innerJoin(
-          processInstances,
-          eq(proposalReviewAssignments.processInstanceId, processInstances.id),
-        )
-        .innerJoin(
-          processProfile,
-          eq(processInstances.profileId, processProfile.id),
-        )
-        .where(eq(proposalReviewRequests.id, revisionRequestId))
-        .limit(1);
-
-      return result[0];
-    });
-
-    if (!context) {
+    if (revisionRequest.state !== ProposalReviewRequestState.RESUBMITTED) {
       console.log(
-        'No revision request context found for request:',
+        'Revision request is not in resubmitted state:',
         revisionRequestId,
+        'state:',
+        revisionRequest.state,
       );
       return;
     }
 
-    // Step 2: Get all author (proposal profile) emails
-    const collaborators = await step.run('get-collaborators', async () => {
-      return db
-        .select({
-          email: profileUsers.email,
-        })
-        .from(profileUsers)
-        .where(eq(profileUsers.profileId, context.proposalProfileId));
-    });
-
-    if (collaborators.length === 0) {
+    if (
+      assignment.status !== ProposalReviewAssignmentStatus.READY_FOR_RE_REVIEW
+    ) {
       console.log(
-        'No collaborators found for revision request:',
-        revisionRequestId,
+        'Assignment is not ready for re-review:',
+        assignmentId,
+        'status:',
+        assignment.status,
       );
       return;
     }
 
-    const proposalUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${context.processProfileSlug}/proposal/${context.proposalProfileId}`;
+    const { proposal, processInstance } = assignment;
+    const authorEmails = proposal.profile.profileUsers;
 
-    // Step 3: Send notification emails to all collaborators
+    if (authorEmails.length === 0) {
+      console.warn(
+        'No author emails found for proposal profile:',
+        proposal.profileId,
+      );
+      return;
+    }
+
+    const processProfile = processInstance.profile;
+    if (!processProfile) {
+      console.error(
+        'No profile found for process instance:',
+        processInstance.id,
+      );
+      return;
+    }
+
+    const proposalName = proposal.profile.name;
+    const processTitle = processProfile.name;
+    const proposalUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processProfile.slug}/proposal/${proposal.profileId}`;
+
     const result = await step.run('send-emails', async () => {
       try {
-        const emails = collaborators.map(({ email }) => ({
+        const emails = authorEmails.map(({ email }) => ({
           to: email,
-          subject: RevisionResubmittedEmail.subject(
-            context.proposalProfileName,
-          ),
+          subject: RevisionResubmittedEmail.subject(proposalName),
           component: () =>
             RevisionResubmittedEmail({
-              proposalName: context.proposalProfileName,
-              processTitle: context.processProfileName,
+              proposalName,
+              processTitle,
               proposalUrl,
             }),
         }));
@@ -122,7 +132,7 @@ export const sendRevisionResubmittedNotification = inngest.createFunction(
       } catch (error) {
         console.error('Failed to send revision resubmitted notifications:', {
           error,
-          revisionRequestId,
+          assignmentId,
         });
         throw error;
       }

--- a/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
@@ -1,0 +1,135 @@
+import { OPURLConfig } from '@op/core';
+import { db } from '@op/db/client';
+import {
+  processInstances,
+  profileUsers,
+  profiles,
+  proposalReviewAssignments,
+  proposalReviewRequests,
+  proposals,
+} from '@op/db/schema';
+import { OPBatchSend, RevisionResubmittedEmail } from '@op/emails';
+import { Events, inngest } from '@op/events';
+import { eq } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+
+const { reviewRevisionResubmitted } = Events;
+
+export const sendRevisionResubmittedNotification = inngest.createFunction(
+  {
+    id: 'sendRevisionResubmittedNotification',
+    debounce: {
+      key: 'event.data.revisionRequestId',
+      period: '1m',
+      timeout: '3m',
+    },
+  },
+  { event: reviewRevisionResubmitted.name },
+  async ({ event, step }) => {
+    const { revisionRequestId } = reviewRevisionResubmitted.schema.parse(
+      event.data,
+    );
+
+    const proposalProfile = alias(profiles, 'proposal_profile');
+    const processProfile = alias(profiles, 'process_profile');
+
+    // Step 1: Get revision request context: proposal + process profile info
+    const context = await step.run('get-revision-context', async () => {
+      const result = await db
+        .select({
+          proposalProfileId: proposals.profileId,
+          proposalProfileName: proposalProfile.name,
+          processProfileName: processProfile.name,
+          processProfileSlug: processProfile.slug,
+        })
+        .from(proposalReviewRequests)
+        .innerJoin(
+          proposalReviewAssignments,
+          eq(proposalReviewRequests.assignmentId, proposalReviewAssignments.id),
+        )
+        .innerJoin(
+          proposals,
+          eq(proposalReviewAssignments.proposalId, proposals.id),
+        )
+        .innerJoin(proposalProfile, eq(proposals.profileId, proposalProfile.id))
+        .innerJoin(
+          processInstances,
+          eq(proposalReviewAssignments.processInstanceId, processInstances.id),
+        )
+        .innerJoin(
+          processProfile,
+          eq(processInstances.profileId, processProfile.id),
+        )
+        .where(eq(proposalReviewRequests.id, revisionRequestId))
+        .limit(1);
+
+      return result[0];
+    });
+
+    if (!context) {
+      console.log(
+        'No revision request context found for request:',
+        revisionRequestId,
+      );
+      return;
+    }
+
+    // Step 2: Get all author (proposal profile) emails
+    const collaborators = await step.run('get-collaborators', async () => {
+      return db
+        .select({
+          email: profileUsers.email,
+        })
+        .from(profileUsers)
+        .where(eq(profileUsers.profileId, context.proposalProfileId));
+    });
+
+    if (collaborators.length === 0) {
+      console.log(
+        'No collaborators found for revision request:',
+        revisionRequestId,
+      );
+      return;
+    }
+
+    const proposalUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${context.processProfileSlug}/proposal/${context.proposalProfileId}`;
+
+    // Step 3: Send notification emails to all collaborators
+    const result = await step.run('send-emails', async () => {
+      try {
+        const emails = collaborators.map(({ email }) => ({
+          to: email,
+          subject: RevisionResubmittedEmail.subject(
+            context.proposalProfileName,
+          ),
+          component: () =>
+            RevisionResubmittedEmail({
+              proposalName: context.proposalProfileName,
+              processTitle: context.processProfileName,
+              proposalUrl,
+            }),
+        }));
+
+        const { data, errors } = await OPBatchSend(emails);
+
+        if (errors.length > 0) {
+          throw Error(`Email batch failed: ${JSON.stringify(errors)}`);
+        }
+
+        return {
+          sent: data.length,
+        };
+      } catch (error) {
+        console.error('Failed to send revision resubmitted notifications:', {
+          error,
+          revisionRequestId,
+        });
+        throw error;
+      }
+    });
+
+    return {
+      message: `${result.sent} revision resubmitted notification(s) sent`,
+    };
+  },
+);


### PR DESCRIPTION
Notify reviewers via email when an author resubmits a revision addressing their feedback, so they know the proposal is ready for re-review.