### PR TITLE
fix(reviews): show numbers and descriptions in scored rubric dropdown

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -306,10 +306,12 @@ function RubricFieldInput({
         );
       }
 
-      const options = parseSchemaOptions(field.schema).map((option) => ({
-        value: option.value,
-        label: option.title || String(option.value),
-      }));
+      // Scored rubric criterion: highest score first (to match the process
+      // builder); each option renders the score with its description below
+      // so reviewers can tell options apart on long scales.
+      const options = [...parseSchemaOptions(field.schema)].sort(
+        (a, b) => Number(b.value) - Number(a.value),
+      );
       const selectedKey =
         typeof value === 'string' || typeof value === 'number'
           ? String(value)
@@ -325,11 +327,29 @@ function RubricFieldInput({
           }}
           className="w-full"
         >
-          {options.map((option) => (
-            <SelectItem key={String(option.value)} id={String(option.value)}>
-              {option.label}
-            </SelectItem>
-          ))}
+          {options.map((option) => {
+            const triggerLabel = option.title
+              ? `${option.value} - ${option.title}`
+              : String(option.value);
+            return (
+              <SelectItem
+                key={String(option.value)}
+                id={String(option.value)}
+                textValue={triggerLabel}
+              >
+                {option.title ? (
+                  <div className="flex flex-col">
+                    <span>{option.value}</span>
+                    <span className="text-sm text-neutral-gray4">
+                      {option.title}
+                    </span>
+                  </div>
+                ) : (
+                  String(option.value)
+                )}
+              </SelectItem>
+            );
+          })}
         </Select>
       );
     }

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -275,7 +275,9 @@ function RubricFieldInput({
 
   switch (field.format) {
     case 'dropdown': {
-      if (inferCriterionType(field.schema) === 'yes_no') {
+      const criterionType = inferCriterionType(field.schema);
+
+      if (criterionType === 'yes_no') {
         return (
           <ToggleButton
             size="small"
@@ -306,52 +308,56 @@ function RubricFieldInput({
         );
       }
 
-      // Scored rubric criterion: highest score first (to match the process
-      // builder); each option renders the score with its description below
-      // so reviewers can tell options apart on long scales.
-      const options = [...parseSchemaOptions(field.schema)].sort(
-        (a, b) => Number(b.value) - Number(a.value),
-      );
-      const selectedKey =
-        typeof value === 'string' || typeof value === 'number'
-          ? String(value)
-          : null;
+      if (criterionType === 'scored') {
+        // Highest score first (to match the process builder); each option
+        // renders the score with its description below so reviewers can
+        // tell options apart on long scales.
+        const options = [...parseSchemaOptions(field.schema)].sort(
+          (a, b) => Number(b.value) - Number(a.value),
+        );
+        const selectedKey =
+          typeof value === 'string' || typeof value === 'number'
+            ? String(value)
+            : null;
 
-      return (
-        <Select
-          aria-label={field.schema.title}
-          placeholder={t('Select an option')}
-          selectedKey={selectedKey}
-          onSelectionChange={(key) => {
-            onChange(parseSelectedValue(key, field.schema));
-          }}
-          className="w-full"
-        >
-          {options.map((option) => {
-            const triggerLabel = option.title
-              ? `${option.value} - ${option.title}`
-              : String(option.value);
-            return (
-              <SelectItem
-                key={String(option.value)}
-                id={String(option.value)}
-                textValue={triggerLabel}
-              >
-                {option.title ? (
-                  <div className="flex flex-col">
-                    <span>{option.value}</span>
-                    <span className="text-sm text-neutral-gray4">
-                      {option.title}
-                    </span>
-                  </div>
-                ) : (
-                  String(option.value)
-                )}
-              </SelectItem>
-            );
-          })}
-        </Select>
-      );
+        return (
+          <Select
+            aria-label={field.schema.title}
+            placeholder={t('Select an option')}
+            selectedKey={selectedKey}
+            onSelectionChange={(key) => {
+              onChange(parseSelectedValue(key, field.schema));
+            }}
+            className="w-full"
+          >
+            {options.map((option) => {
+              const triggerLabel = option.title
+                ? `${option.value} - ${option.title}`
+                : String(option.value);
+              return (
+                <SelectItem
+                  key={String(option.value)}
+                  id={String(option.value)}
+                  textValue={triggerLabel}
+                >
+                  {option.title ? (
+                    <div className="flex flex-col">
+                      <span>{option.value}</span>
+                      <span className="text-sm text-neutral-gray4">
+                        {option.title}
+                      </span>
+                    </div>
+                  ) : (
+                    String(option.value)
+                  )}
+                </SelectItem>
+              );
+            })}
+          </Select>
+        );
+      }
+
+      return null;
     }
 
     case 'long-text':

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -10,7 +10,6 @@ import { AlertBanner } from '@op/ui/AlertBanner';
 import { Button } from '@op/ui/Button';
 import { Header3 } from '@op/ui/Header';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
-import { Select, SelectItem } from '@op/ui/Select';
 import { Surface } from '@op/ui/Surface';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
@@ -21,6 +20,8 @@ import { LuCircleAlert, LuPlus } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 
 import { FieldHeader } from '../forms/FieldHeader';
+import { FormDropdown } from '../forms/FormDropdown';
+import type { FormDropdownOption } from '../forms/FormDropdown';
 import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
 import {
@@ -334,31 +335,34 @@ function RubricFieldInput({
         );
       }
 
-      const options = parseSchemaOptions(field.schema).map((option) => ({
-        value: option.value,
-        label: option.title || String(option.value),
-      }));
+      // Scored rubric criterion: highest score first (to match the process
+      // builder), with each option shown as `{n} - {description}` so the
+      // number stays visible on long scales.
+      const options: FormDropdownOption[] = [
+        ...parseSchemaOptions(field.schema),
+      ]
+        .sort((a, b) => Number(b.value) - Number(a.value))
+        .map((option) => ({
+          value: option.value,
+          label: option.title
+            ? `${option.value} - ${option.title}`
+            : String(option.value),
+          description: option.title || undefined,
+        }));
       const selectedKey =
         typeof value === 'string' || typeof value === 'number'
           ? String(value)
           : null;
 
       return (
-        <Select
-          aria-label={field.schema.title}
-          placeholder={t('Select an option')}
+        <FormDropdown
+          ariaLabel={field.schema.title}
           selectedKey={selectedKey}
           onSelectionChange={(key) => {
             onChange(parseSelectedValue(key, field.schema));
           }}
-          className="w-full"
-        >
-          {options.map((option) => (
-            <SelectItem key={String(option.value)} id={String(option.value)}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </Select>
+          options={options}
+        />
       );
     }
 

--- a/apps/app/src/components/decisions/forms/FormDropdown.tsx
+++ b/apps/app/src/components/decisions/forms/FormDropdown.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Select, SelectItem } from '@op/ui/Select';
+import type { Key } from 'react';
+
+import { useTranslations } from '@/lib/i18n';
+
+export interface FormDropdownOption {
+  value: string | number;
+  label: string;
+  description?: string;
+}
+
+interface FormDropdownProps {
+  ariaLabel?: string;
+  placeholder?: string;
+  selectedKey: string | null;
+  onSelectionChange: (key: Key | null) => void;
+  options: FormDropdownOption[];
+  className?: string;
+}
+
+/**
+ * Generic dropdown for decision forms.
+ *
+ * Renders each option's `label`; when an option is selected and has a
+ * `description`, it surfaces as helper text under the field. Callers shape
+ * their schema options into `FormDropdownOption` however their domain
+ * requires (e.g. rubric scoring prefixes the numeric value onto the label).
+ */
+export function FormDropdown({
+  ariaLabel,
+  placeholder,
+  selectedKey,
+  onSelectionChange,
+  options,
+  className,
+}: FormDropdownProps) {
+  const t = useTranslations();
+  const selected = options.find(
+    (option) => String(option.value) === selectedKey,
+  );
+
+  return (
+    <Select
+      aria-label={ariaLabel}
+      placeholder={placeholder ?? t('Select an option')}
+      selectedKey={selectedKey}
+      onSelectionChange={onSelectionChange}
+      description={selected?.description}
+      className={className ?? 'w-full'}
+    >
+      {options.map((option) => (
+        <SelectItem key={String(option.value)} id={String(option.value)}>
+          {option.label}
+        </SelectItem>
+      ))}
+    </Select>
+  );
+}


### PR DESCRIPTION
Reviewers couldn't tell scores apart on long scales because the dropdown hid the numeric value and sorted ascending, while the process builder shows descriptions descending.


## Demo

| Before | After |
| --- | --- |
| <img width="1154" height="1040" alt="CleanShot 2026-05-03 at 15 40 15@2x" src="https://github.com/user-attachments/assets/09acfe9d-7611-4cc7-9079-7c0045e48f38" /> | <img width="1154" height="1040" alt="CleanShot 2026-05-03 at 15 36 59@2x" src="https://github.com/user-attachments/assets/f9f41089-188f-407a-9b2f-ddb801821b13" /> |


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214138288123149
