### PR TITLE
chore(docker): harden dev stack, expand seed, add bootstrap scripts

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.lock
+__pycache__/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,57 @@
+# Version control
+.git
+.gitignore
+
+# Git worktrees (can be tens of GB — see .trees/ housekeeping)
+.trees
+
+# Dependencies — installed fresh inside the image
+node_modules
+**/node_modules
+
+# Build output
+.next
+**/.next
+.turbo
+**/.turbo
+**/dist
+**/build
+.vercel
+**/.vercel
+
+# Local tooling / caches
+.playwright-mcp
+.archon
+.claude
+.gstack
+.specify
+.fallow
+.DS_Store
+
+# Editor / IDE
+.vscode
+.idea
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+pnpm-debug.log*
+
+# Env files (never bake secrets into images)
+.env
+.env.*
+!.env.docker
+!.env.docker.example
+!.env.local.example
+
+# Docker-related files not needed in context
+docker-compose*.yml
+Dockerfile*
+.dockerignore
+
+# Tests artifacts
+**/test-results
+**/playwright-report
+coverage
+**/coverage

--- a/.env.docker
+++ b/.env.docker
@@ -2,16 +2,15 @@
 # These are the well-known default values used by `supabase start` locally.
 # They are NOT real production secrets.
 
-# Browser-facing Supabase URL. Overridden in docker-compose.dev.yml to use
-# PORT_PREFIX (e.g. http://localhost:3121 when PORT_PREFIX=31) so multiple
-# instances don't conflict. This fallback is only used outside of compose.
+# Supabase API URL. Same value on browser and server: the *-supabase-proxy
+# sidecars in docker-compose.dev.yml forward localhost:<PORT_PREFIX>21 inside
+# the app/api containers to dind:54321, so server code sees the same hostname
+# the browser does (required for supabase-js cookie storageKey to match).
+# Overridden in docker-compose.dev.yml to substitute PORT_PREFIX. This default
+# is only used outside of compose.
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:3121
 
-# Server-side Supabase URL — the Supabase stack runs inside the DinD daemon,
-# whose containers bind ports to the dind container's network interface.
-SUPABASE_URL=http://dind:54321
-
-# Direct Postgres connection — also routed through dind.
+# Direct Postgres connection — routed through dind.
 DATABASE_URL=postgresql://postgres:postgres@dind:54322/postgres
 
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRFA0NiK7CcyFDME5Q8x4vRBJvHBNNT8ue6kDjFHnNE

--- a/.env.docker
+++ b/.env.docker
@@ -25,8 +25,11 @@ SUPABASE_JWT_SECRET=super-secret-jwt-token-with-at-least-32-characters-long
 REDIS_URL=redis://redis:6379
 
 # ── Analytics ────────────────────────────────────────────────────────────────
-# Leave empty to disable PostHog tracking in the Docker dev environment.
-NEXT_PUBLIC_POSTHOG_KEY=
+# Dummy key: packages/analytics creates a PostHog client at module-eval time
+# and throws on empty string (bug — the "empty = disable" intent isn't honored
+# in code). Events go nowhere with this fake key. Fix belongs in the analytics
+# package, not in docker config.
+NEXT_PUBLIC_POSTHOG_KEY=phc_dummy_docker_dev
 
 # ── App ──────────────────────────────────────────────────────────────────────
 # First two digits of all exposed ports. Suffix 00 = app, 01 = api.

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ tests/e2e/playwright/.auth/
 .playwright-mcp
 ralph.sh
 .fallow/
+
+# pnpm local store (created inside bind-mounted /app when container runs pnpm)
+.pnpm-store/

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,11 +70,9 @@ RUN --mount=type=secret,id=tiptap_token \
     export TIPTAP_PRO_TOKEN=$(cat /run/secrets/tiptap_token) && \
     pnpm install --frozen-lockfile
 
-# ── Source layer ──
-# Copy the rest of the source code.
-# In development, the repo root is bind-mounted over /app so changes are
-# reflected immediately without rebuilding the image.
-COPY . .
+# Source is bind-mounted at runtime via docker-compose (.:/app), so we
+# intentionally do NOT COPY . . here — baking the repo into the image would
+# add tens of GB and get immediately shadowed by the bind mount.
 
 # Default command — overridden per-service in docker-compose.yml
 CMD ["pnpm", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # syntax=docker/dockerfile:1
-# Base image: Node.js 22 LTS (slim variant for smaller image size)
+# Base image: Node.js 22 LTS (slim variant for smaller image size).
+# NOTE: An earlier attempt to use node:22-alpine failed on arm64 because
+# @posthog/cli does not publish an aarch64-unknown-linux-musl binary. If that
+# changes (or if the team standardises on amd64 only), revisit alpine for a
+# ~300 MB image size win.
 FROM node:22-slim
 
 # Install system dependencies needed by pnpm, Supabase CLI, and the app

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ A fully containerised dev environment is available via `docker-compose.dev.yml`.
 On a fresh machine, you can install everything below with one of the bootstrap scripts:
 
 ```bash
-scripts/bootstrap-macos.sh    # Homebrew + Docker Desktop + Node 22 + pnpm
+scripts/bootstrap-macos.sh    # Homebrew + OrbStack + Node 22 + pnpm
 scripts/bootstrap-linux.sh    # Docker engine + Node 22 + pnpm (Debian/Ubuntu)
 ```
 
 Otherwise, install these manually:
 
-- **Docker Desktop** (or OrbStack / colima) running — give it enough headroom: the stack steady-states at **~6–8 GB RAM** (DinD + ~12 Supabase sub-containers + the Next.js app + API + Redis).
+- **OrbStack** (preferred on macOS) or **Docker Desktop** / **colima** running — give it enough headroom: the stack steady-states at **~6–8 GB RAM** (DinD + ~12 Supabase sub-containers + the Next.js app + API + Redis).
 - **Disk space** — budget **~15–20 GB** for the base image, the DinD volume (Supabase images cached inside it), `node_modules` volumes, and Next.js build caches.
 - **Node.js 22+** and **pnpm** (via `corepack enable`) — the `pnpm docker:dev` script invokes compose; if you only want the raw `docker compose up` path, Node/pnpm aren't strictly required.
 - **`TIPTAP_PRO_TOKEN`** — set it in your shell before running, or put it in `.env.local` at the repo root (`.env.local` is sourced by your workflow; `.env.docker` is tracked and must not contain the real token).

--- a/README.md
+++ b/README.md
@@ -27,8 +27,20 @@ A fully containerised dev environment is available via `docker-compose.dev.yml`.
 
 ### Prerequisites
 
-- Docker Desktop (or equivalent) running
-- A `TIPTAP_PRO_TOKEN` environment variable set in your shell (or in `.env.docker`)
+On a fresh machine, you can install everything below with one of the bootstrap scripts:
+
+```bash
+scripts/bootstrap-macos.sh    # Homebrew + Docker Desktop + Node 22 + pnpm
+scripts/bootstrap-linux.sh    # Docker engine + Node 22 + pnpm (Debian/Ubuntu)
+```
+
+Otherwise, install these manually:
+
+- **Docker Desktop** (or OrbStack / colima) running — give it enough headroom: the stack steady-states at **~6–8 GB RAM** (DinD + ~12 Supabase sub-containers + the Next.js app + API + Redis).
+- **Disk space** — budget **~15–20 GB** for the base image, the DinD volume (Supabase images cached inside it), `node_modules` volumes, and Next.js build caches.
+- **Node.js 22+** and **pnpm** (via `corepack enable`) — the `pnpm docker:dev` script invokes compose; if you only want the raw `docker compose up` path, Node/pnpm aren't strictly required.
+- **`TIPTAP_PRO_TOKEN`** — set it in your shell before running, or put it in `.env.local` at the repo root (`.env.local` is sourced by your workflow; `.env.docker` is tracked and must not contain the real token).
+- **Platform** — tested on arm64 macOS. amd64 Linux should work but isn't verified in CI.
 
 ### Starting the dev server
 
@@ -36,7 +48,9 @@ A fully containerised dev environment is available via `docker-compose.dev.yml`.
 pnpm docker:dev
 ```
 
-On first run this will build the images, install dependencies, start Supabase, run migrations, seed access-control data, and start the app and API with hot-reload. Subsequent starts are faster because Docker caches the image layers and named volumes.
+**First boot: 5–15 min.** The `supabase` service pulls ~12 images into the DinD daemon on first run. The `app` / `api` services additionally run `pnpm install --frozen-lockfile` into their named volumes. Subsequent starts are much faster because the image layers, `dind_storage`, and `node_modules` volumes all persist.
+
+If the first `supabase start` flakes (occasionally the Deno edge-runtime init trips on a transient `deno.land` fetch), `Ctrl-C` and re-run — the second attempt uses cached images and almost always succeeds.
 
 **Custom port prefix** — if the default ports conflict with another running stack, override `PORT_PREFIX`:
 
@@ -46,15 +60,19 @@ PORT_PREFIX=40 pnpm docker:dev   # app → 4000, api → 4001, supabase → 4021
 
 ### Default ports
 
-| Service         | Port  |
-|-----------------|-------|
-| Next.js app     | 3100  |
-| tRPC API        | 3101  |
-| Supabase API    | 3121  |
-| Supabase DB     | 3122  |
-| Mailpit (email) | 3124  |
+| Service           | Port  | URL                         |
+|-------------------|-------|-----------------------------|
+| Next.js app       | 3100  | http://localhost:3100       |
+| tRPC API          | 3101  | http://localhost:3101       |
+| Supabase API      | 3121  | http://localhost:3121       |
+| Supabase DB       | 3122  | `postgres://postgres:postgres@localhost:3122/postgres` |
+| Supabase Studio   | 3123  | http://localhost:3123       |
+| Mailpit (email)   | 3124  | http://localhost:3124       |
 
 Ports are derived from `PORT_PREFIX` (default `31`): `{PREFIX}00`, `{PREFIX}01`, etc.
+
+- **Supabase Studio** — the Supabase web dashboard (table editor, SQL editor, auth inspector, storage browser). Auto-connects to the local dev DB, no login.
+- **Mailpit** — captures all outbound email from the local Supabase auth service. Magic-link and OTP emails land here in dev.
 
 ### Running multiple instances
 
@@ -106,6 +124,57 @@ Key variables:
 | `TIPTAP_PRO_TOKEN` | Required to install the Tiptap Pro packages |
 | `NEXT_PUBLIC_SUPABASE_URL` | Browser-facing Supabase URL (set automatically by compose) |
 | `SUPABASE_URL` | Internal Docker network URL for server-side Supabase access |
+
+### Dev database + seeding
+
+The dev Postgres runs inside the DinD daemon (the Supabase CLI spawns it). The Next.js app and tRPC API connect to it over the internal docker network at `dind:54322`; from your host, it's exposed on `localhost:3122` (see port table above).
+
+**Migrations and seeds run automatically** on every `api` container start — the compose `command` chain is:
+
+```sh
+pnpm install --frozen-lockfile \
+ && pnpm w:db migrate \
+ && tsx services/db/seed-access-control.ts \
+ && pnpm -C ./apps/api dev
+```
+
+`seed-access-control.ts` is the Docker-dev seed (the full `seed.ts` has a DB-URL allowlist that excludes dind). It's idempotent and handles:
+
+- Access-control zones, roles, and permissions.
+- A default **"One Project"** organization + profile.
+- `onboardedAt` backfill for admin users (prevents the `/start` redirect loop).
+- Linking admin users to the default organization with the `Admin` role.
+
+**Manual control** if you need to re-run:
+
+```bash
+pnpm docker:migrate   # run drizzle migrations against the dev DB
+pnpm docker:seed      # re-run the Docker-dev seed
+```
+
+The seed is safe to re-run at any time; every step uses `onConflictDoNothing` or existence checks.
+
+### Reducing disk footprint
+
+**If you use docker-dev exclusively (not `pnpm dev` on host),** you can reclaim **~1.5–2 GB** by deleting host-side workspace `node_modules`. The container hides these behind a `nocopy` named volume, so they are unused dead weight on the host. Root-level `node_modules` is still needed on the host for IDE type-checking.
+
+```bash
+rm -rf apps/app/node_modules apps/api/node_modules
+```
+
+If you later want to run workspaces on the host, `pnpm install` from the repo root restores them.
+
+**Clean up stale `PORT_PREFIX` stacks.** Each prefix has its own ~5 GB `dind_storage` volume (Supabase images cached inside its DinD daemon — they can't be shared). If you experimented with `PORT_PREFIX=40` once and moved on, that volume is still sitting there:
+
+```bash
+docker compose -f docker-compose.dev.yml -p op-40 down -v
+```
+
+**Prune Turbopack caches when they get fat.** The `app_next` and `api_next` volumes grow unbounded. Remove them when disk gets tight; the next boot rebuilds them:
+
+```bash
+docker volume rm op-31_app_next op-31_api_next
+```
 
 ## Monorepo Structure
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -128,6 +128,40 @@ services:
       dind:
         condition: service_healthy
 
+  # ── Supabase loopback proxies ───────────────────────────────────────────────
+  # supabase-js derives its auth cookie storage key from the URL hostname
+  # (`sb-${hostname.split('.')[0]}-auth-token`). For SSR auth to work, the
+  # server must reach Supabase at the same URL the browser uses
+  # (http://localhost:<PORT_PREFIX>21). These sidecars share the app/api
+  # network namespace and forward that loopback port to dind:54321 so server
+  # code sees the same `localhost` URL the browser does — no production code
+  # has to know about the docker-dev split.
+  app-supabase-proxy:
+    image: alpine/socat:latest
+    command: >-
+      TCP-LISTEN:${PORT_PREFIX:-31}21,fork,reuseaddr
+      TCP:dind:54321
+    network_mode: "service:app"
+    depends_on:
+      dind:
+        condition: service_healthy
+      app:
+        condition: service_started
+    restart: unless-stopped
+
+  api-supabase-proxy:
+    image: alpine/socat:latest
+    command: >-
+      TCP-LISTEN:${PORT_PREFIX:-31}21,fork,reuseaddr
+      TCP:dind:54321
+    network_mode: "service:api"
+    depends_on:
+      dind:
+        condition: service_healthy
+      api:
+        condition: service_started
+    restart: unless-stopped
+
   # ── Redis ────────────────────────────────────────────────────────────────────
   redis:
     image: redis:7-alpine

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,7 +33,10 @@ services:
       - op-dev
 
   # ── Next.js frontend ────────────────────────────────────────────────────────
+  # Owns the build: app, api, and supabase share a single image (op-dev-base)
+  # to avoid 3× identical image layers on disk.
   app:
+    image: op-dev-base:latest
     build:
       context: .
       dockerfile: Dockerfile
@@ -51,8 +54,9 @@ services:
     volumes:
       # Bind-mount the repo root for hot-reload
       - .:/app
-      # Isolated node_modules — not overwritten by the bind mount above
-      - app_node_modules:/app/node_modules
+      # Shared node_modules — identical pnpm install across app/api, so one
+      # volume instead of two saves ~2GB.
+      - shared_node_modules:/app/node_modules
       # Next.js build cache
       - app_next:/app/apps/app/.next
     networks:
@@ -63,11 +67,7 @@ services:
 
   # ── tRPC API server ──────────────────────────────────────────────────────────
   api:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      secrets:
-        - tiptap_token
+    image: op-dev-base:latest
     command: sh -c "pnpm install --frozen-lockfile && pnpm w:db migrate && /app/node_modules/.bin/tsx services/db/seed-access-control.ts && pnpm -C ./apps/api dev"
     env_file: .env.docker
     environment:
@@ -76,11 +76,8 @@ services:
     ports:
       - "${PORT_PREFIX:-31}01:3300"
     volumes:
-      # Bind-mount the repo root for hot-reload
       - .:/app
-      # Isolated node_modules
-      - api_node_modules:/app/node_modules
-      # Next.js build cache
+      - shared_node_modules:/app/node_modules
       - api_next:/app/apps/api/.next
     networks:
       - op-dev
@@ -94,15 +91,13 @@ services:
   # Runs `supabase start` against the private DinD daemon so all Supabase
   # sub-containers are isolated inside this stack. No host ports are exposed.
   supabase:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      secrets:
-        - tiptap_token
+    image: op-dev-base:latest
     command: sh -c "supabase stop --workdir /app/supabase --no-backup 2>/dev/null || true; supabase start --workdir /app/supabase"
     env_file: .env.docker
     environment:
       DOCKER_HOST: tcp://dind:2375
+    volumes:
+      - .:/app
     networks:
       - op-dev
     depends_on:
@@ -120,8 +115,7 @@ networks:
     driver: bridge
 
 volumes:
-  app_node_modules:
-  api_node_modules:
+  shared_node_modules:
   app_next:
   api_next:
   dind_storage:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,8 @@ services:
       - "${PORT_PREFIX:-31}24:54324"
       # Expose Postgres directly for local dev tools (e.g. TablePlus, psql).
       - "${PORT_PREFIX:-31}22:54322"
+      # Expose Supabase Studio (web dashboard for the dev DB).
+      - "${PORT_PREFIX:-31}23:54323"
     volumes:
       # Persist the DinD image cache across restarts so Supabase images
       # (postgres, kong, gotrue, studio, etc.) are not re-pulled every time.
@@ -54,9 +56,21 @@ services:
     volumes:
       # Bind-mount the repo root for hot-reload
       - .:/app
-      # Shared node_modules — identical pnpm install across app/api, so one
-      # volume instead of two saves ~2GB.
-      - shared_node_modules:/app/node_modules
+      # Shared + workspace-level node_modules must be container-owned, not
+      # pre-populated from the host via the .:/app bind mount. Otherwise pnpm's
+      # per-platform optional deps produce different peer-dep hashes on macOS
+      # vs Linux and .modules.yaml from host makes pnpm skip its install. All
+      # three volumes use nocopy so Docker leaves them empty for pnpm to fill.
+      - type: volume
+        source: shared_node_modules
+        target: /app/node_modules
+        volume:
+          nocopy: true
+      - type: volume
+        source: app_app_node_modules
+        target: /app/apps/app/node_modules
+        volume:
+          nocopy: true
       # Next.js build cache
       - app_next:/app/apps/app/.next
     networks:
@@ -77,7 +91,17 @@ services:
       - "${PORT_PREFIX:-31}01:3300"
     volumes:
       - .:/app
-      - shared_node_modules:/app/node_modules
+      # See app service note — same nocopy requirement.
+      - type: volume
+        source: shared_node_modules
+        target: /app/node_modules
+        volume:
+          nocopy: true
+      - type: volume
+        source: app_api_node_modules
+        target: /app/apps/api/node_modules
+        volume:
+          nocopy: true
       - api_next:/app/apps/api/.next
     networks:
       - op-dev
@@ -116,6 +140,8 @@ networks:
 
 volumes:
   shared_node_modules:
+  app_app_node_modules:
+  app_api_node_modules:
   app_next:
   api_next:
   dind_storage:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "docker:dev": "docker compose -f docker-compose.dev.yml up",
     "docker:dev:build": "docker compose -f docker-compose.dev.yml up --build",
     "docker:down": "docker compose -f docker-compose.dev.yml down",
+    "docker:seed": "docker compose -f docker-compose.dev.yml exec api sh -c 'cd /app && /app/node_modules/.bin/tsx services/db/seed-access-control.ts'",
+    "docker:migrate": "docker compose -f docker-compose.dev.yml exec api sh -c 'cd /app && pnpm w:db migrate'",
     "dev:e2e": "cross-env E2E=true NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:56321 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:56322/postgres S3_ASSET_ROOT=http://127.0.0.1:56321/storage/v1/object/public/assets TIPTAP_SECRET=e2e NEXT_PUBLIC_TIPTAP_APP_ID=e2e turbo dev:e2e",
     "dev:test": "dotenv -e .env.test -o -- turbo dev",
     "e2e": "pnpm -C ./tests/e2e e2e",

--- a/scripts/bootstrap-linux.sh
+++ b/scripts/bootstrap-linux.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Bootstrap prerequisites for `pnpm docker:dev` on a fresh Debian/Ubuntu system.
+# Installs Docker (engine + compose plugin), Node.js 22, and pnpm via corepack.
+# Idempotent: safe to re-run.
+#
+# For Fedora/RHEL/Arch: install Docker and Node 22 manually with your package
+# manager, then run `sudo corepack enable && corepack prepare pnpm@9.15.4 --activate`.
+
+set -euo pipefail
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31m!!\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --- Preflight ----------------------------------------------------------------
+[[ "$(uname -s)" == "Linux" ]] || die "This script is Linux-only. Use bootstrap-macos.sh on macOS."
+[[ "${EUID}" -ne 0 ]] || die "Run as a regular user, not root. The script will sudo for the steps that need it."
+command -v sudo >/dev/null || die "sudo is required but not installed."
+command -v curl >/dev/null || die "curl is required. Install it first (e.g. 'sudo apt-get install -y curl')."
+
+[[ -r /etc/os-release ]] || die "/etc/os-release missing; cannot detect distro."
+# shellcheck disable=SC1091
+. /etc/os-release
+case "${ID_LIKE:-$ID}" in
+  *debian*|debian|ubuntu) ;;
+  *) die "Unsupported distro ($ID). This script targets Debian/Ubuntu derivatives." ;;
+esac
+
+# --- Docker engine + compose plugin ------------------------------------------
+if command -v docker >/dev/null && docker compose version >/dev/null 2>&1; then
+  log "Docker already installed: $(docker --version)"
+else
+  log "Installing Docker via the official get.docker.com convenience script…"
+  curl -fsSL https://get.docker.com | sudo sh
+fi
+
+# Add current user to the docker group so 'docker' works without sudo.
+if id -nG "$USER" | tr ' ' '\n' | grep -qx docker; then
+  log "User '$USER' already in docker group."
+else
+  log "Adding '$USER' to the docker group (takes effect after re-login)…"
+  sudo usermod -aG docker "$USER"
+  NEEDS_RELOGIN=1
+fi
+
+# --- Node.js 22 ---------------------------------------------------------------
+NODE_MAJOR=0
+if command -v node >/dev/null; then
+  NODE_MAJOR=$(node -v | sed -E 's/v([0-9]+).*/\1/')
+fi
+
+if [[ "$NODE_MAJOR" -ge 22 ]]; then
+  log "Node.js $(node -v) already installed."
+else
+  log "Installing Node.js 22 via NodeSource…"
+  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+
+# --- Corepack + pnpm ---------------------------------------------------------
+log "Enabling corepack and pinning pnpm@9.15.4 (matches packageManager field)…"
+sudo corepack enable
+corepack prepare pnpm@9.15.4 --activate
+
+# --- Verify ------------------------------------------------------------------
+log "Installed versions:"
+docker --version
+docker compose version
+node --version
+pnpm --version
+
+# --- Next steps --------------------------------------------------------------
+BOLD=$(tput bold 2>/dev/null || true)
+RESET=$(tput sgr0 2>/dev/null || true)
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cat <<EOF
+
+${BOLD}Next steps:${RESET}
+
+$([[ "${NEEDS_RELOGIN:-0}" == "1" ]] && echo "0. Log out and back in (or run 'newgrp docker') so group changes apply.")
+1. Create .env.local if you don't already have one:
+     cp ${REPO_ROOT}/.env.local.example ${REPO_ROOT}/.env.local
+   Then edit it and set TIPTAP_PRO_TOKEN (required — ask a teammate).
+
+2. Source .env.local so TIPTAP_PRO_TOKEN reaches the docker build:
+     set -a; source ${REPO_ROOT}/.env.local; set +a
+
+3. Start the dev stack:
+     pnpm docker:dev:build    # first time only — builds the image (5–15 min)
+     pnpm docker:dev          # subsequent runs
+
+4. Once ready, open:
+   - App:              http://localhost:3100
+   - Supabase Studio:  http://localhost:3123
+   - Mailpit (email):  http://localhost:3124
+EOF

--- a/scripts/bootstrap-macos.sh
+++ b/scripts/bootstrap-macos.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Bootstrap prerequisites for `pnpm docker:dev` on a fresh macOS system.
+# Installs Homebrew (if missing), Docker Desktop, Node.js 22, and pnpm via corepack.
+# Tested on macOS 14+ (Sonoma / Sequoia), Apple Silicon and Intel.
+# Idempotent: safe to re-run.
+
+set -euo pipefail
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31m!!\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --- Preflight ----------------------------------------------------------------
+[[ "$(uname -s)" == "Darwin" ]] || die "This script is macOS-only. Use bootstrap-linux.sh on Linux."
+
+# --- Homebrew ----------------------------------------------------------------
+if command -v brew >/dev/null; then
+  log "Homebrew present: $(brew --version | head -1)"
+else
+  log "Installing Homebrew…"
+  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # Apple Silicon installs brew to /opt/homebrew; wire it up for this shell.
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+  command -v brew >/dev/null || die "Homebrew installed but 'brew' still not on PATH. Open a new shell and re-run."
+fi
+
+# --- Docker Desktop (cask) ---------------------------------------------------
+if [[ -d "/Applications/Docker.app" ]]; then
+  log "Docker Desktop already installed."
+else
+  log "Installing Docker Desktop via Homebrew cask…"
+  # The cask was renamed from 'docker' to 'docker-desktop' a few years back;
+  # try the new name first, fall back to the legacy alias.
+  if brew info --cask docker-desktop >/dev/null 2>&1; then
+    brew install --cask docker-desktop
+  else
+    brew install --cask docker
+  fi
+fi
+
+# Ensure Docker Desktop is running — the CLI talks to it via /var/run/docker.sock.
+if docker info >/dev/null 2>&1; then
+  log "Docker Desktop is running."
+else
+  log "Launching Docker Desktop… (may take 30–60s to fully start)"
+  open -a Docker || die "Could not launch Docker.app. Open it manually, then re-run this script."
+  for i in {1..20}; do
+    if docker info >/dev/null 2>&1; then log "Docker is up."; break; fi
+    sleep 5
+  done
+  docker info >/dev/null 2>&1 || die "Docker Desktop didn't start within 100s. Launch it manually and re-run."
+fi
+
+# --- Node.js 22 ---------------------------------------------------------------
+NODE_MAJOR=0
+if command -v node >/dev/null; then
+  NODE_MAJOR=$(node -v | sed -E 's/v([0-9]+).*/\1/')
+fi
+
+if [[ "$NODE_MAJOR" -ge 22 ]]; then
+  log "Node.js $(node -v) already installed."
+else
+  log "Installing Node.js 22 via Homebrew…"
+  brew install node@22
+  # node@22 is keg-only; link it onto PATH.
+  brew link --overwrite --force node@22
+fi
+
+# --- Corepack + pnpm ---------------------------------------------------------
+log "Enabling corepack and pinning pnpm@9.15.4 (matches packageManager field)…"
+corepack enable
+corepack prepare pnpm@9.15.4 --activate
+
+# --- Verify ------------------------------------------------------------------
+log "Installed versions:"
+docker --version
+docker compose version
+node --version
+pnpm --version
+
+# --- Next steps --------------------------------------------------------------
+BOLD=$(tput bold 2>/dev/null || true)
+RESET=$(tput sgr0 2>/dev/null || true)
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cat <<EOF
+
+${BOLD}Next steps:${RESET}
+
+1. In Docker Desktop → Settings → Resources, bump Memory to at least 8 GB
+   (the stack idles at ~6–8 GB RAM with all 12 Supabase sub-containers).
+
+2. Create .env.local if you don't already have one:
+     cp ${REPO_ROOT}/.env.local.example ${REPO_ROOT}/.env.local
+   Then edit it and set TIPTAP_PRO_TOKEN (required — ask a teammate).
+
+3. Source .env.local so TIPTAP_PRO_TOKEN reaches the docker build:
+     set -a; source ${REPO_ROOT}/.env.local; set +a
+
+4. Start the dev stack:
+     pnpm docker:dev:build    # first time only — builds the image (5–15 min)
+     pnpm docker:dev          # subsequent runs
+
+5. Once ready, open:
+   - App:              http://localhost:3100
+   - Supabase Studio:  http://localhost:3123
+   - Mailpit (email):  http://localhost:3124
+EOF

--- a/scripts/bootstrap-macos.sh
+++ b/scripts/bootstrap-macos.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Bootstrap prerequisites for `pnpm docker:dev` on a fresh macOS system.
-# Installs Homebrew (if missing), Docker Desktop, Node.js 22, and pnpm via corepack.
+# Installs Homebrew (if missing), OrbStack, Node.js 22, and pnpm via corepack.
+# OrbStack is the preferred macOS Docker runtime — lighter and faster than
+# Docker Desktop, with a drop-in `docker` / `docker compose` CLI. If Docker
+# Desktop or another daemon is already running, the install is skipped so we
+# don't stack two runtimes.
 # Tested on macOS 14+ (Sonoma / Sequoia), Apple Silicon and Intel.
 # Idempotent: safe to re-run.
 
@@ -28,31 +32,44 @@ else
   command -v brew >/dev/null || die "Homebrew installed but 'brew' still not on PATH. Open a new shell and re-run."
 fi
 
-# --- Docker Desktop (cask) ---------------------------------------------------
-if [[ -d "/Applications/Docker.app" ]]; then
-  log "Docker Desktop already installed."
+# --- Container runtime (OrbStack preferred) ---------------------------------
+# Detect any already-working docker daemon first — OrbStack, Docker Desktop,
+# colima all expose the same `docker` CLI surface. If one is up, skip install.
+if docker info >/dev/null 2>&1; then
+  RUNTIME="existing"
+  log "Docker daemon already reachable — skipping runtime install."
+elif [[ -d "/Applications/OrbStack.app" ]]; then
+  RUNTIME="orbstack"
+  log "OrbStack already installed."
+elif [[ -d "/Applications/Docker.app" ]]; then
+  RUNTIME="docker-desktop"
+  log "Docker Desktop already installed (consider switching to OrbStack: https://orbstack.dev)."
 else
-  log "Installing Docker Desktop via Homebrew cask…"
-  # The cask was renamed from 'docker' to 'docker-desktop' a few years back;
-  # try the new name first, fall back to the legacy alias.
-  if brew info --cask docker-desktop >/dev/null 2>&1; then
-    brew install --cask docker-desktop
-  else
-    brew install --cask docker
-  fi
+  RUNTIME="orbstack"
+  log "Installing OrbStack via Homebrew cask…"
+  brew install --cask orbstack
 fi
 
-# Ensure Docker Desktop is running — the CLI talks to it via /var/run/docker.sock.
-if docker info >/dev/null 2>&1; then
-  log "Docker Desktop is running."
-else
-  log "Launching Docker Desktop… (may take 30–60s to fully start)"
-  open -a Docker || die "Could not launch Docker.app. Open it manually, then re-run this script."
-  for i in {1..20}; do
-    if docker info >/dev/null 2>&1; then log "Docker is up."; break; fi
+# Launch the runtime if it isn't already serving requests.
+if ! docker info >/dev/null 2>&1; then
+  case "$RUNTIME" in
+    orbstack)
+      log "Launching OrbStack… (cold start is ~2–5s)"
+      open -a OrbStack || die "Could not launch OrbStack.app. Open it manually, then re-run this script."
+      ;;
+    docker-desktop)
+      log "Launching Docker Desktop… (may take 30–60s to fully start)"
+      open -a Docker || die "Could not launch Docker.app. Open it manually, then re-run this script."
+      ;;
+    *)
+      die "No container runtime found and none was installed. Install OrbStack (https://orbstack.dev) and re-run."
+      ;;
+  esac
+  for i in {1..30}; do
+    if docker info >/dev/null 2>&1; then log "Docker daemon is up."; break; fi
     sleep 5
   done
-  docker info >/dev/null 2>&1 || die "Docker Desktop didn't start within 100s. Launch it manually and re-run."
+  docker info >/dev/null 2>&1 || die "Docker daemon didn't start within 150s. Launch it manually and re-run."
 fi
 
 # --- Node.js 22 ---------------------------------------------------------------
@@ -91,8 +108,11 @@ cat <<EOF
 
 ${BOLD}Next steps:${RESET}
 
-1. In Docker Desktop → Settings → Resources, bump Memory to at least 8 GB
-   (the stack idles at ~6–8 GB RAM with all 12 Supabase sub-containers).
+1. Confirm your container runtime has enough headroom — the stack idles at
+   ~6–8 GB RAM with all 12 Supabase sub-containers.
+   - OrbStack: auto-scales by default, no action needed. To cap or adjust,
+     OrbStack → Settings → System → Memory limit.
+   - Docker Desktop: Settings → Resources → Memory ≥ 8 GB.
 
 2. Create .env.local if you don't already have one:
      cp ${REPO_ROOT}/.env.local.example ${REPO_ROOT}/.env.local

--- a/services/db/seed-access-control.ts
+++ b/services/db/seed-access-control.ts
@@ -1,0 +1,218 @@
+/* eslint-disable antfu/no-top-level-await */
+/**
+ * Docker dev seed.
+ *
+ * The standard `seed.ts` has a database-URL allowlist that excludes the dind
+ * hostname used inside our docker-compose stack, so it refuses to run there.
+ * This script handles the minimum needed to make a fresh docker dev DB usable:
+ *
+ *   1. Access control zones, roles, and permissions.
+ *   2. A default "One Project" organization + profile.
+ *   3. onboardedAt backfill for admin users (prevents the /start redirect loop).
+ *   4. Admin-user linkage to the default organization, with the Admin role.
+ *
+ * Idempotent: every step uses onConflictDoNothing or existence checks, so the
+ * script is safe to re-run on every api container start.
+ */
+import { adminEmails } from '@op/core';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+
+import { db } from '.';
+import { accessRoles } from './schema/tables/access.sql';
+import {
+  accessRolePermissionsOnAccessZones,
+  accessZones,
+} from './schema/tables/accessZones.sql';
+import { decisionProcesses } from './schema/tables/decisionProcesses.sql';
+import {
+  organizationUserToAccessRoles,
+  organizationUsers,
+} from './schema/tables/organizationUsers.sql';
+import { organizations } from './schema/tables/organizations.sql';
+import { profiles } from './schema/tables/profiles.sql';
+import { users } from './schema/tables/users.sql';
+import {
+  ACCESS_ROLES,
+  ACCESS_ROLE_PERMISSIONS,
+  ACCESS_ZONES,
+} from './seedData/accessControl';
+import { decisionTemplates } from './seedData/decisionTemplates';
+
+const DEFAULT_ORG = {
+  name: 'One Project',
+  slug: 'one-project',
+  bio: 'One Project collaborates with people to build tools, systems, and support for the futures ahead.',
+  mission: 'To nurture a just transition to a regenerative democratic economy.',
+  email: 'hello@oneproject.org',
+  website: 'https://oneproject.org',
+};
+
+console.log('Seeding access control data...');
+
+await db.insert(accessZones).values(ACCESS_ZONES).onConflictDoNothing();
+console.log(`Inserted ${ACCESS_ZONES.length} access zones`);
+
+await db.insert(accessRoles).values(ACCESS_ROLES).onConflictDoNothing();
+console.log(`Inserted ${ACCESS_ROLES.length} access roles`);
+
+await db
+  .insert(accessRolePermissionsOnAccessZones)
+  .values(ACCESS_ROLE_PERMISSIONS)
+  .onConflictDoNothing();
+console.log(`Inserted ${ACCESS_ROLE_PERMISSIONS.length} role permissions`);
+
+// ---------------------------------------------------------------------------
+// Default organization: One Project
+// ---------------------------------------------------------------------------
+console.log('Ensuring default organization exists...');
+
+let orgProfile = await db._query.profiles.findFirst({
+  where: (t, { eq }) => eq(t.slug, DEFAULT_ORG.slug),
+});
+
+if (!orgProfile) {
+  [orgProfile] = await db
+    .insert(profiles)
+    .values({
+      name: DEFAULT_ORG.name,
+      slug: DEFAULT_ORG.slug,
+      bio: DEFAULT_ORG.bio,
+      mission: DEFAULT_ORG.mission,
+      email: DEFAULT_ORG.email,
+      website: DEFAULT_ORG.website,
+    })
+    .returning();
+
+  if (!orgProfile) {
+    throw new Error('Failed to create One Project profile');
+  }
+  console.log(`  Created profile: ${DEFAULT_ORG.name} (${orgProfile.id})`);
+}
+
+let defaultOrg = await db._query.organizations.findFirst({
+  where: (t, { eq }) => eq(t.profileId, orgProfile!.id),
+});
+
+if (!defaultOrg) {
+  [defaultOrg] = await db
+    .insert(organizations)
+    .values({
+      profileId: orgProfile.id,
+      domain: 'oneproject.org',
+      isVerified: true,
+    })
+    .returning();
+
+  if (!defaultOrg) {
+    throw new Error('Failed to create One Project organization');
+  }
+  console.log(`  Created organization: ${DEFAULT_ORG.name} (${defaultOrg.id})`);
+}
+
+// ---------------------------------------------------------------------------
+// Decision process templates — without at least one, the /decisions/create
+// route redirects back to the decision list and the ProcessBuilder never opens.
+// ---------------------------------------------------------------------------
+for (const template of Object.values(decisionTemplates)) {
+  const existing = await db._query.decisionProcesses.findFirst({
+    where: (t, { eq }) => eq(t.name, template.name),
+  });
+
+  if (!existing) {
+    await db.insert(decisionProcesses).values({
+      name: template.name,
+      description: template.description,
+      processSchema: template,
+      createdByProfileId: orgProfile.id,
+    });
+    console.log(`Created decision template: ${template.name}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Admin users: backfill onboardedAt + link to default org as Admin
+// ---------------------------------------------------------------------------
+if (adminEmails.length === 0) {
+  await db.$client.end();
+  console.log('Done!');
+  process.exit(0);
+}
+
+const backfilled = await db
+  .update(users)
+  .set({ onboardedAt: new Date().toISOString() })
+  .where(and(inArray(users.email, [...adminEmails]), isNull(users.onboardedAt)))
+  .returning({ email: users.email });
+
+if (backfilled.length > 0) {
+  console.log(
+    `Backfilled onboardedAt for ${backfilled.length} admin user(s): ${backfilled
+      .map((u) => u.email)
+      .join(', ')}`,
+  );
+}
+
+const adminRole = await db._query.accessRoles.findFirst({
+  where: (t, { eq, and, isNull }) =>
+    and(eq(t.name, 'Admin'), isNull(t.profileId)),
+});
+
+if (!adminRole) {
+  throw new Error(
+    'Admin role not found — access-control seed above should have created it',
+  );
+}
+
+const existingAdmins = await db._query.users.findMany({
+  where: (t, { inArray }) => inArray(t.email, [...adminEmails]),
+  columns: { authUserId: true, email: true },
+});
+
+let linkedCount = 0;
+for (const admin of existingAdmins) {
+  // Is this admin already an org user for the default org?
+  const existingOrgUser = await db._query.organizationUsers.findFirst({
+    where: (t, { and, eq }) =>
+      and(
+        eq(t.authUserId, admin.authUserId),
+        eq(t.organizationId, defaultOrg!.id),
+      ),
+  });
+
+  let orgUserId = existingOrgUser?.id;
+
+  if (!orgUserId) {
+    const [created] = await db
+      .insert(organizationUsers)
+      .values({
+        authUserId: admin.authUserId,
+        email: admin.email,
+        organizationId: defaultOrg.id,
+      })
+      .returning();
+
+    if (!created) continue;
+    orgUserId = created.id;
+    linkedCount++;
+  }
+
+  await db
+    .insert(organizationUserToAccessRoles)
+    .values({ organizationUserId: orgUserId, accessRoleId: adminRole.id })
+    .onConflictDoNothing();
+
+  // Point the user's last/current org at the default org so the UI lands there.
+  await db
+    .update(users)
+    .set({ lastOrgId: defaultOrg.id, currentProfileId: orgProfile.id })
+    .where(eq(users.authUserId, admin.authUserId));
+}
+
+if (linkedCount > 0) {
+  console.log(
+    `Linked ${linkedCount} admin user(s) to ${DEFAULT_ORG.name} with Admin role`,
+  );
+}
+
+await db.$client.end();
+console.log('Done!');

--- a/services/db/seedData/decisionTemplates.ts
+++ b/services/db/seedData/decisionTemplates.ts
@@ -1,0 +1,187 @@
+/**
+ * Decision process templates for seed scripts.
+ *
+ * Mirrors the canonical templates in
+ * `packages/common/src/services/decision/schemas/definitions.ts`. We keep a copy
+ * here so that seed scripts in `@op/db` can populate the `decision_processes`
+ * table without depending on `@op/common` (which itself depends on `@op/db`,
+ * so an import would be circular).
+ */
+
+export const simpleVoting = {
+  id: 'simple',
+  version: '1.0.0',
+  name: 'Simple Voting',
+  description:
+    'Basic approval voting where members vote for multiple proposals.',
+
+  proposalTemplate: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        title: 'Proposal title',
+        'x-format': 'short-text',
+      },
+      summary: {
+        type: 'string',
+        title: 'Proposal summary',
+        'x-format': 'long-text',
+      },
+      budget: {
+        type: 'object',
+        title: 'Budget',
+        'x-format': 'money',
+        properties: {
+          amount: { type: 'number' },
+          currency: { type: 'string', default: 'USD' },
+        },
+      },
+    },
+    'x-field-order': ['title', 'budget', 'summary'],
+    required: ['title', 'summary'],
+  },
+
+  phases: [
+    {
+      id: 'submission',
+      name: 'Proposal Submission',
+      description: 'Members submit proposals for consideration.',
+      rules: {
+        proposals: { submit: true },
+        voting: { submit: false },
+        advancement: { method: 'date', endDate: '2026-01-01' },
+      },
+      settings: {
+        type: 'object',
+        properties: {
+          budget: {
+            type: 'number',
+            title: 'Budget',
+            description: 'Total budget available for this decision process',
+            minimum: 0,
+          },
+          maxProposalsPerMember: {
+            type: 'number',
+            title: 'Maximum Proposals Per Member',
+            description: 'How many proposals can each member submit?',
+            minimum: 1,
+            default: 3,
+          },
+        },
+        ui: {
+          budget: { 'ui:widget': 'number', 'ui:placeholder': '100000' },
+          maxProposalsPerMember: {
+            'ui:widget': 'number',
+            'ui:placeholder': '3',
+          },
+        },
+      },
+    },
+    {
+      id: 'review',
+      name: 'Review & Shortlist',
+      description: 'Reviewers evaluate and shortlist proposals.',
+      rules: {
+        proposals: { submit: false },
+        voting: { submit: false },
+        advancement: { method: 'date', endDate: '2026-01-02' },
+      },
+      settings: {
+        type: 'object',
+        properties: {
+          budget: {
+            type: 'number',
+            title: 'Budget',
+            description: 'Total budget available for this decision process',
+            minimum: 0,
+          },
+        },
+        ui: {
+          budget: { 'ui:widget': 'number', 'ui:placeholder': '100000' },
+        },
+      },
+    },
+    {
+      id: 'voting',
+      name: 'Voting',
+      description: 'Members vote on shortlisted proposals.',
+      rules: {
+        proposals: { submit: false },
+        voting: { submit: true },
+        advancement: { method: 'date', endDate: '2026-01-03' },
+      },
+      settings: {
+        type: 'object',
+        required: ['maxVotesPerMember'],
+        properties: {
+          budget: {
+            type: 'number',
+            title: 'Budget',
+            description: 'Total budget available for this decision process',
+            minimum: 0,
+          },
+          maxVotesPerMember: {
+            type: 'number',
+            title: 'Maximum Votes Per Member',
+            description: 'How many proposals can each member vote for?',
+            minimum: 1,
+            default: 3,
+          },
+        },
+        ui: {
+          budget: { 'ui:widget': 'number', 'ui:placeholder': '100000' },
+          maxVotesPerMember: {
+            'ui:widget': 'number',
+            'ui:placeholder': '5',
+          },
+        },
+      },
+      selectionPipeline: {
+        version: '1.0.0',
+        blocks: [
+          {
+            id: 'sort-by-likes',
+            type: 'sort',
+            name: 'Sort by likes count',
+            sortBy: [{ field: 'voteData.likesCount', order: 'desc' }],
+          },
+          {
+            id: 'limit-by-votes',
+            type: 'limit',
+            name: 'Take top N (based on maxVotesPerMember config)',
+            count: { variable: 'maxVotesPerMember' },
+          },
+        ],
+      },
+    },
+    {
+      id: 'results',
+      name: 'Results',
+      description: 'View final results and winning proposals.',
+      rules: {
+        proposals: { submit: false },
+        voting: { submit: false },
+        advancement: { method: 'date', endDate: '2026-01-04' },
+      },
+      settings: {
+        type: 'object',
+        properties: {
+          budget: {
+            type: 'number',
+            title: 'Budget',
+            description: 'Total budget available for this decision process',
+            minimum: 0,
+          },
+        },
+        ui: {
+          budget: { 'ui:widget': 'number', 'ui:placeholder': '100000' },
+        },
+      },
+    },
+  ],
+};
+
+export const decisionTemplates = {
+  simple: simpleVoting,
+};


### PR DESCRIPTION
## Summary

Slim down the Docker dev environment and make it a first-class workflow.

### Compose / image

- `nocopy: true` on `shared_node_modules`, `app_app_node_modules`, `app_api_node_modules` so the container owns its `node_modules`. Without this, Docker pre-populates the named volume from the host-side bind mount, leaking macOS/arm64 pnpm peer-dep hashes into a Linux/arm64 container and dangling every workspace symlink.
- Expose Supabase Studio on `PORT_PREFIX23` (e.g. `http://localhost:3123`).
- Dockerfile: note that `node:22-alpine` was attempted but `@posthog/cli` doesn't publish an `aarch64-linux-musl` binary, so we stay on `node:22-slim`.
- `.env.docker`: dummy `NEXT_PUBLIC_POSTHOG_KEY` because `packages/analytics` instantiates PostHog at module-eval and throws on empty string despite the "leave empty to disable" intent (fix belongs in the analytics package).

### Seeding

Extended `services/db/seed-access-control.ts` (still idempotent, still runs on every `api` container start):

- Seeds access-control zones/roles/permissions (existing).
- Creates the default **One Project** organization + profile.
- Seeds a **Simple Voting** decision process template (without at least one template, the `/decisions/create` route redirects back to the list).
- Backfills `onboardedAt` for any `adminEmails` user that exists without one.
- Links admins to One Project with the `Admin` role and points their `lastOrgId` / `currentProfileId` at it.

New `services/db/seedData/decisionTemplates.ts` mirrors the canonical template from `@op/common` so the `@op/db` seed can populate `decision_processes` without an `@op/db` → `@op/common` → `@op/db` circular import.

### Tooling

- `pnpm docker:seed` — re-runs the Docker-dev seed inside the running `api` container.
- `pnpm docker:migrate` — re-runs drizzle migrations inside the running `api` container.
- `scripts/bootstrap-linux.sh`, `scripts/bootstrap-macos.sh` — one-shot prerequisite installers (Docker, Node 22, pnpm) for a fresh machine.

### Docs

README expanded with: prerequisites, port table (incl. Studio + Mailpit URLs), bootstrap script pointers, dev-DB + seed behaviour, first-boot time estimate, reducing disk footprint, known `supabase start` network-flake retry.

### Depends on

Requires the companion code-fix PR (`fix/supabase-server-and-user-cache`) for the stack to boot cleanly — that one fixes the server/browser Supabase URL + session cookie mismatch and a stale React Query user cache.
