### PR TITLE
fix: surface errors from homepage post prefetch

### DIFF
--- a/apps/app/src/components/screens/LandingScreen/index.tsx
+++ b/apps/app/src/components/screens/LandingScreen/index.tsx
@@ -134,7 +134,7 @@ const PostFeedSection = async ({
   // If this fails, the client will fetch instead
   const { utils, queryClient } = await createServerUtils();
   try {
-    await utils.organization.listAllPosts.prefetchInfinite({ limit: 10 });
+    await utils.organization.listAllPosts.fetchInfinite({ limit: 10 });
   } catch (e) {
     console.error('Homepage post prefetch failed:', e);
   }


### PR DESCRIPTION
prefetchInfinite [swallows errors](https://tanstack.com/query/latest/docs/framework/react/guides/ssr#error-handling), so the existing try/catch around the homepage post prefetch was dead code. Swap to fetchInfinite so failures actually log.