### PR TITLE
feat(decisions): enforce per-phase voting cap

### DIFF
--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -181,24 +181,19 @@ const VotingProposalsList = ({
   // Determine voting state
   const hasVoted = voteStatus?.hasVoted || false;
   const isReadOnly = hasVoted || !canVote;
-  const maxVotesPerMember =
-    voteStatus?.votingConfiguration?.maxVotesPerMember || 0;
+  const maxVotesPerMember = voteStatus?.votingConfiguration?.maxVotesPerMember;
 
-  // Handle proposal selection
   const toggleProposal = (proposalId: string) => {
     setSelectedProposalIds((prev) => {
       const isSelected = prev.includes(proposalId);
 
       if (isSelected) {
-        // Remove from selection
         return prev.filter((id) => id !== proposalId);
-      } else {
-        // Add to selection if under limit
-        if (prev.length < maxVotesPerMember) {
-          return [...prev, proposalId];
-        }
-        return prev;
       }
+      if (maxVotesPerMember === undefined || prev.length < maxVotesPerMember) {
+        return [...prev, proposalId];
+      }
+      return prev;
     });
   };
 
@@ -367,9 +362,26 @@ const VotingProposalsList = ({
       <VotingSubmitFooter isVisible={canVote && !isReadOnly}>
         <div className="flex w-full items-center justify-between px-4 sm:max-w-6xl sm:px-8">
           <span className="text-neutral-black">
-            <span className="text-primary-teal">{numSelected}</span> of{' '}
-            {maxVotesPerMember}{' '}
-            {maxVotesPerMember === 1 ? 'proposal' : 'proposals'} selected
+            {maxVotesPerMember !== undefined
+              ? t.rich(
+                  '<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected',
+                  {
+                    numSelected,
+                    max: maxVotesPerMember,
+                    highlight: (chunks: React.ReactNode) => (
+                      <span className="text-primary-teal">{chunks}</span>
+                    ),
+                  },
+                )
+              : t.rich(
+                  '<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected',
+                  {
+                    numSelected,
+                    highlight: (chunks: React.ReactNode) => (
+                      <span className="text-primary-teal">{chunks}</span>
+                    ),
+                  },
+                )}
           </span>
 
           <DialogTrigger>
@@ -382,7 +394,6 @@ const VotingProposalsList = ({
                 <VoteSubmissionModal
                   selectedProposals={selectedProposals}
                   instanceId={instanceId}
-                  maxVotes={maxVotesPerMember}
                   onSuccess={handleVoteSuccess}
                 />
               </Dialog>

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -395,7 +395,6 @@ const VotingProposalsList = ({
                   <VoteSubmissionModal
                     selectedProposals={selectedProposals}
                     instanceId={instanceId}
-                    maxVotes={maxVotesPerMember}
                     onSuccess={handleVoteSuccess}
                   />
                 </Dialog>

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -179,24 +179,19 @@ const VotingProposalsList = ({
   // Determine voting state
   const hasVoted = voteStatus?.hasVoted || false;
   const isReadOnly = hasVoted || !canVote;
-  const maxVotesPerMember =
-    voteStatus?.votingConfiguration?.maxVotesPerMember || 0;
+  const maxVotesPerMember = voteStatus?.votingConfiguration?.maxVotesPerMember;
 
-  // Handle proposal selection
   const toggleProposal = (proposalId: string) => {
     setSelectedProposalIds((prev) => {
       const isSelected = prev.includes(proposalId);
 
       if (isSelected) {
-        // Remove from selection
         return prev.filter((id) => id !== proposalId);
-      } else {
-        // Add to selection if under limit
-        if (prev.length < maxVotesPerMember) {
-          return [...prev, proposalId];
-        }
-        return prev;
       }
+      if (maxVotesPerMember === undefined || prev.length < maxVotesPerMember) {
+        return [...prev, proposalId];
+      }
+      return prev;
     });
   };
 
@@ -366,9 +361,26 @@ const VotingProposalsList = ({
         <FooterBar position="fixed" className="bg-neutral-offWhite/95">
           <FooterBar.Start>
             <span className="text-base text-neutral-black">
-              <span className="text-primary-teal">{numSelected}</span> of{' '}
-              {maxVotesPerMember}{' '}
-              {maxVotesPerMember === 1 ? 'proposal' : 'proposals'} selected
+              {maxVotesPerMember !== undefined
+                ? t.rich(
+                    '<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected',
+                    {
+                      numSelected,
+                      max: maxVotesPerMember,
+                      highlight: (chunks: React.ReactNode) => (
+                        <span className="text-primary-teal">{chunks}</span>
+                      ),
+                    },
+                  )
+                : t.rich(
+                    '<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected',
+                    {
+                      numSelected,
+                      highlight: (chunks: React.ReactNode) => (
+                        <span className="text-primary-teal">{chunks}</span>
+                      ),
+                    },
+                  )}
             </span>
           </FooterBar.Start>
           <FooterBar.Center />

--- a/apps/app/src/components/decisions/VoteReviewStep.tsx
+++ b/apps/app/src/components/decisions/VoteReviewStep.tsx
@@ -13,7 +13,6 @@ import {
 
 interface VoteReviewStepProps {
   proposals: Proposal[];
-  maxVotes: number;
 }
 
 export const VoteReviewStep = ({ proposals }: VoteReviewStepProps) => {

--- a/apps/app/src/components/decisions/VoteSubmissionModal.tsx
+++ b/apps/app/src/components/decisions/VoteSubmissionModal.tsx
@@ -15,12 +15,10 @@ import { VoteReviewStep } from './VoteReviewStep';
 export const VoteSubmissionModal = ({
   selectedProposals,
   instanceId,
-  maxVotes,
   onSuccess,
 }: {
   selectedProposals: Proposal[];
   instanceId: string;
-  maxVotes: number;
   onSuccess: () => void;
 }) => {
   const t = useTranslations();
@@ -53,7 +51,7 @@ export const VoteSubmissionModal = ({
     <>
       <ModalHeader>{t('Review your votes')}</ModalHeader>
       <ModalBody>
-        <VoteReviewStep proposals={selectedProposals} maxVotes={maxVotes} />
+        <VoteReviewStep proposals={selectedProposals} />
       </ModalBody>
       <ModalFooter>
         <Button

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -436,6 +436,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "প্রস্তাব পর্যালোচনা এবং আপনার ভোট দেওয়া কতটা সহজ ছিল? (১ থেকে ৫ স্কেল)",
   "Submitting...": "জমা দেওয়া হচ্ছে...",
   "Submit my votes": "আমার ভোট জমা দিন",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> / {max} প্রস্তাব নির্বাচিত",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected}</highlight> প্রস্তাব নির্বাচিত",
   "Please select at least one role": "অনুগ্রহ করে কমপক্ষে একটি ভূমিকা নির্বাচন করুন",
   "Please select up to two options": "অনুগ্রহ করে দুটি পর্যন্ত অপশন নির্বাচন করুন",
   "Please select your region": "অনুগ্রহ করে আপনার অঞ্চল নির্বাচন করুন",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -440,6 +440,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "প্রস্তাব পর্যালোচনা এবং আপনার ভোট দেওয়া কতটা সহজ ছিল? (১ থেকে ৫ স্কেল)",
   "Submitting...": "জমা দেওয়া হচ্ছে...",
   "Submit my votes": "আমার ভোট জমা দিন",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> / {max} প্রস্তাব নির্বাচিত",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected}</highlight> প্রস্তাব নির্বাচিত",
   "Please select at least one role": "অনুগ্রহ করে কমপক্ষে একটি ভূমিকা নির্বাচন করুন",
   "Please select up to two options": "অনুগ্রহ করে দুটি পর্যন্ত অপশন নির্বাচন করুন",
   "Please select your region": "অনুগ্রহ করে আপনার অঞ্চল নির্বাচন করুন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -438,6 +438,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "How easy was it to review proposals and cast your vote? (1 to 5 scale)",
   "Submitting...": "Submitting...",
   "Submit my votes": "Submit my votes",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected",
   "Please select at least one role": "Please select at least one role",
   "Please select up to two options": "Please select up to two options",
   "Please select your region": "Please select your region",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -443,6 +443,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "How easy was it to review proposals and cast your vote? (1 to 5 scale)",
   "Submitting...": "Submitting...",
   "Submit my votes": "Submit my votes",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected",
   "Please select at least one role": "Please select at least one role",
   "Please select up to two options": "Please select up to two options",
   "Please select your region": "Please select your region",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -436,6 +436,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "¿Qué tan fácil fue revisar las propuestas y emitir tu voto? (escala del 1 al 5)",
   "Submitting...": "Enviando...",
   "Submit my votes": "Enviar mis votos",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> de {max, plural, one {# propuesta seleccionada} other {# propuestas seleccionadas}}",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected, plural, one {# propuesta seleccionada} other {# propuestas seleccionadas}}</highlight>",
   "Please select at least one role": "Por favor selecciona al menos un rol",
   "Please select up to two options": "Por favor selecciona hasta dos opciones",
   "Please select your region": "Por favor selecciona tu región",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -440,6 +440,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "¿Qué tan fácil fue revisar las propuestas y emitir tu voto? (escala del 1 al 5)",
   "Submitting...": "Enviando...",
   "Submit my votes": "Enviar mis votos",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> de {max, plural, one {# propuesta seleccionada} other {# propuestas seleccionadas}}",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected, plural, one {# propuesta seleccionada} other {# propuestas seleccionadas}}</highlight>",
   "Please select at least one role": "Por favor selecciona al menos un rol",
   "Please select up to two options": "Por favor selecciona hasta dos opciones",
   "Please select your region": "Por favor selecciona tu región",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -437,6 +437,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "Dans quelle mesure était-il facile d'examiner les propositions et de voter ? (échelle de 1 à 5)",
   "Submitting...": "Envoi en cours...",
   "Submit my votes": "Soumettre mes votes",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> sur {max, plural, one {# proposition sélectionnée} other {# propositions sélectionnées}}",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected, plural, one {# proposition sélectionnée} other {# propositions sélectionnées}}</highlight>",
   "Please select at least one role": "Veuillez sélectionner au moins un rôle",
   "Please select up to two options": "Veuillez sélectionner jusqu'à deux options",
   "Please select your region": "Veuillez sélectionner votre région",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -441,6 +441,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "Dans quelle mesure était-il facile d'examiner les propositions et de voter ? (échelle de 1 à 5)",
   "Submitting...": "Envoi en cours...",
   "Submit my votes": "Soumettre mes votes",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> sur {max, plural, one {# proposition sélectionnée} other {# propositions sélectionnées}}",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected, plural, one {# proposition sélectionnée} other {# propositions sélectionnées}}</highlight>",
   "Please select at least one role": "Veuillez sélectionner au moins un rôle",
   "Please select up to two options": "Veuillez sélectionner jusqu'à deux options",
   "Please select your region": "Veuillez sélectionner votre région",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -437,6 +437,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "Quão fácil foi revisar as propostas e lançar seu voto? (escala de 1 a 5)",
   "Submitting...": "Enviando...",
   "Submit my votes": "Enviar meus votos",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> de {max, plural, one {# proposta selecionada} other {# propostas selecionadas}}",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected, plural, one {# proposta selecionada} other {# propostas selecionadas}}</highlight>",
   "Please select at least one role": "Por favor, selecione pelo menos um papel",
   "Please select up to two options": "Por favor, selecione até duas opções",
   "Please select your region": "Por favor, selecione sua região",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -441,6 +441,8 @@
   "How easy was it to review proposals and cast your vote? (1 to 5 scale)": "Quão fácil foi revisar as propostas e lançar seu voto? (escala de 1 a 5)",
   "Submitting...": "Enviando...",
   "Submit my votes": "Enviar meus votos",
+  "<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected": "<highlight>{numSelected}</highlight> de {max, plural, one {# proposta selecionada} other {# propostas selecionadas}}",
+  "<highlight>{numSelected, plural, one {# proposal} other {# proposals}}</highlight> selected": "<highlight>{numSelected, plural, one {# proposta selecionada} other {# propostas selecionadas}}</highlight>",
   "Please select at least one role": "Por favor, selecione pelo menos um papel",
   "Please select up to two options": "Por favor, selecione até duas opções",
   "Please select your region": "Por favor, selecione sua região",

--- a/packages/common/src/services/decision/schemaTypes.ts
+++ b/packages/common/src/services/decision/schemaTypes.ts
@@ -1,11 +1,13 @@
 import type { ProposalStatus } from '@op/db/schema';
 import { z } from 'zod';
 
+import type { VoteCap } from './schemas/types';
+
 export interface DecisionProcessSchema {
   allowProposals: boolean;
   allowDecisions: boolean;
   instanceData: {
-    maxVotesPerMember: number;
+    maxVotesPerMember?: VoteCap;
     [key: string]: unknown;
   };
   [key: string]: unknown;
@@ -17,7 +19,7 @@ export const DecisionProcessSchemaBase = z
     allowDecisions: z.boolean(),
     instanceData: z
       .object({
-        maxVotesPerMember: z.int().min(0),
+        maxVotesPerMember: z.int().positive().optional(),
       })
       .and(z.record(z.string(), z.unknown())),
   })
@@ -26,7 +28,7 @@ export const DecisionProcessSchemaBase = z
 export interface VotingConfig {
   allowProposals: boolean;
   allowDecisions: boolean;
-  maxVotesPerMember: number;
+  maxVotesPerMember?: VoteCap;
   schemaType: string;
   additionalConfig?: Record<string, unknown>;
 }

--- a/packages/common/src/services/decision/schemaTypes.ts
+++ b/packages/common/src/services/decision/schemaTypes.ts
@@ -1,13 +1,11 @@
 import type { ProposalStatus } from '@op/db/schema';
 import { z } from 'zod';
 
-import type { VoteCap } from './schemas/types';
-
 export interface DecisionProcessSchema {
   allowProposals: boolean;
   allowDecisions: boolean;
   instanceData: {
-    maxVotesPerMember?: VoteCap;
+    maxVotesPerMember?: number;
     [key: string]: unknown;
   };
   [key: string]: unknown;
@@ -28,7 +26,7 @@ export const DecisionProcessSchemaBase = z
 export interface VotingConfig {
   allowProposals: boolean;
   allowDecisions: boolean;
-  maxVotesPerMember?: VoteCap;
+  maxVotesPerMember?: number;
   schemaType: string;
   additionalConfig?: Record<string, unknown>;
 }

--- a/packages/common/src/services/decision/schemaValidators.test.ts
+++ b/packages/common/src/services/decision/schemaValidators.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isValidDecisionProcessSchema,
+  validateVoteSelection,
+} from './schemaValidators';
+
+describe('validateVoteSelection', () => {
+  const available = ['a', 'b', 'c', 'd', 'e'];
+
+  it('accepts selection within cap', () => {
+    const result = validateVoteSelection(['a', 'b'], 2, available);
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('rejects selection exceeding cap', () => {
+    const result = validateVoteSelection(['a', 'b', 'c'], 2, available);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(['Cannot select more than 2 proposals']);
+  });
+
+  it('accepts selection equal to cap', () => {
+    const result = validateVoteSelection(['a', 'b'], 2, available);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('treats undefined cap as unlimited', () => {
+    const result = validateVoteSelection(
+      ['a', 'b', 'c', 'd', 'e'],
+      undefined,
+      available,
+    );
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('still requires at least one selection when cap is undefined', () => {
+    const result = validateVoteSelection([], undefined, available);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(['At least one proposal must be selected']);
+  });
+
+  it('still requires at least one selection when cap is defined', () => {
+    const result = validateVoteSelection([], 5, available);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(['At least one proposal must be selected']);
+  });
+
+  it('rejects ineligible proposal ids regardless of cap', () => {
+    const result = validateVoteSelection(['a', 'zzz'], undefined, available);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(['Invalid proposal IDs: zzz']);
+  });
+
+  it('rejects duplicates regardless of cap', () => {
+    const result = validateVoteSelection(['a', 'a'], undefined, available);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(['Duplicate proposal IDs: a']);
+  });
+
+  it('reports over-cap and duplicate errors together', () => {
+    const result = validateVoteSelection(['a', 'a', 'a'], 2, available);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Cannot select more than 2 proposals');
+    expect(result.errors).toContain('Duplicate proposal IDs: a, a');
+  });
+
+  it('reports over-cap and ineligible errors together', () => {
+    const result = validateVoteSelection(['a', 'b', 'zzz'], 2, available);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Cannot select more than 2 proposals');
+    expect(result.errors).toContain('Invalid proposal IDs: zzz');
+  });
+});
+
+describe('isValidDecisionProcessSchema', () => {
+  const base = {
+    allowProposals: true,
+    allowDecisions: true,
+    instanceData: {} as Record<string, unknown>,
+  };
+
+  it('accepts schema without maxVotesPerMember', () => {
+    expect(isValidDecisionProcessSchema(base)).toBe(true);
+  });
+
+  it('accepts schema with valid positive integer maxVotesPerMember', () => {
+    expect(
+      isValidDecisionProcessSchema({
+        ...base,
+        instanceData: { maxVotesPerMember: 5 },
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects string maxVotesPerMember (no coercion)', () => {
+    expect(
+      isValidDecisionProcessSchema({
+        ...base,
+        instanceData: { maxVotesPerMember: '5' },
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects zero maxVotesPerMember', () => {
+    expect(
+      isValidDecisionProcessSchema({
+        ...base,
+        instanceData: { maxVotesPerMember: 0 },
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects negative maxVotesPerMember', () => {
+    expect(
+      isValidDecisionProcessSchema({
+        ...base,
+        instanceData: { maxVotesPerMember: -1 },
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects non-integer maxVotesPerMember', () => {
+    expect(
+      isValidDecisionProcessSchema({
+        ...base,
+        instanceData: { maxVotesPerMember: 2.5 },
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects missing allowDecisions', () => {
+    expect(
+      isValidDecisionProcessSchema({
+        allowProposals: true,
+        instanceData: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects null input', () => {
+    expect(isValidDecisionProcessSchema(null)).toBe(false);
+  });
+});

--- a/packages/common/src/services/decision/schemaValidators.ts
+++ b/packages/common/src/services/decision/schemaValidators.ts
@@ -5,6 +5,7 @@ import {
   SchemaValidationResult,
   VotingConfig,
 } from './schemaTypes';
+import type { VoteCap } from './schemas/types';
 
 export function isValidDecisionProcessSchema(
   data: unknown,
@@ -15,22 +16,21 @@ export function isValidDecisionProcessSchema(
 
   const obj = data as Record<string, unknown>;
 
-  return (
-    'allowProposals' in obj &&
-    typeof obj.allowProposals === 'boolean' &&
-    'allowDecisions' in obj &&
-    typeof obj.allowDecisions === 'boolean' &&
-    'instanceData' in obj &&
-    typeof obj.instanceData === 'object' &&
-    obj.instanceData !== null &&
-    typeof (obj.instanceData as Record<string, unknown>).maxVotesPerMember ===
-      'number' &&
-    Number.isInteger(
-      (obj.instanceData as Record<string, unknown>).maxVotesPerMember,
-    ) &&
-    ((obj.instanceData as Record<string, unknown>)
-      .maxVotesPerMember as number) >= 0
-  );
+  if (typeof obj.allowProposals !== 'boolean') {
+    return false;
+  }
+  if (typeof obj.allowDecisions !== 'boolean') {
+    return false;
+  }
+  if (typeof obj.instanceData !== 'object' || obj.instanceData === null) {
+    return false;
+  }
+
+  const max = (obj.instanceData as Record<string, unknown>).maxVotesPerMember;
+  if (max === undefined) {
+    return true;
+  }
+  return typeof max === 'number' && Number.isInteger(max) && max > 0;
 }
 
 export function validateSchemaWithZod(data: unknown): SchemaValidationResult {
@@ -154,7 +154,7 @@ export function extractSupportedProperties(
 
 export function validateVoteSelection(
   selectedProposalIds: string[],
-  maxVotesPerMember: number,
+  maxVotesPerMember: VoteCap,
   availableProposalIds: string[],
 ): {
   isValid: boolean;
@@ -166,7 +166,10 @@ export function validateVoteSelection(
     errors.push('At least one proposal must be selected');
   }
 
-  if (selectedProposalIds.length > maxVotesPerMember) {
+  if (
+    maxVotesPerMember !== undefined &&
+    selectedProposalIds.length > maxVotesPerMember
+  ) {
     errors.push(`Cannot select more than ${maxVotesPerMember} proposals`);
   }
 

--- a/packages/common/src/services/decision/schemaValidators.ts
+++ b/packages/common/src/services/decision/schemaValidators.ts
@@ -5,7 +5,6 @@ import {
   SchemaValidationResult,
   VotingConfig,
 } from './schemaTypes';
-import type { VoteCap } from './schemas/types';
 
 export function isValidDecisionProcessSchema(
   data: unknown,
@@ -154,7 +153,7 @@ export function extractSupportedProperties(
 
 export function validateVoteSelection(
   selectedProposalIds: string[],
-  maxVotesPerMember: VoteCap,
+  maxVotesPerMember: number | undefined,
   availableProposalIds: string[],
 ): {
   isValid: boolean;

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -8,6 +8,9 @@ import type { JSONSchema7 } from 'json-schema';
 import type { SelectionPipeline } from '../selectionPipeline/types';
 import type { ProposalTemplateSchema, RubricTemplateSchema } from '../types';
 
+/** Per-participant vote cap. Undefined means unlimited. */
+export type VoteCap = number | undefined;
+
 /**
  * Phase behavior rules
  */
@@ -20,6 +23,8 @@ export interface PhaseRules {
   voting?: {
     submit?: boolean;
     edit?: boolean;
+    /** Undefined = no limit (distinct from 0, which would block all voting). */
+    maxVotes?: VoteCap;
   };
   advancement?: {
     method: 'date' | 'manual';

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -24,7 +24,7 @@ export interface PhaseRules {
     submit?: boolean;
     edit?: boolean;
     /** Undefined = no limit (distinct from 0, which would block all voting). */
-    maxVotes?: VoteCap;
+    maxVotesPerMember?: VoteCap;
   };
   advancement?: {
     method: 'date' | 'manual';

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -8,9 +8,6 @@ import type { JSONSchema7 } from 'json-schema';
 import type { SelectionPipeline } from '../selectionPipeline/types';
 import type { ProposalTemplateSchema, RubricTemplateSchema } from '../types';
 
-/** Per-participant vote cap. Undefined means unlimited. */
-export type VoteCap = number | undefined;
-
 /**
  * Phase behavior rules
  */
@@ -24,7 +21,7 @@ export interface PhaseRules {
     submit?: boolean;
     edit?: boolean;
     /** Undefined = no limit (distinct from 0, which would block all voting). */
-    maxVotesPerMember?: VoteCap;
+    maxVotesPerMember?: number;
   };
   advancement?: {
     method: 'date' | 'manual';

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -29,7 +29,7 @@ import { isVotingEligible } from './votingEligibility';
 interface PhaseConfig {
   allowProposals: boolean;
   allowDecisions: boolean;
-  maxVotes: VoteCap;
+  maxVotesPerMember: VoteCap;
 }
 
 /** Extract voting/proposal rules for the current phase. */
@@ -58,7 +58,7 @@ function getCurrentPhaseConfig(processInstance: {
   return {
     allowProposals: currentPhase.rules?.proposals?.submit ?? false,
     allowDecisions: currentPhase.rules?.voting?.submit ?? false,
-    maxVotes: currentPhase.rules?.voting?.maxVotes,
+    maxVotesPerMember: currentPhase.rules?.voting?.maxVotesPerMember,
   };
 }
 
@@ -66,7 +66,7 @@ function buildVotingSchemaResult(phaseConfig: PhaseConfig) {
   const result = processDecisionProcessSchema({
     allowProposals: phaseConfig.allowProposals,
     allowDecisions: phaseConfig.allowDecisions,
-    instanceData: { maxVotesPerMember: phaseConfig.maxVotes },
+    instanceData: { maxVotesPerMember: phaseConfig.maxVotesPerMember },
     schemaType: 'simple',
   });
 

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -23,18 +23,20 @@ import { decisionPermission } from './permissions';
 import { processDecisionProcessSchema } from './schemaRegistry';
 import { validateVoteSelection } from './schemaValidators';
 import type { DecisionInstanceData } from './schemas/instanceData';
+import type { VoteCap } from './schemas/types';
 import { isVotingEligible } from './votingEligibility';
 
-/** Extract proposal/voting permissions from the current phase. */
+interface PhaseConfig {
+  allowProposals: boolean;
+  allowDecisions: boolean;
+  maxVotes: VoteCap;
+}
+
+/** Extract voting/proposal rules for the current phase. */
 function getCurrentPhaseConfig(processInstance: {
   instanceData: unknown;
   currentStateId: string | null;
-}):
-  | {
-      allowProposals: boolean;
-      allowDecisions: boolean;
-    }
-  | undefined {
+}): PhaseConfig | undefined {
   const instanceData = processInstance.instanceData as DecisionInstanceData;
   const currentPhaseId = processInstance.currentStateId;
 
@@ -56,7 +58,23 @@ function getCurrentPhaseConfig(processInstance: {
   return {
     allowProposals: currentPhase.rules?.proposals?.submit ?? false,
     allowDecisions: currentPhase.rules?.voting?.submit ?? false,
+    maxVotes: currentPhase.rules?.voting?.maxVotes,
   };
+}
+
+function buildVotingSchemaResult(phaseConfig: PhaseConfig) {
+  const result = processDecisionProcessSchema({
+    allowProposals: phaseConfig.allowProposals,
+    allowDecisions: phaseConfig.allowDecisions,
+    instanceData: { maxVotesPerMember: phaseConfig.maxVotes },
+    schemaType: 'simple',
+  });
+
+  if (!result.isValid || !result.votingConfig) {
+    throw new ValidationError('Invalid process schema');
+  }
+
+  return { ...result, votingConfig: result.votingConfig };
 }
 
 export type CustomData = Record<string, unknown>;
@@ -102,7 +120,7 @@ export interface VotingStatusResult {
   }> | null;
   votingConfiguration: {
     allowDecisions: boolean;
-    maxVotesPerMember: number;
+    maxVotesPerMember: VoteCap;
     schemaType: string;
     isReadOnly: boolean;
   };
@@ -168,8 +186,6 @@ export const submitVote = async ({
       throw new NotFoundError('Decision profile not found');
     }
 
-    const instanceData = processInstance.instanceData as DecisionInstanceData;
-
     // Check user permissions
     const profileUser = await getProfileAccessUser({
       user: { id: authUserId },
@@ -181,34 +197,15 @@ export const submitVote = async ({
       profileUser?.roles ?? [],
     );
 
-    // Extract voting configuration from current phase/state
     const phaseConfig = getCurrentPhaseConfig(processInstance);
 
     if (!phaseConfig) {
       throw new ValidationError('Current state not found');
     }
 
-    // Build schema data for validation
-    const schemaData = {
-      allowProposals: phaseConfig.allowProposals,
-      allowDecisions: phaseConfig.allowDecisions,
-      instanceData: {
-        maxVotesPerMember:
-          Number(instanceData.fieldValues?.maxVotesPerMember) || 5,
-      },
-      schemaType: 'simple',
-    };
-
-    // Process the schema to validate voting is allowed
-    const schemaResult = processDecisionProcessSchema(schemaData);
-
-    if (!schemaResult.isValid || !schemaResult.votingConfig) {
-      throw new ValidationError('Invalid process schema');
-    }
-
+    const schemaResult = buildVotingSchemaResult(phaseConfig);
     const { votingConfig } = schemaResult;
 
-    // Check if voting is currently allowed
     if (!votingConfig.allowDecisions) {
       throw new ValidationError(
         'Voting is not currently allowed for this process',
@@ -361,8 +358,6 @@ export const getVotingStatus = async ({
       throw new NotFoundError('Process instance not found');
     }
 
-    const instanceData = processInstance.instanceData as DecisionInstanceData;
-
     await assertInstanceProfileAccess({
       user: { id: authUserId },
       instance: processInstance,
@@ -370,31 +365,13 @@ export const getVotingStatus = async ({
       orgFallbackPermissions: [{ decisions: permission.READ }],
     });
 
-    // Extract voting configuration from current phase/state
     const phaseConfig = getCurrentPhaseConfig(processInstance);
 
     if (!phaseConfig) {
       throw new ValidationError('Current state not found');
     }
 
-    // Build schema data for validation
-    const schemaData = {
-      allowProposals: phaseConfig.allowProposals,
-      allowDecisions: phaseConfig.allowDecisions,
-      instanceData: {
-        maxVotesPerMember:
-          Number(instanceData.fieldValues?.maxVotesPerMember) || 3,
-      },
-      schemaType: 'simple',
-    };
-
-    // Process the schema
-    const schemaResult = processDecisionProcessSchema(schemaData);
-
-    if (!schemaResult.isValid || !schemaResult.votingConfig) {
-      throw new ValidationError('Invalid process schema');
-    }
-
+    const schemaResult = buildVotingSchemaResult(phaseConfig);
     const { votingConfig } = schemaResult;
 
     // Check if user has voted

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -23,13 +23,12 @@ import { decisionPermission } from './permissions';
 import { processDecisionProcessSchema } from './schemaRegistry';
 import { validateVoteSelection } from './schemaValidators';
 import type { DecisionInstanceData } from './schemas/instanceData';
-import type { VoteCap } from './schemas/types';
 import { isVotingEligible } from './votingEligibility';
 
 interface PhaseConfig {
   allowProposals: boolean;
   allowDecisions: boolean;
-  maxVotesPerMember: VoteCap;
+  maxVotesPerMember: number | undefined;
 }
 
 /** Extract voting/proposal rules for the current phase. */
@@ -120,7 +119,7 @@ export interface VotingStatusResult {
   }> | null;
   votingConfiguration: {
     allowDecisions: boolean;
-    maxVotesPerMember: VoteCap;
+    maxVotesPerMember: number | undefined;
     schemaType: string;
     isReadOnly: boolean;
   };

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -106,7 +106,7 @@ const phaseRulesEncoder = z.object({
     .object({
       submit: z.boolean().optional(),
       edit: z.boolean().optional(),
-      maxVotes: z.number().int().positive().optional(),
+      maxVotesPerMember: z.number().int().positive().optional(),
     })
     .optional(),
   advancement: z

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -3,6 +3,7 @@ import {
   checkpointVersionSchema,
   proposalSchema,
 } from '@op/common/client';
+import type { PhaseRules as CommonPhaseRules } from '@op/common/src/services/decision';
 import {
   ProcessStatus,
   ProposalStatus,
@@ -105,6 +106,7 @@ const phaseRulesEncoder = z.object({
     .object({
       submit: z.boolean().optional(),
       edit: z.boolean().optional(),
+      maxVotes: z.number().int().positive().optional(),
     })
     .optional(),
   advancement: z
@@ -113,7 +115,7 @@ const phaseRulesEncoder = z.object({
       endDate: z.string().optional(),
     })
     .optional(),
-});
+}) satisfies z.ZodType<CommonPhaseRules>;
 
 /** Selection pipeline block encoder */
 const selectionPipelineBlockEncoder = z.object({

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -4,6 +4,7 @@ import {
   proposalSchema,
   rubricTemplateSchema,
 } from '@op/common/client';
+import type { PhaseRules as CommonPhaseRules } from '@op/common/src/services/decision';
 import {
   ProcessStatus,
   ProposalStatus,
@@ -63,6 +64,7 @@ const phaseRulesEncoder = z.object({
     .object({
       submit: z.boolean().optional(),
       edit: z.boolean().optional(),
+      maxVotes: z.number().int().positive().optional(),
     })
     .optional(),
   advancement: z
@@ -71,7 +73,7 @@ const phaseRulesEncoder = z.object({
       endDate: z.string().optional(),
     })
     .optional(),
-});
+}) satisfies z.ZodType<CommonPhaseRules>;
 
 /** Selection pipeline block encoder */
 const selectionPipelineBlockEncoder = z.object({

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -64,7 +64,7 @@ const phaseRulesEncoder = z.object({
     .object({
       submit: z.boolean().optional(),
       edit: z.boolean().optional(),
-      maxVotes: z.number().int().positive().optional(),
+      maxVotesPerMember: z.number().int().positive().optional(),
     })
     .optional(),
   advancement: z

--- a/services/api/src/routers/decision/voting.test.ts
+++ b/services/api/src/routers/decision/voting.test.ts
@@ -19,9 +19,9 @@ async function createAuthenticatedCaller(email: string) {
 
 /**
  * Voting schema with three phases: submission, voting, results.
- * `maxVotes` can be overridden per test by caller-side edits to the returned object.
+ * `maxVotesPerMember` can be overridden per test by caller-side edits to the returned object.
  */
-function buildVotingSchema(maxVotes?: number) {
+function buildVotingSchema(maxVotesPerMember?: number) {
   return {
     id: 'voting-test',
     version: '1.0.0',
@@ -42,7 +42,10 @@ function buildVotingSchema(maxVotes?: number) {
         name: 'Voting',
         rules: {
           proposals: { submit: false },
-          voting: { submit: true, ...(maxVotes !== undefined && { maxVotes }) },
+          voting: {
+            submit: true,
+            ...(maxVotesPerMember !== undefined && { maxVotesPerMember }),
+          },
           advancement: { method: 'manual' as const },
         },
       },
@@ -61,12 +64,16 @@ function buildVotingSchema(maxVotes?: number) {
 
 async function setupVotingInstance(
   testData: TestDecisionsDataManager,
-  opts: { maxVotes?: number; proposalCount: number; votingEnabled?: boolean },
+  opts: {
+    maxVotesPerMember?: number;
+    proposalCount: number;
+    votingEnabled?: boolean;
+  },
 ) {
   const setup = await testData.createDecisionSetup({
     instanceCount: 1,
     grantAccess: true,
-    processSchema: buildVotingSchema(opts.maxVotes),
+    processSchema: buildVotingSchema(opts.maxVotesPerMember),
   });
 
   const instance = setup.instances[0];
@@ -95,13 +102,13 @@ async function setupVotingInstance(
 }
 
 describe.concurrent('submitVote', () => {
-  it('rejects selection exceeding phase maxVotes', async ({
+  it('rejects selection exceeding phase maxVotesPerMember', async ({
     task,
     onTestFinished,
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
     const { setup, instance, proposals } = await setupVotingInstance(testData, {
-      maxVotes: 2,
+      maxVotesPerMember: 2,
       proposalCount: 3,
     });
 
@@ -115,13 +122,13 @@ describe.concurrent('submitVote', () => {
     ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
   });
 
-  it('accepts selection at the phase maxVotes cap', async ({
+  it('accepts selection at the phase maxVotesPerMember cap', async ({
     task,
     onTestFinished,
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
     const { setup, instance, proposals } = await setupVotingInstance(testData, {
-      maxVotes: 2,
+      maxVotesPerMember: 2,
       proposalCount: 3,
     });
 
@@ -135,13 +142,13 @@ describe.concurrent('submitVote', () => {
     expect(result.selectedProposalIds).toHaveLength(2);
   });
 
-  it('treats undefined maxVotes as unlimited', async ({
+  it('treats undefined maxVotesPerMember as unlimited', async ({
     task,
     onTestFinished,
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
     const { setup, instance, proposals } = await setupVotingInstance(testData, {
-      maxVotes: undefined,
+      maxVotesPerMember: undefined,
       proposalCount: 5,
     });
 
@@ -183,7 +190,7 @@ describe.concurrent('getVotingStatus', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
     const { setup, instance } = await setupVotingInstance(testData, {
-      maxVotes: undefined,
+      maxVotesPerMember: undefined,
       proposalCount: 0,
     });
 
@@ -199,7 +206,7 @@ describe.concurrent('getVotingStatus', () => {
   it('returns the phase cap when set', async ({ task, onTestFinished }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
     const { setup, instance } = await setupVotingInstance(testData, {
-      maxVotes: 3,
+      maxVotesPerMember: 3,
       proposalCount: 0,
     });
 

--- a/services/api/src/routers/decision/voting.test.ts
+++ b/services/api/src/routers/decision/voting.test.ts
@@ -1,0 +1,214 @@
+import { ProposalStatus, processInstances } from '@op/db/schema';
+import { db, eq } from '@op/db/test';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '..';
+import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../test/supabase-utils';
+import { createCallerFactory } from '../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+/**
+ * Voting schema with three phases: submission, voting, results.
+ * `maxVotes` can be overridden per test by caller-side edits to the returned object.
+ */
+function buildVotingSchema(maxVotes?: number) {
+  return {
+    id: 'voting-test',
+    version: '1.0.0',
+    name: 'Voting Test Schema',
+    description: 'Schema for voting integration tests',
+    phases: [
+      {
+        id: 'submission',
+        name: 'Submission',
+        rules: {
+          proposals: { submit: true },
+          voting: { submit: false },
+          advancement: { method: 'manual' as const },
+        },
+      },
+      {
+        id: 'voting',
+        name: 'Voting',
+        rules: {
+          proposals: { submit: false },
+          voting: { submit: true, ...(maxVotes !== undefined && { maxVotes }) },
+          advancement: { method: 'manual' as const },
+        },
+      },
+      {
+        id: 'results',
+        name: 'Results',
+        rules: {
+          proposals: { submit: false },
+          voting: { submit: false },
+          advancement: { method: 'manual' as const },
+        },
+      },
+    ],
+  };
+}
+
+async function setupVotingInstance(
+  testData: TestDecisionsDataManager,
+  opts: { maxVotes?: number; proposalCount: number; votingEnabled?: boolean },
+) {
+  const setup = await testData.createDecisionSetup({
+    instanceCount: 1,
+    grantAccess: true,
+    processSchema: buildVotingSchema(opts.maxVotes),
+  });
+
+  const instance = setup.instances[0];
+  if (!instance) {
+    throw new Error('No instance created');
+  }
+
+  const proposals = await Promise.all(
+    Array.from({ length: opts.proposalCount }, (_, i) =>
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: `Proposal ${i + 1}` },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ),
+  );
+
+  const targetPhase = opts.votingEnabled === false ? 'submission' : 'voting';
+  await db
+    .update(processInstances)
+    .set({ currentStateId: targetPhase })
+    .where(eq(processInstances.id, instance.instance.id));
+
+  return { setup, instance, proposals };
+}
+
+describe.concurrent('submitVote', () => {
+  it('rejects selection exceeding phase maxVotes', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance, proposals } = await setupVotingInstance(testData, {
+      maxVotes: 2,
+      proposalCount: 3,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.submitVote({
+        processInstanceId: instance.instance.id,
+        selectedProposalIds: proposals.map((p) => p.id),
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
+  });
+
+  it('accepts selection at the phase maxVotes cap', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance, proposals } = await setupVotingInstance(testData, {
+      maxVotes: 2,
+      proposalCount: 3,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.submitVote({
+      processInstanceId: instance.instance.id,
+      selectedProposalIds: proposals.slice(0, 2).map((p) => p.id),
+    });
+
+    expect(result.selectedProposalIds).toHaveLength(2);
+  });
+
+  it('treats undefined maxVotes as unlimited', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance, proposals } = await setupVotingInstance(testData, {
+      maxVotes: undefined,
+      proposalCount: 5,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.submitVote({
+      processInstanceId: instance.instance.id,
+      selectedProposalIds: proposals.map((p) => p.id),
+    });
+
+    expect(result.selectedProposalIds).toHaveLength(5);
+  });
+
+  it('rejects voting when phase disallows voting', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance, proposals } = await setupVotingInstance(testData, {
+      proposalCount: 2,
+      votingEnabled: false,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.submitVote({
+        processInstanceId: instance.instance.id,
+        selectedProposalIds: [proposals[0]!.id],
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
+  });
+});
+
+describe.concurrent('getVotingStatus', () => {
+  it('returns undefined maxVotesPerMember when phase has no cap', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await setupVotingInstance(testData, {
+      maxVotes: undefined,
+      proposalCount: 0,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const status = await caller.decision.getVotingStatus({
+      processInstanceId: instance.instance.id,
+    });
+
+    expect(status.votingConfiguration.maxVotesPerMember).toBeUndefined();
+  });
+
+  it('returns the phase cap when set', async ({ task, onTestFinished }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await setupVotingInstance(testData, {
+      maxVotes: 3,
+      proposalCount: 0,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const status = await caller.decision.getVotingStatus({
+      processInstanceId: instance.instance.id,
+    });
+
+    expect(status.votingConfiguration.maxVotesPerMember).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `maxVotes` to phase rules; voting service reads it from the current phase
- Drop the dead instance-level `fieldValues.maxVotesPerMember` fallback (previously hardcoded to 5/3)
- Undefined `maxVotes` = no cap, threaded through validator, tRPC response, and ballot UI

UI picker stacked on this branch: #1034