### PR TITLE
feat(reviews): share pending revision request view across reviewers

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -38,7 +38,7 @@ interface ReviewFormState {
   isSubmitted: boolean;
   isPausedForRevision: boolean;
   revisionRequest: ProposalReviewRequest | null;
-  canCancelRevisionRequest: boolean;
+  isOwnRevisionRequest: boolean;
   canRequestRevision: boolean;
   rubricTemplate: RubricTemplateSchema;
   review: ProposalReview | null;
@@ -114,7 +114,7 @@ function ReviewFormProviderInner({
 
   // Only trust the per-assignment request when it is still REQUESTED — a
   // locally cached CANCELLED/RESUBMITTED entry must not gate the UI.
-  const ownRequestedRevisionRequest =
+  const ownRevisionRequest =
     revisionRequest?.state === ProposalReviewRequestState.REQUESTED
       ? revisionRequest
       : null;
@@ -123,10 +123,10 @@ function ReviewFormProviderInner({
   // outstanding request from any other reviewer on the same proposal so
   // every reviewer sees the same paused state + feedback.
   const effectiveRevisionRequest =
-    ownRequestedRevisionRequest ??
+    ownRevisionRequest ??
     proposalRevisionRequestList.revisionRequests[0]?.revisionRequest ??
     null;
-  const canCancelRevisionRequest = !!ownRequestedRevisionRequest;
+  const isOwnRevisionRequest = !!ownRevisionRequest;
 
   const [values, setValues] = useState<Record<string, unknown>>(
     review?.reviewData.answers ?? {},
@@ -219,14 +219,14 @@ function ReviewFormProviderInner({
   );
 
   const handleCancelRevision = useCallback(() => {
-    if (!ownRequestedRevisionRequest) {
+    if (!ownRevisionRequest) {
       return;
     }
     cancelRevisionMutation.mutate({
       assignmentId,
-      revisionRequestId: ownRequestedRevisionRequest.id,
+      revisionRequestId: ownRevisionRequest.id,
     });
-  }, [assignmentId, ownRequestedRevisionRequest, cancelRevisionMutation]);
+  }, [assignmentId, ownRevisionRequest, cancelRevisionMutation]);
 
   const state = useMemo<ReviewFormState>(
     () => ({
@@ -237,7 +237,7 @@ function ReviewFormProviderInner({
       isSubmitted,
       isPausedForRevision,
       revisionRequest: effectiveRevisionRequest,
-      canCancelRevisionRequest,
+      isOwnRevisionRequest,
       canRequestRevision,
       rubricTemplate,
       review,
@@ -257,7 +257,7 @@ function ReviewFormProviderInner({
       isSubmitted,
       isPausedForRevision,
       effectiveRevisionRequest,
-      canCancelRevisionRequest,
+      isOwnRevisionRequest,
       canRequestRevision,
       rubricTemplate,
       review,

--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -39,6 +39,7 @@ interface ReviewFormState {
   isPausedForRevision: boolean;
   revisionRequest: ProposalReviewRequest | null;
   canCancelRevisionRequest: boolean;
+  canRequestRevision: boolean;
   rubricTemplate: RubricTemplateSchema;
   review: ProposalReview | null;
   assignment: ProposalReviewAssignment;
@@ -108,17 +109,24 @@ function ReviewFormProviderInner({
       { refetchOnMount: 'always' },
     );
 
+  const hasAnyOpenRevisionRequest =
+    proposalRevisionRequestList.revisionRequests.length > 0;
+
+  // Only trust the per-assignment request when it is still REQUESTED — a
+  // locally cached CANCELLED/RESUBMITTED entry must not gate the UI.
+  const ownRequestedRevisionRequest =
+    revisionRequest?.state === ProposalReviewRequestState.REQUESTED
+      ? revisionRequest
+      : null;
+
   // Prefer the reviewer's own request; otherwise surface the earliest
   // outstanding request from any other reviewer on the same proposal so
   // every reviewer sees the same paused state + feedback.
   const effectiveRevisionRequest =
-    revisionRequest ??
+    ownRequestedRevisionRequest ??
     proposalRevisionRequestList.revisionRequests[0]?.revisionRequest ??
     null;
-  const canCancelRevisionRequest =
-    !!effectiveRevisionRequest &&
-    effectiveRevisionRequest.assignmentId === assignmentId &&
-    effectiveRevisionRequest.state === ProposalReviewRequestState.REQUESTED;
+  const canCancelRevisionRequest = !!ownRequestedRevisionRequest;
 
   const [values, setValues] = useState<Record<string, unknown>>(
     review?.reviewData.answers ?? {},
@@ -127,8 +135,8 @@ function ReviewFormProviderInner({
     review?.reviewData.rationales ?? {},
   );
   const isSubmitted = review?.state === 'submitted';
-  const isPausedForRevision =
-    effectiveRevisionRequest?.state === ProposalReviewRequestState.REQUESTED;
+  const isPausedForRevision = hasAnyOpenRevisionRequest;
+  const canRequestRevision = !isSubmitted && !hasAnyOpenRevisionRequest;
 
   const submitReview = trpc.decision.submitReview.useMutation({
     onSuccess: () => {
@@ -211,19 +219,14 @@ function ReviewFormProviderInner({
   );
 
   const handleCancelRevision = useCallback(() => {
-    if (!canCancelRevisionRequest || !effectiveRevisionRequest) {
+    if (!ownRequestedRevisionRequest) {
       return;
     }
     cancelRevisionMutation.mutate({
       assignmentId,
-      revisionRequestId: effectiveRevisionRequest.id,
+      revisionRequestId: ownRequestedRevisionRequest.id,
     });
-  }, [
-    assignmentId,
-    canCancelRevisionRequest,
-    effectiveRevisionRequest,
-    cancelRevisionMutation,
-  ]);
+  }, [assignmentId, ownRequestedRevisionRequest, cancelRevisionMutation]);
 
   const state = useMemo<ReviewFormState>(
     () => ({
@@ -232,9 +235,10 @@ function ReviewFormProviderInner({
       canSubmit: canSubmit && !isSubmitted && !isPausedForRevision,
       isSubmitting: submitReview.isPending,
       isSubmitted,
-      isPausedForRevision: !!isPausedForRevision,
+      isPausedForRevision,
       revisionRequest: effectiveRevisionRequest,
       canCancelRevisionRequest,
+      canRequestRevision,
       rubricTemplate,
       review,
       assignment,
@@ -254,6 +258,7 @@ function ReviewFormProviderInner({
       isPausedForRevision,
       effectiveRevisionRequest,
       canCancelRevisionRequest,
+      canRequestRevision,
       rubricTemplate,
       review,
       assignment,

--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -6,6 +6,7 @@ import {
   type ProposalReview,
   type ProposalReviewAssignment,
   type ProposalReviewRequest,
+  ProposalReviewRequestState,
   type RubricTemplateSchema,
   schemaValidator,
 } from '@op/common/client';
@@ -37,6 +38,7 @@ interface ReviewFormState {
   isSubmitted: boolean;
   isPausedForRevision: boolean;
   revisionRequest: ProposalReviewRequest | null;
+  canCancelRevisionRequest: boolean;
   rubricTemplate: RubricTemplateSchema;
   review: ProposalReview | null;
   assignment: ProposalReviewAssignment;
@@ -97,6 +99,27 @@ function ReviewFormProviderInner({
     throw new Error(`Review assignment ${assignmentId} has no rubric template`);
   }
 
+  const [proposalRevisionRequestList] =
+    trpc.decision.listProposalRevisionRequests.useSuspenseQuery(
+      {
+        proposalId: assignment.proposal.id,
+        states: [ProposalReviewRequestState.REQUESTED],
+      },
+      { refetchOnMount: 'always' },
+    );
+
+  // Prefer the reviewer's own request; otherwise surface the earliest
+  // outstanding request from any other reviewer on the same proposal so
+  // every reviewer sees the same paused state + feedback.
+  const effectiveRevisionRequest =
+    revisionRequest ??
+    proposalRevisionRequestList.revisionRequests[0]?.revisionRequest ??
+    null;
+  const canCancelRevisionRequest =
+    !!effectiveRevisionRequest &&
+    effectiveRevisionRequest.assignmentId === assignmentId &&
+    effectiveRevisionRequest.state === ProposalReviewRequestState.REQUESTED;
+
   const [values, setValues] = useState<Record<string, unknown>>(
     review?.reviewData.answers ?? {},
   );
@@ -104,7 +127,8 @@ function ReviewFormProviderInner({
     review?.reviewData.rationales ?? {},
   );
   const isSubmitted = review?.state === 'submitted';
-  const isPausedForRevision = revisionRequest?.state === 'requested';
+  const isPausedForRevision =
+    effectiveRevisionRequest?.state === ProposalReviewRequestState.REQUESTED;
 
   const submitReview = trpc.decision.submitReview.useMutation({
     onSuccess: () => {
@@ -187,14 +211,19 @@ function ReviewFormProviderInner({
   );
 
   const handleCancelRevision = useCallback(() => {
-    if (!revisionRequest) {
+    if (!canCancelRevisionRequest || !effectiveRevisionRequest) {
       return;
     }
     cancelRevisionMutation.mutate({
       assignmentId,
-      revisionRequestId: revisionRequest.id,
+      revisionRequestId: effectiveRevisionRequest.id,
     });
-  }, [assignmentId, revisionRequest, cancelRevisionMutation]);
+  }, [
+    assignmentId,
+    canCancelRevisionRequest,
+    effectiveRevisionRequest,
+    cancelRevisionMutation,
+  ]);
 
   const state = useMemo<ReviewFormState>(
     () => ({
@@ -204,7 +233,8 @@ function ReviewFormProviderInner({
       isSubmitting: submitReview.isPending,
       isSubmitted,
       isPausedForRevision: !!isPausedForRevision,
-      revisionRequest,
+      revisionRequest: effectiveRevisionRequest,
+      canCancelRevisionRequest,
       rubricTemplate,
       review,
       assignment,
@@ -222,7 +252,8 @@ function ReviewFormProviderInner({
       canSubmit,
       isSubmitted,
       isPausedForRevision,
-      revisionRequest,
+      effectiveRevisionRequest,
+      canCancelRevisionRequest,
       rubricTemplate,
       review,
       assignment,

--- a/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ProposalReviewRequestState } from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { useState } from 'react';
@@ -21,18 +20,11 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
     canSubmit,
     isSubmitting,
     isSubmitted,
-    revisionRequest,
+    canRequestRevision,
     handleSubmit,
   } = useReviewForm();
 
   const [isRequestModalOpen, setIsRequestModalOpen] = useState(false);
-
-  // Only show when pressing the button would start a new request: no request
-  // yet, or the last one was cancelled. While REQUESTED, the rubric pane
-  // already surfaces the pending request via its alert banner.
-  const canRequestRevision =
-    !revisionRequest ||
-    revisionRequest.state === ProposalReviewRequestState.CANCELLED;
 
   return (
     <>

--- a/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
+++ b/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
@@ -20,7 +20,7 @@ export function ViewRevisionRequestModal({
   const t = useTranslations();
   const {
     revisionRequest,
-    canCancelRevisionRequest,
+    isOwnRevisionRequest,
     cancelRevisionRequest,
     isCancellingRevision,
   } = useReviewForm();
@@ -66,7 +66,7 @@ export function ViewRevisionRequestModal({
         </div>
       </ModalBody>
       <ModalFooter>
-        {canCancelRevisionRequest && (
+        {isOwnRevisionRequest && (
           <Button
             color="secondary"
             onPress={handleCancelRequest}

--- a/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
+++ b/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ProposalReviewRequestState } from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
@@ -19,8 +18,12 @@ export function ViewRevisionRequestModal({
   onOpenChange,
 }: ViewRevisionRequestModalProps) {
   const t = useTranslations();
-  const { revisionRequest, cancelRevisionRequest, isCancellingRevision } =
-    useReviewForm();
+  const {
+    revisionRequest,
+    canCancelRevisionRequest,
+    cancelRevisionRequest,
+    isCancellingRevision,
+  } = useReviewForm();
 
   const handleCancelRequest = () => {
     cancelRevisionRequest();
@@ -34,8 +37,6 @@ export function ViewRevisionRequestModal({
   const sentDate = revisionRequest.requestedAt
     ? new Date(revisionRequest.requestedAt)
     : null;
-  const canCancel =
-    revisionRequest.state === ProposalReviewRequestState.REQUESTED;
 
   return (
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable>
@@ -65,7 +66,7 @@ export function ViewRevisionRequestModal({
         </div>
       </ModalBody>
       <ModalFooter>
-        {canCancel && (
+        {canCancelRevisionRequest && (
           <Button
             color="secondary"
             onPress={handleCancelRequest}

--- a/tests/e2e/tests/review-shared-revision-view.spec.ts
+++ b/tests/e2e/tests/review-shared-revision-view.spec.ts
@@ -1,0 +1,220 @@
+import type {
+  DecisionSchemaDefinition,
+  RubricTemplateSchema,
+} from '@op/common';
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+  processInstances,
+} from '@op/db/schema';
+import { db, eq } from '@op/db/test';
+import {
+  createDecisionInstance,
+  createInstanceMember,
+  createReviewAssignment,
+  createReviewScenario,
+  getSeededTemplate,
+  grantInstanceReviewerRole,
+} from '@op/test';
+
+import {
+  TEST_USER_DEFAULT_PASSWORD,
+  authenticateAsUser,
+  expect,
+  test,
+} from '../fixtures/index.js';
+
+const REQUEST_COMMENT = 'Please add a detailed budget breakdown.';
+
+const REVIEW_SCHEMA = {
+  id: 'shared-revision-view-schema',
+  version: '1.0.0',
+  name: 'Shared Revision View Schema',
+  description:
+    'Schema with a review-capable middle phase for the shared revision view test.',
+  phases: [
+    {
+      id: 'submission',
+      name: 'Submission',
+      description: 'Submit proposals',
+      rules: {
+        proposals: { submit: true },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'review',
+      name: 'Review',
+      description: 'Review proposals',
+      rules: {
+        proposals: { submit: false, review: true },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'results',
+      name: 'Results',
+      description: 'Final results',
+      rules: {
+        proposals: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+  ],
+} satisfies DecisionSchemaDefinition;
+
+// Minimal rubric — just enough to unblock the review page's notFound() when
+// rubricTemplate is null. We never interact with it.
+const RUBRIC_TEMPLATE = {
+  type: 'object',
+  required: ['innovation'],
+  'x-field-order': ['innovation'],
+  properties: {
+    innovation: {
+      type: 'integer',
+      title: 'Innovation',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 1, title: '1' },
+        { const: 2, title: '2' },
+      ],
+    },
+  },
+} as const satisfies RubricTemplateSchema;
+
+test.describe('Review — shared revision request view', () => {
+  test('a second reviewer sees the pending revision but cannot cancel it', async ({
+    browser,
+    org,
+    supabaseAdmin,
+  }, testInfo) => {
+    const testId = `shared-rev-${testInfo.workerIndex}-${Date.now()}`;
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: REVIEW_SCHEMA,
+    });
+
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...(instance.instance.instanceData as Record<string, unknown>),
+          rubricTemplate: RUBRIC_TEMPLATE,
+        },
+        currentStateId: 'review',
+      })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    const { user: author } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-author`,
+      instanceProfileId: instance.profileId,
+    });
+    const { user: reviewerA } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-reviewer-a`,
+      instanceProfileId: instance.profileId,
+    });
+    const { user: reviewerB } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-reviewer-b`,
+      instanceProfileId: instance.profileId,
+    });
+
+    await grantInstanceReviewerRole({
+      instanceProfileId: instance.profileId,
+      authUserId: reviewerA.authUserId,
+      email: reviewerA.email,
+      roleName: `ReviewerA-${testId}`,
+    });
+    await grantInstanceReviewerRole({
+      instanceProfileId: instance.profileId,
+      authUserId: reviewerB.authUserId,
+      email: reviewerB.email,
+      roleName: `ReviewerB-${testId}`,
+    });
+
+    // Reviewer A owns the revision request.
+    const { proposal, assignedProposalHistoryId, revisionRequest } =
+      await createReviewScenario({
+        instance: { id: instance.instance.id },
+        author,
+        reviewer: { profileId: reviewerA.profileId },
+        proposalData: {
+          title: 'Community Solar Initiative',
+          collaborationDocId: 'test-proposal-view-doc',
+        },
+        assignmentStatus:
+          ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+        revisionRequest: {
+          state: ProposalReviewRequestState.REQUESTED,
+          requestComment: REQUEST_COMMENT,
+        },
+      });
+
+    if (!revisionRequest) {
+      throw new Error('createReviewScenario did not return a revision request');
+    }
+
+    // Reviewer B has their own assignment on the same proposal — no request.
+    const reviewerBAssignment = await createReviewAssignment({
+      processInstanceId: instance.instance.id,
+      proposalId: proposal.id,
+      reviewerProfileId: reviewerB.profileId,
+      assignedProposalHistoryId,
+    });
+
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await authenticateAsUser(page, {
+      email: reviewerB.email,
+      password: TEST_USER_DEFAULT_PASSWORD,
+    });
+
+    await page.goto(
+      `/en/decisions/${instance.slug}/reviews/${reviewerBAssignment.id}`,
+    );
+
+    // Shared paused state — banner + "View feedback" affordance render for
+    // reviewer B even though the request is on reviewer A's assignment.
+    // ReviewLayout renders the rubric pane twice (desktop + mobile
+    // responsive containers), so both copies exist in the DOM; pick the
+    // first one — which is the desktop copy that's visible at Playwright's
+    // default 1280px viewport.
+    await expect(
+      page.getByText('Proposal Revision Requested').first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.getByRole('button', { name: 'View feedback' }).first(),
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: 'View feedback' }).first().click();
+
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+    await expect(
+      modal.getByRole('heading', { name: 'Revision request' }),
+    ).toBeVisible();
+    await expect(modal.getByText(REQUEST_COMMENT)).toBeVisible();
+
+    // Ownership gate: Cancel is hidden because the request belongs to
+    // reviewer A, not the current viewer.
+    await expect(
+      modal.getByRole('button', { name: 'Cancel request' }),
+    ).toHaveCount(0);
+    await expect(
+      modal.getByRole('button', { name: 'Close', exact: true }),
+    ).toBeVisible();
+
+    // Navbar's "Request revision" is hidden too — reviewer B shouldn't race
+    // into a duplicate request while one is already open.
+    await expect(
+      page.getByRole('button', { name: 'Request revision' }),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Every reviewer on a proposal sees the same paused-for-revision banner and feedback modal when any reviewer has an open revision request, so they have context to stop instead of racing into duplicates. Cancel stays owner-only.

Gating is currently enforced on the client rather than the API because we expect the API may soon need to support multiple concurrent revision requests.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214152232549652