### PR TITLE
feat(reviews): render submitted reviews as read-only result cards

### DIFF
--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -313,7 +313,7 @@ export function ProposalView({
       }
     >
       {activeRevisionRequest ? (
-        <SplitPane className="mx-auto w-full max-w-[68rem]">
+        <SplitPane className="mx-auto w-full max-w-6xl">
           <SplitPane.Pane id="proposal" label={t('Proposal')} className="gap-8">
             {proposalBody}
           </SplitPane.Pane>

--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -7,6 +7,8 @@ import {
   type ProposalReviewAssignment,
   type ProposalReviewRequest,
   ProposalReviewRequestState,
+  ProposalReviewState,
+  type RubricReviewData,
   type RubricTemplateSchema,
   schemaValidator,
 } from '@op/common/client';
@@ -30,9 +32,9 @@ const AUTOSAVE_DEBOUNCE_MS = 1000;
 
 interface ReviewFormState {
   /** Rubric answers keyed by criterion id; validated against the rubricTemplate. */
-  values: Record<string, unknown>;
+  values: RubricReviewData['answers'];
   /** Optional free-text rationale per criterion id (always optional). */
-  rationales: Record<string, string>;
+  rationales: RubricReviewData['rationales'];
   /** Optional free-text feedback shown to the author after the review phase. */
   overallComment: string;
   canSubmit: boolean;
@@ -131,16 +133,16 @@ function ReviewFormProviderInner({
     null;
   const isOwnRevisionRequest = !!ownRevisionRequest;
 
-  const [values, setValues] = useState<Record<string, unknown>>(
+  const [values, setValues] = useState<RubricReviewData['answers']>(
     review?.reviewData.answers ?? {},
   );
-  const [rationales, setRationales] = useState<Record<string, string>>(
+  const [rationales, setRationales] = useState<RubricReviewData['rationales']>(
     review?.reviewData.rationales ?? {},
   );
   const [overallComment, setOverallComment] = useState<string>(
     review?.overallComment ?? '',
   );
-  const isSubmitted = review?.state === 'submitted';
+  const isSubmitted = review?.state === ProposalReviewState.SUBMITTED;
   const isPausedForRevision = hasAnyOpenRevisionRequest;
   const canRequestRevision = !isSubmitted && !hasAnyOpenRevisionRequest;
 
@@ -308,8 +310,8 @@ function useAutosaveDraft({
   enabled,
 }: {
   assignmentId: string;
-  answers: Record<string, unknown>;
-  rationales: Record<string, string>;
+  answers: RubricReviewData['answers'];
+  rationales: RubricReviewData['rationales'];
   overallComment: string;
   enabled: boolean;
 }) {

--- a/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
@@ -11,7 +11,7 @@ export function FormShell({ children }: { children: ReactNode }) {
   return (
     <div className="flex flex-col gap-6">
       <div className="border-b border-neutral-gray1 pb-4">
-        <Header3 className="font-serif">
+        <Header3 className="font-serif font-light">
           <TranslatedText text="Review Proposal" />
         </Header3>
       </div>

--- a/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
@@ -11,7 +11,7 @@ export function FormShell({ children }: { children: ReactNode }) {
   return (
     <div className="flex flex-col gap-6">
       <div className="border-b border-neutral-gray1 pb-4">
-        <Header3 className="font-serif !text-title-base font-light">
+        <Header3 className="font-serif">
           <TranslatedText text="Review Proposal" />
         </Header3>
       </div>

--- a/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
@@ -3,17 +3,16 @@ import { Header3 } from '@op/ui/Header';
 import { Surface } from '@op/ui/Surface';
 import type { ReactNode } from 'react';
 
-import { useTranslations } from '@/lib/i18n';
+import { TranslatedText } from '@/components/TranslatedText';
 
 import { getCriteria } from '../rubricTemplate';
 
 export function FormShell({ children }: { children: ReactNode }) {
-  const t = useTranslations();
   return (
     <div className="flex flex-col gap-6">
       <div className="border-b border-neutral-gray1 pb-4">
         <Header3 className="font-serif !text-title-base font-light">
-          {t('Review Proposal')}
+          <TranslatedText text="Review Proposal" />
         </Header3>
       </div>
       {children}
@@ -28,7 +27,6 @@ export function TotalScoreCard({
   rubricTemplate: RubricTemplateSchema;
   values: Record<string, unknown>;
 }) {
-  const t = useTranslations();
   const criteria = getCriteria(rubricTemplate);
 
   const totalScore = criteria.reduce<number | null>((total, criterion) => {
@@ -47,7 +45,7 @@ export function TotalScoreCard({
       className="flex items-start justify-between rounded-lg border-neutral-gray1 p-4"
     >
       <span className="text-base text-neutral-charcoal">
-        {t('Total Score')}
+        <TranslatedText text="Total Score" />
       </span>
       <span className="text-base text-neutral-black">
         {totalScore === null ? '–' : totalScore}

--- a/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
@@ -1,9 +1,25 @@
 import type { RubricTemplateSchema } from '@op/common/client';
+import { Header3 } from '@op/ui/Header';
 import { Surface } from '@op/ui/Surface';
+import type { ReactNode } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
 import { getCriteria } from '../rubricTemplate';
+
+export function FormShell({ children }: { children: ReactNode }) {
+  const t = useTranslations();
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="border-b border-neutral-gray1 pb-4">
+        <Header3 className="font-serif !text-title-base font-light">
+          {t('Review Proposal')}
+        </Header3>
+      </div>
+      {children}
+    </div>
+  );
+}
 
 export function TotalScoreCard({
   rubricTemplate,

--- a/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
@@ -1,4 +1,4 @@
-import type { RubricTemplateSchema } from '@op/common/client';
+import type { RubricReviewData, RubricTemplateSchema } from '@op/common/client';
 import { Header3 } from '@op/ui/Header';
 import { Surface } from '@op/ui/Surface';
 import type { ReactNode } from 'react';
@@ -25,7 +25,7 @@ export function TotalScoreCard({
   values,
 }: {
   rubricTemplate: RubricTemplateSchema;
-  values: Record<string, unknown>;
+  values: RubricReviewData['answers'];
 }) {
   const criteria = getCriteria(rubricTemplate);
 

--- a/apps/app/src/components/decisions/Review/ReviewLayout.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayout.tsx
@@ -34,7 +34,10 @@ export async function ReviewLayout({
         <div className="flex h-dvh flex-col bg-white">
           <ReviewNavbar decisionSlug={decisionSlug} />
 
-          <SplitPane className="mx-auto max-w-5xl" defaultMobileTabId="review">
+          <SplitPane
+            className="mx-auto max-w-[68rem]"
+            defaultMobileTabId="review"
+          >
             <SplitPane.Pane
               id="proposal"
               label={<TranslatedText text="Proposal" />}

--- a/apps/app/src/components/decisions/Review/ReviewLayout.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayout.tsx
@@ -34,10 +34,7 @@ export async function ReviewLayout({
         <div className="flex h-dvh flex-col bg-white">
           <ReviewNavbar decisionSlug={decisionSlug} />
 
-          <SplitPane
-            className="mx-auto max-w-[68rem]"
-            defaultMobileTabId="review"
-          >
+          <SplitPane className="mx-auto max-w-6xl" defaultMobileTabId="review">
             <SplitPane.Pane
               id="proposal"
               label={<TranslatedText text="Proposal" />}

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  ProposalReviewState,
   type XFormatPropertySchema,
   isOverallRecommendationField,
   parseSchemaOptions,
@@ -49,7 +50,7 @@ export function ReviewRubricForm() {
   );
   const [isViewModalOpen, setIsViewModalOpen] = useState(false);
 
-  if (review?.state === 'submitted') {
+  if (review?.state === ProposalReviewState.SUBMITTED) {
     return (
       <FormShell>
         <SubmittedReviewView rubricTemplate={template} review={review} />

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -30,20 +30,20 @@ import {
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
 export function ReviewRubricForm() {
-  const { isSubmitted, rubricTemplate, values, rationales, review } =
-    useReviewForm();
+  const { rubricTemplate, review } = useReviewForm();
 
   return (
     <FormShell>
-      {isSubmitted ? (
+      {review?.state === 'submitted' ? (
         <>
           <SubmittedReviewView
             rubricTemplate={rubricTemplate}
-            values={values}
-            rationales={rationales}
-            overallComment={review?.overallComment}
+            review={review}
           />
-          <TotalScoreCard rubricTemplate={rubricTemplate} values={values} />
+          <TotalScoreCard
+            rubricTemplate={rubricTemplate}
+            values={review.reviewData.answers}
+          />
         </>
       ) : (
         <EditableReviewForm />

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -128,7 +128,7 @@ export function ReviewRubricForm() {
 
           {isSubmitted ? (
             review?.overallComment ? (
-              <section className="flex flex-col gap-3 border-b border-neutral-gray1 pb-6">
+              <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
                 <FieldHeader title={t('Feedback to Author')} />
                 <ResultCard description={review.overallComment} />
               </section>

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -422,7 +422,7 @@ function ResultCard({
         </div>
       )}
       {description && (
-        <div className="min-w-0 flex-1 text-xs text-neutral-gray4">
+        <div className="min-w-0 flex-1 text-sm text-neutral-gray4">
           {description}
         </div>
       )}

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -13,7 +13,7 @@ import { Select, SelectItem } from '@op/ui/Select';
 import { Surface } from '@op/ui/Surface';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
-import type { Key } from 'react';
+import type { Key, ReactNode } from 'react';
 import { useState } from 'react';
 import { LuCircleAlert, LuPlus } from 'react-icons/lu';
 
@@ -193,12 +193,17 @@ function RubricCriterionSection({
 }) {
   const t = useTranslations();
   const criterionType = inferCriterionType(field.schema);
+  const { isSubmitted } = useReviewForm();
   const scoreLabel = maxPoints > 0 ? `${maxPoints} ${t('pts')}` : null;
-  const badgeLabel = criterionType === 'yes_no' ? t('No/Yes') : scoreLabel;
+  const badgeLabel = isSubmitted
+    ? null
+    : criterionType === 'yes_no'
+      ? t('No/Yes')
+      : scoreLabel;
 
   return (
     <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
-      {criterionType === 'yes_no' ? (
+      {criterionType === 'yes_no' && !isSubmitted ? (
         <>
           <FieldHeader title={field.schema.title} badge={badgeLabel} />
 
@@ -226,11 +231,13 @@ function RubricCriterionSection({
         </>
       )}
 
-      <RubricRationaleField
-        value={rationaleValue}
-        onChange={onRationaleChange}
-        placeholder={rationalePlaceholder}
-      />
+      {!isSubmitted && (
+        <RubricRationaleField
+          value={rationaleValue}
+          onChange={onRationaleChange}
+          placeholder={rationalePlaceholder}
+        />
+      )}
     </section>
   );
 }
@@ -282,7 +289,8 @@ function RubricRationaleField({
 }
 
 /**
- * Render the input control for a rubric field.
+ * Render the input control for a rubric field, or a read-only result card
+ * once the review has been submitted.
  */
 function RubricFieldInput({
   field,
@@ -294,6 +302,11 @@ function RubricFieldInput({
   onChange: (value: unknown) => void;
 }) {
   const t = useTranslations();
+  const { isSubmitted } = useReviewForm();
+
+  if (isSubmitted) {
+    return <RubricFieldResult field={field} value={value} />;
+  }
 
   switch (field.format) {
     case 'dropdown': {
@@ -380,6 +393,87 @@ function RubricFieldInput({
     default:
       return null;
   }
+}
+
+/**
+ * Read-only card shown in place of the input once the review is submitted.
+ */
+function ResultCard({
+  value,
+  description,
+}: {
+  value?: ReactNode;
+  description?: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-neutral-gray1 p-6">
+      {value !== undefined && value !== null && value !== '' && (
+        <div className="font-serif text-title-base font-light text-neutral-black">
+          {value}
+        </div>
+      )}
+      {description && (
+        <div className="min-w-0 flex-1 text-xs text-neutral-gray4">
+          {description}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Map a submitted value to a read-only result card per field format.
+ */
+function RubricFieldResult({
+  field,
+  value,
+}: {
+  field: FieldDescriptor;
+  value: unknown;
+}) {
+  const t = useTranslations();
+  const { rationales } = useReviewForm();
+  const rationale = rationales[field.key]?.trim() || undefined;
+
+  if (field.format === 'dropdown') {
+    if (inferCriterionType(field.schema) === 'yes_no') {
+      const label =
+        value === 'yes' ? t('Yes') : value === 'no' ? t('No') : undefined;
+      return <ResultCard value={label} description={rationale} />;
+    }
+
+    const options = parseSchemaOptions(field.schema);
+    const selected = options.find(
+      (option) => String(option.value) === String(value),
+    );
+
+    // For scored criteria the value carries meaning (e.g. "4") and the
+    // title describes what that score means. For non-numeric dropdowns
+    // (overall recommendation) the raw value is just a lowercase key,
+    // so the title is the only useful label.
+    if (typeof selected?.value === 'number') {
+      return (
+        <ResultCard
+          value={selected.value}
+          description={selected.title || rationale}
+        />
+      );
+    }
+
+    return (
+      <ResultCard
+        value={selected?.title ?? selected?.value}
+        description={rationale}
+      />
+    );
+  }
+
+  if (field.format === 'long-text' || field.format === 'short-text') {
+    const text = typeof value === 'string' ? value.trim() : '';
+    return text ? <ResultCard description={text} /> : null;
+  }
+
+  return null;
 }
 
 /**

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -23,7 +23,8 @@ import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
 import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
 import { useReviewForm } from './ReviewFormContext';
-import { SubmittedReviewView, TotalScoreCard } from './SubmittedReviewView';
+import { SubmittedReviewView } from './SubmittedReviewView';
+import { TotalScoreCard } from './TotalScoreCard';
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
 /**

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -7,6 +7,7 @@ import {
 } from '@op/common/client';
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Button } from '@op/ui/Button';
+import { Header3 } from '@op/ui/Header';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { Select, SelectItem } from '@op/ui/Select';
 import { TextField } from '@op/ui/TextField';
@@ -22,37 +23,13 @@ import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
 import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
 import { useReviewForm } from './ReviewFormContext';
-import {
-  FormShell,
-  SubmittedReviewView,
-  TotalScoreCard,
-} from './SubmittedReviewView';
+import { SubmittedReviewView, TotalScoreCard } from './SubmittedReviewView';
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
+/**
+ * Schema-driven review rubric form renderer.
+ */
 export function ReviewRubricForm() {
-  const { rubricTemplate, review } = useReviewForm();
-
-  return (
-    <FormShell>
-      {review?.state === 'submitted' ? (
-        <>
-          <SubmittedReviewView
-            rubricTemplate={rubricTemplate}
-            review={review}
-          />
-          <TotalScoreCard
-            rubricTemplate={rubricTemplate}
-            values={review.reviewData.answers}
-          />
-        </>
-      ) : (
-        <EditableReviewForm />
-      )}
-    </FormShell>
-  );
-}
-
-function EditableReviewForm() {
   const t = useTranslations();
   const {
     rubricTemplate: template,
@@ -63,16 +40,64 @@ function EditableReviewForm() {
     handleRationaleChange,
     handleOverallCommentChange,
     isPausedForRevision,
+    review,
   } = useReviewForm();
   const fields = compileRubricSchema(template);
 
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(
     overallComment.length > 0,
   );
+  const [isViewModalOpen, setIsViewModalOpen] = useState(false);
+
+  if (review?.state === 'submitted') {
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="border-b border-neutral-gray1 pb-4">
+          <Header3 className="font-serif !text-title-base font-light">
+            {t('Review Proposal')}
+          </Header3>
+        </div>
+        <SubmittedReviewView rubricTemplate={template} review={review} />
+        <TotalScoreCard rubricTemplate={template} values={values} />
+      </div>
+    );
+  }
 
   return (
-    <>
-      {isPausedForRevision && <PausedForRevisionBanner />}
+    <div className="flex flex-col gap-6">
+      <div className="border-b border-neutral-gray1 pb-4">
+        <Header3 className="font-serif !text-title-base font-light">
+          {t('Review Proposal')}
+        </Header3>
+      </div>
+
+      {isPausedForRevision && (
+        <>
+          <AlertBanner
+            intent="warning"
+            variant="banner"
+            icon={<LuCircleAlert className="size-4" />}
+          >
+            <span>
+              <strong>{t('Proposal Revision Requested')}</strong>
+              <br />
+              {t('Reviewing is paused until author submits a revision.')}{' '}
+              <button
+                type="button"
+                className="underline"
+                onClick={() => setIsViewModalOpen(true)}
+              >
+                {t('View feedback')}
+              </button>
+            </span>
+          </AlertBanner>
+
+          <ViewRevisionRequestModal
+            isOpen={isViewModalOpen}
+            onOpenChange={setIsViewModalOpen}
+          />
+        </>
+      )}
 
       <div
         className={
@@ -132,43 +157,13 @@ function EditableReviewForm() {
           <TotalScoreCard rubricTemplate={template} values={values} />
         </div>
       </div>
-    </>
+    </div>
   );
 }
 
-function PausedForRevisionBanner() {
-  const t = useTranslations();
-  const [isViewModalOpen, setIsViewModalOpen] = useState(false);
-
-  return (
-    <>
-      <AlertBanner
-        intent="warning"
-        variant="banner"
-        icon={<LuCircleAlert className="size-4" />}
-      >
-        <span>
-          <strong>{t('Proposal Revision Requested')}</strong>
-          <br />
-          {t('Reviewing is paused until author submits a revision.')}{' '}
-          <button
-            type="button"
-            className="underline"
-            onClick={() => setIsViewModalOpen(true)}
-          >
-            {t('View feedback')}
-          </button>
-        </span>
-      </AlertBanner>
-
-      <ViewRevisionRequestModal
-        isOpen={isViewModalOpen}
-        onOpenChange={setIsViewModalOpen}
-      />
-    </>
-  );
-}
-
+/**
+ * Render one rubric criterion with an always-on rationale textarea below.
+ */
 function RubricCriterionSection({
   field,
   maxPoints,
@@ -274,6 +269,9 @@ function RubricRationaleField({
   );
 }
 
+/**
+ * Render the input control for a rubric field.
+ */
 function RubricFieldInput({
   field,
   value,

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -7,13 +7,11 @@ import {
 } from '@op/common/client';
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Button } from '@op/ui/Button';
-import { Header3 } from '@op/ui/Header';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { Select, SelectItem } from '@op/ui/Select';
-import { Surface } from '@op/ui/Surface';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
-import type { Key, ReactNode } from 'react';
+import type { Key } from 'react';
 import { useState } from 'react';
 import { LuCircleAlert, LuPlus } from 'react-icons/lu';
 
@@ -22,17 +20,31 @@ import { useTranslations } from '@/lib/i18n';
 import { FieldHeader } from '../forms/FieldHeader';
 import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
-import {
-  getCriteria,
-  getCriterionMaxPoints,
-  inferCriterionType,
-} from '../rubricTemplate';
+import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
 import { useReviewForm } from './ReviewFormContext';
+import {
+  FormShell,
+  SubmittedReviewView,
+  TotalScoreCard,
+} from './SubmittedReviewView';
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
 export function ReviewRubricForm() {
-  const { isSubmitted } = useReviewForm();
-  return isSubmitted ? <SubmittedReviewView /> : <EditableReviewForm />;
+  const { isSubmitted, rubricTemplate, values, rationales, review } =
+    useReviewForm();
+
+  if (isSubmitted) {
+    return (
+      <SubmittedReviewView
+        rubricTemplate={rubricTemplate}
+        values={values}
+        rationales={rationales}
+        overallComment={review?.overallComment}
+      />
+    );
+  }
+
+  return <EditableReviewForm />;
 }
 
 function EditableReviewForm() {
@@ -112,63 +124,10 @@ function EditableReviewForm() {
             </Button>
           )}
 
-          <TotalScoreCard />
+          <TotalScoreCard rubricTemplate={template} values={values} />
         </div>
       </div>
     </FormShell>
-  );
-}
-
-function SubmittedReviewView() {
-  const t = useTranslations();
-  const {
-    rubricTemplate: template,
-    values,
-    rationales,
-    review,
-  } = useReviewForm();
-  const fields = compileRubricSchema(template);
-
-  return (
-    <FormShell>
-      <div className="flex flex-col gap-6">
-        {fields.map((field) => (
-          <ResultSection
-            key={field.key}
-            title={field.schema.title}
-            description={field.schema.description}
-          >
-            <RubricFieldResult
-              field={field}
-              value={values[field.key]}
-              rationale={rationales[field.key]?.trim() || undefined}
-            />
-          </ResultSection>
-        ))}
-
-        {review?.overallComment && (
-          <ResultSection title={t('Feedback to Author')}>
-            <ResultCard description={review.overallComment} />
-          </ResultSection>
-        )}
-
-        <TotalScoreCard />
-      </div>
-    </FormShell>
-  );
-}
-
-function FormShell({ children }: { children: ReactNode }) {
-  const t = useTranslations();
-  return (
-    <div className="flex flex-col gap-6">
-      <div className="border-b border-neutral-gray1 pb-4">
-        <Header3 className="font-serif !text-title-base font-light">
-          {t('Review Proposal')}
-        </Header3>
-      </div>
-      {children}
-    </div>
   );
 }
 
@@ -202,53 +161,6 @@ function PausedForRevisionBanner() {
         onOpenChange={setIsViewModalOpen}
       />
     </>
-  );
-}
-
-function TotalScoreCard() {
-  const t = useTranslations();
-  const { rubricTemplate: template, values } = useReviewForm();
-  const criteria = getCriteria(template);
-
-  const totalScore = criteria.reduce<number | null>((total, criterion) => {
-    const value = values[criterion.id];
-
-    if (typeof value !== 'number') {
-      return total;
-    }
-
-    return (total ?? 0) + value;
-  }, null);
-
-  return (
-    <Surface
-      variant="filled"
-      className="flex items-start justify-between rounded-lg border-neutral-gray1 p-4"
-    >
-      <span className="text-base text-neutral-charcoal">
-        {t('Total Score')}
-      </span>
-      <span className="text-base text-neutral-black">
-        {totalScore === null ? '–' : totalScore}
-      </span>
-    </Surface>
-  );
-}
-
-function ResultSection({
-  title,
-  description,
-  children,
-}: {
-  title?: string;
-  description?: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
-      <FieldHeader title={title} description={description} />
-      {children}
-    </section>
   );
 }
 
@@ -453,77 +365,6 @@ function RubricFieldInput({
     default:
       return null;
   }
-}
-
-function ResultCard({
-  value,
-  description,
-}: {
-  value?: ReactNode;
-  description?: ReactNode;
-}) {
-  return (
-    <div className="flex items-center gap-4 rounded-xl border border-neutral-gray1 p-6">
-      {value !== undefined && value !== null && value !== '' && (
-        <div className="font-serif text-title-base font-light text-neutral-black">
-          {value}
-        </div>
-      )}
-      {description && (
-        <div className="min-w-0 flex-1 text-sm text-neutral-gray4">
-          {description}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function RubricFieldResult({
-  field,
-  value,
-  rationale,
-}: {
-  field: FieldDescriptor;
-  value: unknown;
-  rationale?: string;
-}) {
-  const t = useTranslations();
-
-  if (field.format === 'dropdown') {
-    if (inferCriterionType(field.schema) === 'yes_no') {
-      const label =
-        value === 'yes' ? t('Yes') : value === 'no' ? t('No') : undefined;
-      return <ResultCard value={label} description={rationale} />;
-    }
-
-    const options = parseSchemaOptions(field.schema);
-    const selected = options.find(
-      (option) => String(option.value) === String(value),
-    );
-
-    if (isOverallRecommendationField(field.key)) {
-      return (
-        <ResultCard
-          value={selected?.title ?? selected?.value}
-          description={rationale}
-        />
-      );
-    }
-
-    return (
-      <ResultCard
-        value={selected?.value}
-        description={selected?.title || rationale}
-      />
-    );
-  }
-
-  if (field.format === 'long-text' || field.format === 'short-text') {
-    const text = typeof value === 'string' ? value.trim() : '';
-    return <ResultCard description={text || '—'} />;
-  }
-
-  return null;
 }
 
 /**

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -33,21 +33,23 @@ export function ReviewRubricForm() {
   const { isSubmitted, rubricTemplate, values, rationales, review } =
     useReviewForm();
 
-  if (isSubmitted) {
-    return (
-      <FormShell>
-        <SubmittedReviewView
-          rubricTemplate={rubricTemplate}
-          values={values}
-          rationales={rationales}
-          overallComment={review?.overallComment}
-        />
-        <TotalScoreCard rubricTemplate={rubricTemplate} values={values} />
-      </FormShell>
-    );
-  }
-
-  return <EditableReviewForm />;
+  return (
+    <FormShell>
+      {isSubmitted ? (
+        <>
+          <SubmittedReviewView
+            rubricTemplate={rubricTemplate}
+            values={values}
+            rationales={rationales}
+            overallComment={review?.overallComment}
+          />
+          <TotalScoreCard rubricTemplate={rubricTemplate} values={values} />
+        </>
+      ) : (
+        <EditableReviewForm />
+      )}
+    </FormShell>
+  );
 }
 
 function EditableReviewForm() {
@@ -69,7 +71,7 @@ function EditableReviewForm() {
   );
 
   return (
-    <FormShell>
+    <>
       {isPausedForRevision && <PausedForRevisionBanner />}
 
       <div
@@ -130,7 +132,7 @@ function EditableReviewForm() {
           <TotalScoreCard rubricTemplate={template} values={values} />
         </div>
       </div>
-    </FormShell>
+    </>
   );
 }
 

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -65,6 +65,55 @@ export function ReviewRubricForm() {
     return (total ?? 0) + value;
   }, null);
 
+  const renderFeedbackToAuthor = () => {
+    if (isSubmitted) {
+      if (!review?.overallComment) {
+        return null;
+      }
+
+      return (
+        <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
+          <FieldHeader title={t('Feedback to Author')} />
+          <ResultCard description={review.overallComment} />
+        </section>
+      );
+    }
+
+    if (isFeedbackOpen) {
+      return (
+        <section className="flex flex-col gap-3 border-b border-neutral-gray1 pb-6">
+          <FieldHeader
+            title={t('Feedback to Author')}
+            description={t(
+              'Shared anonymously with the author after the review phase ends',
+            )}
+            className="gap-1"
+          />
+
+          <TextField
+            aria-label={t('Feedback to Author')}
+            value={overallComment}
+            onChange={handleOverallCommentChange}
+            useTextArea
+            textareaProps={{ rows: 3 }}
+          />
+        </section>
+      );
+    }
+
+    return (
+      <Button
+        color="secondary"
+        size="medium"
+        className="w-full"
+        onPress={() => setIsFeedbackOpen(true)}
+      >
+        <LuPlus className="size-4" />
+        {t('Feedback to Author')}
+      </Button>
+    );
+  };
+
   return (
     <div className="flex flex-col gap-6">
       <div className="border-b border-neutral-gray1 pb-4">
@@ -126,42 +175,7 @@ export function ReviewRubricForm() {
             />
           ))}
 
-          {isSubmitted ? (
-            review?.overallComment ? (
-              <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
-                <FieldHeader title={t('Feedback to Author')} />
-                <ResultCard description={review.overallComment} />
-              </section>
-            ) : null
-          ) : isFeedbackOpen ? (
-            <section className="flex flex-col gap-3 border-b border-neutral-gray1 pb-6">
-              <FieldHeader
-                title={t('Feedback to Author')}
-                description={t(
-                  'Shared anonymously with the author after the review phase ends',
-                )}
-                className="gap-1"
-              />
-
-              <TextField
-                aria-label={t('Feedback to Author')}
-                value={overallComment}
-                onChange={handleOverallCommentChange}
-                useTextArea
-                textareaProps={{ rows: 3 }}
-              />
-            </section>
-          ) : (
-            <Button
-              color="secondary"
-              size="medium"
-              className="w-full"
-              onPress={() => setIsFeedbackOpen(true)}
-            >
-              <LuPlus className="size-4" />
-              {t('Feedback to Author')}
-            </Button>
-          )}
+          {renderFeedbackToAuthor()}
 
           <Surface
             variant="filled"
@@ -297,10 +311,6 @@ function RubricRationaleField({
   );
 }
 
-/**
- * Render the input control for a rubric field, or a read-only result card
- * once the review has been submitted.
- */
 function RubricFieldInput({
   field,
   value,
@@ -404,9 +414,6 @@ function RubricFieldInput({
   }
 }
 
-/**
- * Read-only card shown in place of the input once the review is submitted.
- */
 function ResultCard({
   value,
   description,
@@ -430,9 +437,6 @@ function ResultCard({
   );
 }
 
-/**
- * Map a submitted value to a read-only result card per field format.
- */
 function RubricFieldResult({
   field,
   value,
@@ -456,23 +460,19 @@ function RubricFieldResult({
       (option) => String(option.value) === String(value),
     );
 
-    // For scored criteria the value carries meaning (e.g. "4") and the
-    // title describes what that score means. For non-numeric dropdowns
-    // (overall recommendation) the raw value is just a lowercase key,
-    // so the title is the only useful label.
-    if (typeof selected?.value === 'number') {
+    if (isOverallRecommendationField(field.key)) {
       return (
         <ResultCard
-          value={selected.value}
-          description={selected.title || rationale}
+          value={selected?.title ?? selected?.value}
+          description={rationale}
         />
       );
     }
 
     return (
       <ResultCard
-        value={selected?.title ?? selected?.value}
-        description={rationale}
+        value={selected?.value}
+        description={selected?.title || rationale}
       />
     );
   }

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -133,7 +133,11 @@ function SubmittedReviewView() {
     <FormShell>
       <div className="flex flex-col gap-6">
         {fields.map((field) => (
-          <ResultSection key={field.key} title={field.schema.title}>
+          <ResultSection
+            key={field.key}
+            title={field.schema.title}
+            description={field.schema.description}
+          >
             <RubricFieldResult
               field={field}
               value={values[field.key]}
@@ -233,14 +237,16 @@ function TotalScoreCard() {
 
 function ResultSection({
   title,
+  description,
   children,
 }: {
   title?: string;
+  description?: string;
   children: ReactNode;
 }) {
   return (
     <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
-      <FieldHeader title={title} />
+      <FieldHeader title={title} description={description} />
       {children}
     </section>
   );
@@ -276,7 +282,7 @@ function RubricCriterionSection({
 
           <div className="flex items-start gap-3">
             {field.schema.description && (
-              <p className="flex-1 text-base text-neutral-charcoal">
+              <p className="flex-1 text-sm text-neutral-charcoal">
                 {field.schema.description}
               </p>
             )}
@@ -286,13 +292,11 @@ function RubricCriterionSection({
         </>
       ) : (
         <>
-          <FieldHeader title={field.schema.title} badge={badgeLabel} />
-
-          {field.schema.description && (
-            <p className="text-base text-neutral-charcoal">
-              {field.schema.description}
-            </p>
-          )}
+          <FieldHeader
+            title={field.schema.title}
+            description={field.schema.description}
+            badge={badgeLabel}
+          />
 
           <RubricFieldInput field={field} value={value} onChange={onChange} />
         </>

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -35,12 +35,15 @@ export function ReviewRubricForm() {
 
   if (isSubmitted) {
     return (
-      <SubmittedReviewView
-        rubricTemplate={rubricTemplate}
-        values={values}
-        rationales={rationales}
-        overallComment={review?.overallComment}
-      />
+      <FormShell>
+        <SubmittedReviewView
+          rubricTemplate={rubricTemplate}
+          values={values}
+          rationales={rationales}
+          overallComment={review?.overallComment}
+        />
+        <TotalScoreCard rubricTemplate={rubricTemplate} values={values} />
+      </FormShell>
     );
   }
 

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -44,6 +44,8 @@ export function ReviewRubricForm() {
     handleRationaleChange,
     handleOverallCommentChange,
     isPausedForRevision,
+    isSubmitted,
+    review,
   } = useReviewForm();
   const fields = compileRubricSchema(template);
   const criteria = getCriteria(template);
@@ -124,7 +126,14 @@ export function ReviewRubricForm() {
             />
           ))}
 
-          {isFeedbackOpen ? (
+          {isSubmitted ? (
+            review?.overallComment ? (
+              <section className="flex flex-col gap-3 border-b border-neutral-gray1 pb-6">
+                <FieldHeader title={t('Feedback to Author')} />
+                <ResultCard description={review.overallComment} />
+              </section>
+            ) : null
+          ) : isFeedbackOpen ? (
             <section className="flex flex-col gap-3 border-b border-neutral-gray1 pb-6">
               <FieldHeader
                 title={t('Feedback to Author')}

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -7,7 +7,6 @@ import {
 } from '@op/common/client';
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Button } from '@op/ui/Button';
-import { Header3 } from '@op/ui/Header';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { Select, SelectItem } from '@op/ui/Select';
 import { TextField } from '@op/ui/TextField';
@@ -23,8 +22,8 @@ import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
 import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
 import { useReviewForm } from './ReviewFormContext';
+import { FormShell, TotalScoreCard } from './ReviewFormShell';
 import { SubmittedReviewView } from './SubmittedReviewView';
-import { TotalScoreCard } from './TotalScoreCard';
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
 /**
@@ -52,26 +51,15 @@ export function ReviewRubricForm() {
 
   if (review?.state === 'submitted') {
     return (
-      <div className="flex flex-col gap-6">
-        <div className="border-b border-neutral-gray1 pb-4">
-          <Header3 className="font-serif !text-title-base font-light">
-            {t('Review Proposal')}
-          </Header3>
-        </div>
+      <FormShell>
         <SubmittedReviewView rubricTemplate={template} review={review} />
         <TotalScoreCard rubricTemplate={template} values={values} />
-      </div>
+      </FormShell>
     );
   }
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="border-b border-neutral-gray1 pb-4">
-        <Header3 className="font-serif !text-title-base font-light">
-          {t('Review Proposal')}
-        </Header3>
-      </div>
-
+    <FormShell>
       {isPausedForRevision && (
         <>
           <AlertBanner
@@ -158,7 +146,7 @@ export function ReviewRubricForm() {
           <TotalScoreCard rubricTemplate={template} values={values} />
         </div>
       </div>
-    </div>
+    </FormShell>
   );
 }
 

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -30,10 +30,12 @@ import {
 import { useReviewForm } from './ReviewFormContext';
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
-/**
- * Schema-driven review rubric form renderer.
- */
 export function ReviewRubricForm() {
+  const { isSubmitted } = useReviewForm();
+  return isSubmitted ? <SubmittedReviewView /> : <EditableReviewForm />;
+}
+
+function EditableReviewForm() {
   const t = useTranslations();
   const {
     rubricTemplate: template,
@@ -44,111 +46,16 @@ export function ReviewRubricForm() {
     handleRationaleChange,
     handleOverallCommentChange,
     isPausedForRevision,
-    isSubmitted,
-    review,
   } = useReviewForm();
   const fields = compileRubricSchema(template);
-  const criteria = getCriteria(template);
 
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(
     overallComment.length > 0,
   );
-  const [isViewModalOpen, setIsViewModalOpen] = useState(false);
-
-  const totalScore = criteria.reduce<number | null>((total, criterion) => {
-    const value = values[criterion.id];
-
-    if (typeof value !== 'number') {
-      return total;
-    }
-
-    return (total ?? 0) + value;
-  }, null);
-
-  const renderFeedbackToAuthor = () => {
-    if (isSubmitted) {
-      if (!review?.overallComment) {
-        return null;
-      }
-
-      return (
-        <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
-          <FieldHeader title={t('Feedback to Author')} />
-          <ResultCard description={review.overallComment} />
-        </section>
-      );
-    }
-
-    if (isFeedbackOpen) {
-      return (
-        <section className="flex flex-col gap-3 border-b border-neutral-gray1 pb-6">
-          <FieldHeader
-            title={t('Feedback to Author')}
-            description={t(
-              'Shared anonymously with the author after the review phase ends',
-            )}
-            className="gap-1"
-          />
-
-          <TextField
-            aria-label={t('Feedback to Author')}
-            value={overallComment}
-            onChange={handleOverallCommentChange}
-            useTextArea
-            textareaProps={{ rows: 3 }}
-          />
-        </section>
-      );
-    }
-
-    return (
-      <Button
-        color="secondary"
-        size="medium"
-        className="w-full"
-        onPress={() => setIsFeedbackOpen(true)}
-      >
-        <LuPlus className="size-4" />
-        {t('Feedback to Author')}
-      </Button>
-    );
-  };
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="border-b border-neutral-gray1 pb-4">
-        <Header3 className="font-serif !text-title-base font-light">
-          {t('Review Proposal')}
-        </Header3>
-      </div>
-
-      {isPausedForRevision && (
-        <>
-          <AlertBanner
-            intent="warning"
-            variant="banner"
-            icon={<LuCircleAlert className="size-4" />}
-          >
-            <span>
-              <strong>{t('Proposal Revision Requested')}</strong>
-              <br />
-              {t('Reviewing is paused until author submits a revision.')}{' '}
-              <button
-                type="button"
-                className="underline"
-                onClick={() => setIsViewModalOpen(true)}
-              >
-                {t('View feedback')}
-              </button>
-            </span>
-          </AlertBanner>
-
-          <ViewRevisionRequestModal
-            isOpen={isViewModalOpen}
-            onOpenChange={setIsViewModalOpen}
-          />
-        </>
-      )}
+    <FormShell>
+      {isPausedForRevision && <PausedForRevisionBanner />}
 
       <div
         className={
@@ -175,28 +82,170 @@ export function ReviewRubricForm() {
             />
           ))}
 
-          {renderFeedbackToAuthor()}
+          {isFeedbackOpen ? (
+            <section className="flex flex-col gap-3 border-b border-neutral-gray1 pb-6">
+              <FieldHeader
+                title={t('Feedback to Author')}
+                description={t(
+                  'Shared anonymously with the author after the review phase ends',
+                )}
+                className="gap-1"
+              />
 
-          <Surface
-            variant="filled"
-            className="flex items-start justify-between rounded-lg border-neutral-gray1 p-4"
-          >
-            <span className="text-base text-neutral-charcoal">
-              {t('Total Score')}
-            </span>
-            <span className="text-base text-neutral-black">
-              {totalScore === null ? '–' : totalScore}
-            </span>
-          </Surface>
+              <TextField
+                aria-label={t('Feedback to Author')}
+                value={overallComment}
+                onChange={handleOverallCommentChange}
+                useTextArea
+                textareaProps={{ rows: 3 }}
+              />
+            </section>
+          ) : (
+            <Button
+              color="secondary"
+              size="medium"
+              className="w-full"
+              onPress={() => setIsFeedbackOpen(true)}
+            >
+              <LuPlus className="size-4" />
+              {t('Feedback to Author')}
+            </Button>
+          )}
+
+          <TotalScoreCard />
         </div>
       </div>
+    </FormShell>
+  );
+}
+
+function SubmittedReviewView() {
+  const t = useTranslations();
+  const {
+    rubricTemplate: template,
+    values,
+    rationales,
+    review,
+  } = useReviewForm();
+  const fields = compileRubricSchema(template);
+
+  return (
+    <FormShell>
+      <div className="flex flex-col gap-6">
+        {fields.map((field) => (
+          <ResultSection key={field.key} title={field.schema.title}>
+            <RubricFieldResult
+              field={field}
+              value={values[field.key]}
+              rationale={rationales[field.key]?.trim() || undefined}
+            />
+          </ResultSection>
+        ))}
+
+        {review?.overallComment && (
+          <ResultSection title={t('Feedback to Author')}>
+            <ResultCard description={review.overallComment} />
+          </ResultSection>
+        )}
+
+        <TotalScoreCard />
+      </div>
+    </FormShell>
+  );
+}
+
+function FormShell({ children }: { children: ReactNode }) {
+  const t = useTranslations();
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="border-b border-neutral-gray1 pb-4">
+        <Header3 className="font-serif !text-title-base font-light">
+          {t('Review Proposal')}
+        </Header3>
+      </div>
+      {children}
     </div>
   );
 }
 
-/**
- * Render one rubric criterion with an always-on rationale textarea below.
- */
+function PausedForRevisionBanner() {
+  const t = useTranslations();
+  const [isViewModalOpen, setIsViewModalOpen] = useState(false);
+
+  return (
+    <>
+      <AlertBanner
+        intent="warning"
+        variant="banner"
+        icon={<LuCircleAlert className="size-4" />}
+      >
+        <span>
+          <strong>{t('Proposal Revision Requested')}</strong>
+          <br />
+          {t('Reviewing is paused until author submits a revision.')}{' '}
+          <button
+            type="button"
+            className="underline"
+            onClick={() => setIsViewModalOpen(true)}
+          >
+            {t('View feedback')}
+          </button>
+        </span>
+      </AlertBanner>
+
+      <ViewRevisionRequestModal
+        isOpen={isViewModalOpen}
+        onOpenChange={setIsViewModalOpen}
+      />
+    </>
+  );
+}
+
+function TotalScoreCard() {
+  const t = useTranslations();
+  const { rubricTemplate: template, values } = useReviewForm();
+  const criteria = getCriteria(template);
+
+  const totalScore = criteria.reduce<number | null>((total, criterion) => {
+    const value = values[criterion.id];
+
+    if (typeof value !== 'number') {
+      return total;
+    }
+
+    return (total ?? 0) + value;
+  }, null);
+
+  return (
+    <Surface
+      variant="filled"
+      className="flex items-start justify-between rounded-lg border-neutral-gray1 p-4"
+    >
+      <span className="text-base text-neutral-charcoal">
+        {t('Total Score')}
+      </span>
+      <span className="text-base text-neutral-black">
+        {totalScore === null ? '–' : totalScore}
+      </span>
+    </Surface>
+  );
+}
+
+function ResultSection({
+  title,
+  children,
+}: {
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
+      <FieldHeader title={title} />
+      {children}
+    </section>
+  );
+}
+
 function RubricCriterionSection({
   field,
   maxPoints,
@@ -216,17 +265,12 @@ function RubricCriterionSection({
 }) {
   const t = useTranslations();
   const criterionType = inferCriterionType(field.schema);
-  const { isSubmitted } = useReviewForm();
   const scoreLabel = maxPoints > 0 ? `${maxPoints} ${t('pts')}` : null;
-  const badgeLabel = isSubmitted
-    ? null
-    : criterionType === 'yes_no'
-      ? t('No/Yes')
-      : scoreLabel;
+  const badgeLabel = criterionType === 'yes_no' ? t('No/Yes') : scoreLabel;
 
   return (
     <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
-      {criterionType === 'yes_no' && !isSubmitted ? (
+      {criterionType === 'yes_no' ? (
         <>
           <FieldHeader title={field.schema.title} badge={badgeLabel} />
 
@@ -254,13 +298,11 @@ function RubricCriterionSection({
         </>
       )}
 
-      {!isSubmitted && (
-        <RubricRationaleField
-          value={rationaleValue}
-          onChange={onRationaleChange}
-          placeholder={rationalePlaceholder}
-        />
-      )}
+      <RubricRationaleField
+        value={rationaleValue}
+        onChange={onRationaleChange}
+        placeholder={rationalePlaceholder}
+      />
     </section>
   );
 }
@@ -321,11 +363,6 @@ function RubricFieldInput({
   onChange: (value: unknown) => void;
 }) {
   const t = useTranslations();
-  const { isSubmitted } = useReviewForm();
-
-  if (isSubmitted) {
-    return <RubricFieldResult field={field} value={value} />;
-  }
 
   switch (field.format) {
     case 'dropdown': {
@@ -440,13 +477,13 @@ function ResultCard({
 function RubricFieldResult({
   field,
   value,
+  rationale,
 }: {
   field: FieldDescriptor;
   value: unknown;
+  rationale?: string;
 }) {
   const t = useTranslations();
-  const { rationales } = useReviewForm();
-  const rationale = rationales[field.key]?.trim() || undefined;
 
   if (field.format === 'dropdown') {
     if (inferCriterionType(field.schema) === 'yes_no') {

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -479,7 +479,7 @@ function RubricFieldResult({
 
   if (field.format === 'long-text' || field.format === 'short-text') {
     const text = typeof value === 'string' ? value.trim() : '';
-    return text ? <ResultCard description={text} /> : null;
+    return <ResultCard description={text || '—'} />;
   }
 
   return null;

--- a/apps/app/src/components/decisions/Review/ReviewSkeleton.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewSkeleton.tsx
@@ -8,7 +8,7 @@ export function ReviewSkeleton() {
           <div className="h-8 w-32 animate-pulse rounded bg-gray-200" />
         </div>
       </div>
-      <div className="mx-auto hidden min-h-0 w-full max-w-[68rem] flex-1 sm:flex">
+      <div className="mx-auto hidden min-h-0 w-full max-w-6xl flex-1 sm:flex">
         <div className="flex-1 border-r p-12">
           <div className="space-y-4">
             <div className="h-10 w-3/4 animate-pulse rounded bg-gray-200" />

--- a/apps/app/src/components/decisions/Review/ReviewSkeleton.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewSkeleton.tsx
@@ -8,7 +8,7 @@ export function ReviewSkeleton() {
           <div className="h-8 w-32 animate-pulse rounded bg-gray-200" />
         </div>
       </div>
-      <div className="mx-auto hidden min-h-0 w-full max-w-5xl flex-1 sm:flex">
+      <div className="mx-auto hidden min-h-0 w-full max-w-[68rem] flex-1 sm:flex">
         <div className="flex-1 border-r p-12">
           <div className="space-y-4">
             <div className="h-10 w-3/4 animate-pulse rounded bg-gray-200" />

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -4,7 +4,6 @@ import {
   isOverallRecommendationField,
   parseSchemaOptions,
 } from '@op/common/client';
-import { Header3 } from '@op/ui/Header';
 import type { ReactNode } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -85,7 +84,11 @@ function ResultCard({
     <div className="flex flex-col gap-4 rounded-xl border border-neutral-gray1 p-6">
       {hasTopRow && (
         <div className="flex items-center gap-4">
-          {hasValue && <Header3 className="font-serif">{value}</Header3>}
+          {hasValue && (
+            <span className="font-serif !text-title-base text-neutral-black">
+              {value}
+            </span>
+          )}
           {hasDescription && (
             <div className="min-w-0 flex-1 text-sm text-neutral-gray4">
               {description}

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -4,7 +4,6 @@ import {
   isOverallRecommendationField,
   parseSchemaOptions,
 } from '@op/common/client';
-import { Header3 } from '@op/ui/Header';
 import { Surface } from '@op/ui/Surface';
 import type { ReactNode } from 'react';
 
@@ -47,20 +46,6 @@ export function SubmittedReviewView({
           <ResultCard description={review.overallComment} />
         </ResultSection>
       )}
-    </div>
-  );
-}
-
-export function FormShell({ children }: { children: ReactNode }) {
-  const t = useTranslations();
-  return (
-    <div className="flex flex-col gap-6">
-      <div className="border-b border-neutral-gray1 pb-4">
-        <Header3 className="font-serif !text-title-base font-light">
-          {t('Review Proposal')}
-        </Header3>
-      </div>
-      {children}
     </div>
   );
 }

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -1,4 +1,5 @@
 import {
+  type ProposalReview,
   type RubricTemplateSchema,
   isOverallRecommendationField,
   parseSchemaOptions,
@@ -16,17 +17,14 @@ import { getCriteria, inferCriterionType } from '../rubricTemplate';
 
 export function SubmittedReviewView({
   rubricTemplate,
-  values,
-  rationales,
-  overallComment,
+  review,
 }: {
   rubricTemplate: RubricTemplateSchema;
-  values: Record<string, unknown>;
-  rationales: Record<string, string>;
-  overallComment?: string | null;
+  review: ProposalReview;
 }) {
   const t = useTranslations();
   const fields = compileRubricSchema(rubricTemplate);
+  const { answers, rationales } = review.reviewData;
 
   return (
     <div className="flex flex-col gap-6">
@@ -38,15 +36,15 @@ export function SubmittedReviewView({
         >
           <RubricFieldResult
             field={field}
-            value={values[field.key]}
+            value={answers[field.key]}
             rationale={rationales[field.key]?.trim() || undefined}
           />
         </ResultSection>
       ))}
 
-      {overallComment && (
+      {review.overallComment && (
         <ResultSection title={t('Feedback to Author')}>
-          <ResultCard description={overallComment} />
+          <ResultCard description={review.overallComment} />
         </ResultSection>
       )}
     </div>

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -29,31 +29,27 @@ export function SubmittedReviewView({
   const fields = compileRubricSchema(rubricTemplate);
 
   return (
-    <FormShell>
-      <div className="flex flex-col gap-6">
-        {fields.map((field) => (
-          <ResultSection
-            key={field.key}
-            title={field.schema.title}
-            description={field.schema.description}
-          >
-            <RubricFieldResult
-              field={field}
-              value={values[field.key]}
-              rationale={rationales[field.key]?.trim() || undefined}
-            />
-          </ResultSection>
-        ))}
+    <div className="flex flex-col gap-6">
+      {fields.map((field) => (
+        <ResultSection
+          key={field.key}
+          title={field.schema.title}
+          description={field.schema.description}
+        >
+          <RubricFieldResult
+            field={field}
+            value={values[field.key]}
+            rationale={rationales[field.key]?.trim() || undefined}
+          />
+        </ResultSection>
+      ))}
 
-        {overallComment && (
-          <ResultSection title={t('Feedback to Author')}>
-            <ResultCard description={overallComment} />
-          </ResultSection>
-        )}
-
-        <TotalScoreCard rubricTemplate={rubricTemplate} values={values} />
-      </div>
-    </FormShell>
+      {overallComment && (
+        <ResultSection title={t('Feedback to Author')}>
+          <ResultCard description={overallComment} />
+        </ResultSection>
+      )}
+    </div>
   );
 }
 

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -1,0 +1,195 @@
+import {
+  type RubricTemplateSchema,
+  isOverallRecommendationField,
+  parseSchemaOptions,
+} from '@op/common/client';
+import { Header3 } from '@op/ui/Header';
+import { Surface } from '@op/ui/Surface';
+import type { ReactNode } from 'react';
+
+import { useTranslations } from '@/lib/i18n';
+
+import { FieldHeader } from '../forms/FieldHeader';
+import { compileRubricSchema } from '../forms/rubric';
+import type { FieldDescriptor } from '../forms/types';
+import { getCriteria, inferCriterionType } from '../rubricTemplate';
+
+export function SubmittedReviewView({
+  rubricTemplate,
+  values,
+  rationales,
+  overallComment,
+}: {
+  rubricTemplate: RubricTemplateSchema;
+  values: Record<string, unknown>;
+  rationales: Record<string, string>;
+  overallComment?: string | null;
+}) {
+  const t = useTranslations();
+  const fields = compileRubricSchema(rubricTemplate);
+
+  return (
+    <FormShell>
+      <div className="flex flex-col gap-6">
+        {fields.map((field) => (
+          <ResultSection
+            key={field.key}
+            title={field.schema.title}
+            description={field.schema.description}
+          >
+            <RubricFieldResult
+              field={field}
+              value={values[field.key]}
+              rationale={rationales[field.key]?.trim() || undefined}
+            />
+          </ResultSection>
+        ))}
+
+        {overallComment && (
+          <ResultSection title={t('Feedback to Author')}>
+            <ResultCard description={overallComment} />
+          </ResultSection>
+        )}
+
+        <TotalScoreCard rubricTemplate={rubricTemplate} values={values} />
+      </div>
+    </FormShell>
+  );
+}
+
+export function FormShell({ children }: { children: ReactNode }) {
+  const t = useTranslations();
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="border-b border-neutral-gray1 pb-4">
+        <Header3 className="font-serif !text-title-base font-light">
+          {t('Review Proposal')}
+        </Header3>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function TotalScoreCard({
+  rubricTemplate,
+  values,
+}: {
+  rubricTemplate: RubricTemplateSchema;
+  values: Record<string, unknown>;
+}) {
+  const t = useTranslations();
+  const criteria = getCriteria(rubricTemplate);
+
+  const totalScore = criteria.reduce<number | null>((total, criterion) => {
+    const value = values[criterion.id];
+
+    if (typeof value !== 'number') {
+      return total;
+    }
+
+    return (total ?? 0) + value;
+  }, null);
+
+  return (
+    <Surface
+      variant="filled"
+      className="flex items-start justify-between rounded-lg border-neutral-gray1 p-4"
+    >
+      <span className="text-base text-neutral-charcoal">
+        {t('Total Score')}
+      </span>
+      <span className="text-base text-neutral-black">
+        {totalScore === null ? '–' : totalScore}
+      </span>
+    </Surface>
+  );
+}
+
+function ResultSection({
+  title,
+  description,
+  children,
+}: {
+  title?: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
+      <FieldHeader title={title} description={description} />
+      {children}
+    </section>
+  );
+}
+
+function ResultCard({
+  value,
+  description,
+}: {
+  value?: ReactNode;
+  description?: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-neutral-gray1 p-6">
+      {value !== undefined && value !== null && value !== '' && (
+        <div className="font-serif text-title-base font-light text-neutral-black">
+          {value}
+        </div>
+      )}
+      {description && (
+        <div className="min-w-0 flex-1 text-sm text-neutral-gray4">
+          {description}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RubricFieldResult({
+  field,
+  value,
+  rationale,
+}: {
+  field: FieldDescriptor;
+  value: unknown;
+  rationale?: string;
+}) {
+  const t = useTranslations();
+
+  if (field.format === 'dropdown') {
+    if (inferCriterionType(field.schema) === 'yes_no') {
+      const label =
+        value === 'yes' ? t('Yes') : value === 'no' ? t('No') : undefined;
+      return <ResultCard value={label} description={rationale} />;
+    }
+
+    const options = parseSchemaOptions(field.schema);
+    const selected = options.find(
+      (option) => String(option.value) === String(value),
+    );
+
+    if (isOverallRecommendationField(field.key)) {
+      return (
+        <ResultCard
+          value={selected?.title ?? selected?.value}
+          description={rationale}
+        />
+      );
+    }
+
+    return (
+      <ResultCard
+        value={selected?.value}
+        description={selected?.title || rationale}
+      />
+    );
+  }
+
+  if (field.format === 'long-text' || field.format === 'short-text') {
+    const text = typeof value === 'string' ? value.trim() : '';
+    return <ResultCard description={text || '—'} />;
+  }
+
+  return null;
+}

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -69,21 +69,38 @@ function ResultSection({
 function ResultCard({
   value,
   description,
+  rationale,
 }: {
   value?: ReactNode;
   description?: ReactNode;
+  rationale?: ReactNode;
 }) {
+  const hasValue = value !== undefined && value !== null && value !== '';
+  const hasDescription = !!description;
+  const hasRationale = !!rationale;
+  const hasTopRow = hasValue || hasDescription;
+
   return (
-    <div className="flex items-center gap-4 rounded-xl border border-neutral-gray1 p-6">
-      {value !== undefined && value !== null && value !== '' && (
-        <div className="font-serif text-title-base font-light text-neutral-black">
-          {value}
+    <div className="flex flex-col gap-4 rounded-xl border border-neutral-gray1 p-6">
+      {hasTopRow && (
+        <div className="flex items-center gap-4">
+          {hasValue && (
+            <div className="font-serif text-title-base font-light text-neutral-black">
+              {value}
+            </div>
+          )}
+          {hasDescription && (
+            <div className="min-w-0 flex-1 text-sm text-neutral-gray4">
+              {description}
+            </div>
+          )}
         </div>
       )}
-      {description && (
-        <div className="min-w-0 flex-1 text-sm text-neutral-gray4">
-          {description}
-        </div>
+      {hasRationale && hasTopRow && (
+        <div className="h-px w-full bg-neutral-gray1" />
+      )}
+      {hasRationale && (
+        <div className="text-base text-neutral-charcoal">{rationale}</div>
       )}
     </div>
   );
@@ -125,6 +142,7 @@ function RubricFieldResult({
       <ResultCard
         value={selected?.value}
         description={selected?.title || rationale}
+        rationale={selected?.title ? rationale : undefined}
       />
     );
   }

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -4,6 +4,7 @@ import {
   isOverallRecommendationField,
   parseSchemaOptions,
 } from '@op/common/client';
+import { Header3 } from '@op/ui/Header';
 import type { ReactNode } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -84,11 +85,7 @@ function ResultCard({
     <div className="flex flex-col gap-4 rounded-xl border border-neutral-gray1 p-6">
       {hasTopRow && (
         <div className="flex items-center gap-4">
-          {hasValue && (
-            <div className="font-serif text-title-base font-light text-neutral-black">
-              {value}
-            </div>
-          )}
+          {hasValue && <Header3 className="font-serif">{value}</Header3>}
           {hasDescription && (
             <div className="min-w-0 flex-1 text-sm text-neutral-gray4">
               {description}

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -4,7 +4,6 @@ import {
   isOverallRecommendationField,
   parseSchemaOptions,
 } from '@op/common/client';
-import { Surface } from '@op/ui/Surface';
 import type { ReactNode } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -12,7 +11,7 @@ import { useTranslations } from '@/lib/i18n';
 import { FieldHeader } from '../forms/FieldHeader';
 import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
-import { getCriteria, inferCriterionType } from '../rubricTemplate';
+import { inferCriterionType } from '../rubricTemplate';
 
 export function SubmittedReviewView({
   rubricTemplate,
@@ -47,41 +46,6 @@ export function SubmittedReviewView({
         </ResultSection>
       )}
     </div>
-  );
-}
-
-export function TotalScoreCard({
-  rubricTemplate,
-  values,
-}: {
-  rubricTemplate: RubricTemplateSchema;
-  values: Record<string, unknown>;
-}) {
-  const t = useTranslations();
-  const criteria = getCriteria(rubricTemplate);
-
-  const totalScore = criteria.reduce<number | null>((total, criterion) => {
-    const value = values[criterion.id];
-
-    if (typeof value !== 'number') {
-      return total;
-    }
-
-    return (total ?? 0) + value;
-  }, null);
-
-  return (
-    <Surface
-      variant="filled"
-      className="flex items-start justify-between rounded-lg border-neutral-gray1 p-4"
-    >
-      <span className="text-base text-neutral-charcoal">
-        {t('Total Score')}
-      </span>
-      <span className="text-base text-neutral-black">
-        {totalScore === null ? '–' : totalScore}
-      </span>
-    </Surface>
   );
 }
 

--- a/apps/app/src/components/decisions/Review/TotalScoreCard.tsx
+++ b/apps/app/src/components/decisions/Review/TotalScoreCard.tsx
@@ -1,0 +1,41 @@
+import type { RubricTemplateSchema } from '@op/common/client';
+import { Surface } from '@op/ui/Surface';
+
+import { useTranslations } from '@/lib/i18n';
+
+import { getCriteria } from '../rubricTemplate';
+
+export function TotalScoreCard({
+  rubricTemplate,
+  values,
+}: {
+  rubricTemplate: RubricTemplateSchema;
+  values: Record<string, unknown>;
+}) {
+  const t = useTranslations();
+  const criteria = getCriteria(rubricTemplate);
+
+  const totalScore = criteria.reduce<number | null>((total, criterion) => {
+    const value = values[criterion.id];
+
+    if (typeof value !== 'number') {
+      return total;
+    }
+
+    return (total ?? 0) + value;
+  }, null);
+
+  return (
+    <Surface
+      variant="filled"
+      className="flex items-start justify-between rounded-lg border-neutral-gray1 p-4"
+    >
+      <span className="text-base text-neutral-charcoal">
+        {t('Total Score')}
+      </span>
+      <span className="text-base text-neutral-black">
+        {totalScore === null ? '–' : totalScore}
+      </span>
+    </Surface>
+  );
+}

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -433,7 +433,7 @@ function ProposalEditorInner({
           <RichTextEditorToolbar editor={focusedEditor} />
         </div>
         {revisionRequest ? (
-          <SplitPane className="mx-auto w-full max-w-[68rem]">
+          <SplitPane className="mx-auto w-full max-w-6xl">
             <SplitPane.Pane
               id="proposal"
               label={t('Proposal')}

--- a/packages/common/src/services/decision/schemas/reviews.ts
+++ b/packages/common/src/services/decision/schemas/reviews.ts
@@ -8,7 +8,11 @@ import { z } from 'zod';
 import type { RubricTemplateSchema } from '../types';
 import { proposalSchema } from './proposal';
 
-export { ProposalReviewAssignmentStatus, ProposalReviewRequestState };
+export {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+  ProposalReviewState,
+};
 
 const jsonObjectSchema = z.record(z.string(), z.unknown());
 


### PR DESCRIPTION
Replaces the editable rubric controls with answer cards once a review is submitted so reviewers can read back what they turned in, including the overall feedback to the author.

## Demo

<img width="3024" height="1810" alt="CleanShot 2026-04-23 at 18 13 27@2x" src="https://github.com/user-attachments/assets/932baf16-b8fe-42e6-86bb-72538ce6d781" />
