### PR TITLE
refactor(ui): extract shared SplitPane for proposal/review layouts

### DIFF
--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -11,6 +11,7 @@ import {
   type SupportedLocale,
 } from '@op/common/client';
 import { Header3 } from '@op/ui/Header';
+import { SplitPane } from '@op/ui/SplitPane';
 import { Surface } from '@op/ui/Surface';
 import { useLocale } from 'next-intl';
 import { useQueryStates } from 'nuqs';
@@ -312,16 +313,20 @@ export function ProposalView({
       }
     >
       {activeRevisionRequest ? (
-        <div className="mx-auto flex w-full max-w-[68rem] flex-1 items-start">
-          <div className="flex min-w-0 basis-1/2 flex-col gap-8 border-r border-neutral-gray1 py-12 pr-12 pl-6 sm:pl-12">
+        <SplitPane className="mx-auto w-full max-w-[68rem]">
+          <SplitPane.Pane id="proposal" label={t('Proposal')} className="gap-8">
             {proposalBody}
-          </div>
-          <div className="min-w-0 basis-1/2 bg-white">
+          </SplitPane.Pane>
+          <SplitPane.Pane
+            id="feedback"
+            label={t('Revision feedback')}
+            className="bg-white p-0 sm:p-0"
+          >
             <ProposalRevisionSubmittedPanel
               revisionRequest={activeRevisionRequest}
             />
-          </div>
-        </div>
+          </SplitPane.Pane>
+        </SplitPane>
       ) : (
         <div className="flex-1 px-6 py-8">
           <div className="mx-auto flex max-w-xl flex-col gap-8">

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -320,7 +320,8 @@ export function ProposalView({
           <SplitPane.Pane
             id="feedback"
             label={t('Revision feedback')}
-            className="bg-white p-0 sm:p-0"
+            className="bg-white"
+            unpadded
           >
             <ProposalRevisionSubmittedPanel
               revisionRequest={activeRevisionRequest}

--- a/apps/app/src/components/decisions/Review/ReviewLayout.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayout.tsx
@@ -34,10 +34,7 @@ export async function ReviewLayout({
         <div className="flex h-dvh flex-col bg-white">
           <ReviewNavbar decisionSlug={decisionSlug} />
 
-          <SplitPane
-            className="mx-auto max-w-5xl"
-            defaultMobileTabId="review"
-          >
+          <SplitPane className="mx-auto max-w-5xl" defaultMobileTabId="review">
             <SplitPane.Pane
               id="proposal"
               label={<TranslatedText text="Proposal" />}

--- a/apps/app/src/components/decisions/Review/ReviewLayout.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayout.tsx
@@ -3,7 +3,7 @@ import {
   createServerUtils,
   dehydrate,
 } from '@op/api/server';
-import { Tab, TabList, TabPanel, Tabs } from '@op/ui/Tabs';
+import { SplitPane } from '@op/ui/SplitPane';
 
 import { TranslatedText } from '@/components/TranslatedText';
 
@@ -34,40 +34,23 @@ export async function ReviewLayout({
         <div className="flex h-dvh flex-col bg-white">
           <ReviewNavbar decisionSlug={decisionSlug} />
 
-          <div className="mx-auto hidden min-h-0 max-w-5xl flex-1 sm:flex">
-            <ReviewProposalPane className="border-r p-12" />
-            <div className="min-w-0 flex-1 overflow-y-auto px-12 pt-12 pb-4">
-              <ReviewRubricForm />
-            </div>
-          </div>
-
-          <Tabs
-            className="min-h-0 flex-1 gap-0 sm:hidden"
-            defaultSelectedKey="review"
+          <SplitPane
+            className="mx-auto max-w-5xl"
+            defaultMobileTabId="review"
           >
-            <TabList className="mx-6" variant="default">
-              <Tab id="proposal">
-                <TranslatedText text="Proposal" />
-              </Tab>
-              <Tab id="review">
-                <TranslatedText text="Review" />
-              </Tab>
-            </TabList>
-
-            <TabPanel
+            <SplitPane.Pane
               id="proposal"
-              className="min-h-0 overflow-y-auto px-6 pt-8 pb-4"
+              label={<TranslatedText text="Proposal" />}
             >
               <ReviewProposalPane />
-            </TabPanel>
-
-            <TabPanel
+            </SplitPane.Pane>
+            <SplitPane.Pane
               id="review"
-              className="min-h-0 overflow-y-auto px-6 pt-8 pb-4"
+              label={<TranslatedText text="Review" />}
             >
               <ReviewRubricForm />
-            </TabPanel>
-          </Tabs>
+            </SplitPane.Pane>
+          </SplitPane>
         </div>
       </ReviewFormProvider>
     </HydrationBoundary>

--- a/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { ProposalReviewRequestState } from '@op/common/client';
-import { cn } from '@op/ui/utils';
 
 import { ProposalPreview } from '../ProposalPreview';
 import { AuthorRevisionNote, RevisedOnBadge } from './AuthorRevisionNote';
 import { useReviewForm } from './ReviewFormContext';
 
-export function ReviewProposalPane({ className }: { className?: string }) {
+export function ReviewProposalPane() {
   const { assignment, revisionRequest } = useReviewForm();
 
   const respondedAt =
@@ -17,18 +16,16 @@ export function ReviewProposalPane({ className }: { className?: string }) {
   const responseComment = respondedAt ? revisionRequest?.responseComment : null;
 
   return (
-    <div className={cn('min-w-0 flex-1 overflow-y-auto', className)}>
-      <ProposalPreview
-        proposal={assignment.proposal}
-        submissionMetaSuffix={
-          respondedAt ? <RevisedOnBadge respondedAt={respondedAt} /> : undefined
-        }
-        headerBanner={
-          responseComment ? (
-            <AuthorRevisionNote comment={responseComment} />
-          ) : undefined
-        }
-      />
-    </div>
+    <ProposalPreview
+      proposal={assignment.proposal}
+      submissionMetaSuffix={
+        respondedAt ? <RevisedOnBadge respondedAt={respondedAt} /> : undefined
+      }
+      headerBanner={
+        responseComment ? (
+          <AuthorRevisionNote comment={responseComment} />
+        ) : undefined
+      }
+    />
   );
 }

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -11,6 +11,7 @@ import {
   type ProposalTemplateSchema,
   parseProposalData,
 } from '@op/common/client';
+import { SplitPane } from '@op/ui/SplitPane';
 import { toast } from '@op/ui/Toast';
 import type { Editor } from '@tiptap/react';
 import { useLocale } from 'next-intl';
@@ -433,14 +434,22 @@ function ProposalEditorInner({
           <RichTextEditorToolbar editor={focusedEditor} />
         </div>
         {revisionRequest ? (
-          <div className="mx-auto flex w-full max-w-[68rem] flex-1 overflow-hidden">
-            <div className="flex min-w-0 basis-1/2 flex-col gap-4 overflow-y-auto border-r border-neutral-gray1 py-12 pr-12">
+          <SplitPane className="mx-auto w-full max-w-[68rem]">
+            <SplitPane.Pane
+              id="proposal"
+              label={t('Proposal')}
+              className="gap-4"
+            >
               {editorBody}
-            </div>
-            <div className="min-w-0 basis-1/2 overflow-y-auto bg-white">
+            </SplitPane.Pane>
+            <SplitPane.Pane
+              id="feedback"
+              label={t('Revision feedback')}
+              className="bg-white p-0 sm:p-0"
+            >
               <RevisionFeedbackPanel revisionRequest={revisionRequest} />
-            </div>
-          </div>
+            </SplitPane.Pane>
+          </SplitPane>
         ) : (
           <div className="flex flex-1 flex-col gap-12 py-12">
             <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 px-6">

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -445,7 +445,8 @@ function ProposalEditorInner({
             <SplitPane.Pane
               id="feedback"
               label={t('Revision feedback')}
-              className="bg-white p-0 sm:p-0"
+              className="bg-white"
+              unpadded
             >
               <RevisionFeedbackPanel revisionRequest={revisionRequest} />
             </SplitPane.Pane>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -49,6 +49,7 @@
     "./ReactionsButton": "./src/components/ReactionsButton.tsx",
     "./RichTextEditor": "./src/components/RichTextEditor/index.ts",
     "./Sortable": "./src/components/Sortable/index.ts",
+    "./SplitPane": "./src/components/SplitPane.tsx",
     "./Surface": "./src/components/Surface.tsx",
     "./RAC": "./src/RAC.ts",
     "./RAH": "./src/RAH.ts",

--- a/packages/ui/src/components/SplitPane.tsx
+++ b/packages/ui/src/components/SplitPane.tsx
@@ -61,7 +61,7 @@ function SplitPaneImpl({
   ];
 
   return (
-    <div className={cn('flex min-h-0 flex-1 flex-col', className)}>
+    <div className={cn('flex min-h-0 w-full flex-1 flex-col', className)}>
       <div
         role="tablist"
         aria-orientation="horizontal"

--- a/packages/ui/src/components/SplitPane.tsx
+++ b/packages/ui/src/components/SplitPane.tsx
@@ -13,6 +13,7 @@ import { cn, tv } from '../lib/utils';
 import { Tab, TabList, Tabs } from './Tabs';
 
 export interface SplitPaneProps {
+  /** One or more `SplitPane.Pane` children. */
   children: ReactNode;
   /** Id of the pane shown by default on mobile. Defaults to the first pane. */
   defaultMobileTabId?: string;
@@ -35,15 +36,15 @@ function Pane(_props: SplitPanePaneProps): null {
 // Each pane mounts once — visibility on mobile is toggled via CSS so stateful
 // children (collaborative editors, forms) don't get double-mounted.
 const paneStyles = tv({
-  base: 'flex min-w-0 flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable] sm:basis-1/2',
+  base: 'flex min-w-0 flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable]',
   variants: {
     padding: {
       default: 'px-6 pt-8 pb-4 sm:p-12',
       none: '',
     },
-    position: {
-      left: 'sm:border-r sm:border-neutral-gray1',
-      right: '',
+    divider: {
+      true: 'sm:border-r sm:border-neutral-gray1',
+      false: '',
     },
     active: {
       true: 'flex',
@@ -66,10 +67,8 @@ function SplitPaneImpl({
   );
 
   if (process.env.NODE_ENV !== 'production') {
-    if (panes.length !== 2) {
-      throw new Error(
-        `SplitPane expects exactly 2 children, received ${panes.length}.`,
-      );
+    if (panes.length < 1) {
+      throw new Error('SplitPane expects at least 1 child.');
     }
     for (const pane of panes) {
       if (!pane.props.id || !pane.props.label) {
@@ -80,53 +79,46 @@ function SplitPaneImpl({
     }
   }
 
-  if (panes.length !== 2) {
+  if (panes.length < 1) {
     return null;
   }
 
-  const [left, right] = panes as [
-    ReactElement<SplitPanePaneProps>,
-    ReactElement<SplitPanePaneProps>,
-  ];
-
   const handleSelectionChange = (key: Key) => setActiveId(String(key));
+  const showTabs = panes.length > 1;
 
   return (
     <div className={cn('flex min-h-0 w-full flex-1 flex-col', className)}>
-      <Tabs
-        className="gap-0 sm:hidden"
-        selectedKey={activeId}
-        onSelectionChange={handleSelectionChange}
-      >
-        <TabList className="mx-6" variant="default">
-          <Tab id={left.props.id}>{left.props.label}</Tab>
-          <Tab id={right.props.id}>{right.props.label}</Tab>
-        </TabList>
-      </Tabs>
+      {showTabs ? (
+        <Tabs
+          className="gap-0 sm:hidden"
+          selectedKey={activeId}
+          onSelectionChange={handleSelectionChange}
+        >
+          <TabList className="mx-6" variant="default">
+            {panes.map((pane) => (
+              <Tab key={pane.props.id} id={pane.props.id}>
+                {pane.props.label}
+              </Tab>
+            ))}
+          </TabList>
+        </Tabs>
+      ) : null}
 
       <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
-        <div
-          role="tabpanel"
-          className={paneStyles({
-            position: 'left',
-            padding: left.props.unpadded ? 'none' : 'default',
-            active: activeId === left.props.id,
-            className: left.props.className,
-          })}
-        >
-          {left.props.children}
-        </div>
-        <div
-          role="tabpanel"
-          className={paneStyles({
-            position: 'right',
-            padding: right.props.unpadded ? 'none' : 'default',
-            active: activeId === right.props.id,
-            className: right.props.className,
-          })}
-        >
-          {right.props.children}
-        </div>
+        {panes.map((pane, index) => (
+          <div
+            key={pane.props.id}
+            role="tabpanel"
+            className={paneStyles({
+              divider: index < panes.length - 1,
+              padding: pane.props.unpadded ? 'none' : 'default',
+              active: !showTabs || activeId === pane.props.id,
+              className: pane.props.className,
+            })}
+          >
+            {pane.props.children}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/packages/ui/src/components/SplitPane.tsx
+++ b/packages/ui/src/components/SplitPane.tsx
@@ -21,7 +21,7 @@ export interface SplitPaneProps {
 
 export interface SplitPanePaneProps {
   id: string;
-  label: string;
+  label: ReactNode;
   className?: string;
   /** Strip the pane's default padding (e.g. when the child handles its own). */
   unpadded?: boolean;

--- a/packages/ui/src/components/SplitPane.tsx
+++ b/packages/ui/src/components/SplitPane.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import {
+  Children,
+  type ReactElement,
+  type ReactNode,
+  isValidElement,
+  useState,
+} from 'react';
+
+import { cn } from '../lib/utils';
+
+export interface SplitPaneProps {
+  children: ReactNode;
+  /** Id of the pane shown by default on mobile. Defaults to the first pane. */
+  defaultMobileTab?: string;
+  className?: string;
+  mobileTabListClassName?: string;
+}
+
+export interface SplitPanePaneProps {
+  id: string;
+  label: string;
+  className?: string;
+  children: ReactNode;
+}
+
+// Marker subcomponent — SplitPane reads its props. Never renders on its own.
+function Pane(_props: SplitPanePaneProps): null {
+  return null;
+}
+
+// Each pane mounts once — visibility on mobile is toggled via CSS so stateful
+// children (collaborative editors, forms) don't get double-mounted.
+const paneBase =
+  'flex min-w-0 flex-1 flex-col overflow-y-auto px-6 pt-8 pb-4 [scrollbar-gutter:stable] sm:basis-1/2 sm:p-12';
+
+function SplitPaneImpl({
+  children,
+  defaultMobileTab,
+  className,
+  mobileTabListClassName,
+}: SplitPaneProps) {
+  const panes = Children.toArray(children).filter(
+    (child): child is ReactElement<SplitPanePaneProps> =>
+      isValidElement(child) && child.type === Pane,
+  );
+
+  const firstPaneId = panes[0]?.props.id ?? '';
+  const [activeId, setActiveId] = useState<string>(
+    defaultMobileTab ?? firstPaneId,
+  );
+
+  if (panes.length !== 2) {
+    return null;
+  }
+
+  const [left, right] = panes as [
+    ReactElement<SplitPanePaneProps>,
+    ReactElement<SplitPanePaneProps>,
+  ];
+
+  return (
+    <div className={cn('flex min-h-0 flex-1 flex-col', className)}>
+      <div
+        role="tablist"
+        aria-orientation="horizontal"
+        className={cn(
+          'mx-6 flex gap-4 border-b border-neutral-offWhite sm:hidden',
+          mobileTabListClassName,
+        )}
+      >
+        {panes.map((pane) => (
+          <SplitPaneTabButton
+            key={pane.props.id}
+            isSelected={activeId === pane.props.id}
+            onPress={() => setActiveId(pane.props.id)}
+          >
+            {pane.props.label}
+          </SplitPaneTabButton>
+        ))}
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
+        <div
+          role="tabpanel"
+          className={cn(
+            paneBase,
+            'sm:border-r sm:border-neutral-gray1',
+            activeId === left.props.id ? 'flex' : 'hidden sm:flex',
+            left.props.className,
+          )}
+        >
+          {left.props.children}
+        </div>
+        <div
+          role="tabpanel"
+          className={cn(
+            paneBase,
+            activeId === right.props.id ? 'flex' : 'hidden sm:flex',
+            right.props.className,
+          )}
+        >
+          {right.props.children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const SplitPane = Object.assign(SplitPaneImpl, { Pane });
+
+function SplitPaneTabButton({
+  isSelected,
+  onPress,
+  children,
+}: {
+  isSelected: boolean;
+  onPress: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={isSelected}
+      onClick={onPress}
+      className={cn(
+        'flex h-8 cursor-pointer items-center px-2 py-3 text-base font-normal outline-hidden transition focus-visible:bg-neutral-offWhite',
+        isSelected
+          ? 'border-b border-charcoal text-charcoal'
+          : 'border-b border-transparent text-neutral-gray4',
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/src/components/SplitPane.tsx
+++ b/packages/ui/src/components/SplitPane.tsx
@@ -58,20 +58,29 @@ function SplitPaneImpl({
   className,
 }: SplitPaneProps) {
   const panes = Children.toArray(children).filter(
-    (child): child is ReactElement<SplitPanePaneProps> =>
-      isValidElement(child) && child.type === Pane,
+    (child): child is ReactElement<SplitPanePaneProps> => isValidElement(child),
   );
 
   const [activeId, setActiveId] = useState<string>(
     defaultMobileTabId ?? panes[0]?.props.id ?? '',
   );
 
-  if (panes.length !== 2) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        `SplitPane expects exactly 2 SplitPane.Pane children, received ${panes.length}.`,
+  if (process.env.NODE_ENV !== 'production') {
+    if (panes.length !== 2) {
+      throw new Error(
+        `SplitPane expects exactly 2 children, received ${panes.length}.`,
       );
     }
+    for (const pane of panes) {
+      if (!pane.props.id || !pane.props.label) {
+        throw new Error(
+          'SplitPane children must have `id` and `label` props (use SplitPane.Pane).',
+        );
+      }
+    }
+  }
+
+  if (panes.length !== 2) {
     return null;
   }
 

--- a/packages/ui/src/components/SplitPane.tsx
+++ b/packages/ui/src/components/SplitPane.tsx
@@ -7,51 +7,71 @@ import {
   isValidElement,
   useState,
 } from 'react';
+import type { Key } from 'react-aria-components';
 
-import { cn } from '../lib/utils';
+import { cn, tv } from '../lib/utils';
+import { Tab, TabList, Tabs } from './Tabs';
 
 export interface SplitPaneProps {
   children: ReactNode;
   /** Id of the pane shown by default on mobile. Defaults to the first pane. */
-  defaultMobileTab?: string;
+  defaultMobileTabId?: string;
   className?: string;
-  mobileTabListClassName?: string;
 }
 
 export interface SplitPanePaneProps {
   id: string;
   label: string;
   className?: string;
+  /** Strip the pane's default padding (e.g. when the child handles its own). */
+  unpadded?: boolean;
   children: ReactNode;
 }
 
-// Marker subcomponent — SplitPane reads its props. Never renders on its own.
 function Pane(_props: SplitPanePaneProps): null {
   return null;
 }
 
 // Each pane mounts once — visibility on mobile is toggled via CSS so stateful
 // children (collaborative editors, forms) don't get double-mounted.
-const paneBase =
-  'flex min-w-0 flex-1 flex-col overflow-y-auto px-6 pt-8 pb-4 [scrollbar-gutter:stable] sm:basis-1/2 sm:p-12';
+const paneStyles = tv({
+  base: 'flex min-w-0 flex-1 flex-col overflow-y-auto [scrollbar-gutter:stable] sm:basis-1/2',
+  variants: {
+    padding: {
+      default: 'px-6 pt-8 pb-4 sm:p-12',
+      none: '',
+    },
+    position: {
+      left: 'sm:border-r sm:border-neutral-gray1',
+      right: '',
+    },
+    active: {
+      true: 'flex',
+      false: 'hidden sm:flex',
+    },
+  },
+});
 
 function SplitPaneImpl({
   children,
-  defaultMobileTab,
+  defaultMobileTabId,
   className,
-  mobileTabListClassName,
 }: SplitPaneProps) {
   const panes = Children.toArray(children).filter(
     (child): child is ReactElement<SplitPanePaneProps> =>
       isValidElement(child) && child.type === Pane,
   );
 
-  const firstPaneId = panes[0]?.props.id ?? '';
   const [activeId, setActiveId] = useState<string>(
-    defaultMobileTab ?? firstPaneId,
+    defaultMobileTabId ?? panes[0]?.props.id ?? '',
   );
 
   if (panes.length !== 2) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `SplitPane expects exactly 2 SplitPane.Pane children, received ${panes.length}.`,
+      );
+    }
     return null;
   }
 
@@ -60,46 +80,41 @@ function SplitPaneImpl({
     ReactElement<SplitPanePaneProps>,
   ];
 
+  const handleSelectionChange = (key: Key) => setActiveId(String(key));
+
   return (
     <div className={cn('flex min-h-0 w-full flex-1 flex-col', className)}>
-      <div
-        role="tablist"
-        aria-orientation="horizontal"
-        className={cn(
-          'mx-6 flex gap-4 border-b border-neutral-offWhite sm:hidden',
-          mobileTabListClassName,
-        )}
+      <Tabs
+        className="gap-0 sm:hidden"
+        selectedKey={activeId}
+        onSelectionChange={handleSelectionChange}
       >
-        {panes.map((pane) => (
-          <SplitPaneTabButton
-            key={pane.props.id}
-            isSelected={activeId === pane.props.id}
-            onPress={() => setActiveId(pane.props.id)}
-          >
-            {pane.props.label}
-          </SplitPaneTabButton>
-        ))}
-      </div>
+        <TabList className="mx-6" variant="default">
+          <Tab id={left.props.id}>{left.props.label}</Tab>
+          <Tab id={right.props.id}>{right.props.label}</Tab>
+        </TabList>
+      </Tabs>
 
       <div className="flex min-h-0 flex-1 flex-col sm:flex-row">
         <div
           role="tabpanel"
-          className={cn(
-            paneBase,
-            'sm:border-r sm:border-neutral-gray1',
-            activeId === left.props.id ? 'flex' : 'hidden sm:flex',
-            left.props.className,
-          )}
+          className={paneStyles({
+            position: 'left',
+            padding: left.props.unpadded ? 'none' : 'default',
+            active: activeId === left.props.id,
+            className: left.props.className,
+          })}
         >
           {left.props.children}
         </div>
         <div
           role="tabpanel"
-          className={cn(
-            paneBase,
-            activeId === right.props.id ? 'flex' : 'hidden sm:flex',
-            right.props.className,
-          )}
+          className={paneStyles({
+            position: 'right',
+            padding: right.props.unpadded ? 'none' : 'default',
+            active: activeId === right.props.id,
+            className: right.props.className,
+          })}
         >
           {right.props.children}
         </div>
@@ -109,30 +124,3 @@ function SplitPaneImpl({
 }
 
 export const SplitPane = Object.assign(SplitPaneImpl, { Pane });
-
-function SplitPaneTabButton({
-  isSelected,
-  onPress,
-  children,
-}: {
-  isSelected: boolean;
-  onPress: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={isSelected}
-      onClick={onPress}
-      className={cn(
-        'flex h-8 cursor-pointer items-center px-2 py-3 text-base font-normal outline-hidden transition focus-visible:bg-neutral-offWhite',
-        isSelected
-          ? 'border-b border-charcoal text-charcoal'
-          : 'border-b border-transparent text-neutral-gray4',
-      )}
-    >
-      {children}
-    </button>
-  );
-}

--- a/packages/ui/stories/SplitPane.stories.tsx
+++ b/packages/ui/stories/SplitPane.stories.tsx
@@ -57,7 +57,7 @@ export const Default: Story = {
 
 export const DefaultsToSecondOnMobile: Story = {
   render: () => (
-    <SplitPane defaultMobileTab="review">
+    <SplitPane defaultMobileTabId="review">
       <SplitPane.Pane id="proposal" label="Proposal">
         <SamplePane title="Proposal" tone="plain" />
       </SplitPane.Pane>

--- a/packages/ui/stories/SplitPane.stories.tsx
+++ b/packages/ui/stories/SplitPane.stories.tsx
@@ -67,3 +67,29 @@ export const DefaultsToSecondOnMobile: Story = {
     </SplitPane>
   ),
 };
+
+export const SinglePane: Story = {
+  render: () => (
+    <SplitPane>
+      <SplitPane.Pane id="proposal" label="Proposal">
+        <SamplePane title="Proposal" tone="plain" />
+      </SplitPane.Pane>
+    </SplitPane>
+  ),
+};
+
+export const ThreePanes: Story = {
+  render: () => (
+    <SplitPane>
+      <SplitPane.Pane id="proposal" label="Proposal">
+        <SamplePane title="Proposal" tone="plain" />
+      </SplitPane.Pane>
+      <SplitPane.Pane id="review" label="Review">
+        <SamplePane title="Review" tone="muted" />
+      </SplitPane.Pane>
+      <SplitPane.Pane id="history" label="History">
+        <SamplePane title="History" tone="muted" />
+      </SplitPane.Pane>
+    </SplitPane>
+  ),
+};

--- a/packages/ui/stories/SplitPane.stories.tsx
+++ b/packages/ui/stories/SplitPane.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SplitPane } from '../src/components/SplitPane';
+
+const meta: Meta<typeof SplitPane> = {
+  title: 'SplitPane',
+  component: SplitPane,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex h-dvh flex-col bg-white">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SplitPane>;
+
+const SamplePane = ({
+  title,
+  tone,
+}: {
+  title: string;
+  tone: 'muted' | 'plain';
+}) => (
+  <div
+    className={`flex flex-col gap-4 ${tone === 'muted' ? 'text-neutral-gray4' : 'text-charcoal'}`}
+  >
+    <h2 className="text-title-base">{title}</h2>
+    {Array.from({ length: 12 }).map((_, i) => (
+      <p key={i} className="text-sm">
+        Paragraph {i + 1}. Each side scrolls independently, and both sides share
+        a stable scrollbar gutter so the layout doesn't shift.
+      </p>
+    ))}
+  </div>
+);
+
+export const Default: Story = {
+  render: () => (
+    <SplitPane>
+      <SplitPane.Pane id="proposal" label="Proposal">
+        <SamplePane title="Proposal" tone="plain" />
+      </SplitPane.Pane>
+      <SplitPane.Pane id="review" label="Review">
+        <SamplePane title="Review" tone="muted" />
+      </SplitPane.Pane>
+    </SplitPane>
+  ),
+};
+
+export const DefaultsToSecondOnMobile: Story = {
+  render: () => (
+    <SplitPane defaultMobileTab="review">
+      <SplitPane.Pane id="proposal" label="Proposal">
+        <SamplePane title="Proposal" tone="plain" />
+      </SplitPane.Pane>
+      <SplitPane.Pane id="review" label="Review">
+        <SamplePane title="Review" tone="muted" />
+      </SplitPane.Pane>
+    </SplitPane>
+  ),
+};


### PR DESCRIPTION
Unifies the three duplicated split-pane layouts behind one component so mobile tab behaviour, scrolling, and padding stay consistent across proposal view, proposal editor, and review. Each pane mounts once and toggles via CSS to keep stateful children (editors, forms) from remounting on tab switch.

https://apps-workshop-git-harmonise-split-pane-views-oneproject.vercel.app/?path=/docs/splitpane--docs