### PR TITLE
feat(reviews): add admin endpoint to list all review assignments in a process

### DIFF
--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -56,6 +56,7 @@ export * from './runGenerateReviewAssignments';
 export * from './listProposalSubmitters';
 export * from './getReviewAssignment';
 export * from './listReviewAssignments';
+export * from './listAllReviewAssignments';
 export * from './listProposalsRevisionRequests';
 export * from './listProposalRevisionRequests';
 export * from './submitRevisionResponse';

--- a/packages/common/src/services/decision/listAllReviewAssignments.ts
+++ b/packages/common/src/services/decision/listAllReviewAssignments.ts
@@ -1,0 +1,82 @@
+import { db } from '@op/db/client';
+import { ProposalReviewAssignmentStatus } from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+
+import { UnauthorizedError } from '../../utils';
+import { assertUserByAuthId } from '../assert';
+import { getInstance } from './getInstance';
+import {
+  getActiveRevisionRequest,
+  resolveAssignmentProposal,
+  reviewAssignmentWithConfig,
+} from './reviewHelpers';
+import { type ReviewItemList, reviewItemListSchema } from './schemas/reviews';
+
+/**
+ * Admin-scoped endpoint that returns every review assignment in a process
+ * instance without the heavy TipTap payload (document/html/template/attachments).
+ *
+ * Callers pair this with `listProposals` or `listReviewAssignments` when they
+ * need proposal bodies.
+ */
+export async function listAllReviewAssignments({
+  processInstanceId,
+  status,
+  dir = 'asc',
+  user,
+}: {
+  processInstanceId: string;
+  status?: ProposalReviewAssignmentStatus;
+  dir?: 'asc' | 'desc';
+  user: User;
+}): Promise<ReviewItemList> {
+  const [instance, dbUser] = await Promise.all([
+    getInstance({ instanceId: processInstanceId, user }),
+    assertUserByAuthId(user.id),
+  ]);
+
+  if (!dbUser.profileId) {
+    throw new UnauthorizedError('User must have an active profile');
+  }
+
+  if (!instance.access.admin) {
+    throw new UnauthorizedError(
+      "You don't have admin access to this process instance",
+    );
+  }
+
+  const assignments = await db.query.proposalReviewAssignments.findMany({
+    where: {
+      processInstanceId,
+      ...(status && { status }),
+    },
+    with: reviewAssignmentWithConfig,
+    orderBy: {
+      assignedAt: dir,
+    },
+  });
+
+  const rubricTemplate = instance.instanceData.rubricTemplate ?? null;
+
+  const items = assignments.map((assignment) => {
+    const proposalSnapshot = resolveAssignmentProposal(assignment);
+
+    return {
+      assignment: {
+        id: assignment.id,
+        processInstanceId: assignment.processInstanceId,
+        phaseId: assignment.phaseId,
+        status: assignment.status,
+        reviewer: assignment.reviewer,
+        proposal: proposalSnapshot,
+      },
+      review: assignment.reviews[0] ?? null,
+      revisionRequest: getActiveRevisionRequest(assignment.requests),
+    };
+  });
+
+  return reviewItemListSchema.parse({
+    items,
+    rubricTemplate,
+  });
+}

--- a/packages/common/src/services/decision/reviewHelpers.ts
+++ b/packages/common/src/services/decision/reviewHelpers.ts
@@ -32,6 +32,11 @@ export const reviewAssignmentWithConfig = {
       profile: true,
     },
   },
+  reviewer: {
+    with: {
+      avatarImage: true,
+    },
+  },
   reviews: true,
   requests: {
     orderBy: {

--- a/packages/common/src/services/decision/schemas/reviews.ts
+++ b/packages/common/src/services/decision/schemas/reviews.ts
@@ -6,7 +6,7 @@ import {
 import { z } from 'zod';
 
 import type { RubricTemplateSchema } from '../types';
-import { proposalSchema } from './proposal';
+import { proposalProfileSchema, proposalSchema } from './proposal';
 
 export { ProposalReviewAssignmentStatus, ProposalReviewRequestState };
 
@@ -83,6 +83,39 @@ export const reviewAssignmentListSchema = z.object({
   assignments: z.array(reviewAssignmentExtendedSchema),
 });
 
+// ── Lean review assignment schemas (admin overview) ─────────────────────
+//
+// These schemas power admin-facing screens that aggregate over every
+// assignment in a process instance and refresh on realtime updates. They
+// intentionally omit the heavy TipTap payload so the wire shape stays small.
+
+export const proposalSummarySchema = proposalSchema.omit({
+  documentContent: true,
+  htmlContent: true,
+  proposalTemplate: true,
+  attachments: true,
+});
+
+export const reviewAssignmentLeanSchema = z.object({
+  id: z.uuid(),
+  processInstanceId: z.uuid(),
+  phaseId: z.string(),
+  status: z.enum(ProposalReviewAssignmentStatus),
+  reviewer: proposalProfileSchema,
+  proposal: proposalSummarySchema,
+});
+
+export const reviewItemSchema = z.object({
+  assignment: reviewAssignmentLeanSchema,
+  review: proposalReviewSchema.nullable(),
+  revisionRequest: proposalReviewRequestSchema.nullable(),
+});
+
+export const reviewItemListSchema = z.object({
+  items: z.array(reviewItemSchema),
+  rubricTemplate: rubricTemplateSchema.nullable(),
+});
+
 // ── Proposal-scoped revision request schemas ──────────────────────────
 
 export const proposalRevisionRequestItemSchema = z.object({
@@ -112,3 +145,7 @@ export type ProposalRevisionRequestItem = z.infer<
 export type ProposalRevisionRequestList = z.infer<
   typeof proposalRevisionRequestListSchema
 >;
+export type ProposalSummary = z.infer<typeof proposalSummarySchema>;
+export type ReviewAssignmentLean = z.infer<typeof reviewAssignmentLeanSchema>;
+export type ReviewItem = z.infer<typeof reviewItemSchema>;
+export type ReviewItemList = z.infer<typeof reviewItemListSchema>;

--- a/services/api/src/routers/decision/reviews/index.ts
+++ b/services/api/src/routers/decision/reviews/index.ts
@@ -1,6 +1,7 @@
 import { mergeRouters } from '../../../trpcFactory';
 import { cancelRevisionRequestRouter } from './cancelRevisionRequest';
 import { getReviewAssignmentRouter } from './getReviewAssignment';
+import { listAllReviewAssignmentsRouter } from './listAllReviewAssignments';
 import { listProposalRevisionRequestsRouter } from './listProposalRevisionRequests';
 import { listProposalsRevisionRequestsRouter } from './listProposalsRevisionRequests';
 import { listReviewAssignmentsRouter } from './listReviewAssignments';
@@ -12,6 +13,7 @@ import { submitRevisionResponseRouter } from './submitRevisionResponse';
 export const reviewsRouter = mergeRouters(
   cancelRevisionRequestRouter,
   getReviewAssignmentRouter,
+  listAllReviewAssignmentsRouter,
   listProposalRevisionRequestsRouter,
   listProposalsRevisionRequestsRouter,
   listReviewAssignmentsRouter,

--- a/services/api/src/routers/decision/reviews/listAllReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/reviews/listAllReviewAssignments.test.ts
@@ -1,0 +1,198 @@
+import type { RubricTemplateSchema } from '@op/common';
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+  ProposalReviewState,
+} from '@op/db/schema';
+import { createProposalReview, createRevisionRequest } from '@op/test';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestReviewsDataManager } from '../../../test/helpers/TestReviewsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+const rubricTemplate: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': ['impact'],
+  properties: {
+    impact: {
+      type: 'integer',
+      title: 'Impact',
+      'x-format': 'dropdown',
+      minimum: 1,
+      maximum: 5,
+      oneOf: [
+        { const: 1, title: 'Low' },
+        { const: 5, title: 'High' },
+      ],
+    },
+  },
+  required: ['impact'],
+};
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+describe.concurrent('listAllReviewAssignments', () => {
+  it('returns every assignment in the instance for an admin, including ones without reviews', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const first = await testData.createReviewAssignment({
+      title: 'First Proposal',
+    });
+
+    const otherReviewer = await testData.createReviewer(first.context);
+    const second = await testData.createReviewAssignment({
+      context: first.context,
+      reviewer: otherReviewer,
+      title: 'Second Proposal',
+    });
+
+    // Default context user is provisioned with admin access on the instance.
+    const adminCaller = await createAuthenticatedCaller(
+      first.context.defaultReviewer.email,
+    );
+    const result = await adminCaller.decision.listAllReviewAssignments({
+      processInstanceId: first.context.instance.instance.id,
+    });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items.map((item) => item.assignment.id)).toEqual(
+      expect.arrayContaining([first.assignment.id, second.assignment.id]),
+    );
+
+    for (const item of result.items) {
+      expect(item.review).toBeNull();
+      expect(item.assignment.reviewer).toMatchObject({
+        id: expect.any(String),
+      });
+    }
+  });
+
+  it('omits documentContent, htmlContent, proposalTemplate, and attachments from proposal payloads', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Shape Check',
+    });
+
+    const adminCaller = await createAuthenticatedCaller(
+      created.context.defaultReviewer.email,
+    );
+    const result = await adminCaller.decision.listAllReviewAssignments({
+      processInstanceId: created.context.instance.instance.id,
+    });
+
+    expect(result.items).toHaveLength(1);
+    const proposal = result.items[0]!.assignment.proposal;
+
+    expect(proposal).not.toHaveProperty('documentContent');
+    expect(proposal).not.toHaveProperty('htmlContent');
+    expect(proposal).not.toHaveProperty('proposalTemplate');
+    expect(proposal).not.toHaveProperty('attachments');
+  });
+
+  it('includes rubric template at the response root and review + revision data on items', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'With Rubric',
+      status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+    });
+
+    await Promise.all([
+      testData.setRubricTemplate(created.context, rubricTemplate),
+      createProposalReview({
+        assignmentId: created.assignment.id,
+        state: ProposalReviewState.DRAFT,
+        reviewData: {
+          answers: { impact: 5 },
+          rationales: { impact: 'Strong fit' },
+        },
+        overallComment: 'Promising',
+      }),
+      createRevisionRequest({
+        assignmentId: created.assignment.id,
+        requestComment: 'Please expand the budget.',
+      }),
+    ]);
+
+    const adminCaller = await createAuthenticatedCaller(
+      created.context.defaultReviewer.email,
+    );
+    const result = await adminCaller.decision.listAllReviewAssignments({
+      processInstanceId: created.context.instance.instance.id,
+    });
+
+    expect(result.rubricTemplate).toEqual(rubricTemplate);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({
+      assignment: {
+        id: created.assignment.id,
+        status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+      },
+      review: {
+        assignmentId: created.assignment.id,
+        state: ProposalReviewState.DRAFT,
+      },
+      revisionRequest: {
+        assignmentId: created.assignment.id,
+        state: ProposalReviewRequestState.REQUESTED,
+        requestComment: 'Please expand the budget.',
+      },
+    });
+  });
+
+  it('rejects reviewer-only callers without admin access', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    const reviewerOnly = await testData.createInstanceReviewerWithRole(
+      created.context,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(reviewerOnly.email);
+
+    await expect(
+      reviewerCaller.decision.listAllReviewAssignments({
+        processInstanceId: created.context.instance.instance.id,
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
+  });
+
+  it('rejects non-participant callers (e.g. the proposal author)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+
+    const authorCaller = await createAuthenticatedCaller(created.author.email);
+
+    await expect(
+      authorCaller.decision.listAllReviewAssignments({
+        processInstanceId: created.context.instance.instance.id,
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
+  });
+});

--- a/services/api/src/routers/decision/reviews/listAllReviewAssignments.ts
+++ b/services/api/src/routers/decision/reviews/listAllReviewAssignments.ts
@@ -1,0 +1,33 @@
+import {
+  Channels,
+  listAllReviewAssignments,
+  reviewItemListSchema,
+} from '@op/common';
+import { ProposalReviewAssignmentStatus } from '@op/db/schema';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const listAllReviewAssignmentsRouter = router({
+  listAllReviewAssignments: commonAuthedProcedure()
+    .input(
+      z.object({
+        processInstanceId: z.uuid(),
+        status: z.enum(ProposalReviewAssignmentStatus).optional(),
+        dir: z.enum(['asc', 'desc']).optional(),
+      }),
+    )
+    .output(reviewItemListSchema)
+    .query(async ({ ctx, input }) => {
+      ctx.registerQueryChannels([
+        Channels.reviewAssignments(input.processInstanceId),
+      ]);
+
+      return await listAllReviewAssignments({
+        processInstanceId: input.processInstanceId,
+        status: input.status,
+        dir: input.dir,
+        user: ctx.user,
+      });
+    }),
+});


### PR DESCRIPTION
Gives admins a lean, process-wide view of reviewer workload without loading heavy proposal document/template content.