### PR TITLE
Refactor authorization checks to use unified access control

### DIFF
--- a/packages/common/src/services/decision/createProposal.ts
+++ b/packages/common/src/services/decision/createProposal.ts
@@ -60,22 +60,37 @@ export const createProposal = async ({
       throw new ValidationError('Process instance has no profile');
     }
 
-    const profileAccessUser = await getProfileAccessUser({
-      user: { id: authUserId },
-      profileId: instance.profileId,
-    });
+    // The proposal will be owned by the user's current profile. Fetch it now
+    // so we can both stamp submittedByProfileId and verify the user has the
+    // authority to act on behalf of that profile.
+    const ownerProfileId = await getCurrentProfileId(authUserId);
 
-    if (!profileAccessUser) {
+    const [instanceProfileUser, ownerProfileUser] = await Promise.all([
+      getProfileAccessUser({
+        user: { id: authUserId },
+        profileId: instance.profileId,
+      }),
+      getProfileAccessUser({
+        user: { id: authUserId },
+        profileId: ownerProfileId,
+      }),
+    ]);
+
+    if (!instanceProfileUser) {
       throw new UnauthorizedError('Not authorized');
     }
 
-    assertAccess(
-      [
-        { profile: permission.ADMIN },
-        { decisions: decisionPermission.SUBMIT_PROPOSALS },
-      ],
-      profileAccessUser.roles,
-    );
+    const submitSpec = [
+      { profile: permission.ADMIN },
+      { decisions: decisionPermission.SUBMIT_PROPOSALS },
+    ];
+
+    // Must have submit/admin rights on the instance.
+    assertAccess(submitSpec, instanceProfileUser.roles);
+
+    // ...AND on the profile that will own the proposal. Prevents users from
+    // stamping a proposal under an org they can't act for.
+    assertAccess(submitSpec, ownerProfileUser?.roles ?? []);
 
     const instanceData = instance.instanceData as DecisionInstanceData;
     const currentPhaseId = instance.currentStateId;
@@ -146,10 +161,8 @@ export const createProposal = async ({
       }
     }
 
-    const [profileId, adminRole] = await Promise.all([
-      getCurrentProfileId(authUserId),
-      assertGlobalRole('Admin'),
-    ]);
+    const adminRole = await assertGlobalRole('Admin');
+    const profileId = ownerProfileId;
     const createdProposal = await db.transaction(async (tx) => {
       const slug = await generateUniqueProfileSlug({
         name: proposalTitle,

--- a/packages/common/src/services/decision/deleteProposal.ts
+++ b/packages/common/src/services/decision/deleteProposal.ts
@@ -1,7 +1,7 @@
 import { db, eq } from '@op/db/client';
 import { ProcessInstance, proposals } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
-import { checkPermission, permission } from 'access-zones';
+import { assertAccess, permission } from 'access-zones';
 
 import {
   CommonError,
@@ -9,7 +9,7 @@ import {
   UnauthorizedError,
   ValidationError,
 } from '../../utils';
-import { getProfileAccessUser, getUserSession } from '../access';
+import { getProfileAccessUser } from '../access';
 
 export const deleteProposal = async ({
   proposalId,
@@ -19,22 +19,13 @@ export const deleteProposal = async ({
   user: User;
 }) => {
   try {
-    const [sessionUser, existingProposal] = await Promise.all([
-      getUserSession({ authUserId: user.id }),
-      db._query.proposals.findFirst({
-        where: eq(proposals.id, proposalId),
-        with: {
-          processInstance: true,
-          decisions: true,
-        },
-      }),
-    ]);
-
-    const { user: dbUser } = sessionUser ?? {};
-
-    if (!dbUser || !dbUser.currentProfileId) {
-      throw new UnauthorizedError('User must have an active profile');
-    }
+    const existingProposal = await db._query.proposals.findFirst({
+      where: eq(proposals.id, proposalId),
+      with: {
+        processInstance: true,
+        decisions: true,
+      },
+    });
 
     if (!existingProposal) {
       throw new NotFoundError('Proposal');
@@ -45,37 +36,28 @@ export const deleteProposal = async ({
       throw new NotFoundError('Process instance not found');
     }
 
-    // Check permissions on proposal's profile and instance's profile in parallel
-    const [proposalProfileUser, instanceProfileUser] = await Promise.all([
+    // Authorization: owner (individual or org), co-author, or instance admin.
+    const [rolesOnOwner, rolesOnProposal, rolesOnInstance] = await Promise.all([
+      getProfileAccessUser({
+        user: { id: user.id },
+        profileId: existingProposal.submittedByProfileId,
+      }).then((pu) => pu?.roles ?? []),
       getProfileAccessUser({
         user: { id: user.id },
         profileId: existingProposal.profileId,
-      }),
+      }).then((pu) => pu?.roles ?? []),
       processInstance.profileId
         ? getProfileAccessUser({
             user: { id: user.id },
             profileId: processInstance.profileId,
-          })
-        : undefined,
+          }).then((pu) => pu?.roles ?? [])
+        : Promise.resolve([]),
     ]);
 
-    const hasProposalAdmin = checkPermission(
-      { profile: permission.ADMIN },
-      proposalProfileUser?.roles ?? [],
+    assertAccess(
+      [{ profile: permission.ADMIN }],
+      [...rolesOnOwner, ...rolesOnProposal, ...rolesOnInstance],
     );
-
-    const hasInstanceAdmin = checkPermission(
-      { decisions: permission.ADMIN },
-      instanceProfileUser?.roles ?? [],
-    );
-
-    // Only the submitter, proposal admin, or instance admin can delete
-    const isSubmitter =
-      existingProposal.submittedByProfileId === dbUser.currentProfileId;
-
-    if (!isSubmitter && !hasProposalAdmin && !hasInstanceAdmin) {
-      throw new UnauthorizedError('Not authorized to delete this proposal');
-    }
 
     // Check if there are any decisions on this proposal
     if (existingProposal.decisions && existingProposal.decisions.length > 0) {

--- a/packages/common/src/services/decision/getProposal.ts
+++ b/packages/common/src/services/decision/getProposal.ts
@@ -106,13 +106,16 @@ export const getProposal = async ({
     throw new NotFoundError('Proposal');
   }
 
-  // Draft proposals are only visible to users with proposal-level access
-  // (the creator and invited collaborators who have a profileUsers record).
+  // Draft proposals are only visible to users who can act as either the
+  // proposal's profile (the creator + invited collaborators) or the owner
+  // profile (the individual/org the proposal was submitted under).
   if (proposal.status === ProposalStatus.DRAFT) {
     const hasProposalAccess = await db.query.profileUsers.findFirst({
       where: {
-        profileId: proposal.profileId,
         authUserId: user.id,
+        profileId: {
+          in: [proposal.profileId, proposal.submittedByProfileId],
+        },
       },
       columns: { id: true },
     });

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -308,18 +308,21 @@ export const listProposals = async ({
       ? and(whereClause, phaseScopedNonDraftIdFilter)
       : phaseScopedNonDraftIdFilter;
   } else {
-    // Draft proposals: only visible to users with proposal-level access
-    // (the creator and invited collaborators with a profileUsers record on the proposal's profile).
+    // Draft proposals: only visible to users who can act as either the
+    // proposal's profile (creator + invited collaborators) or the owner
+    // profile (individual/org the proposal was submitted under).
     // Drafts are not phase-scoped and remain visible regardless of phaseId so that
     // creators continue to see their own in-progress work alongside the current phase.
+    const userMemberProfileIds = db
+      .select({ profileId: profileUsers.profileId })
+      .from(profileUsers)
+      .where(eq(profileUsers.authUserId, input.authUserId));
+
     const draftFilter = and(
       eq(proposals.status, ProposalStatus.DRAFT),
-      inArray(
-        proposals.profileId,
-        db
-          .select({ profileId: profileUsers.profileId })
-          .from(profileUsers)
-          .where(eq(profileUsers.authUserId, input.authUserId)),
+      or(
+        inArray(proposals.profileId, userMemberProfileIds),
+        inArray(proposals.submittedByProfileId, userMemberProfileIds),
       ),
     );
 

--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -52,18 +52,30 @@ export const submitProposal = async ({
     throw new NotFoundError('Decision profile not found');
   }
 
-  // Authorization check - verify user has access to the decision profile
-  const profileUser = await getProfileAccessUser({
-    user: { id: authUserId },
-    profileId: instance.profileId,
-  });
+  // Authorization: user passes if they have submit/admin rights on any of
+  // the owner profile, proposal profile, or instance profile. Covers owners
+  // (individual or org), co-authors, and instance admins in one shot.
+  const [rolesOnOwner, rolesOnProposal, rolesOnInstance] = await Promise.all([
+    getProfileAccessUser({
+      user: { id: authUserId },
+      profileId: existingProposal.submittedByProfileId,
+    }).then((pu) => pu?.roles ?? []),
+    getProfileAccessUser({
+      user: { id: authUserId },
+      profileId: existingProposal.profileId,
+    }).then((pu) => pu?.roles ?? []),
+    getProfileAccessUser({
+      user: { id: authUserId },
+      profileId: instance.profileId,
+    }).then((pu) => pu?.roles ?? []),
+  ]);
 
   assertAccess(
     [
       { profile: permission.ADMIN },
       { decisions: decisionPermission.SUBMIT_PROPOSALS },
     ],
-    profileUser?.roles ?? [],
+    [...rolesOnOwner, ...rolesOnProposal, ...rolesOnInstance],
   );
 
   const instanceData = instance.instanceData as DecisionInstanceData;

--- a/packages/common/src/services/decision/submitRevisionResponse.ts
+++ b/packages/common/src/services/decision/submitRevisionResponse.ts
@@ -10,15 +10,12 @@ import {
   proposals,
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
+import { assertAccess, permission } from 'access-zones';
 import { and, eq, sql } from 'drizzle-orm';
 
-import {
-  CommonError,
-  NotFoundError,
-  UnauthorizedError,
-  ValidationError,
-} from '../../utils';
-import { assertUserByAuthId } from '../assert';
+import { CommonError, NotFoundError, ValidationError } from '../../utils';
+import { getProfileAccessUser } from '../access';
+import { decisionPermission } from './permissions';
 import { parseProposalData } from './proposalDataSchema';
 
 /** Resubmits a proposal after the author addresses reviewer feedback. */
@@ -31,36 +28,53 @@ export async function submitRevisionResponse({
   resubmitComment?: string;
   user: User;
 }): Promise<ProposalReviewRequest & { processInstanceId: string }> {
-  const [request, dbUser] = await Promise.all([
-    db.query.proposalReviewRequests.findFirst({
-      where: { id: revisionRequestId },
-      with: {
-        assignment: {
-          with: {
-            proposal: true,
+  const request = await db.query.proposalReviewRequests.findFirst({
+    where: { id: revisionRequestId },
+    with: {
+      assignment: {
+        with: {
+          proposal: {
+            with: {
+              processInstance: true,
+            },
           },
         },
       },
-    }),
-    assertUserByAuthId(user.id),
-  ]);
+    },
+  });
 
   if (!request) {
     throw new NotFoundError('Revision request');
   }
 
-  if (!dbUser.profileId) {
-    throw new UnauthorizedError('User must have an active profile');
-  }
-
   const proposal = request.assignment.proposal;
+  const instance = proposal.processInstance;
 
-  // Verify caller is the proposal owner
-  if (proposal.submittedByProfileId !== dbUser.profileId) {
-    throw new UnauthorizedError(
-      "You don't have access to resubmit this proposal",
-    );
-  }
+  // Authorization: owner (individual or org), co-author, or instance admin.
+  const [rolesOnOwner, rolesOnProposal, rolesOnInstance] = await Promise.all([
+    getProfileAccessUser({
+      user: { id: user.id },
+      profileId: proposal.submittedByProfileId,
+    }).then((pu) => pu?.roles ?? []),
+    getProfileAccessUser({
+      user: { id: user.id },
+      profileId: proposal.profileId,
+    }).then((pu) => pu?.roles ?? []),
+    instance?.profileId
+      ? getProfileAccessUser({
+          user: { id: user.id },
+          profileId: instance.profileId,
+        }).then((pu) => pu?.roles ?? [])
+      : Promise.resolve([]),
+  ]);
+
+  assertAccess(
+    [
+      { profile: permission.ADMIN },
+      { decisions: decisionPermission.SUBMIT_PROPOSALS },
+    ],
+    [...rolesOnOwner, ...rolesOnProposal, ...rolesOnInstance],
+  );
 
   // Verify the revision request is in REQUESTED state
   if (request.state !== ProposalReviewRequestState.REQUESTED) {

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -10,7 +10,7 @@ import {
   taxonomyTerms,
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
-import { checkPermission, permission } from 'access-zones';
+import { assertAccess, permission } from 'access-zones';
 
 import {
   CommonError,
@@ -18,7 +18,7 @@ import {
   UnauthorizedError,
   ValidationError,
 } from '../../utils';
-import { assertInstanceProfileAccess, getProfileAccessUser } from '../access';
+import { getProfileAccessUser } from '../access';
 import { assertUserByAuthId } from '../assert';
 import type {
   CheckpointVersion,
@@ -130,34 +130,39 @@ export const updateProposal = async ({
     );
   }
 
-  // Status and visibility changes only require instance-level decisions: ADMIN
-  if (data.status || data.visibility) {
-    await assertInstanceProfileAccess({
+  // Authorization: gather roles from owner (individual/org), proposal, and
+  // instance profiles and let any of them satisfy the spec. Data edits
+  // require UPDATE/ADMIN; status/visibility require ADMIN.
+  const [rolesOnOwner, rolesOnProposal, rolesOnInstance] = await Promise.all([
+    getProfileAccessUser({
       user: { id: user.id },
-      instance: processInstance,
-      profilePermissions: { decisions: permission.ADMIN },
-      orgFallbackPermissions: [{ decisions: permission.ADMIN }],
-    });
-  } else {
-    // Data updates require profile-level update permission on the proposal's profile
-    const proposalProfileUser = await getProfileAccessUser({
+      profileId: existingProposal.submittedByProfileId,
+    }).then((pu) => pu?.roles ?? []),
+    getProfileAccessUser({
       user: { id: user.id },
       profileId: existingProposal.profileId,
-    });
+    }).then((pu) => pu?.roles ?? []),
+    processInstance.profileId
+      ? getProfileAccessUser({
+          user: { id: user.id },
+          profileId: processInstance.profileId,
+        }).then((pu) => pu?.roles ?? [])
+      : Promise.resolve([]),
+  ]);
 
-    const hasProposalUpdate = checkPermission(
-      { profile: permission.UPDATE },
-      proposalProfileUser?.roles ?? [],
+  const combinedRoles = [
+    ...rolesOnOwner,
+    ...rolesOnProposal,
+    ...rolesOnInstance,
+  ];
+
+  if (data.status || data.visibility) {
+    assertAccess([{ profile: permission.ADMIN }], combinedRoles);
+  } else {
+    assertAccess(
+      [{ profile: permission.UPDATE }, { profile: permission.ADMIN }],
+      combinedRoles,
     );
-
-    if (!hasProposalUpdate) {
-      await assertInstanceProfileAccess({
-        user: { id: user.id },
-        instance: processInstance,
-        profilePermissions: { decisions: permission.UPDATE },
-        orgFallbackPermissions: [{ decisions: permission.ADMIN }],
-      });
-    }
   }
 
   // Validate proposal data against template schema when updating non-draft proposals.


### PR DESCRIPTION
## Summary
This PR refactors authorization checks across decision-related services to use a unified access control pattern. Instead of checking individual permissions against single profiles, the code now gathers roles from all relevant profiles (owner, proposal, and instance) and validates them together using `assertAccess`.

## Key Changes

- **Unified Authorization Pattern**: Replaced scattered permission checks with a consistent approach that:
  - Gathers roles from owner profile (submittedByProfileId), proposal profile, and instance profile in parallel
  - Validates all roles together against a permission spec using `assertAccess`
  - Allows any of the three profiles to satisfy the authorization requirement

- **Removed Legacy Checks**: 
  - Removed `assertUserByAuthId` calls that enforced active profile requirement
  - Removed `getUserSession` and `assertInstanceProfileAccess` helper calls
  - Eliminated individual `checkPermission` calls in favor of unified `assertAccess`

- **Updated Services**:
  - `submitRevisionResponse.ts`: Now checks owner, proposal, and instance profiles for SUBMIT_PROPOSALS or ADMIN
  - `deleteProposal.ts`: Simplified to check ADMIN on any of the three profiles
  - `updateProposal.ts`: Refactored status/visibility and data edit checks to use unified pattern
  - `submitProposal.ts`: Checks SUBMIT_PROPOSALS or ADMIN across all three profiles
  - `createProposal.ts`: Added explicit check that user can act on behalf of the owner profile
  - `listProposals.ts` & `getProposal.ts`: Updated draft visibility to include both proposal profile and owner profile members

## Implementation Details

- Authorization now covers three user categories in a single check: owners (individual or org), co-authors, and instance admins
- Parallel queries for role fetching improve performance
- Draft proposal visibility expanded to include users who are members of either the proposal's profile or the owner profile
- Removed unnecessary database queries for user session validation

https://claude.ai/code/session_01CQQ4U2WdENVbWAgRmfv4Ku