### PR TITLE
refactor(admin): convert platform admin routes to drizzle v2 db.query

### DIFF
--- a/services/api/src/routers/platform/admin/addUsersToOrganization.ts
+++ b/services/api/src/routers/platform/admin/addUsersToOrganization.ts
@@ -48,12 +48,11 @@ export const addUsersToOrganizationRouter = router({
 
       // Validate all entities exist
       const [organization, users, existingRoles] = await Promise.all([
-        db._query.organizations.findFirst({
-          where: (table, { eq }) => eq(table.id, organizationId),
+        db.query.organizations.findFirst({
+          where: { id: organizationId },
         }),
-        db._query.users.findMany({
-          where: (table, { inArray }) =>
-            inArray(table.authUserId, allAuthUserIds),
+        db.query.users.findMany({
+          where: { authUserId: { in: allAuthUserIds } },
         }),
         db.query.accessRoles.findMany({
           where: { id: { in: allRoleIds } },

--- a/services/api/src/routers/platform/admin/listAllDecisionInstances.ts
+++ b/services/api/src/routers/platform/admin/listAllDecisionInstances.ts
@@ -6,22 +6,13 @@ import {
 import { adminDecisionInstanceSchema } from '@op/common/client';
 import { and, count, countDistinct, db, ilike, inArray } from '@op/db/client';
 import { processInstances, proposals } from '@op/db/schema';
+import type { SQL } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { withAuthenticatedPlatformAdmin } from '../../../middlewares/withAuthenticatedPlatformAdmin';
 import withRateLimited from '../../../middlewares/withRateLimited';
 import { commonProcedure, router } from '../../../trpcFactory';
 import { dbFilter } from '../../../utils';
-
-// Drizzle's _query typing widens single `one` relations to `T | T[]` when nested
-// in findMany. See services/api/src/routers/decision/proposals/get.ts:54 for the
-// same workaround.
-const unwrapOne = <T>(value: T | T[] | null | undefined): T | undefined => {
-  if (value == null) {
-    return undefined;
-  }
-  return Array.isArray(value) ? value[0] : value;
-};
 
 const phaseLookupInstanceData = z
   .object({
@@ -101,30 +92,37 @@ export const listAllDecisionInstancesRouter = router({
     )
     .query(async ({ input }) => {
       const { cursor, dir = 'desc', query, limit } = input ?? {};
+      const decodedCursor = cursor ? decodeCursor(cursor) : undefined;
+      const hasSearch = !!(query && query.length >= 2);
 
-      const cursorCondition = cursor
-        ? getGenericCursorCondition({
-            columns: {
-              id: processInstances.id,
-              date: processInstances.createdAt,
-            },
-            cursor: decodeCursor(cursor),
-          })
+      // Used by the count() select below against the raw schema table.
+      const searchCondition = hasSearch
+        ? ilike(processInstances.name, `%${query}%`)
         : undefined;
 
-      const searchCondition =
-        query && query.length >= 2
-          ? ilike(processInstances.name, `%${query}%`)
-          : undefined;
-
-      const whereCondition =
-        searchCondition && cursorCondition
-          ? and(cursorCondition, searchCondition)
-          : searchCondition || cursorCondition;
+      const hasWhere = !!decodedCursor || hasSearch;
 
       const [instances, [totalCountResult]] = await Promise.all([
-        db._query.processInstances.findMany({
-          where: whereCondition,
+        db.query.processInstances.findMany({
+          // RAW receives V2's aliased table; build conditions against it.
+          where: hasWhere
+            ? {
+                RAW: (table) => {
+                  const conds: SQL[] = [];
+                  if (decodedCursor) {
+                    const cursorCond = getGenericCursorCondition({
+                      columns: { id: table.id, date: table.createdAt },
+                      cursor: decodedCursor,
+                    });
+                    if (cursorCond) conds.push(cursorCond);
+                  }
+                  if (hasSearch) {
+                    conds.push(ilike(table.name, `%${query}%`));
+                  }
+                  return conds.length > 1 ? and(...conds)! : conds[0]!;
+                },
+              }
+            : undefined,
           with: {
             steward: {
               columns: { name: true },
@@ -133,10 +131,7 @@ export const listAllDecisionInstancesRouter = router({
               columns: { processSchema: true },
             },
           },
-          orderBy: (_, { asc, desc }) =>
-            dir === 'asc'
-              ? asc(processInstances.createdAt)
-              : desc(processInstances.createdAt),
+          orderBy: { createdAt: dir },
           ...(limit !== undefined && { limit: limit + 1 }),
         }),
         db
@@ -177,8 +172,6 @@ export const listAllDecisionInstancesRouter = router({
 
       return {
         items: items.map((instance) => {
-          const steward = unwrapOne(instance.steward);
-          const process = unwrapOne(instance.process);
           const stats = statsByInstance.get(instance.id);
           return adminDecisionInstanceSchema.parse({
             id: instance.id,
@@ -186,9 +179,9 @@ export const listAllDecisionInstancesRouter = router({
             currentPhase: resolveCurrentPhase({
               currentStateId: instance.currentStateId,
               instanceData: instance.instanceData,
-              processSchema: process?.processSchema,
+              processSchema: instance.process?.processSchema,
             }),
-            stewardName: steward?.name ?? null,
+            stewardName: instance.steward?.name ?? null,
             status: instance.status,
             proposalCount: stats?.proposalCount ?? 0,
             participantCount: stats?.participantCount ?? 0,

--- a/services/api/src/routers/platform/admin/listAllOrganizations.ts
+++ b/services/api/src/routers/platform/admin/listAllOrganizations.ts
@@ -1,6 +1,7 @@
 import { decodeCursor, encodeCursor } from '@op/common';
 import { and, count, db, eq, ilike, inArray, lt, or } from '@op/db/client';
 import { organizations, profiles } from '@op/db/schema';
+import type { SQL } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { adminOrgEncoder } from '../../../encoders';
@@ -61,29 +62,36 @@ export const listAllOrganizationsRouter = router({
             ).map((p) => p.id)
           : null;
 
-      // Build cursor condition for keyset pagination
-      const cursorCondition = cursorValue
-        ? or(
-            lt(organizations.createdAt, cursorValue.date),
-            and(
-              eq(organizations.createdAt, cursorValue.date),
-              lt(organizations.id, cursorValue.id),
-            ),
-          )
-        : undefined;
-
-      const searchCondition = matchingProfileIds
-        ? inArray(organizations.profileId, matchingProfileIds)
-        : undefined;
-
-      const whereCondition =
-        cursorCondition && searchCondition
-          ? and(cursorCondition, searchCondition)
-          : cursorCondition || searchCondition;
+      const hasWhere = !!cursorValue || !!matchingProfileIds;
 
       const [allOrgs, totalCount] = await Promise.all([
-        db._query.organizations.findMany({
-          where: whereCondition,
+        db.query.organizations.findMany({
+          // V2 RAW callback passes the aliased table used inside the generated
+          // SQL. Conditions must be built against that alias, not the schema
+          // ref, otherwise Postgres throws "invalid reference to FROM-clause
+          // entry".
+          where: hasWhere
+            ? {
+                RAW: (table) => {
+                  const conds: SQL[] = [];
+                  if (cursorValue) {
+                    conds.push(
+                      or(
+                        lt(table.createdAt, cursorValue.date),
+                        and(
+                          eq(table.createdAt, cursorValue.date),
+                          lt(table.id, cursorValue.id),
+                        ),
+                      )!,
+                    );
+                  }
+                  if (matchingProfileIds) {
+                    conds.push(inArray(table.profileId, matchingProfileIds));
+                  }
+                  return conds.length > 1 ? and(...conds)! : conds[0]!;
+                },
+              }
+            : undefined,
           with: {
             profile: {
               columns: {
@@ -125,10 +133,7 @@ export const listAllOrganizationsRouter = router({
               },
             },
           },
-          orderBy: (_, { asc, desc }) =>
-            dir === 'asc'
-              ? asc(organizations.createdAt)
-              : desc(organizations.createdAt),
+          orderBy: { createdAt: dir },
           ...(limit !== undefined && { limit: limit + 1 }),
         }),
         db

--- a/services/api/src/routers/platform/admin/listAllUsers.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.ts
@@ -5,6 +5,7 @@ import {
 } from '@op/common';
 import { and, count, db, ilike } from '@op/db/client';
 import { users } from '@op/db/schema';
+import type { SQL } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { userEncoder } from '../../../encoders/';
@@ -34,36 +35,40 @@ export const listAllUsersRouter = router({
     )
     .query(async ({ input }) => {
       const { cursor, dir = 'desc', query, limit } = input ?? {};
+      const decodedCursor = cursor ? decodeCursor(cursor) : undefined;
+      const hasSearch = !!(query && query.length >= 2);
 
-      // Cursor-based pagination using createdAt timestamp
-      // Combines createdAt with id as tiebreaker for users created at the same time
-      const cursorCondition = cursor
-        ? getGenericCursorCondition({
-            columns: {
-              id: users.id,
-              date: users.createdAt,
-            },
-            cursor: decodeCursor(cursor),
-          })
+      // Used by the count() select below; references the raw schema table.
+      const searchCondition = hasSearch
+        ? ilike(users.email, `%${query}%`)
         : undefined;
 
-      // Build search condition if query is provided (separate from cursor for total count)
-      const searchCondition =
-        query && query.length >= 2
-          ? ilike(users.email, `%${query}%`)
-          : undefined;
+      const hasWhere = !!decodedCursor || hasSearch;
 
-      // Combine search with cursor for pagination query
-      const whereCondition =
-        searchCondition && cursorCondition
-          ? and(cursorCondition, searchCondition)
-          : searchCondition || cursorCondition;
-
-      // Parallel database queries for optimal performance
+      // Uses V2 `db.query` (single SQL via LATERAL joins) instead of V1 `db._query`
+      // to avoid fan-out that saturates the Supavisor transaction-mode pool.
+      // The RAW callback receives the aliased table used inside V2's generated
+      // SQL — conditions must be built against that alias, not the schema ref.
       const [allUsers, [totalCountResult]] = await Promise.all([
-        // Fetch users with complete profile, organization, and role data
-        db._query.users.findMany({
-          where: whereCondition,
+        db.query.users.findMany({
+          where: hasWhere
+            ? {
+                RAW: (table) => {
+                  const conds: SQL[] = [];
+                  if (decodedCursor) {
+                    const cursorCond = getGenericCursorCondition({
+                      columns: { id: table.id, date: table.createdAt },
+                      cursor: decodedCursor,
+                    });
+                    if (cursorCond) conds.push(cursorCond);
+                  }
+                  if (hasSearch) {
+                    conds.push(ilike(table.email, `%${query}%`));
+                  }
+                  return conds.length > 1 ? and(...conds)! : conds[0]!;
+                },
+              }
+            : undefined,
           with: {
             authUser: true,
             profile: true,
@@ -92,9 +97,7 @@ export const listAllUsersRouter = router({
               },
             },
           },
-          orderBy: (_, { asc, desc }) =>
-            dir === 'asc' ? asc(users.createdAt) : desc(users.createdAt),
-          // Fetch one extra item to determine if more pages exist (when limit is provided)
+          orderBy: { createdAt: dir },
           ...(limit !== undefined && { limit: limit + 1 }),
         }),
         db.select({ value: count() }).from(users).where(searchCondition),

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -494,6 +494,19 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.users.profileId,
       to: r.profiles.id,
     }),
+    avatarImage: r.one.objectsInStorage({
+      from: r.users.avatarImageId,
+      to: r.objectsInStorage.id,
+    }),
+    organizationUsers: r.many.organizationUsers({
+      from: r.users.authUserId,
+      to: r.organizationUsers.authUserId,
+    }),
+    authUser: r.one.authUsers({
+      from: r.users.authUserId,
+      to: r.authUsers.id,
+      optional: false,
+    }),
   },
 
   /**


### PR DESCRIPTION
Collapses each admin listing into a single LATERAL-join SQL statement (rather than V1's per-relation-level fan-out), so admin pages issue one round-trip per procedure instead of 6-7.