### PR TITLE
chore(tests): migrate api test suites to drizzle v2 query api

### DIFF
--- a/services/api/src/routers/decision/instances/advancePhase.test.ts
+++ b/services/api/src/routers/decision/instances/advancePhase.test.ts
@@ -4,7 +4,6 @@ import {
   ProcessStatus,
   decisionTransitionProposals,
   processInstances,
-  stateTransitionHistory,
 } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
@@ -102,8 +101,8 @@ describe.concurrent('advancePhase', () => {
 
     expect(reloaded!.currentStateId).toBe('final');
 
-    const history = await db._query.stateTransitionHistory.findFirst({
-      where: eq(stateTransitionHistory.processInstanceId, loaded.dbInstance.id),
+    const history = await db.query.stateTransitionHistory.findFirst({
+      where: { processInstanceId: loaded.dbInstance.id },
     });
     expect(history).toBeDefined();
     expect(history!.fromStateId).toBe('initial');
@@ -170,8 +169,8 @@ describe.concurrent('advancePhase', () => {
       transitionData: { source: 'cron', batch: 42 },
     });
 
-    const history = await db._query.stateTransitionHistory.findFirst({
-      where: eq(stateTransitionHistory.processInstanceId, loaded.dbInstance.id),
+    const history = await db.query.stateTransitionHistory.findFirst({
+      where: { processInstanceId: loaded.dbInstance.id },
     });
     expect(history!.transitionData).toEqual({ source: 'cron', batch: 42 });
   });

--- a/services/api/src/routers/decision/instances/createInstanceFromTemplate.test.ts
+++ b/services/api/src/routers/decision/instances/createInstanceFromTemplate.test.ts
@@ -4,12 +4,7 @@ import {
   simpleVoting,
 } from '@op/common';
 import { db, eq } from '@op/db/client';
-import {
-  decisionProcessTransitions,
-  decisionProcesses,
-  processInstances,
-  users,
-} from '@op/db/schema';
+import { decisionProcesses, users } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
@@ -100,8 +95,8 @@ describe.concurrent('createInstanceFromTemplate', () => {
     expect(result.processInstance.status).toBe('draft');
 
     // Verify instance data has phases
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, result.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: result.processInstance.id },
     });
 
     expect(instance).toBeDefined();
@@ -137,11 +132,8 @@ describe.concurrent('createInstanceFromTemplate', () => {
 
     // Verify NO transitions were created for DRAFT instance
     // Transitions are only created when the instance is published
-    const transitions = await db._query.decisionProcessTransitions.findMany({
-      where: eq(
-        decisionProcessTransitions.processInstanceId,
-        result.processInstance.id,
-      ),
+    const transitions = await db.query.decisionProcessTransitions.findMany({
+      where: { processInstanceId: result.processInstance.id },
     });
 
     expect(transitions.length).toBe(0);
@@ -260,8 +252,8 @@ describe.concurrent('createInstanceFromTemplate', () => {
 
     testData.trackProfileForCleanup(result.id);
 
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, result.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: result.processInstance.id },
     });
 
     const instanceData = instance!.instanceData as DecisionInstanceData;

--- a/services/api/src/routers/decision/instances/duplicateInstance.test.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.test.ts
@@ -1,12 +1,7 @@
 import { type DecisionInstanceData, simpleVoting } from '@op/common';
 import type { DecisionSchemaDefinition } from '@op/common';
 import { db, eq } from '@op/db/client';
-import {
-  accessRoles,
-  decisionProcesses,
-  processInstances,
-  users,
-} from '@op/db/schema';
+import { decisionProcesses, users } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
@@ -123,8 +118,8 @@ describe.concurrent('duplicateInstance', () => {
     expect(duplicate.processInstance.id).not.toBe(source.processInstance.id);
 
     // Verify instanceData was copied
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, duplicate.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
     });
     const instanceData = instance!.instanceData as DecisionInstanceData;
 
@@ -173,12 +168,12 @@ describe.concurrent('duplicateInstance', () => {
     testData.trackProfileForCleanup(duplicate.id);
 
     // Verify new roles were created (not shared with source)
-    const duplicateRoles = await db._query.accessRoles.findMany({
-      where: eq(accessRoles.profileId, duplicate.id),
+    const duplicateRoles = await db.query.accessRoles.findMany({
+      where: { profileId: duplicate.id },
     });
 
-    const sourceRoles = await db._query.accessRoles.findMany({
-      where: eq(accessRoles.profileId, source.id),
+    const sourceRoles = await db.query.accessRoles.findMany({
+      where: { profileId: source.id },
     });
 
     const duplicateRoleNames = duplicateRoles.map((r) => r.name).sort();
@@ -223,8 +218,8 @@ describe.concurrent('duplicateInstance', () => {
 
     testData.trackProfileForCleanup(duplicate.id);
 
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, duplicate.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
     });
     const instanceData = instance!.instanceData as DecisionInstanceData;
 
@@ -254,8 +249,8 @@ describe.concurrent('duplicateInstance', () => {
 
     testData.trackProfileForCleanup(duplicate.id);
 
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, duplicate.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
     });
     const instanceData = instance!.instanceData as DecisionInstanceData;
 
@@ -304,8 +299,8 @@ describe.concurrent('duplicateInstance', () => {
 
     testData.trackProfileForCleanup(duplicate.id);
 
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, duplicate.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
     });
     const instanceData = instance!.instanceData as DecisionInstanceData;
 
@@ -336,8 +331,8 @@ describe.concurrent('duplicateInstance', () => {
 
     testData.trackProfileForCleanup(duplicate.id);
 
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, duplicate.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
     });
 
     expect(instance!.description).toBe('Test description to copy');
@@ -366,8 +361,8 @@ describe.concurrent('duplicateInstance', () => {
     expect(duplicate.name).toBe(duplicateName);
 
     // processInstance.name should also match
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, duplicate.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
     });
     expect(instance!.name).toBe(duplicateName);
   });
@@ -398,8 +393,8 @@ describe.concurrent('duplicateInstance', () => {
 
     testData.trackProfileForCleanup(duplicate.id);
 
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, duplicate.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
     });
 
     expect(instance!.stewardProfileId).toBe(userRecord!.profileId);
@@ -424,11 +419,11 @@ describe.concurrent('duplicateInstance', () => {
     testData.trackProfileForCleanup(duplicate.id);
 
     const [sourceInstance, duplicateInstance] = await Promise.all([
-      db._query.processInstances.findFirst({
-        where: eq(processInstances.id, source.processInstance.id),
+      db.query.processInstances.findFirst({
+        where: { id: source.processInstance.id },
       }),
-      db._query.processInstances.findFirst({
-        where: eq(processInstances.id, duplicate.processInstance.id),
+      db.query.processInstances.findFirst({
+        where: { id: duplicate.processInstance.id },
       }),
     ]);
 
@@ -492,8 +487,8 @@ describe.concurrent('duplicateInstance', () => {
 
     testData.trackProfileForCleanup(duplicate.id);
 
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, duplicate.processInstance.id),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
     });
     const instanceData = instance!.instanceData as DecisionInstanceData;
 

--- a/services/api/src/routers/decision/instances/transitionMonitor.test.ts
+++ b/services/api/src/routers/decision/instances/transitionMonitor.test.ts
@@ -157,8 +157,8 @@ async function createPublishedInstanceWithDueTransitions(
     // Make all transitions due by setting scheduledDate to past times.
     // Stagger them to preserve correct ordering (monitor orders by scheduledDate).
     const fetchedTransitions =
-      await db._query.decisionProcessTransitions.findMany({
-        where: eq(decisionProcessTransitions.processInstanceId, instanceId),
+      await db.query.decisionProcessTransitions.findMany({
+        where: { processInstanceId: instanceId },
       });
 
     // Sort by the original scheduled date to maintain creation order
@@ -180,8 +180,8 @@ async function createPublishedInstanceWithDueTransitions(
   }
 
   // Get the transitions
-  const transitions = await db._query.decisionProcessTransitions.findMany({
-    where: eq(decisionProcessTransitions.processInstanceId, instanceId),
+  const transitions = await db.query.decisionProcessTransitions.findMany({
+    where: { processInstanceId: instanceId },
   });
 
   return {
@@ -208,8 +208,8 @@ describe('processDecisionsTransitions', () => {
     );
 
     // Capture updatedAt before processing
-    const beforeInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instanceId),
+    const beforeInstance = await db.query.processInstances.findFirst({
+      where: { id: instanceId },
     });
     const updatedAtBefore = beforeInstance!.updatedAt;
 
@@ -222,8 +222,8 @@ describe('processDecisionsTransitions', () => {
     expect(result.failed).toBe(0);
 
     // Verify instance state was updated
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instanceId),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: instanceId },
     });
 
     expect(instance).toBeDefined();
@@ -240,8 +240,8 @@ describe('processDecisionsTransitions', () => {
 
     // Verify transitions are marked completed
     const completedTransitions =
-      await db._query.decisionProcessTransitions.findMany({
-        where: eq(decisionProcessTransitions.processInstanceId, instanceId),
+      await db.query.decisionProcessTransitions.findMany({
+        where: { processInstanceId: instanceId },
       });
 
     for (const transition of completedTransitions) {
@@ -307,11 +307,8 @@ describe('processDecisionsTransitions', () => {
     await processDecisionsTransitions();
 
     // The transition should NOT have been processed because the instance is DRAFT
-    const transitions = await db._query.decisionProcessTransitions.findMany({
-      where: eq(
-        decisionProcessTransitions.processInstanceId,
-        result.processInstance.id,
-      ),
+    const transitions = await db.query.decisionProcessTransitions.findMany({
+      where: { processInstanceId: result.processInstance.id },
     });
 
     for (const transition of transitions) {
@@ -341,8 +338,8 @@ describe('processDecisionsTransitions', () => {
 
     // Future transitions should not be processed
     const refreshedTransitions =
-      await db._query.decisionProcessTransitions.findMany({
-        where: eq(decisionProcessTransitions.processInstanceId, instanceId),
+      await db.query.decisionProcessTransitions.findMany({
+        where: { processInstanceId: instanceId },
       });
 
     for (const transition of refreshedTransitions) {
@@ -350,8 +347,8 @@ describe('processDecisionsTransitions', () => {
     }
 
     // Instance should still be in the initial state
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instanceId),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: instanceId },
     });
 
     expect(instance!.currentStateId).toBe('submission');
@@ -376,16 +373,16 @@ describe('processDecisionsTransitions', () => {
     expect(result.failed).toBe(0);
 
     // Instance should be at the final state (results)
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instanceId),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: instanceId },
     });
 
     expect(instance!.currentStateId).toBe('results');
 
     // All transitions should be completed
     const completedTransitions =
-      await db._query.decisionProcessTransitions.findMany({
-        where: eq(decisionProcessTransitions.processInstanceId, instanceId),
+      await db.query.decisionProcessTransitions.findMany({
+        where: { processInstanceId: instanceId },
       });
 
     expect(completedTransitions.every((t) => t.completedAt !== null)).toBe(
@@ -423,11 +420,9 @@ describe('processDecisionsTransitions', () => {
     const result = await processDecisionsTransitions();
 
     // The first transition should not be re-processed
-    const refreshedFirst = await db._query.decisionProcessTransitions.findFirst(
-      {
-        where: eq(decisionProcessTransitions.id, firstTransition!.id),
-      },
-    );
+    const refreshedFirst = await db.query.decisionProcessTransitions.findFirst({
+      where: { id: firstTransition!.id },
+    });
 
     // The first transition should still have a completedAt set (it was pre-completed)
     expect(refreshedFirst!.completedAt).not.toBeNull();
@@ -466,8 +461,8 @@ describe('processDecisionsTransitions', () => {
       .where(eq(proposals.id, proposal.id));
 
     // Make only the first transition (submission → review) due
-    const transitions = await db._query.decisionProcessTransitions.findMany({
-      where: eq(decisionProcessTransitions.processInstanceId, instanceId),
+    const transitions = await db.query.decisionProcessTransitions.findMany({
+      where: { processInstanceId: instanceId },
     });
     transitions.sort(
       (a, b) =>
@@ -579,8 +574,8 @@ describe('processDecisionsTransitions', () => {
     });
 
     // Make its transitions due with staggered past dates
-    const badTransitions = await db._query.decisionProcessTransitions.findMany({
-      where: eq(decisionProcessTransitions.processInstanceId, badInstanceId),
+    const badTransitions = await db.query.decisionProcessTransitions.findMany({
+      where: { processInstanceId: badInstanceId },
     });
 
     badTransitions.sort(
@@ -615,8 +610,8 @@ describe('processDecisionsTransitions', () => {
     expect(monitorResult.errors.length).toBeGreaterThanOrEqual(1);
 
     // Verify the good instance was processed
-    const goodInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, goodInstanceId),
+    const goodInstance = await db.query.processInstances.findFirst({
+      where: { id: goodInstanceId },
     });
     expect(goodInstance!.currentStateId).toBe('results');
   });
@@ -647,15 +642,15 @@ describe('processDecisionsTransitions', () => {
     expect(result2.failed).toBe(0);
 
     // Instance should be at the final state
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instanceId),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: instanceId },
     });
     expect(instance!.currentStateId).toBe('results');
 
     // Each transition should have completedAt set exactly once
     const completedTransitions =
-      await db._query.decisionProcessTransitions.findMany({
-        where: eq(decisionProcessTransitions.processInstanceId, instanceId),
+      await db.query.decisionProcessTransitions.findMany({
+        where: { processInstanceId: instanceId },
       });
 
     expect(completedTransitions).toHaveLength(3);

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -1,6 +1,6 @@
 import { type DecisionInstanceData } from '@op/common';
-import { db, eq } from '@op/db/client';
-import { ProcessStatus, processInstances } from '@op/db/schema';
+import { db } from '@op/db/client';
+import { ProcessStatus } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
@@ -226,8 +226,8 @@ describe.concurrent('updateDecisionInstance', () => {
     });
 
     // Verify the config was updated in the database
-    const dbInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const dbInstance = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
 
     const instanceData = dbInstance!.instanceData as DecisionInstanceData;
@@ -251,8 +251,8 @@ describe.concurrent('updateDecisionInstance', () => {
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     // Get current phases to know which phase IDs exist
-    const dbInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const dbInstance = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     const currentData = dbInstance!.instanceData as DecisionInstanceData;
     const firstPhaseId = currentData.phases[0]?.phaseId;
@@ -272,8 +272,8 @@ describe.concurrent('updateDecisionInstance', () => {
     });
 
     // Verify the settings were updated
-    const updatedInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const updatedInstance = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
 
     const instanceData = updatedInstance!.instanceData as DecisionInstanceData;
@@ -318,8 +318,8 @@ describe.concurrent('updateDecisionInstance', () => {
     expect(result.processInstance.status).toBe(ProcessStatus.PUBLISHED);
 
     // Verify config in database
-    const dbInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const dbInstance = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
 
     const instanceData = dbInstance!.instanceData as DecisionInstanceData;
@@ -450,8 +450,8 @@ describe.concurrent('updateDecisionInstance', () => {
     });
 
     // Get current phases
-    const dbInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const dbInstance = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     const currentData = dbInstance!.instanceData as DecisionInstanceData;
 
@@ -470,8 +470,8 @@ describe.concurrent('updateDecisionInstance', () => {
     expect(result.processInstance.id).toBe(instance.instance.id);
 
     // Verify phases were updated in the database
-    const updatedInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const updatedInstance = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     const updatedData = updatedInstance!.instanceData as DecisionInstanceData;
     for (const phase of updatedData.phases) {
@@ -758,8 +758,8 @@ describe.concurrent('updateDecisionInstance', () => {
     });
 
     // Get current phases
-    const dbInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const dbInstance = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     const currentData = dbInstance!.instanceData as DecisionInstanceData;
     const phaseIds = currentData.phases.map((p) => p.phaseId);
@@ -776,8 +776,8 @@ describe.concurrent('updateDecisionInstance', () => {
     expect(result.processInstance.id).toBe(instance.instance.id);
 
     // Verify names were updated
-    const updatedInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const updatedInstance = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     const updatedData = updatedInstance!.instanceData as DecisionInstanceData;
     for (const phase of updatedData.phases) {
@@ -814,8 +814,8 @@ describe.concurrent('updateDecisionInstance', () => {
     expect(result.processInstance.id).toBe(instance.instance.id);
 
     // Verify the steward was updated in the database
-    const dbInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const dbInstance = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
 
     expect(dbInstance!.stewardProfileId).toBe(newStewardId);

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -789,8 +789,8 @@ describe.concurrent('getProposal', () => {
 
     // 2. Remove proposalTemplate from instanceData so resolveProposalTemplate
     //    falls back to process_schema (matching how legacy instances work).
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
 
     if (!instanceRecord) {
@@ -885,8 +885,8 @@ describe.concurrent('getProposal', () => {
       .set({ processSchema: horizonProcessSchema })
       .where(eq(decisionProcesses.id, setup.process.id));
 
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
 
     if (!instanceRecord) {
@@ -973,8 +973,8 @@ describe.concurrent('getProposal', () => {
       .set({ processSchema: simpleProcessSchema })
       .where(eq(decisionProcesses.id, setup.process.id));
 
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
 
     if (!instanceRecord) {

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -898,8 +898,8 @@ describe.concurrent('listProposals', () => {
       .where(eq(decisionProcesses.id, setup.process.id));
 
     // 2. Strip proposalTemplate from instanceData so resolver falls back to process_schema
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
 
     if (!instanceRecord) {

--- a/services/api/src/routers/organization/deleteOrganization.test.ts
+++ b/services/api/src/routers/organization/deleteOrganization.test.ts
@@ -1,6 +1,4 @@
 import { db } from '@op/db/client';
-import { profiles } from '@op/db/schema';
-import { eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 import { organizationRouter } from '.';
@@ -39,8 +37,8 @@ describe.concurrent('organization.deleteOrganization', () => {
     expect(result.deletedId).toBe(organizationProfile.id);
 
     // Verify the organization was actually deleted from the database
-    const deletedProfile = await db._query.profiles.findFirst({
-      where: eq(profiles.id, organizationProfile.id),
+    const deletedProfile = await db.query.profiles.findFirst({
+      where: { id: organizationProfile.id },
     });
     expect(deletedProfile).toBeUndefined();
   });
@@ -90,8 +88,8 @@ describe.concurrent('organization.deleteOrganization', () => {
     });
 
     // Verify the organization was NOT deleted
-    const existingProfile = await db._query.profiles.findFirst({
-      where: eq(profiles.id, organizationProfile.id),
+    const existingProfile = await db.query.profiles.findFirst({
+      where: { id: organizationProfile.id },
     });
     expect(existingProfile).toBeDefined();
     expect(existingProfile?.id).toBe(organizationProfile.id);
@@ -127,8 +125,8 @@ describe.concurrent('organization.deleteOrganization', () => {
     ).rejects.toThrow();
 
     // Verify the organization was NOT deleted
-    const existingProfile = await db._query.profiles.findFirst({
-      where: eq(profiles.id, organizationProfile.id),
+    const existingProfile = await db.query.profiles.findFirst({
+      where: { id: organizationProfile.id },
     });
     expect(existingProfile).toBeDefined();
     expect(existingProfile?.id).toBe(organizationProfile.id);

--- a/services/api/src/routers/organization/listUsers.test.ts
+++ b/services/api/src/routers/organization/listUsers.test.ts
@@ -54,12 +54,11 @@ describe.concurrent('organization.listUsers', () => {
     });
 
     // Get the organization user
-    const orgUser = await db._query.organizationUsers.findFirst({
-      where: (table, { eq, and }) =>
-        and(
-          eq(table.organizationId, organization.id),
-          eq(table.authUserId, adminUser.authUserId),
-        ),
+    const orgUser = await db.query.organizationUsers.findFirst({
+      where: {
+        organizationId: organization.id,
+        authUserId: adminUser.authUserId,
+      },
     });
 
     if (!orgUser) {

--- a/services/api/src/routers/platform/admin/addUsersToOrganization.test.ts
+++ b/services/api/src/routers/platform/admin/addUsersToOrganization.test.ts
@@ -390,12 +390,11 @@ describe.concurrent('platform.admin.addUsersToOrganization', () => {
       ]);
 
       // Verify organizationUser record and role assignment
-      const orgUser = await db._query.organizationUsers.findFirst({
-        where: (table, { and, eq }) =>
-          and(
-            eq(table.authUserId, userToAdd.authUserId),
-            eq(table.organizationId, targetOrg.id),
-          ),
+      const orgUser = await db.query.organizationUsers.findFirst({
+        where: {
+          authUserId: userToAdd.authUserId,
+          organizationId: targetOrg.id,
+        },
         with: {
           roles: {
             with: {
@@ -463,12 +462,11 @@ describe.concurrent('platform.admin.addUsersToOrganization', () => {
       expect(result[0]?.authUserId).toBe(userToAdd.authUserId);
 
       // Verify role is assigned
-      const orgUser = await db._query.organizationUsers.findFirst({
-        where: (table, { and, eq }) =>
-          and(
-            eq(table.authUserId, userToAdd.authUserId),
-            eq(table.organizationId, targetOrg.id),
-          ),
+      const orgUser = await db.query.organizationUsers.findFirst({
+        where: {
+          authUserId: userToAdd.authUserId,
+          organizationId: targetOrg.id,
+        },
         with: {
           roles: {
             with: {
@@ -541,8 +539,8 @@ describe.concurrent('platform.admin.addUsersToOrganization', () => {
       expect(result).toHaveLength(3);
 
       // Verify each user has correct roles
-      const orgUsers = await db._query.organizationUsers.findMany({
-        where: (table, { eq }) => eq(table.organizationId, targetOrg.id),
+      const orgUsers = await db.query.organizationUsers.findMany({
+        where: { organizationId: targetOrg.id },
         with: {
           roles: {
             with: {

--- a/services/api/src/routers/profile/createRole.test.ts
+++ b/services/api/src/routers/profile/createRole.test.ts
@@ -58,17 +58,16 @@ describe.concurrent('profile.createRole', () => {
     });
 
     // Verify permissions were actually persisted in database
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     const permission =
-      await db._query.accessRolePermissionsOnAccessZones.findFirst({
-        where: (table, { eq, and }) =>
-          and(
-            eq(table.accessRoleId, result.id),
-            eq(table.accessZoneId, decisionsZone!.id),
-          ),
+      await db.query.accessRolePermissionsOnAccessZones.findFirst({
+        where: {
+          accessRoleId: result.id,
+          accessZoneId: decisionsZone!.id,
+        },
       });
 
     expect(permission).toBeDefined();

--- a/services/api/src/routers/profile/decisionRoles.test.ts
+++ b/services/api/src/routers/profile/decisionRoles.test.ts
@@ -179,17 +179,16 @@ describe.concurrent('profile.decisionRoles', () => {
       },
     });
 
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     const permission =
-      await db._query.accessRolePermissionsOnAccessZones.findFirst({
-        where: (table, { eq, and }) =>
-          and(
-            eq(table.accessRoleId, customRole!.id),
-            eq(table.accessZoneId, decisionsZone!.id),
-          ),
+      await db.query.accessRolePermissionsOnAccessZones.findFirst({
+        where: {
+          accessRoleId: customRole!.id,
+          accessZoneId: decisionsZone!.id,
+        },
       });
 
     expect(permission).toBeDefined();
@@ -375,8 +374,8 @@ describe.concurrent('profile.decisionRoles', () => {
     });
 
     // Verify only one permission entry exists (not duplicated)
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     const permissions = await db
@@ -438,17 +437,16 @@ describe.concurrent('profile.decisionRoles', () => {
       },
     });
 
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     const permission =
-      await db._query.accessRolePermissionsOnAccessZones.findFirst({
-        where: (table, { eq, and }) =>
-          and(
-            eq(table.accessRoleId, customRole!.id),
-            eq(table.accessZoneId, decisionsZone!.id),
-          ),
+      await db.query.accessRolePermissionsOnAccessZones.findFirst({
+        where: {
+          accessRoleId: customRole!.id,
+          accessZoneId: decisionsZone!.id,
+        },
       });
 
     expect(permission).toBeDefined();

--- a/services/api/src/routers/profile/invite.test.ts
+++ b/services/api/src/routers/profile/invite.test.ts
@@ -62,25 +62,23 @@ describe.concurrent('Profile Invite Integration Tests', () => {
     expect(result.details.failed).toHaveLength(0);
 
     // Verify profile_invites record was created
-    const invite = await db._query.profileInvites.findFirst({
-      where: (table, { eq, and, isNull }) =>
-        and(
-          eq(table.profileId, profile.id),
-          eq(table.email, standaloneUser.email.toLowerCase()),
-          isNull(table.acceptedOn),
-        ),
+    const invite = await db.query.profileInvites.findFirst({
+      where: {
+        profileId: profile.id,
+        email: standaloneUser.email.toLowerCase(),
+        acceptedOn: { isNull: true },
+      },
     });
 
     expect(invite).toBeDefined();
     expect(invite?.accessRoleId).toBe(ROLES.MEMBER.id);
 
     // Verify user was NOT added to profileUsers directly
-    const profileUser = await db._query.profileUsers.findFirst({
-      where: (table, { eq, and }) =>
-        and(
-          eq(table.profileId, profile.id),
-          eq(table.email, standaloneUser.email.toLowerCase()),
-        ),
+    const profileUser = await db.query.profileUsers.findFirst({
+      where: {
+        profileId: profile.id,
+        email: standaloneUser.email.toLowerCase(),
+      },
     });
 
     expect(profileUser).toBeUndefined();
@@ -141,20 +139,19 @@ describe.concurrent('Profile Invite Integration Tests', () => {
     expect(result.details.successful).toContain(newEmail.toLowerCase());
 
     // Verify the allowList entry was created (for new users who need to sign up)
-    const allowListEntry = await db._query.allowList.findFirst({
-      where: (table, { eq }) => eq(table.email, newEmail.toLowerCase()),
+    const allowListEntry = await db.query.allowList.findFirst({
+      where: { email: newEmail.toLowerCase() },
     });
 
     expect(allowListEntry).toBeDefined();
 
     // Verify profile_invites record was created
-    const invite = await db._query.profileInvites.findFirst({
-      where: (table, { eq, and, isNull }) =>
-        and(
-          eq(table.profileId, profile.id),
-          eq(table.email, newEmail.toLowerCase()),
-          isNull(table.acceptedOn),
-        ),
+    const invite = await db.query.profileInvites.findFirst({
+      where: {
+        profileId: profile.id,
+        email: newEmail.toLowerCase(),
+        acceptedOn: { isNull: true },
+      },
     });
 
     expect(invite).toBeDefined();
@@ -220,9 +217,8 @@ describe.concurrent('Profile Invite Integration Tests', () => {
     });
 
     // Verify existing user was NOT added to allowList (they already have an account)
-    const allowListEntry = await db._query.allowList.findFirst({
-      where: (table, { eq }) =>
-        eq(table.email, standaloneUser.email.toLowerCase()),
+    const allowListEntry = await db.query.allowList.findFirst({
+      where: { email: standaloneUser.email.toLowerCase() },
     });
 
     expect(allowListEntry).toBeUndefined();
@@ -310,22 +306,20 @@ describe.concurrent('Profile Invite Integration Tests', () => {
     expect(result.details.successful).toContain(user2.email.toLowerCase());
 
     // Verify each invite was created with the correct role
-    const invite1 = await db._query.profileInvites.findFirst({
-      where: (table, { eq, and, isNull }) =>
-        and(
-          eq(table.profileId, profile.id),
-          eq(table.email, user1.email.toLowerCase()),
-          isNull(table.acceptedOn),
-        ),
+    const invite1 = await db.query.profileInvites.findFirst({
+      where: {
+        profileId: profile.id,
+        email: user1.email.toLowerCase(),
+        acceptedOn: { isNull: true },
+      },
     });
 
-    const invite2 = await db._query.profileInvites.findFirst({
-      where: (table, { eq, and, isNull }) =>
-        and(
-          eq(table.profileId, profile.id),
-          eq(table.email, user2.email.toLowerCase()),
-          isNull(table.acceptedOn),
-        ),
+    const invite2 = await db.query.profileInvites.findFirst({
+      where: {
+        profileId: profile.id,
+        email: user2.email.toLowerCase(),
+        acceptedOn: { isNull: true },
+      },
     });
 
     expect(invite1).toBeDefined();
@@ -468,8 +462,8 @@ describe.concurrent('Profile Invite Integration Tests', () => {
     });
 
     // Set INVITE_MEMBERS decision bit on the decisions zone for this role
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     if (!decisionsZone) {
@@ -608,8 +602,8 @@ describe.concurrent('Profile Invite Integration Tests', () => {
     expect(result.details.successful).toContain(newEmail.toLowerCase());
 
     // Verify only one allowList entry exists (no duplicate)
-    const allowListEntries = await db._query.allowList.findMany({
-      where: (table, { eq }) => eq(table.email, newEmail.toLowerCase()),
+    const allowListEntries = await db.query.allowList.findMany({
+      where: { email: newEmail.toLowerCase() },
     });
 
     expect(allowListEntries).toHaveLength(1);
@@ -689,19 +683,18 @@ describe.concurrent('Profile Invite Integration Tests', () => {
     vi.mocked(event.send).mockResolvedValue({ ids: ['mock-event-id'] });
 
     // Verify NO profileInvites record was created (transaction rolled back)
-    const invite = await db._query.profileInvites.findFirst({
-      where: (table, { eq, and }) =>
-        and(
-          eq(table.profileId, profile.id),
-          eq(table.email, newEmail.toLowerCase()),
-        ),
+    const invite = await db.query.profileInvites.findFirst({
+      where: {
+        profileId: profile.id,
+        email: newEmail.toLowerCase(),
+      },
     });
 
     expect(invite).toBeUndefined();
 
     // Verify NO allowList entry was created (transaction rolled back)
-    const allowListEntry = await db._query.allowList.findFirst({
-      where: (table, { eq }) => eq(table.email, newEmail.toLowerCase()),
+    const allowListEntry = await db.query.allowList.findFirst({
+      where: { email: newEmail.toLowerCase() },
     });
 
     expect(allowListEntry).toBeUndefined();
@@ -736,13 +729,12 @@ describe.concurrent('Profile Invite Integration Tests', () => {
     ).rejects.toThrow();
 
     // Verify no invite was created (transaction rolled back)
-    const invites = await db._query.profileInvites.findMany({
-      where: (table, { eq, and, isNull }) =>
-        and(
-          eq(table.profileId, profile.id),
-          eq(table.email, standaloneUser.email.toLowerCase()),
-          isNull(table.acceptedOn),
-        ),
+    const invites = await db.query.profileInvites.findMany({
+      where: {
+        profileId: profile.id,
+        email: standaloneUser.email.toLowerCase(),
+        acceptedOn: { isNull: true },
+      },
     });
 
     expect(invites).toHaveLength(0);
@@ -777,21 +769,20 @@ describe.concurrent('Profile Invite Integration Tests', () => {
     expect(result.details.successful).not.toContain(mixedCaseEmail);
 
     // Verify the database record uses lowercase
-    const invite = await db._query.profileInvites.findFirst({
-      where: (table, { eq, and, isNull }) =>
-        and(
-          eq(table.profileId, profile.id),
-          eq(table.email, normalizedEmail),
-          isNull(table.acceptedOn),
-        ),
+    const invite = await db.query.profileInvites.findFirst({
+      where: {
+        profileId: profile.id,
+        email: normalizedEmail,
+        acceptedOn: { isNull: true },
+      },
     });
 
     expect(invite).toBeDefined();
     expect(invite?.email).toBe(normalizedEmail);
 
     // Verify allowList also uses lowercase
-    const allowListEntry = await db._query.allowList.findFirst({
-      where: (table, { eq }) => eq(table.email, normalizedEmail),
+    const allowListEntry = await db.query.allowList.findFirst({
+      where: { email: normalizedEmail },
     });
 
     expect(allowListEntry).toBeDefined();

--- a/services/api/src/routers/profile/requests/deleteJoinRequest.test.ts
+++ b/services/api/src/routers/profile/requests/deleteJoinRequest.test.ts
@@ -1,6 +1,5 @@
 import { db } from '@op/db/client';
-import { JoinProfileRequestStatus, joinProfileRequests } from '@op/db/schema';
-import { eq } from 'drizzle-orm';
+import { JoinProfileRequestStatus } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { TestJoinProfileRequestDataManager } from '../../../test/helpers/TestJoinProfileRequestDataManager';
@@ -50,8 +49,8 @@ describe.concurrent('profile.deleteJoinRequest', () => {
     expect(result.status).toBe(JoinProfileRequestStatus.PENDING);
 
     // Verify the request was deleted from database
-    const deletedRequest = await db._query.joinProfileRequests.findFirst({
-      where: eq(joinProfileRequests.id, joinRequest.id),
+    const deletedRequest = await db.query.joinProfileRequests.findFirst({
+      where: { id: joinRequest.id },
     });
 
     expect(deletedRequest).toBeUndefined();

--- a/services/api/src/routers/profile/requests/updateJoinRequest.test.ts
+++ b/services/api/src/routers/profile/requests/updateJoinRequest.test.ts
@@ -1,6 +1,5 @@
 import { db } from '@op/db/client';
-import { JoinProfileRequestStatus, organizations } from '@op/db/schema';
-import { eq } from 'drizzle-orm';
+import { JoinProfileRequestStatus } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { TestJoinProfileRequestDataManager } from '../../../test/helpers/TestJoinProfileRequestDataManager';
@@ -191,8 +190,8 @@ describe.concurrent('profile.updateJoinRequest', () => {
     });
 
     // Get the organization for the target profile
-    const targetOrg = await db._query.organizations.findFirst({
-      where: eq(organizations.profileId, targetProfile.id),
+    const targetOrg = await db.query.organizations.findFirst({
+      where: { profileId: targetProfile.id },
     });
 
     const { session } = await createIsolatedSession(targetAdmin.email);
@@ -206,12 +205,11 @@ describe.concurrent('profile.updateJoinRequest', () => {
     expect(result.status).toBe(JoinProfileRequestStatus.APPROVED);
 
     // Verify that the organization membership was created
-    const membership = await db._query.organizationUsers.findFirst({
-      where: (table, { and, eq }) =>
-        and(
-          eq(table.authUserId, requester.authUserId),
-          eq(table.organizationId, targetOrg!.id),
-        ),
+    const membership = await db.query.organizationUsers.findFirst({
+      where: {
+        authUserId: requester.authUserId,
+        organizationId: targetOrg!.id,
+      },
     });
 
     expect(membership).toBeDefined();
@@ -234,8 +232,8 @@ describe.concurrent('profile.updateJoinRequest', () => {
       await testData.createOrganization();
 
     // Get the organization for the target profile
-    const targetOrg = await db._query.organizations.findFirst({
-      where: eq(organizations.profileId, targetProfile.id),
+    const targetOrg = await db.query.organizations.findFirst({
+      where: { profileId: targetProfile.id },
     });
 
     // Insert a pending join request using the manager
@@ -254,12 +252,11 @@ describe.concurrent('profile.updateJoinRequest', () => {
     });
 
     // Verify the membership was created with the Member role
-    const membership = await db._query.organizationUsers.findFirst({
-      where: (table, { and, eq }) =>
-        and(
-          eq(table.authUserId, requester.authUserId),
-          eq(table.organizationId, targetOrg!.id),
-        ),
+    const membership = await db.query.organizationUsers.findFirst({
+      where: {
+        authUserId: requester.authUserId,
+        organizationId: targetOrg!.id,
+      },
       with: {
         roles: {
           with: {
@@ -292,8 +289,8 @@ describe.concurrent('profile.updateJoinRequest', () => {
       await testData.createOrganization();
 
     // Get the organization for the target profile
-    const targetOrg = await db._query.organizations.findFirst({
-      where: eq(organizations.profileId, targetProfile.id),
+    const targetOrg = await db.query.organizations.findFirst({
+      where: { profileId: targetProfile.id },
     });
 
     // Insert a pending join request using the manager
@@ -314,12 +311,11 @@ describe.concurrent('profile.updateJoinRequest', () => {
     expect(result.status).toBe(JoinProfileRequestStatus.REJECTED);
 
     // Verify that no organization membership was created
-    const membership = await db._query.organizationUsers.findFirst({
-      where: (table, { and, eq }) =>
-        and(
-          eq(table.authUserId, requester.authUserId),
-          eq(table.organizationId, targetOrg!.id),
-        ),
+    const membership = await db.query.organizationUsers.findFirst({
+      where: {
+        authUserId: requester.authUserId,
+        organizationId: targetOrg!.id,
+      },
     });
 
     expect(membership).toBeUndefined();
@@ -340,8 +336,8 @@ describe.concurrent('profile.updateJoinRequest', () => {
       await testData.createOrganization();
 
     // Get the organization for the target profile
-    const targetOrg = await db._query.organizations.findFirst({
-      where: eq(organizations.profileId, targetProfile.id),
+    const targetOrg = await db.query.organizations.findFirst({
+      where: { profileId: targetProfile.id },
     });
 
     // First, create an existing membership for the requester in the target organization
@@ -369,12 +365,11 @@ describe.concurrent('profile.updateJoinRequest', () => {
     expect(result.status).toBe(JoinProfileRequestStatus.APPROVED);
 
     // Verify there's still only one membership (the existing one)
-    const memberships = await db._query.organizationUsers.findMany({
-      where: (table, { and, eq }) =>
-        and(
-          eq(table.authUserId, requester.authUserId),
-          eq(table.organizationId, targetOrg!.id),
-        ),
+    const memberships = await db.query.organizationUsers.findMany({
+      where: {
+        authUserId: requester.authUserId,
+        organizationId: targetOrg!.id,
+      },
     });
 
     expect(memberships).toHaveLength(1);

--- a/services/api/src/routers/profile/updateRolePermission.test.ts
+++ b/services/api/src/routers/profile/updateRolePermission.test.ts
@@ -60,17 +60,16 @@ describe.concurrent('profile.updateRolePermission', () => {
     expect(result.name).toBe(customRole!.name);
 
     // Verify permissions were updated in database
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     const permission =
-      await db._query.accessRolePermissionsOnAccessZones.findFirst({
-        where: (table, { eq, and }) =>
-          and(
-            eq(table.accessRoleId, customRole!.id),
-            eq(table.accessZoneId, decisionsZone!.id),
-          ),
+      await db.query.accessRolePermissionsOnAccessZones.findFirst({
+        where: {
+          accessRoleId: customRole!.id,
+          accessZoneId: decisionsZone!.id,
+        },
       });
 
     expect(permission).toBeDefined();
@@ -136,8 +135,8 @@ describe.concurrent('profile.updateRolePermission', () => {
     });
 
     // Verify only one permission entry exists
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     const permissions = await db
@@ -209,8 +208,8 @@ describe.concurrent('profile.updateRolePermission', () => {
     );
 
     // Verify no permissions were created (role should have no permissions)
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     const permissions = await db
@@ -321,17 +320,16 @@ describe.concurrent('profile.updateRolePermission', () => {
       },
     });
 
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     const finalPerm =
-      await db._query.accessRolePermissionsOnAccessZones.findFirst({
-        where: (table, { eq, and }) =>
-          and(
-            eq(table.accessRoleId, customRole!.id),
-            eq(table.accessZoneId, decisionsZone!.id),
-          ),
+      await db.query.accessRolePermissionsOnAccessZones.findFirst({
+        where: {
+          accessRoleId: customRole!.id,
+          accessZoneId: decisionsZone!.id,
+        },
       });
 
     expect(finalPerm).toBeDefined();
@@ -396,8 +394,8 @@ describe.concurrent('profile.updateRolePermission', () => {
     );
 
     // Verify no permissions were created for the role
-    const decisionsZone = await db._query.accessZones.findFirst({
-      where: (table, { eq }) => eq(table.name, 'decisions'),
+    const decisionsZone = await db.query.accessZones.findFirst({
+      where: { name: 'decisions' },
     });
 
     const permissions = await db

--- a/services/api/src/routers/profile/users/removeUser.test.ts
+++ b/services/api/src/routers/profile/users/removeUser.test.ts
@@ -47,8 +47,8 @@ describe.concurrent('profile.users.removeUser', () => {
     });
 
     // Verify user was removed
-    const removedUser = await db._query.profileUsers.findFirst({
-      where: eq(profileUsers.id, memberUser.profileUserId),
+    const removedUser = await db.query.profileUsers.findFirst({
+      where: { id: memberUser.profileUserId },
     });
 
     expect(removedUser).toBeUndefined();

--- a/services/api/src/routers/profile/users/updateUserRoles.test.ts
+++ b/services/api/src/routers/profile/users/updateUserRoles.test.ts
@@ -1,7 +1,5 @@
 import { db } from '@op/db/client';
-import { profileUsers } from '@op/db/schema';
 import { ROLES } from '@op/db/seedData/accessControl';
-import { eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 import { TestProfileUserDataManager } from '../../../test/helpers/TestProfileUserDataManager';
@@ -38,8 +36,8 @@ describe.concurrent('profile.users.updateUserRoles', () => {
     expect(result).toBeDefined();
 
     // Verify role was updated
-    const updatedUser = await db._query.profileUsers.findFirst({
-      where: eq(profileUsers.id, memberUser.profileUserId),
+    const updatedUser = await db.query.profileUsers.findFirst({
+      where: { id: memberUser.profileUserId },
       with: {
         roles: {
           with: {
@@ -71,8 +69,8 @@ describe.concurrent('profile.users.updateUserRoles', () => {
     const caller = createCaller(await createTestContextWithSession(session));
 
     // Verify member starts with one role (MEMBER)
-    const initialUser = await db._query.profileUsers.findFirst({
-      where: eq(profileUsers.id, memberUser.profileUserId),
+    const initialUser = await db.query.profileUsers.findFirst({
+      where: { id: memberUser.profileUserId },
       with: {
         roles: {
           with: {
@@ -92,8 +90,8 @@ describe.concurrent('profile.users.updateUserRoles', () => {
     });
 
     // Verify user now has both roles
-    const userWithBothRoles = await db._query.profileUsers.findFirst({
-      where: eq(profileUsers.id, memberUser.profileUserId),
+    const userWithBothRoles = await db.query.profileUsers.findFirst({
+      where: { id: memberUser.profileUserId },
       with: {
         roles: {
           with: {
@@ -115,8 +113,8 @@ describe.concurrent('profile.users.updateUserRoles', () => {
     });
 
     // Verify user now has only ADMIN role
-    const userWithAdminOnly = await db._query.profileUsers.findFirst({
-      where: eq(profileUsers.id, memberUser.profileUserId),
+    const userWithAdminOnly = await db.query.profileUsers.findFirst({
+      where: { id: memberUser.profileUserId },
       with: {
         roles: {
           with: {

--- a/services/api/src/routers/translation/translateDecision.test.ts
+++ b/services/api/src/routers/translation/translateDecision.test.ts
@@ -60,8 +60,8 @@ describe('translation.translateDecision', () => {
     }
 
     // Patch instanceData to add translatable phase content
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     if (!instanceRecord) {
       throw new Error('Instance record not found');
@@ -129,8 +129,8 @@ describe('translation.translateDecision', () => {
       throw new Error('No instance created');
     }
 
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     if (!instanceRecord) {
       throw new Error('Instance record not found');
@@ -200,8 +200,8 @@ describe('translation.translateDecision', () => {
     }
 
     // Remove phase names from instanceData to produce an instance with no translatable content
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     if (!instanceRecord) {
       throw new Error('Instance record not found');
@@ -256,8 +256,8 @@ describe('translation.translateDecision', () => {
       throw new Error('No instance created');
     }
 
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     if (!instanceRecord) {
       throw new Error('Instance record not found');
@@ -389,8 +389,8 @@ describe('translation.translateDecision', () => {
     }
 
     // Patch instance with some content so we get a non-empty result
-    const instanceRecord = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, instance.instance.id),
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
     });
     if (!instanceRecord) {
       throw new Error('Instance record not found');


### PR DESCRIPTION
Move 19 router test files off db._query so we can keep retiring v1 relations once the application code follows.