### PR TITLE
feat(reviews): persist reviewer feedback to author on draft + submit

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -33,6 +33,8 @@ interface ReviewFormState {
   values: Record<string, unknown>;
   /** Optional free-text rationale per criterion id (always optional). */
   rationales: Record<string, string>;
+  /** Optional free-text feedback shown to the author after the review phase. */
+  overallComment: string;
   canSubmit: boolean;
   isSubmitting: boolean;
   isSubmitted: boolean;
@@ -45,6 +47,7 @@ interface ReviewFormState {
   assignment: ProposalReviewAssignment;
   handleValueChange: (key: string, value: unknown) => void;
   handleRationaleChange: (key: string, value: string) => void;
+  handleOverallCommentChange: (value: string) => void;
   handleSubmit: () => void;
   requestRevision: (comment: string) => void;
   cancelRevisionRequest: () => void;
@@ -134,6 +137,9 @@ function ReviewFormProviderInner({
   const [rationales, setRationales] = useState<Record<string, string>>(
     review?.reviewData.rationales ?? {},
   );
+  const [overallComment, setOverallComment] = useState<string>(
+    review?.overallComment ?? '',
+  );
   const isSubmitted = review?.state === 'submitted';
   const isPausedForRevision = hasAnyOpenRevisionRequest;
   const canRequestRevision = !isSubmitted && !hasAnyOpenRevisionRequest;
@@ -154,6 +160,7 @@ function ReviewFormProviderInner({
     assignmentId,
     answers: values,
     rationales,
+    overallComment,
     enabled: !isSubmitted && !isPausedForRevision,
   });
 
@@ -201,12 +208,21 @@ function ReviewFormProviderInner({
     [scheduleAutosave],
   );
 
+  const handleOverallCommentChange = useCallback(
+    (value: string) => {
+      setOverallComment(value);
+      scheduleAutosave();
+    },
+    [scheduleAutosave],
+  );
+
   const handleSubmit = useCallback(() => {
     submitReview.mutate({
       assignmentId,
       reviewData: { answers: values, rationales },
+      overallComment: overallComment.trim() ? overallComment : null,
     });
-  }, [assignmentId, values, rationales, submitReview]);
+  }, [assignmentId, values, rationales, overallComment, submitReview]);
 
   const handleRequestRevision = useCallback(
     (comment: string) => {
@@ -232,6 +248,7 @@ function ReviewFormProviderInner({
     () => ({
       values,
       rationales,
+      overallComment,
       canSubmit: canSubmit && !isSubmitted && !isPausedForRevision,
       isSubmitting: submitReview.isPending,
       isSubmitted,
@@ -244,6 +261,7 @@ function ReviewFormProviderInner({
       assignment,
       handleValueChange,
       handleRationaleChange,
+      handleOverallCommentChange,
       handleSubmit,
       requestRevision: handleRequestRevision,
       cancelRevisionRequest: handleCancelRevision,
@@ -253,6 +271,7 @@ function ReviewFormProviderInner({
     [
       values,
       rationales,
+      overallComment,
       canSubmit,
       isSubmitted,
       isPausedForRevision,
@@ -267,6 +286,7 @@ function ReviewFormProviderInner({
       cancelRevisionMutation.isPending,
       handleValueChange,
       handleRationaleChange,
+      handleOverallCommentChange,
       handleSubmit,
       handleRequestRevision,
       handleCancelRevision,
@@ -284,11 +304,13 @@ function useAutosaveDraft({
   assignmentId,
   answers,
   rationales,
+  overallComment,
   enabled,
 }: {
   assignmentId: string;
   answers: Record<string, unknown>;
   rationales: Record<string, string>;
+  overallComment: string;
   enabled: boolean;
 }) {
   const saveReviewDraft = trpc.decision.saveReviewDraft.useMutation();
@@ -314,6 +336,7 @@ function useAutosaveDraft({
       .mutateAsync({
         assignmentId,
         reviewData: { answers, rationales },
+        overallComment: overallComment.trim() ? overallComment : null,
       })
       .catch(() => {})
       .then(() => {

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -39,21 +39,19 @@ export function ReviewRubricForm() {
     rubricTemplate: template,
     values,
     rationales,
+    overallComment,
     handleValueChange,
     handleRationaleChange,
+    handleOverallCommentChange,
     isPausedForRevision,
   } = useReviewForm();
   const fields = compileRubricSchema(template);
   const criteria = getCriteria(template);
 
-  const [feedbackToAuthor, setFeedbackToAuthor] = useState('');
-  const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
+  const [isFeedbackOpen, setIsFeedbackOpen] = useState(
+    overallComment.length > 0,
+  );
   const [isViewModalOpen, setIsViewModalOpen] = useState(false);
-
-  const handleFeedbackChange = (value: string) => {
-    // TODO: wire feedback to author into review submission
-    setFeedbackToAuthor(value);
-  };
 
   const totalScore = criteria.reduce<number | null>((total, criterion) => {
     const value = values[criterion.id];
@@ -138,8 +136,8 @@ export function ReviewRubricForm() {
 
               <TextField
                 aria-label={t('Feedback to Author')}
-                value={feedbackToAuthor}
-                onChange={handleFeedbackChange}
+                value={overallComment}
+                onChange={handleOverallCommentChange}
                 useTextArea
                 textareaProps={{ rows: 3 }}
               />

--- a/packages/common/src/services/decision/saveReviewDraft.ts
+++ b/packages/common/src/services/decision/saveReviewDraft.ts
@@ -22,10 +22,12 @@ import type { RubricReviewData } from './schemas/reviews';
 export async function saveReviewDraft({
   assignmentId,
   reviewData,
+  overallComment,
   user,
 }: {
   assignmentId: string;
   reviewData: RubricReviewData;
+  overallComment?: string | null;
   user: User;
 }): Promise<{ review: ProposalReview; processInstanceId: string }> {
   const context = await assertReviewAssignmentContext({
@@ -51,12 +53,14 @@ export async function saveReviewDraft({
         assignmentId,
         state: ProposalReviewState.DRAFT,
         reviewData,
+        overallComment: overallComment ?? null,
         submittedAt: null,
       })
       .onConflictDoUpdate({
         target: proposalReviews.assignmentId,
         set: {
           reviewData,
+          overallComment: overallComment ?? null,
         },
         // Atomic guard against a late-arriving draft overwriting a row that
         // was submitted after this request's early state check passed. When

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
@@ -216,6 +216,49 @@ describe.concurrent('saveReviewDraft', () => {
     expect(result.overallComment).toBeNull();
   });
 
+  it('persists overallComment on the draft and round-trips updates', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(created.context, rubricTemplate);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    const first = await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: { answers: { impact: 2 }, rationales: {} },
+      overallComment: 'Initial feedback draft',
+    });
+
+    expect(first.overallComment).toBe('Initial feedback draft');
+
+    // Upsert path: an edit to overallComment should overwrite, and clearing
+    // it should persist as null.
+    const second = await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: { answers: { impact: 2 }, rationales: {} },
+      overallComment: 'Revised feedback draft',
+    });
+    expect(second.overallComment).toBe('Revised feedback draft');
+
+    const cleared = await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: { answers: { impact: 2 }, rationales: {} },
+      overallComment: null,
+    });
+    expect(cleared.overallComment).toBeNull();
+
+    const review = await db.query.proposalReviews.findFirst({
+      where: { assignmentId: created.assignment.id },
+    });
+    expect(review?.state).toBe(ProposalReviewState.DRAFT);
+    expect(review?.overallComment).toBeNull();
+  });
+
   it('does not downgrade non-PENDING assignment statuses', async ({
     task,
     onTestFinished,

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.ts
@@ -10,6 +10,7 @@ import { commonAuthedProcedure, router } from '../../../trpcFactory';
 const saveReviewDraftInputSchema = z.object({
   assignmentId: z.uuid(),
   reviewData: rubricReviewDataSchema,
+  overallComment: z.string().nullable().optional(),
 });
 
 export const saveReviewDraftRouter = router({
@@ -20,6 +21,7 @@ export const saveReviewDraftRouter = router({
       const { review, processInstanceId } = await saveReviewDraft({
         assignmentId: input.assignmentId,
         reviewData: input.reviewData,
+        overallComment: input.overallComment,
         user: ctx.user,
       });
 


### PR DESCRIPTION
This persists overallComment through saveReviewDraft and restores it when the form reopens. Surfacing the feedback to the author is a separate PR.