### PR TITLE
fix(ui): text clipping on Select component

### DIFF
--- a/packages/ui/src/components/ListBox.tsx
+++ b/packages/ui/src/components/ListBox.tsx
@@ -135,7 +135,7 @@ export const DropdownItem = (
     >
       {composeRenderProps(props.children, (children, { isSelected }) => (
         <>
-          <span className="group-hover:bgt-neutral-gray1 flex h-full flex-1 items-center gap-2 truncate font-normal text-inherit">
+          <span className="flex h-full flex-1 items-center gap-2 font-normal text-inherit group-hover:bg-neutral-gray1">
             {children}
           </span>
           <span className="flex w-5 items-center">
@@ -157,7 +157,7 @@ export const DropdownSection = <T extends object>(
 ) => {
   return (
     <ListBoxSection className="after:block after:h-[5px] after:content-[''] first:mt-[-5px]">
-      <Header className="sticky top-[-5px] z-10 -mx-1 -mt-px truncate border-y border-neutral-300 bg-neutral-300/60 px-4 py-1 text-sm font-semibold text-neutral-gray4 backdrop-blur-md [&+*]:mt-1">
+      <Header className="sticky top-[-5px] z-10 -mx-1 -mt-px truncate border-y border-neutral-300 bg-neutral-gray1 px-4 py-1 text-sm font-semibold text-neutral-gray4 [&+*]:mt-1">
         {props.title}
       </Header>
       <Collection items={props.items}>{props.children}</Collection>

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -23,7 +23,7 @@ import { Popover } from './Popover';
 import type { PopoverProps } from './Popover';
 
 const selectStyles = tv({
-  base: 'flex min-w-0 flex-row justify-between rounded-lg border text-base leading-3 text-neutral-black outline outline-0 group-data-[invalid=true]:outline-1 group-data-[invalid=true]:outline-functional-red placeholder:text-neutral-gray4 hover:border-neutral-gray2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue active:border-neutral-gray4 active:outline disabled:border-neutral-gray2',
+  base: 'flex min-w-0 flex-row justify-between rounded-lg border text-base leading-none text-neutral-black outline outline-0 group-data-[invalid=true]:outline-1 group-data-[invalid=true]:outline-functional-red placeholder:text-neutral-gray4 hover:border-neutral-gray2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue active:border-neutral-gray4 active:outline disabled:border-neutral-gray2',
   variants: {
     isDisabled: {
       true: 'bg-neutral-gray1 text-neutral-gray4',
@@ -120,14 +120,16 @@ export const Select = <T extends object>({
           <span className="flex h-full w-full flex-1 items-center justify-between gap-1">
             <SelectValue
               className={cn(
-                'flex h-full min-w-0 flex-1 items-center text-ellipsis data-[placeholder]:text-neutral-gray4',
+                'min-w-0 flex-1 truncate text-left data-[placeholder]:text-neutral-gray4',
                 props.selectValueClassName,
               )}
             >
-              {variant === 'pill'
-                ? ({ selectedText, isPlaceholder }) =>
-                    isPlaceholder ? null : selectedText
-                : undefined}
+              {({ defaultChildren, selectedText, isPlaceholder }) => {
+                if (isPlaceholder) {
+                  return variant === 'pill' ? null : defaultChildren;
+                }
+                return selectedText;
+              }}
             </SelectValue>
             {icon ?? (
               <LuChevronDown
@@ -142,7 +144,7 @@ export const Select = <T extends object>({
       <FieldError>{errorMessage}</FieldError>
       <Popover
         className={cn(
-          'absolute z-10 !max-h-60 max-w-56 min-w-(--trigger-width) overflow-hidden rounded border bg-white p-2 shadow',
+          'absolute z-10 !max-h-60 min-w-(--trigger-width) overflow-hidden rounded border bg-white p-2 shadow',
           popoverClassName,
         )}
         {...popoverProps}

--- a/packages/ui/stories/Select.stories.tsx
+++ b/packages/ui/stories/Select.stories.tsx
@@ -108,6 +108,16 @@ export const PillVariant = (args: any) => (
   </div>
 );
 
+export const NarrowTrigger = () => (
+  <div className="w-36">
+    <Select label="Role" defaultSelectedKey="owner">
+      <SelectItem id="participant">Participant</SelectItem>
+      <SelectItem id="admin">Admin</SelectItem>
+      <SelectItem id="owner">Owner of Everything</SelectItem>
+    </Select>
+  </div>
+);
+
 export const SmallVariant = (args: any) => (
   <div className="flex flex-col gap-4">
     <Select {...args} size="small" placeholder="Select category">


### PR DESCRIPTION
Text was clipping on the Select component, now it does not. When it is too long to render, it truncates with an ellipsis.

## Demo

<img width="714" height="810" alt="select-truncation" src="https://github.com/user-attachments/assets/3c019829-e55a-436e-8fb4-0ce8f2e55439" />
