### PR TITLE
feat(reviews): autosave review drafts as reviewers edit

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -148,8 +148,6 @@ export function ReviewFormProvider({
   );
 
   const handleSubmit = useCallback(() => {
-    // A trailing autosave landing after submit is filtered out at the DB
-    // level by saveReviewDraft's setWhere guard, so no client-side flush.
     submitReview.mutate({
       assignmentId,
       reviewData: { answers: values, rationales },

--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -213,7 +213,6 @@ export function ReviewFormProvider({
     // Await pending/in-flight drafts so a trailing autosave can't overwrite
     // the submitted payload on the same client.
     await flushPendingChanges();
-    // TODO: include overallComment (feedback to author) in submission
     submitReview.mutate({
       assignmentId,
       reviewData: { answers: values, rationales },

--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -102,21 +102,62 @@ export function ReviewFormProvider({
   });
   autosavePayloadRef.current = { values, rationales };
 
-  const debouncedSaveDraft = useDebouncedCallback(() => {
-    if (isSubmitted || isPausedForRevision) {
-      return;
-    }
-    const { values: latestValues, rationales: latestRationales } =
-      autosavePayloadRef.current;
-    saveReviewDraft.mutate({
-      assignmentId,
-      reviewData: { answers: latestValues, rationales: latestRationales },
-    });
-  }, AUTOSAVE_DEBOUNCE_MS);
+  const inflightAutosaveRef = useRef<Promise<unknown> | null>(null);
+  const hasPendingAutosaveRef = useRef(false);
 
+  const triggerAutosave = useCallback(() => {
+    const run = () => {
+      if (isSubmitted || isPausedForRevision) {
+        return;
+      }
+      // If a save is in flight, defer — the current save's .finally re-fires
+      // run() so edits made mid-save are persisted with the latest payload.
+      if (inflightAutosaveRef.current) {
+        hasPendingAutosaveRef.current = true;
+        return;
+      }
+      const { values: latestValues, rationales: latestRationales } =
+        autosavePayloadRef.current;
+      hasPendingAutosaveRef.current = false;
+      const promise = saveReviewDraft.mutateAsync({
+        assignmentId,
+        reviewData: { answers: latestValues, rationales: latestRationales },
+      });
+      inflightAutosaveRef.current = promise;
+      promise
+        .catch(() => {})
+        .finally(() => {
+          inflightAutosaveRef.current = null;
+          if (hasPendingAutosaveRef.current) {
+            run();
+          }
+        });
+    };
+    run();
+  }, [assignmentId, isPausedForRevision, isSubmitted, saveReviewDraft]);
+
+  const debouncedSaveDraft = useDebouncedCallback(
+    triggerAutosave,
+    AUTOSAVE_DEBOUNCE_MS,
+  );
+
+  const flushPendingChanges = useCallback(async (): Promise<boolean> => {
+    debouncedSaveDraft.flush();
+    while (inflightAutosaveRef.current) {
+      try {
+        await inflightAutosaveRef.current;
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  }, [debouncedSaveDraft]);
+
+  // Flush (not cancel) on unmount so edits made in the final debounce window
+  // are persisted when the reviewer navigates away.
   useEffect(() => {
     return () => {
-      debouncedSaveDraft.cancel();
+      debouncedSaveDraft.flush();
     };
   }, [debouncedSaveDraft]);
 
@@ -168,16 +209,16 @@ export function ReviewFormProvider({
     [debouncedSaveDraft],
   );
 
-  const handleSubmit = useCallback(() => {
-    // Drop any pending draft save — submitReview will persist the final
-    // payload and upgrade the existing draft row to SUBMITTED.
-    debouncedSaveDraft.cancel();
+  const handleSubmit = useCallback(async () => {
+    // Await pending/in-flight drafts so a trailing autosave can't overwrite
+    // the submitted payload on the same client.
+    await flushPendingChanges();
     // TODO: include overallComment (feedback to author) in submission
     submitReview.mutate({
       assignmentId,
       reviewData: { answers: values, rationales },
     });
-  }, [assignmentId, values, rationales, submitReview, debouncedSaveDraft]);
+  }, [assignmentId, values, rationales, submitReview, flushPendingChanges]);
 
   const handleRequestRevision = useCallback(
     (comment: string) => {

--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -92,7 +92,7 @@ export function ReviewFormProvider({
     },
   });
 
-  const autosave = useAutosaveDraft({
+  const scheduleAutosave = useAutosaveDraft({
     assignmentId,
     answers: values,
     rationales,
@@ -134,28 +134,27 @@ export function ReviewFormProvider({
   const handleValueChange = useCallback(
     (key: string, value: unknown) => {
       setValues((current) => ({ ...current, [key]: value }));
-      autosave.schedule();
+      scheduleAutosave();
     },
-    [autosave],
+    [scheduleAutosave],
   );
 
   const handleRationaleChange = useCallback(
     (key: string, value: string) => {
       setRationales((current) => ({ ...current, [key]: value }));
-      autosave.schedule();
+      scheduleAutosave();
     },
-    [autosave],
+    [scheduleAutosave],
   );
 
-  const handleSubmit = useCallback(async () => {
-    // Await pending/in-flight drafts so a trailing autosave can't overwrite
-    // the submitted payload on the same client.
-    await autosave.flush();
+  const handleSubmit = useCallback(() => {
+    // A trailing autosave landing after submit is filtered out at the DB
+    // level by saveReviewDraft's setWhere guard, so no client-side flush.
     submitReview.mutate({
       assignmentId,
       reviewData: { answers: values, rationales },
     });
-  }, [assignmentId, values, rationales, submitReview, autosave]);
+  }, [assignmentId, values, rationales, submitReview]);
 
   const handleRequestRevision = useCallback(
     (comment: string) => {
@@ -265,13 +264,6 @@ function useAutosaveDraft({
 
   const debouncedSave = useDebouncedCallback(save, AUTOSAVE_DEBOUNCE_MS);
 
-  const flush = useCallback(async () => {
-    debouncedSave.flush();
-    while (inflightRef.current) {
-      await inflightRef.current;
-    }
-  }, [debouncedSave]);
-
   // Flush (not cancel) on unmount so edits in the final debounce window
   // are persisted when the reviewer navigates away.
   useEffect(
@@ -281,8 +273,5 @@ function useAutosaveDraft({
     [debouncedSave],
   );
 
-  return useMemo(
-    () => ({ schedule: debouncedSave, flush }),
-    [debouncedSave, flush],
-  );
+  return debouncedSave;
 }

--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -92,74 +92,12 @@ export function ReviewFormProvider({
     },
   });
 
-  const saveReviewDraft = trpc.decision.saveReviewDraft.useMutation();
-
-  // Ref keeps the debounced callback stable while always reading the freshest
-  // form state — avoids rebuilding the debounce on every keystroke.
-  const autosavePayloadRef = useRef({
-    values,
+  const autosave = useAutosaveDraft({
+    assignmentId,
+    answers: values,
     rationales,
+    enabled: !isSubmitted && !isPausedForRevision,
   });
-  autosavePayloadRef.current = { values, rationales };
-
-  const inflightAutosaveRef = useRef<Promise<unknown> | null>(null);
-  const hasPendingAutosaveRef = useRef(false);
-
-  const triggerAutosave = useCallback(() => {
-    const run = () => {
-      if (isSubmitted || isPausedForRevision) {
-        return;
-      }
-      // If a save is in flight, defer — the current save's .finally re-fires
-      // run() so edits made mid-save are persisted with the latest payload.
-      if (inflightAutosaveRef.current) {
-        hasPendingAutosaveRef.current = true;
-        return;
-      }
-      const { values: latestValues, rationales: latestRationales } =
-        autosavePayloadRef.current;
-      hasPendingAutosaveRef.current = false;
-      const promise = saveReviewDraft.mutateAsync({
-        assignmentId,
-        reviewData: { answers: latestValues, rationales: latestRationales },
-      });
-      inflightAutosaveRef.current = promise;
-      promise
-        .catch(() => {})
-        .finally(() => {
-          inflightAutosaveRef.current = null;
-          if (hasPendingAutosaveRef.current) {
-            run();
-          }
-        });
-    };
-    run();
-  }, [assignmentId, isPausedForRevision, isSubmitted, saveReviewDraft]);
-
-  const debouncedSaveDraft = useDebouncedCallback(
-    triggerAutosave,
-    AUTOSAVE_DEBOUNCE_MS,
-  );
-
-  const flushPendingChanges = useCallback(async (): Promise<boolean> => {
-    debouncedSaveDraft.flush();
-    while (inflightAutosaveRef.current) {
-      try {
-        await inflightAutosaveRef.current;
-      } catch {
-        return false;
-      }
-    }
-    return true;
-  }, [debouncedSaveDraft]);
-
-  // Flush (not cancel) on unmount so edits made in the final debounce window
-  // are persisted when the reviewer navigates away.
-  useEffect(() => {
-    return () => {
-      debouncedSaveDraft.flush();
-    };
-  }, [debouncedSaveDraft]);
 
   const requestRevisionMutation = trpc.decision.requestRevision.useMutation({
     onSuccess: () => {
@@ -196,28 +134,28 @@ export function ReviewFormProvider({
   const handleValueChange = useCallback(
     (key: string, value: unknown) => {
       setValues((current) => ({ ...current, [key]: value }));
-      debouncedSaveDraft();
+      autosave.schedule();
     },
-    [debouncedSaveDraft],
+    [autosave],
   );
 
   const handleRationaleChange = useCallback(
     (key: string, value: string) => {
       setRationales((current) => ({ ...current, [key]: value }));
-      debouncedSaveDraft();
+      autosave.schedule();
     },
-    [debouncedSaveDraft],
+    [autosave],
   );
 
   const handleSubmit = useCallback(async () => {
     // Await pending/in-flight drafts so a trailing autosave can't overwrite
     // the submitted payload on the same client.
-    await flushPendingChanges();
+    await autosave.flush();
     submitReview.mutate({
       assignmentId,
       reviewData: { answers: values, rationales },
     });
-  }, [assignmentId, values, rationales, submitReview, flushPendingChanges]);
+  }, [assignmentId, values, rationales, submitReview, autosave]);
 
   const handleRequestRevision = useCallback(
     (comment: string) => {
@@ -278,5 +216,73 @@ export function ReviewFormProvider({
     <ReviewFormContext.Provider value={state}>
       {children}
     </ReviewFormContext.Provider>
+  );
+}
+
+function useAutosaveDraft({
+  assignmentId,
+  answers,
+  rationales,
+  enabled,
+}: {
+  assignmentId: string;
+  answers: Record<string, unknown>;
+  rationales: Record<string, string>;
+  enabled: boolean;
+}) {
+  const saveReviewDraft = trpc.decision.saveReviewDraft.useMutation();
+
+  const inflightRef = useRef<Promise<void> | null>(null);
+  // Set when an edit lands during an in-flight save; the save's .then
+  // re-arms the debounce so the latest payload reaches the server.
+  const rerunRef = useRef(false);
+
+  // Closure captures the latest answers/rationales on each render.
+  // useDebouncedCallback stores the callback in its own ref, so the
+  // debounce instance stays stable while always calling the latest `save`.
+  const save = () => {
+    if (!enabled) {
+      return;
+    }
+    if (inflightRef.current) {
+      rerunRef.current = true;
+      return;
+    }
+    rerunRef.current = false;
+    inflightRef.current = saveReviewDraft
+      .mutateAsync({
+        assignmentId,
+        reviewData: { answers, rationales },
+      })
+      .catch(() => {})
+      .then(() => {
+        inflightRef.current = null;
+        if (rerunRef.current) {
+          debouncedSave();
+        }
+      });
+  };
+
+  const debouncedSave = useDebouncedCallback(save, AUTOSAVE_DEBOUNCE_MS);
+
+  const flush = useCallback(async () => {
+    debouncedSave.flush();
+    while (inflightRef.current) {
+      await inflightRef.current;
+    }
+  }, [debouncedSave]);
+
+  // Flush (not cancel) on unmount so edits in the final debounce window
+  // are persisted when the reviewer navigates away.
+  useEffect(
+    () => () => {
+      debouncedSave.flush();
+    },
+    [debouncedSave],
+  );
+
+  return useMemo(
+    () => ({ schedule: debouncedSave, flush }),
+    [debouncedSave, flush],
   );
 }

--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -7,6 +7,7 @@ import {
   type RubricTemplateSchema,
   schemaValidator,
 } from '@op/common/client';
+import { useDebouncedCallback } from '@op/hooks';
 import { toast } from '@op/ui/Toast';
 import { useRouter } from 'next/navigation';
 import {
@@ -14,11 +15,15 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
+
+const AUTOSAVE_DEBOUNCE_MS = 1000;
 
 interface ReviewFormState {
   /** Rubric answers keyed by criterion id; validated against the template. */
@@ -87,6 +92,34 @@ export function ReviewFormProvider({
     },
   });
 
+  const saveReviewDraft = trpc.decision.saveReviewDraft.useMutation();
+
+  // Ref keeps the debounced callback stable while always reading the freshest
+  // form state — avoids rebuilding the debounce on every keystroke.
+  const autosavePayloadRef = useRef({
+    values,
+    rationales,
+  });
+  autosavePayloadRef.current = { values, rationales };
+
+  const debouncedSaveDraft = useDebouncedCallback(() => {
+    if (isSubmitted || isPausedForRevision) {
+      return;
+    }
+    const { values: latestValues, rationales: latestRationales } =
+      autosavePayloadRef.current;
+    saveReviewDraft.mutate({
+      assignmentId,
+      reviewData: { answers: latestValues, rationales: latestRationales },
+    });
+  }, AUTOSAVE_DEBOUNCE_MS);
+
+  useEffect(() => {
+    return () => {
+      debouncedSaveDraft.cancel();
+    };
+  }, [debouncedSaveDraft]);
+
   const requestRevisionMutation = trpc.decision.requestRevision.useMutation({
     onSuccess: () => {
       toast.success({ message: t('Revision requested') });
@@ -119,21 +152,32 @@ export function ReviewFormProvider({
     [template, values],
   );
 
-  const handleValueChange = useCallback((key: string, value: unknown) => {
-    setValues((current) => ({ ...current, [key]: value }));
-  }, []);
+  const handleValueChange = useCallback(
+    (key: string, value: unknown) => {
+      setValues((current) => ({ ...current, [key]: value }));
+      debouncedSaveDraft();
+    },
+    [debouncedSaveDraft],
+  );
 
-  const handleRationaleChange = useCallback((key: string, value: string) => {
-    setRationales((current) => ({ ...current, [key]: value }));
-  }, []);
+  const handleRationaleChange = useCallback(
+    (key: string, value: string) => {
+      setRationales((current) => ({ ...current, [key]: value }));
+      debouncedSaveDraft();
+    },
+    [debouncedSaveDraft],
+  );
 
   const handleSubmit = useCallback(() => {
+    // Drop any pending draft save — submitReview will persist the final
+    // payload and upgrade the existing draft row to SUBMITTED.
+    debouncedSaveDraft.cancel();
     // TODO: include overallComment (feedback to author) in submission
     submitReview.mutate({
       assignmentId,
       reviewData: { answers: values, rationales },
     });
-  }, [assignmentId, values, rationales, submitReview]);
+  }, [assignmentId, values, rationales, submitReview, debouncedSaveDraft]);
 
   const handleRequestRevision = useCallback(
     (comment: string) => {

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -60,6 +60,7 @@ export * from './listProposalsRevisionRequests';
 export * from './listProposalRevisionRequests';
 export * from './submitRevisionResponse';
 export * from './submitReview';
+export * from './saveReviewDraft';
 export * from './requestRevision';
 export * from './cancelRevisionRequest';
 export * from './deleteProposal';

--- a/packages/common/src/services/decision/saveReviewDraft.ts
+++ b/packages/common/src/services/decision/saveReviewDraft.ts
@@ -6,9 +6,9 @@ import {
   proposalReviews,
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
-import { eq } from 'drizzle-orm';
+import { eq, ne } from 'drizzle-orm';
 
-import { CommonError, ValidationError } from '../../utils';
+import { ValidationError } from '../../utils';
 import { assertReviewAssignmentContext } from './reviewHelpers';
 import type { RubricReviewData } from './schemas/reviews';
 
@@ -60,11 +60,17 @@ export async function saveReviewDraft({
         set: {
           reviewData,
         },
+        // Atomic guard against a late-arriving draft overwriting a row that
+        // was submitted after this request's early state check passed. When
+        // the row is SUBMITTED the UPDATE is skipped and `.returning()` is
+        // empty, which we surface as the same ValidationError the sequential
+        // path throws.
+        setWhere: ne(proposalReviews.state, ProposalReviewState.SUBMITTED),
       })
       .returning();
 
     if (!draft) {
-      throw new CommonError('Failed to save review draft');
+      throw new ValidationError('Review has already been submitted');
     }
 
     if (context.assignment.status === ProposalReviewAssignmentStatus.PENDING) {

--- a/packages/common/src/services/decision/saveReviewDraft.ts
+++ b/packages/common/src/services/decision/saveReviewDraft.ts
@@ -10,16 +10,13 @@ import { eq } from 'drizzle-orm';
 
 import { CommonError, ValidationError } from '../../utils';
 import { assertReviewAssignmentContext } from './reviewHelpers';
-import {
-  type ProposalReview,
-  type RubricReviewData,
-  proposalReviewSchema,
-} from './schemas/reviews';
+import type { RubricReviewData } from './schemas/reviews';
 
 /**
- * Persists a draft review for the current reviewer. Idempotent — repeated
- * calls upsert the draft payload without touching submission state. Refuses
- * once the review has been submitted so drafts can't overwrite a final review.
+ * Persists a draft review for the current reviewer. Upserts the draft row
+ * for the assignment — last write wins — without touching submission state.
+ * Refuses once the review has been submitted so drafts can't overwrite a
+ * final review.
  */
 export async function saveReviewDraft({
   assignmentId,
@@ -29,7 +26,10 @@ export async function saveReviewDraft({
   assignmentId: string;
   reviewData: RubricReviewData;
   user: User;
-}): Promise<ProposalReview & { processInstanceId: string }> {
+}): Promise<{
+  review: typeof proposalReviews.$inferSelect;
+  processInstanceId: string;
+}> {
   const context = await assertReviewAssignmentContext({
     assignmentId,
     user,
@@ -80,16 +80,7 @@ export async function saveReviewDraft({
   });
 
   return {
-    ...proposalReviewSchema.parse({
-      id: review.id,
-      assignmentId: review.assignmentId,
-      state: review.state,
-      reviewData: review.reviewData,
-      overallComment: review.overallComment ?? null,
-      submittedAt: review.submittedAt ?? null,
-      createdAt: review.createdAt ?? null,
-      updatedAt: review.updatedAt ?? null,
-    }),
+    review,
     processInstanceId: context.assignment.processInstanceId,
   };
 }

--- a/packages/common/src/services/decision/saveReviewDraft.ts
+++ b/packages/common/src/services/decision/saveReviewDraft.ts
@@ -1,5 +1,6 @@
 import { db } from '@op/db/client';
 import {
+  type ProposalReview,
   ProposalReviewAssignmentStatus,
   ProposalReviewState,
   proposalReviewAssignments,
@@ -26,10 +27,7 @@ export async function saveReviewDraft({
   assignmentId: string;
   reviewData: RubricReviewData;
   user: User;
-}): Promise<{
-  review: typeof proposalReviews.$inferSelect;
-  processInstanceId: string;
-}> {
+}): Promise<{ review: ProposalReview; processInstanceId: string }> {
   const context = await assertReviewAssignmentContext({
     assignmentId,
     user,

--- a/packages/common/src/services/decision/saveReviewDraft.ts
+++ b/packages/common/src/services/decision/saveReviewDraft.ts
@@ -24,12 +24,10 @@ import {
 export async function saveReviewDraft({
   assignmentId,
   reviewData,
-  overallComment,
   user,
 }: {
   assignmentId: string;
   reviewData: RubricReviewData;
-  overallComment?: string | null;
   user: User;
 }): Promise<ProposalReview & { processInstanceId: string }> {
   const context = await assertReviewAssignmentContext({
@@ -55,14 +53,12 @@ export async function saveReviewDraft({
         assignmentId,
         state: ProposalReviewState.DRAFT,
         reviewData,
-        overallComment: overallComment ?? null,
         submittedAt: null,
       })
       .onConflictDoUpdate({
         target: proposalReviews.assignmentId,
         set: {
           reviewData,
-          overallComment: overallComment ?? null,
         },
       })
       .returning();

--- a/packages/common/src/services/decision/saveReviewDraft.ts
+++ b/packages/common/src/services/decision/saveReviewDraft.ts
@@ -1,0 +1,99 @@
+import { db } from '@op/db/client';
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewState,
+  proposalReviewAssignments,
+  proposalReviews,
+} from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+import { eq } from 'drizzle-orm';
+
+import { CommonError, ValidationError } from '../../utils';
+import { assertReviewAssignmentContext } from './reviewHelpers';
+import {
+  type ProposalReview,
+  type RubricReviewData,
+  proposalReviewSchema,
+} from './schemas/reviews';
+
+/**
+ * Persists a draft review for the current reviewer. Idempotent — repeated
+ * calls upsert the draft payload without touching submission state. Refuses
+ * once the review has been submitted so drafts can't overwrite a final review.
+ */
+export async function saveReviewDraft({
+  assignmentId,
+  reviewData,
+  overallComment,
+  user,
+}: {
+  assignmentId: string;
+  reviewData: RubricReviewData;
+  overallComment?: string | null;
+  user: User;
+}): Promise<ProposalReview & { processInstanceId: string }> {
+  const context = await assertReviewAssignmentContext({
+    assignmentId,
+    user,
+  });
+
+  if (
+    context.assignment.status === ProposalReviewAssignmentStatus.COMPLETED ||
+    context.review?.state === ProposalReviewState.SUBMITTED
+  ) {
+    throw new ValidationError('Review has already been submitted');
+  }
+
+  if (!context.rubricTemplate) {
+    throw new ValidationError('Rubric template not found for this assignment');
+  }
+
+  const review = await db.transaction(async (tx) => {
+    const [draft] = await tx
+      .insert(proposalReviews)
+      .values({
+        assignmentId,
+        state: ProposalReviewState.DRAFT,
+        reviewData,
+        overallComment: overallComment ?? null,
+        submittedAt: null,
+      })
+      .onConflictDoUpdate({
+        target: proposalReviews.assignmentId,
+        set: {
+          reviewData,
+          overallComment: overallComment ?? null,
+        },
+      })
+      .returning();
+
+    if (!draft) {
+      throw new CommonError('Failed to save review draft');
+    }
+
+    if (context.assignment.status === ProposalReviewAssignmentStatus.PENDING) {
+      await tx
+        .update(proposalReviewAssignments)
+        .set({
+          status: ProposalReviewAssignmentStatus.IN_PROGRESS,
+        })
+        .where(eq(proposalReviewAssignments.id, assignmentId));
+    }
+
+    return draft;
+  });
+
+  return {
+    ...proposalReviewSchema.parse({
+      id: review.id,
+      assignmentId: review.assignmentId,
+      state: review.state,
+      reviewData: review.reviewData,
+      overallComment: review.overallComment ?? null,
+      submittedAt: review.submittedAt ?? null,
+      createdAt: review.createdAt ?? null,
+      updatedAt: review.updatedAt ?? null,
+    }),
+    processInstanceId: context.assignment.processInstanceId,
+  };
+}

--- a/packages/common/src/services/decision/submitReview.ts
+++ b/packages/common/src/services/decision/submitReview.ts
@@ -11,22 +11,23 @@ import { eq } from 'drizzle-orm';
 import { CommonError, ValidationError } from '../../utils';
 import { assertReviewAssignmentContext } from './reviewHelpers';
 import { schemaValidator } from './schemaValidator';
-import {
-  type ProposalReview,
-  type RubricReviewData,
-  proposalReviewSchema,
-} from './schemas/reviews';
+import type { RubricReviewData } from './schemas/reviews';
 
 /** Validates and submits a review for the current reviewer. */
 export async function submitReview({
   assignmentId,
   reviewData,
+  overallComment,
   user,
 }: {
   assignmentId: string;
   reviewData: RubricReviewData;
+  overallComment?: string | null;
   user: User;
-}): Promise<ProposalReview & { processInstanceId: string }> {
+}): Promise<{
+  review: typeof proposalReviews.$inferSelect;
+  processInstanceId: string;
+}> {
   const context = await assertReviewAssignmentContext({
     assignmentId,
     user,
@@ -54,6 +55,7 @@ export async function submitReview({
         assignmentId,
         state: ProposalReviewState.SUBMITTED,
         reviewData,
+        overallComment: overallComment ?? null,
         submittedAt,
       })
       .onConflictDoUpdate({
@@ -61,6 +63,7 @@ export async function submitReview({
         set: {
           state: ProposalReviewState.SUBMITTED,
           reviewData,
+          overallComment: overallComment ?? null,
           submittedAt,
         },
       })
@@ -82,16 +85,7 @@ export async function submitReview({
   });
 
   return {
-    ...proposalReviewSchema.parse({
-      id: review.id,
-      assignmentId: review.assignmentId,
-      state: review.state,
-      reviewData: review.reviewData,
-      overallComment: review.overallComment ?? null,
-      submittedAt: review.submittedAt ?? null,
-      createdAt: review.createdAt ?? null,
-      updatedAt: review.updatedAt ?? null,
-    }),
+    review,
     processInstanceId: context.assignment.processInstanceId,
   };
 }

--- a/packages/common/src/services/decision/submitReview.ts
+++ b/packages/common/src/services/decision/submitReview.ts
@@ -21,12 +21,10 @@ import {
 export async function submitReview({
   assignmentId,
   reviewData,
-  overallComment,
   user,
 }: {
   assignmentId: string;
   reviewData: RubricReviewData;
-  overallComment?: string | null;
   user: User;
 }): Promise<ProposalReview & { processInstanceId: string }> {
   const context = await assertReviewAssignmentContext({
@@ -56,7 +54,6 @@ export async function submitReview({
         assignmentId,
         state: ProposalReviewState.SUBMITTED,
         reviewData,
-        overallComment: overallComment ?? null,
         submittedAt,
       })
       .onConflictDoUpdate({
@@ -64,7 +61,6 @@ export async function submitReview({
         set: {
           state: ProposalReviewState.SUBMITTED,
           reviewData,
-          overallComment: overallComment ?? null,
           submittedAt,
         },
       })

--- a/packages/common/src/services/decision/submitReview.ts
+++ b/packages/common/src/services/decision/submitReview.ts
@@ -1,5 +1,6 @@
 import { db } from '@op/db/client';
 import {
+  type ProposalReview,
   ProposalReviewAssignmentStatus,
   ProposalReviewState,
   proposalReviewAssignments,
@@ -24,10 +25,7 @@ export async function submitReview({
   reviewData: RubricReviewData;
   overallComment?: string | null;
   user: User;
-}): Promise<{
-  review: typeof proposalReviews.$inferSelect;
-  processInstanceId: string;
-}> {
+}): Promise<{ review: ProposalReview; processInstanceId: string }> {
   const context = await assertReviewAssignmentContext({
     assignmentId,
     user,

--- a/services/api/src/routers/decision/reviews/index.ts
+++ b/services/api/src/routers/decision/reviews/index.ts
@@ -5,6 +5,7 @@ import { listProposalRevisionRequestsRouter } from './listProposalRevisionReques
 import { listProposalsRevisionRequestsRouter } from './listProposalsRevisionRequests';
 import { listReviewAssignmentsRouter } from './listReviewAssignments';
 import { requestRevisionRouter } from './requestRevision';
+import { saveReviewDraftRouter } from './saveReviewDraft';
 import { submitReviewRouter } from './submitReview';
 import { submitRevisionResponseRouter } from './submitRevisionResponse';
 
@@ -15,6 +16,7 @@ export const reviewsRouter = mergeRouters(
   listProposalsRevisionRequestsRouter,
   listReviewAssignmentsRouter,
   requestRevisionRouter,
+  saveReviewDraftRouter,
   submitRevisionResponseRouter,
   submitReviewRouter,
 );

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
@@ -59,7 +59,6 @@ describe.concurrent('saveReviewDraft', () => {
         answers: { impact: 2 },
         rationales: { impact: 'Still weighing tradeoffs' },
       },
-      overallComment: 'Leaning positive',
     });
 
     expect(result.state).toBe(ProposalReviewState.DRAFT);
@@ -68,7 +67,6 @@ describe.concurrent('saveReviewDraft', () => {
     expect(result.reviewData.rationales).toEqual({
       impact: 'Still weighing tradeoffs',
     });
-    expect(result.overallComment).toBe('Leaning positive');
 
     const assignment = await db.query.proposalReviewAssignments.findFirst({
       where: {
@@ -109,7 +107,6 @@ describe.concurrent('saveReviewDraft', () => {
         answers: { impact: 3 },
         rationales: { impact: 'Updated rationale' },
       },
-      overallComment: 'Changed my mind',
     });
 
     expect(second.state).toBe(ProposalReviewState.DRAFT);
@@ -117,7 +114,6 @@ describe.concurrent('saveReviewDraft', () => {
     expect(second.reviewData.rationales).toEqual({
       impact: 'Updated rationale',
     });
-    expect(second.overallComment).toBe('Changed my mind');
 
     const reviews = await db.query.proposalReviews.findMany({
       where: {
@@ -154,7 +150,6 @@ describe.concurrent('saveReviewDraft', () => {
         answers: { impact: 3 },
         rationales: { impact: 'Final notes' },
       },
-      overallComment: 'Ship it',
     });
 
     expect(submitted.state).toBe(ProposalReviewState.SUBMITTED);
@@ -193,7 +188,6 @@ describe.concurrent('saveReviewDraft', () => {
         answers: { impact: 3 },
         rationales: { impact: 'Final' },
       },
-      overallComment: 'Submitted',
     });
 
     await expect(
@@ -203,7 +197,6 @@ describe.concurrent('saveReviewDraft', () => {
           answers: { impact: 1 },
           rationales: { impact: 'Trying to overwrite' },
         },
-        overallComment: 'New draft',
       }),
     ).rejects.toThrow('Review has already been submitted');
 
@@ -217,7 +210,6 @@ describe.concurrent('saveReviewDraft', () => {
       answers: { impact: 3 },
       rationales: { impact: 'Final' },
     });
-    expect(review?.overallComment).toBe('Submitted');
   });
 
   it('rejects callers who are not the assigned reviewer', async ({

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
@@ -1,0 +1,304 @@
+import type { RubricTemplateSchema } from '@op/common';
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewState,
+} from '@op/db/schema';
+import { db } from '@op/db/test';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestReviewsDataManager } from '../../../test/helpers/TestReviewsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+const rubricTemplate: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': ['impact'],
+  properties: {
+    impact: {
+      type: 'integer',
+      title: 'Impact',
+      'x-format': 'dropdown',
+      minimum: 1,
+      maximum: 5,
+      oneOf: [
+        { const: 1, title: 'Low' },
+        { const: 2, title: 'Medium' },
+        { const: 3, title: 'High' },
+      ],
+    },
+  },
+  required: ['impact'],
+};
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+describe.concurrent('saveReviewDraft', () => {
+  it('creates a draft and transitions the assignment to IN_PROGRESS', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(created.context, rubricTemplate);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { impact: 2 },
+        rationales: { impact: 'Still weighing tradeoffs' },
+      },
+      overallComment: 'Leaning positive',
+    });
+
+    expect(result.state).toBe(ProposalReviewState.DRAFT);
+    expect(result.submittedAt).toBeNull();
+    expect(result.reviewData.answers).toEqual({ impact: 2 });
+    expect(result.reviewData.rationales).toEqual({
+      impact: 'Still weighing tradeoffs',
+    });
+    expect(result.overallComment).toBe('Leaning positive');
+
+    const assignment = await db.query.proposalReviewAssignments.findFirst({
+      where: {
+        id: created.assignment.id,
+      },
+      with: { reviews: true },
+    });
+
+    expect(assignment?.status).toBe(ProposalReviewAssignmentStatus.IN_PROGRESS);
+    expect(assignment?.completedAt).toBeNull();
+    expect(assignment?.reviews[0]?.state).toBe(ProposalReviewState.DRAFT);
+    expect(assignment?.reviews[0]?.submittedAt).toBeNull();
+  });
+
+  it('is idempotent — repeated saves upsert the same draft row', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(created.context, rubricTemplate);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { impact: 1 },
+        rationales: {},
+      },
+    });
+
+    const second = await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { impact: 3 },
+        rationales: { impact: 'Updated rationale' },
+      },
+      overallComment: 'Changed my mind',
+    });
+
+    expect(second.state).toBe(ProposalReviewState.DRAFT);
+    expect(second.reviewData.answers).toEqual({ impact: 3 });
+    expect(second.reviewData.rationales).toEqual({
+      impact: 'Updated rationale',
+    });
+    expect(second.overallComment).toBe('Changed my mind');
+
+    const reviews = await db.query.proposalReviews.findMany({
+      where: {
+        assignmentId: created.assignment.id,
+      },
+    });
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]?.state).toBe(ProposalReviewState.DRAFT);
+  });
+
+  it('lets submitReview promote a saved draft to SUBMITTED', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(created.context, rubricTemplate);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { impact: 2 },
+        rationales: { impact: 'Draft notes' },
+      },
+    });
+
+    const submitted = await reviewerCaller.decision.submitReview({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { impact: 3 },
+        rationales: { impact: 'Final notes' },
+      },
+      overallComment: 'Ship it',
+    });
+
+    expect(submitted.state).toBe(ProposalReviewState.SUBMITTED);
+    expect(submitted.submittedAt).toBeTruthy();
+    expect(submitted.reviewData.answers).toEqual({ impact: 3 });
+    expect(submitted.reviewData.rationales).toEqual({
+      impact: 'Final notes',
+    });
+
+    const assignment = await db.query.proposalReviewAssignments.findFirst({
+      where: {
+        id: created.assignment.id,
+      },
+      with: { reviews: true },
+    });
+    expect(assignment?.status).toBe(ProposalReviewAssignmentStatus.COMPLETED);
+    expect(assignment?.reviews).toHaveLength(1);
+    expect(assignment?.reviews[0]?.state).toBe(ProposalReviewState.SUBMITTED);
+  });
+
+  it('refuses to save a draft after the review has been submitted', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(created.context, rubricTemplate);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await reviewerCaller.decision.submitReview({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { impact: 3 },
+        rationales: { impact: 'Final' },
+      },
+      overallComment: 'Submitted',
+    });
+
+    await expect(
+      reviewerCaller.decision.saveReviewDraft({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: { impact: 1 },
+          rationales: { impact: 'Trying to overwrite' },
+        },
+        overallComment: 'New draft',
+      }),
+    ).rejects.toThrow('Review has already been submitted');
+
+    const review = await db.query.proposalReviews.findFirst({
+      where: {
+        assignmentId: created.assignment.id,
+      },
+    });
+    expect(review?.state).toBe(ProposalReviewState.SUBMITTED);
+    expect(review?.reviewData).toMatchObject({
+      answers: { impact: 3 },
+      rationales: { impact: 'Final' },
+    });
+    expect(review?.overallComment).toBe('Submitted');
+  });
+
+  it('rejects callers who are not the assigned reviewer', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(created.context, rubricTemplate);
+    const otherReviewer = await testData.createReviewer(created.context);
+
+    const otherCaller = await createAuthenticatedCaller(otherReviewer.email);
+
+    await expect(
+      otherCaller.decision.saveReviewDraft({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: { impact: 2 },
+          rationales: {},
+        },
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
+  });
+
+  it('accepts a fully empty payload via schema defaults', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(created.context, rubricTemplate);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    const result = await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: {},
+        rationales: {},
+      },
+    });
+
+    expect(result.state).toBe(ProposalReviewState.DRAFT);
+    expect(result.reviewData.answers).toEqual({});
+    expect(result.reviewData.rationales).toEqual({});
+    expect(result.overallComment).toBeNull();
+  });
+
+  it('does not downgrade non-PENDING assignment statuses', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      status: ProposalReviewAssignmentStatus.READY_FOR_RE_REVIEW,
+    });
+    await testData.setRubricTemplate(created.context, rubricTemplate);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { impact: 2 },
+        rationales: {},
+      },
+    });
+
+    const assignment = await db.query.proposalReviewAssignments.findFirst({
+      where: {
+        id: created.assignment.id,
+      },
+    });
+    expect(assignment?.status).toBe(
+      ProposalReviewAssignmentStatus.READY_FOR_RE_REVIEW,
+    );
+  });
+});

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
@@ -81,7 +81,7 @@ describe.concurrent('saveReviewDraft', () => {
     expect(assignment?.reviews[0]?.submittedAt).toBeNull();
   });
 
-  it('is idempotent — repeated saves upsert the same draft row', async ({
+  it('upserts a single draft row per assignment — last write wins', async ({
     task,
     onTestFinished,
   }) => {
@@ -122,52 +122,6 @@ describe.concurrent('saveReviewDraft', () => {
     });
     expect(reviews).toHaveLength(1);
     expect(reviews[0]?.state).toBe(ProposalReviewState.DRAFT);
-  });
-
-  it('lets submitReview promote a saved draft to SUBMITTED', async ({
-    task,
-    onTestFinished,
-  }) => {
-    const testData = new TestReviewsDataManager(task.id, onTestFinished);
-    const created = await testData.createReviewAssignment();
-    await testData.setRubricTemplate(created.context, rubricTemplate);
-
-    const reviewerCaller = await createAuthenticatedCaller(
-      created.reviewer.email,
-    );
-
-    await reviewerCaller.decision.saveReviewDraft({
-      assignmentId: created.assignment.id,
-      reviewData: {
-        answers: { impact: 2 },
-        rationales: { impact: 'Draft notes' },
-      },
-    });
-
-    const submitted = await reviewerCaller.decision.submitReview({
-      assignmentId: created.assignment.id,
-      reviewData: {
-        answers: { impact: 3 },
-        rationales: { impact: 'Final notes' },
-      },
-    });
-
-    expect(submitted.state).toBe(ProposalReviewState.SUBMITTED);
-    expect(submitted.submittedAt).toBeTruthy();
-    expect(submitted.reviewData.answers).toEqual({ impact: 3 });
-    expect(submitted.reviewData.rationales).toEqual({
-      impact: 'Final notes',
-    });
-
-    const assignment = await db.query.proposalReviewAssignments.findFirst({
-      where: {
-        id: created.assignment.id,
-      },
-      with: { reviews: true },
-    });
-    expect(assignment?.status).toBe(ProposalReviewAssignmentStatus.COMPLETED);
-    expect(assignment?.reviews).toHaveLength(1);
-    expect(assignment?.reviews[0]?.state).toBe(ProposalReviewState.SUBMITTED);
   });
 
   it('refuses to save a draft after the review has been submitted', async ({

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.ts
@@ -10,7 +10,6 @@ import { commonAuthedProcedure, router } from '../../../trpcFactory';
 const saveReviewDraftInputSchema = z.object({
   assignmentId: z.uuid(),
   reviewData: rubricReviewDataSchema,
-  overallComment: z.string().nullable().optional(),
 });
 
 export const saveReviewDraftRouter = router({
@@ -21,7 +20,6 @@ export const saveReviewDraftRouter = router({
       const result = await saveReviewDraft({
         assignmentId: input.assignmentId,
         reviewData: input.reviewData,
-        overallComment: input.overallComment,
         user: ctx.user,
       });
 

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.ts
@@ -17,7 +17,7 @@ export const saveReviewDraftRouter = router({
     .input(saveReviewDraftInputSchema)
     .output(proposalReviewSchema)
     .mutation(async ({ ctx, input }) => {
-      const result = await saveReviewDraft({
+      const { review, processInstanceId } = await saveReviewDraft({
         assignmentId: input.assignmentId,
         reviewData: input.reviewData,
         user: ctx.user,
@@ -25,9 +25,9 @@ export const saveReviewDraftRouter = router({
 
       ctx.registerMutationChannels([
         Channels.reviewAssignment(input.assignmentId),
-        Channels.reviewAssignments(result.processInstanceId),
+        Channels.reviewAssignments(processInstanceId),
       ]);
 
-      return proposalReviewSchema.parse(result);
+      return proposalReviewSchema.parse(review);
     }),
 });

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.ts
@@ -1,0 +1,35 @@
+import { Channels, saveReviewDraft } from '@op/common';
+import {
+  proposalReviewSchema,
+  rubricReviewDataSchema,
+} from '@op/common/client';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+const saveReviewDraftInputSchema = z.object({
+  assignmentId: z.uuid(),
+  reviewData: rubricReviewDataSchema,
+  overallComment: z.string().nullable().optional(),
+});
+
+export const saveReviewDraftRouter = router({
+  saveReviewDraft: commonAuthedProcedure()
+    .input(saveReviewDraftInputSchema)
+    .output(proposalReviewSchema)
+    .mutation(async ({ ctx, input }) => {
+      const result = await saveReviewDraft({
+        assignmentId: input.assignmentId,
+        reviewData: input.reviewData,
+        overallComment: input.overallComment,
+        user: ctx.user,
+      });
+
+      ctx.registerMutationChannels([
+        Channels.reviewAssignment(input.assignmentId),
+        Channels.reviewAssignments(result.processInstanceId),
+      ]);
+
+      return proposalReviewSchema.parse(result);
+    }),
+});

--- a/services/api/src/routers/decision/reviews/submitReview.test.ts
+++ b/services/api/src/routers/decision/reviews/submitReview.test.ts
@@ -59,6 +59,7 @@ describe.concurrent('submitReview', () => {
         answers: { impact: 3 },
         rationales: { impact: 'Solid execution plan' },
       },
+      overallComment: 'Ready to move forward',
     });
 
     expect(result.state).toBe(ProposalReviewState.SUBMITTED);

--- a/services/api/src/routers/decision/reviews/submitReview.test.ts
+++ b/services/api/src/routers/decision/reviews/submitReview.test.ts
@@ -59,7 +59,6 @@ describe.concurrent('submitReview', () => {
         answers: { impact: 3 },
         rationales: { impact: 'Solid execution plan' },
       },
-      overallComment: 'Ready to move forward',
     });
 
     expect(result.state).toBe(ProposalReviewState.SUBMITTED);

--- a/services/api/src/routers/decision/reviews/submitReview.ts
+++ b/services/api/src/routers/decision/reviews/submitReview.ts
@@ -10,7 +10,6 @@ import { commonAuthedProcedure, router } from '../../../trpcFactory';
 const reviewInputSchema = z.object({
   assignmentId: z.uuid(),
   reviewData: rubricReviewDataSchema,
-  overallComment: z.string().nullable().optional(),
 });
 
 export const submitReviewRouter = router({
@@ -21,7 +20,6 @@ export const submitReviewRouter = router({
       const result = await submitReview({
         assignmentId: input.assignmentId,
         reviewData: input.reviewData,
-        overallComment: input.overallComment,
         user: ctx.user,
       });
 

--- a/services/api/src/routers/decision/reviews/submitReview.ts
+++ b/services/api/src/routers/decision/reviews/submitReview.ts
@@ -10,6 +10,7 @@ import { commonAuthedProcedure, router } from '../../../trpcFactory';
 const reviewInputSchema = z.object({
   assignmentId: z.uuid(),
   reviewData: rubricReviewDataSchema,
+  overallComment: z.string().nullable().optional(),
 });
 
 export const submitReviewRouter = router({
@@ -17,17 +18,18 @@ export const submitReviewRouter = router({
     .input(reviewInputSchema)
     .output(proposalReviewSchema)
     .mutation(async ({ ctx, input }) => {
-      const result = await submitReview({
+      const { review, processInstanceId } = await submitReview({
         assignmentId: input.assignmentId,
         reviewData: input.reviewData,
+        overallComment: input.overallComment,
         user: ctx.user,
       });
 
       ctx.registerMutationChannels([
         Channels.reviewAssignment(input.assignmentId),
-        Channels.reviewAssignments(result.processInstanceId),
+        Channels.reviewAssignments(processInstanceId),
       ]);
 
-      return proposalReviewSchema.parse(result);
+      return proposalReviewSchema.parse(review);
     }),
 });


### PR DESCRIPTION
Persist in-progress reviewer input continuously so navigating away no longer loses work, and surface the assignment as in-progress as soon as the reviewer starts filling out the rubric.