### PR TITLE
refactor(common): migrate organization + assert services to drizzle v2 query api

### DIFF
--- a/packages/common/src/services/assert/assertOrganization.ts
+++ b/packages/common/src/services/assert/assertOrganization.ts
@@ -16,8 +16,8 @@ export async function assertOrganization(
   error: Error = new NotFoundError('Organization', id),
   db: DbClient = defaultDb,
 ): Promise<Organization> {
-  const organization = await db._query.organizations.findFirst({
-    where: (table, { eq }) => eq(table.id, id),
+  const organization = await db.query.organizations.findFirst({
+    where: { id },
   });
 
   if (!organization) {
@@ -40,8 +40,8 @@ export async function assertOrganizationByProfileId(
   error: Error = new NotFoundError('Organization', profileId),
   db: DbClient = defaultDb,
 ): Promise<Organization> {
-  const organization = await db._query.organizations.findFirst({
-    where: (table, { eq }) => eq(table.profileId, profileId),
+  const organization = await db.query.organizations.findFirst({
+    where: { profileId },
   });
 
   if (!organization) {

--- a/packages/common/src/services/assert/assertProfile.ts
+++ b/packages/common/src/services/assert/assertProfile.ts
@@ -16,8 +16,8 @@ export async function assertProfile(
   error: Error = new NotFoundError('Profile', id),
   db: DbClient = defaultDb,
 ): Promise<Profile> {
-  const profile = await db._query.profiles.findFirst({
-    where: (table, { eq }) => eq(table.id, id),
+  const profile = await db.query.profiles.findFirst({
+    where: { id },
   });
 
   if (!profile) {
@@ -40,8 +40,8 @@ export async function assertProfileBySlug(
   error: Error = new NotFoundError('Profile', slug),
   db: DbClient = defaultDb,
 ): Promise<Profile> {
-  const profile = await db._query.profiles.findFirst({
-    where: (table, { eq }) => eq(table.slug, slug),
+  const profile = await db.query.profiles.findFirst({
+    where: { slug },
   });
 
   if (!profile) {

--- a/packages/common/src/services/assert/assertProfileUser.ts
+++ b/packages/common/src/services/assert/assertProfileUser.ts
@@ -11,8 +11,8 @@ export async function assertProfileUser(
   error: Error = new NotFoundError('User not found', id),
   db: DbClient = defaultDb,
 ): Promise<ProfileUser> {
-  const profileUser = await db._query.profileUsers.findFirst({
-    where: (table, { eq }) => eq(table.id, id),
+  const profileUser = await db.query.profileUsers.findFirst({
+    where: { id },
   });
 
   if (!profileUser) {

--- a/packages/common/src/services/organization/deleteOrganization.ts
+++ b/packages/common/src/services/organization/deleteOrganization.ts
@@ -15,8 +15,8 @@ export async function deleteOrganization({
   user: User;
 }) {
   // First, find the organization by its profile ID to get the organization ID
-  const organization = await db._query.organizations.findFirst({
-    where: (table, { eq }) => eq(table.profileId, organizationProfileId),
+  const organization = await db.query.organizations.findFirst({
+    where: { profileId: organizationProfileId },
   });
 
   if (!organization) {

--- a/packages/common/src/services/organization/deleteOrganizationUser.ts
+++ b/packages/common/src/services/organization/deleteOrganizationUser.ts
@@ -28,12 +28,11 @@ export async function deleteOrganizationUser({
   assertAccess({ admin: permission.UPDATE }, orgUser?.roles || []);
 
   // Check if the organization user to delete exists
-  const targetOrgUser = await db._query.organizationUsers.findFirst({
-    where: (table, { eq, and }) =>
-      and(
-        eq(table.id, organizationUserId),
-        eq(table.organizationId, organizationId),
-      ),
+  const targetOrgUser = await db.query.organizationUsers.findFirst({
+    where: {
+      id: organizationUserId,
+      organizationId,
+    },
   });
 
   if (!targetOrgUser) {

--- a/packages/common/src/services/organization/getOrganization.ts
+++ b/packages/common/src/services/organization/getOrganization.ts
@@ -1,5 +1,5 @@
-import { db, eq, inArray } from '@op/db/client';
-import { profiles, taxonomyTerms } from '@op/db/schema';
+import { db, eq } from '@op/db/client';
+import { profiles } from '@op/db/schema';
 
 import { NotFoundError } from '../../utils';
 
@@ -51,7 +51,11 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
           },
         },
       },
-      strategies: true,
+      strategies: {
+        with: {
+          term: true,
+        },
+      },
     },
   });
 
@@ -59,17 +63,9 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
     throw new NotFoundError('Could not find organization');
   }
 
-  const termIds = org.strategies.map((record) => record.taxonomyTermId);
-  const terms = termIds.length
-    ? await db
-        .select()
-        .from(taxonomyTerms)
-        .where(inArray(taxonomyTerms.id, termIds))
-    : [];
-
   return {
     ...org,
     whereWeWork: org.whereWeWork.map((record) => record.location),
-    strategies: terms,
+    strategies: org.strategies.map((record) => record.term),
   };
 };

--- a/packages/common/src/services/organization/getOrganization.ts
+++ b/packages/common/src/services/organization/getOrganization.ts
@@ -1,5 +1,5 @@
-import { db, eq, sql } from '@op/db/client';
-import { locations, profiles } from '@op/db/schema';
+import { db, eq } from '@op/db/client';
+import { profiles } from '@op/db/schema';
 
 import { NotFoundError } from '../../utils';
 
@@ -20,8 +20,8 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
     throw new NotFoundError('Could not find organization');
   }
 
-  const org = await db._query.organizations.findFirst({
-    where: (table, { eq }) => eq(table.profileId, profileId),
+  const org = await db.query.organizations.findFirst({
+    where: { profileId },
     with: {
       projects: true,
       links: true,
@@ -35,8 +35,10 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
         with: {
           location: {
             extras: {
-              x: sql<number>`ST_X(${locations.location})`.as('x'),
-              y: sql<number>`ST_Y(${locations.location})`.as('y'),
+              x: (table, { sql }) =>
+                sql<number>`ST_X(${table.location})`.as('x'),
+              y: (table, { sql }) =>
+                sql<number>`ST_Y(${table.location})`.as('y'),
             },
             columns: {
               id: true,
@@ -45,7 +47,6 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
               countryCode: true,
               countryName: true,
               metadata: true,
-              latLng: false,
             },
           },
         },
@@ -63,8 +64,9 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
     throw new NotFoundError('Could not find organization');
   }
 
-  org.whereWeWork = org.whereWeWork.map((record) => record.location);
-  org.strategies = org.strategies.map((record) => record.term);
-
-  return org;
+  return {
+    ...org,
+    whereWeWork: org.whereWeWork.map((record) => record.location),
+    strategies: org.strategies.map((record) => record.term),
+  };
 };

--- a/packages/common/src/services/organization/getOrganization.ts
+++ b/packages/common/src/services/organization/getOrganization.ts
@@ -1,5 +1,5 @@
-import { db, eq } from '@op/db/client';
-import { profiles } from '@op/db/schema';
+import { db, eq, inArray } from '@op/db/client';
+import { profiles, taxonomyTerms } from '@op/db/schema';
 
 import { NotFoundError } from '../../utils';
 
@@ -51,12 +51,7 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
           },
         },
       },
-      // TODO: CONVERT TO TERMS
-      strategies: {
-        with: {
-          term: true,
-        },
-      },
+      strategies: true,
     },
   });
 
@@ -64,9 +59,17 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
     throw new NotFoundError('Could not find organization');
   }
 
+  const termIds = org.strategies.map((record) => record.taxonomyTermId);
+  const terms = termIds.length
+    ? await db
+        .select()
+        .from(taxonomyTerms)
+        .where(inArray(taxonomyTerms.id, termIds))
+    : [];
+
   return {
     ...org,
     whereWeWork: org.whereWeWork.map((record) => record.location),
-    strategies: org.strategies.map((record) => record.term),
+    strategies: terms,
   };
 };

--- a/packages/common/src/services/organization/getOrganizationUsers.ts
+++ b/packages/common/src/services/organization/getOrganizationUsers.ts
@@ -28,8 +28,8 @@ export const getOrganizationUsers = async ({
   assertAccess({ admin: permission.READ }, orgUser?.roles || []);
 
   // Fetch all users in the organization with their roles and avatar images
-  const organizationUsers = await db._query.organizationUsers.findMany({
-    where: (table, { eq }) => eq(table.organizationId, organization.id),
+  const organizationUsers = await db.query.organizationUsers.findMany({
+    where: { organizationId: organization.id },
     with: {
       roles: {
         with: {

--- a/packages/common/src/services/organization/getOrganizationsByProfile.ts
+++ b/packages/common/src/services/organization/getOrganizationsByProfile.ts
@@ -1,12 +1,12 @@
-import { db, sql } from '@op/db/client';
-import { locations } from '@op/db/schema';
+import { db } from '@op/db/client';
 
 export const getOrganizationsByProfile = async (profileId: string) => {
   // Find all users who have access to this profile
   // Either as their personal profile or as their current profile
-  const usersWithProfile = await db._query.users.findMany({
-    where: (table, { eq, or }) =>
-      or(eq(table.profileId, profileId), eq(table.currentProfileId, profileId)),
+  const usersWithProfile = await db.query.users.findMany({
+    where: {
+      OR: [{ profileId }, { currentProfileId: profileId }],
+    },
     with: {
       organizationUsers: {
         with: {
@@ -24,8 +24,10 @@ export const getOrganizationsByProfile = async (profileId: string) => {
                 with: {
                   location: {
                     extras: {
-                      x: sql<number>`ST_X(${locations.location})`.as('x'),
-                      y: sql<number>`ST_Y(${locations.location})`.as('y'),
+                      x: (table, { sql }) =>
+                        sql<number>`ST_X(${table.location})`.as('x'),
+                      y: (table, { sql }) =>
+                        sql<number>`ST_Y(${table.location})`.as('y'),
                     },
                     columns: {
                       id: true,
@@ -34,7 +36,6 @@ export const getOrganizationsByProfile = async (profileId: string) => {
                       countryCode: true,
                       countryName: true,
                       metadata: true,
-                      latLng: false,
                     },
                   },
                 },

--- a/packages/common/src/services/organization/inviteUsers.ts
+++ b/packages/common/src/services/organization/inviteUsers.ts
@@ -69,8 +69,8 @@ export const inviteUsersToOrganization = async (
 
   assertAccess({ profile: permission.ADMIN }, orgUser.roles || []);
 
-  const authUser = (await db._query.users.findFirst({
-    where: (table, { eq }) => eq(table.authUserId, user.id),
+  const authUser = (await db.query.users.findFirst({
+    where: { authUserId: user.id },
     with: {
       currentOrganization: {
         with: {
@@ -99,11 +99,11 @@ export const inviteUsersToOrganization = async (
     const email = rawEmail.toLowerCase();
     try {
       // Check if user already exists in the system
-      const existingUser = await db._query.users.findFirst({
-        where: (table, { eq }) => eq(table.email, email),
+      const existingUser = await db.query.users.findFirst({
+        where: { email },
         with: {
           organizationUsers: {
-            where: (table, { eq }) => eq(table.organizationId, organizationId),
+            where: { organizationId },
           },
         },
       });
@@ -165,8 +165,8 @@ export const inviteUsersToOrganization = async (
       }
 
       // Check if email is already in the allowList
-      const existingEntry = await db._query.allowList.findFirst({
-        where: (table, { eq }) => eq(table.email, email),
+      const existingEntry = await db.query.allowList.findFirst({
+        where: { email },
       });
 
       if (!existingEntry) {
@@ -259,8 +259,8 @@ export const inviteNewUsers = async (input: InviteNewUsersInput) => {
   const { emails, personalMessage, user } = input;
 
   // Get the current user's database record with profile details
-  const authUser = (await db._query.users.findFirst({
-    where: (table, { eq }) => eq(table.authUserId, user.id),
+  const authUser = (await db.query.users.findFirst({
+    where: { authUserId: user.id },
     with: {
       currentOrganization: {
         with: {
@@ -301,8 +301,8 @@ export const inviteNewUsers = async (input: InviteNewUsersInput) => {
     const email = rawEmail.toLowerCase();
     try {
       // Check if email is already in the allowList
-      const existingEntry = await db._query.allowList.findFirst({
-        where: (table, { eq }) => eq(table.email, email),
+      const existingEntry = await db.query.allowList.findFirst({
+        where: { email },
       });
 
       if (!existingEntry) {

--- a/packages/common/src/services/organization/listOrganizations.ts
+++ b/packages/common/src/services/organization/listOrganizations.ts
@@ -1,4 +1,5 @@
 import { db } from '@op/db/client';
+import { organizations } from '@op/db/schema';
 
 import {
   NotFoundError,
@@ -19,6 +20,11 @@ export const listOrganizations = async ({
   dir?: 'asc' | 'desc';
 }) => {
   try {
+    const orderByColumn =
+      orderBy === 'createdAt'
+        ? organizations.createdAt
+        : organizations.updatedAt;
+
     const decodedCursor = cursor
       ? decodeCursor<{ value: string | Date }>(cursor)
       : undefined;
@@ -26,13 +32,12 @@ export const listOrganizations = async ({
     const result = await db.query.organizations.findMany({
       where: decodedCursor
         ? {
-            RAW: (table) =>
+            RAW: () =>
               getCursorCondition({
-                column:
-                  orderBy === 'createdAt' ? table.createdAt : table.updatedAt,
+                column: orderByColumn,
                 cursor: decodedCursor,
                 direction: dir,
-              })!,
+              }),
           }
         : undefined,
       with: {
@@ -65,10 +70,8 @@ export const listOrganizations = async ({
           },
         },
       },
-      orderBy: (table, { asc, desc }) => {
-        const col = orderBy === 'createdAt' ? table.createdAt : table.updatedAt;
-        return dir === 'asc' ? asc(col) : desc(col);
-      },
+      orderBy: (_, { asc, desc }) =>
+        dir === 'asc' ? asc(orderByColumn) : desc(orderByColumn),
       limit: limit + 1, // Fetch one extra to check hasMore
     });
 

--- a/packages/common/src/services/organization/listOrganizations.ts
+++ b/packages/common/src/services/organization/listOrganizations.ts
@@ -1,6 +1,11 @@
 import { db } from '@op/db/client';
 
-import { NotFoundError, decodeCursor, encodeCursor } from '../../utils';
+import {
+  NotFoundError,
+  decodeCursor,
+  encodeCursor,
+  getCursorCondition,
+} from '../../utils';
 
 export const listOrganizations = async ({
   cursor,
@@ -18,14 +23,18 @@ export const listOrganizations = async ({
       ? decodeCursor<{ value: string | Date }>(cursor)
       : undefined;
 
-    const cursorOp = decodedCursor
-      ? dir === 'asc'
-        ? { gt: decodedCursor.value }
-        : { lt: decodedCursor.value }
-      : undefined;
-
     const result = await db.query.organizations.findMany({
-      where: cursorOp ? { [orderBy]: cursorOp } : undefined,
+      where: decodedCursor
+        ? {
+            RAW: (table) =>
+              getCursorCondition({
+                column:
+                  orderBy === 'createdAt' ? table.createdAt : table.updatedAt,
+                cursor: decodedCursor,
+                direction: dir,
+              })!,
+          }
+        : undefined,
       with: {
         projects: true,
         links: true,

--- a/packages/common/src/services/organization/listOrganizations.ts
+++ b/packages/common/src/services/organization/listOrganizations.ts
@@ -1,12 +1,6 @@
-import { db, sql } from '@op/db/client';
-import { locations, organizations } from '@op/db/schema';
+import { db } from '@op/db/client';
 
-import {
-  NotFoundError,
-  decodeCursor,
-  encodeCursor,
-  getCursorCondition,
-} from '../../utils';
+import { NotFoundError, decodeCursor, encodeCursor } from '../../utils';
 
 export const listOrganizations = async ({
   cursor,
@@ -20,22 +14,18 @@ export const listOrganizations = async ({
   dir?: 'asc' | 'desc';
 }) => {
   try {
-    const orderByColumn =
-      orderBy === 'createdAt'
-        ? organizations.createdAt
-        : organizations.updatedAt;
-
-    // Build cursor condition for unfiltered query
-    const cursorCondition = cursor
-      ? getCursorCondition({
-          column: orderByColumn,
-          cursor: decodeCursor<{ value: string | Date }>(cursor),
-          direction: dir,
-        })
+    const decodedCursor = cursor
+      ? decodeCursor<{ value: string | Date }>(cursor)
       : undefined;
 
-    const result = await db._query.organizations.findMany({
-      where: cursorCondition,
+    const cursorOp = decodedCursor
+      ? dir === 'asc'
+        ? { gt: decodedCursor.value }
+        : { lt: decodedCursor.value }
+      : undefined;
+
+    const result = await db.query.organizations.findMany({
+      where: cursorOp ? { [orderBy]: cursorOp } : undefined,
       with: {
         projects: true,
         links: true,
@@ -49,8 +39,10 @@ export const listOrganizations = async ({
           with: {
             location: {
               extras: {
-                x: sql<number>`ST_X(${locations.location})`.as('x'),
-                y: sql<number>`ST_Y(${locations.location})`.as('y'),
+                x: (table, { sql }) =>
+                  sql<number>`ST_X(${table.location})`.as('x'),
+                y: (table, { sql }) =>
+                  sql<number>`ST_Y(${table.location})`.as('y'),
               },
               columns: {
                 id: true,
@@ -59,14 +51,15 @@ export const listOrganizations = async ({
                 countryCode: true,
                 countryName: true,
                 metadata: true,
-                latLng: false,
               },
             },
           },
         },
       },
-      orderBy: (_, { asc, desc }) =>
-        dir === 'asc' ? asc(orderByColumn) : desc(orderByColumn),
+      orderBy: (table, { asc, desc }) => {
+        const col = orderBy === 'createdAt' ? table.createdAt : table.updatedAt;
+        return dir === 'asc' ? asc(col) : desc(col);
+      },
       limit: limit + 1, // Fetch one extra to check hasMore
     });
 
@@ -74,12 +67,13 @@ export const listOrganizations = async ({
       throw new NotFoundError('Organizations not found');
     }
 
-    result.forEach((org) => {
-      org.whereWeWork = org.whereWeWork.map((item) => item.location);
-    });
+    const flattened = result.map((org) => ({
+      ...org,
+      whereWeWork: org.whereWeWork.map((item) => item.location),
+    }));
 
-    const hasMore = result.length > limit;
-    const items = result.slice(0, limit);
+    const hasMore = flattened.length > limit;
+    const items = flattened.slice(0, limit);
     const lastItem = items[items.length - 1];
 
     const orderByValue =

--- a/packages/common/src/services/organization/listOrganizations.ts
+++ b/packages/common/src/services/organization/listOrganizations.ts
@@ -1,5 +1,4 @@
 import { db } from '@op/db/client';
-import { organizations } from '@op/db/schema';
 
 import {
   NotFoundError,
@@ -20,11 +19,6 @@ export const listOrganizations = async ({
   dir?: 'asc' | 'desc';
 }) => {
   try {
-    const orderByColumn =
-      orderBy === 'createdAt'
-        ? organizations.createdAt
-        : organizations.updatedAt;
-
     const decodedCursor = cursor
       ? decodeCursor<{ value: string | Date }>(cursor)
       : undefined;
@@ -32,9 +26,9 @@ export const listOrganizations = async ({
     const result = await db.query.organizations.findMany({
       where: decodedCursor
         ? {
-            RAW: () =>
+            RAW: (table) =>
               getCursorCondition({
-                column: orderByColumn,
+                column: table[orderBy],
                 cursor: decodedCursor,
                 direction: dir,
               }),
@@ -70,8 +64,8 @@ export const listOrganizations = async ({
           },
         },
       },
-      orderBy: (_, { asc, desc }) =>
-        dir === 'asc' ? asc(orderByColumn) : desc(orderByColumn),
+      orderBy: (table, { asc, desc }) =>
+        dir === 'asc' ? asc(table[orderBy]) : desc(table[orderBy]),
       limit: limit + 1, // Fetch one extra to check hasMore
     });
 

--- a/packages/common/src/services/organization/relationships.ts
+++ b/packages/common/src/services/organization/relationships.ts
@@ -1,13 +1,11 @@
 import { OPURLConfig } from '@op/core';
-import { and, db, eq, inArray, or } from '@op/db/client';
+import { and, db, eq, inArray } from '@op/db/client';
 import {
   Organization,
   Profile,
   accessRoles,
   organizationRelationships,
   organizationUserToAccessRoles,
-  organizationUsers,
-  organizations,
 } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 import { relationshipMap } from '@op/types';
@@ -88,12 +86,12 @@ export const sendRelationshipNotification = async ({
   relationships: Array<string>;
 }) => {
   const [sourceOrg, targetOrg] = await Promise.all([
-    db._query.organizations.findFirst({
-      where: eq(organizations.id, from),
+    db.query.organizations.findFirst({
+      where: { id: from },
       with: { profile: true },
     }),
-    db._query.organizations.findFirst({
-      where: eq(organizations.id, to),
+    db.query.organizations.findFirst({
+      where: { id: to },
       with: { profile: true },
     }),
   ]);
@@ -104,23 +102,24 @@ export const sendRelationshipNotification = async ({
 
   // Send email notifications to target organization admin users only
   try {
-    const adminUsers = await db._query.organizationUsers.findMany({
-      where: and(
-        eq(organizationUsers.organizationId, to),
-        inArray(
-          organizationUsers.id,
-          db
-            .select({
-              userId: organizationUserToAccessRoles.organizationUserId,
-            })
-            .from(organizationUserToAccessRoles)
-            .leftJoin(
-              accessRoles,
-              eq(organizationUserToAccessRoles.accessRoleId, accessRoles.id),
-            )
-            .where(eq(accessRoles.name, 'Admin')),
-        ),
-      ),
+    const adminUsers = await db.query.organizationUsers.findMany({
+      where: {
+        organizationId: to,
+        RAW: (table) =>
+          inArray(
+            table.id,
+            db
+              .select({
+                userId: organizationUserToAccessRoles.organizationUserId,
+              })
+              .from(organizationUserToAccessRoles)
+              .leftJoin(
+                accessRoles,
+                eq(organizationUserToAccessRoles.accessRoleId, accessRoles.id),
+              )
+              .where(eq(accessRoles.name, 'Admin')),
+          ),
+      },
     });
 
     const appUrlConfig = OPURLConfig('APP');
@@ -174,19 +173,11 @@ export const getRelatedOrganizations = async ({
   // }
   //
 
-  const where = () =>
-    and(
-      or(
-        eq(organizationRelationships.sourceOrganizationId, orgId),
-        eq(organizationRelationships.targetOrganizationId, orgId),
-      ),
-      ...(pending !== null
-        ? [eq(organizationRelationships.pending, pending)]
-        : []),
-    );
-
-  const relationships = await db._query.organizationRelationships.findMany({
-    where,
+  const relationships = await db.query.organizationRelationships.findMany({
+    where: {
+      OR: [{ sourceOrganizationId: orgId }, { targetOrganizationId: orgId }],
+      ...(pending !== null && { pending }),
+    },
     with: {
       targetOrganization: {
         with: {
@@ -285,25 +276,18 @@ export const getDirectedRelationships = async ({
   // }
   //
   const allRelationshipsFromDb =
-    await db._query.organizationRelationships.findMany({
-      where: () =>
-        and(
-          or(
-            eq(organizationRelationships.sourceOrganizationId, from),
-            eq(organizationRelationships.targetOrganizationId, from),
-          ),
-          ...(to
-            ? [
-                or(
-                  eq(organizationRelationships.targetOrganizationId, to),
-                  eq(organizationRelationships.sourceOrganizationId, to),
-                ),
-              ]
-            : []),
-          ...(pending !== null
-            ? [eq(organizationRelationships.pending, pending)]
-            : []),
-        ),
+    await db.query.organizationRelationships.findMany({
+      where: {
+        OR: [{ sourceOrganizationId: from }, { targetOrganizationId: from }],
+        ...(to && {
+          AND: [
+            {
+              OR: [{ targetOrganizationId: to }, { sourceOrganizationId: to }],
+            },
+          ],
+        }),
+        ...(pending !== null && { pending }),
+      },
       with: {
         targetOrganization: {
           with: {
@@ -365,15 +349,12 @@ export const getPendingRelationships = async ({
     throw new UnauthorizedError('You are not a member of this organization');
   }
 
-  const where = () =>
-    and(
-      eq(organizationRelationships.targetOrganizationId, orgId),
-      eq(organizationRelationships.pending, true),
-    );
-
   const [relationships] = await Promise.all([
-    db._query.organizationRelationships.findMany({
-      where,
+    db.query.organizationRelationships.findMany({
+      where: {
+        targetOrganizationId: orgId,
+        pending: true,
+      },
       with: {
         targetOrganization: {
           with: {

--- a/packages/common/src/services/organization/updateOrganization.ts
+++ b/packages/common/src/services/organization/updateOrganization.ts
@@ -291,11 +291,11 @@ export const updateOrganization = async ({
 
   // Fetch the updated organization and profile separately to ensure proper typing
   const [updatedOrg, updatedProfile] = await Promise.all([
-    db._query.organizations.findFirst({
-      where: eq(organizations.id, organizationId),
+    db.query.organizations.findFirst({
+      where: { id: organizationId },
     }),
-    db._query.profiles.findFirst({
-      where: eq(profiles.id, existingOrg.profileId),
+    db.query.profiles.findFirst({
+      where: { id: existingOrg.profileId },
       with: {
         headerImage: true,
         avatarImage: true,

--- a/packages/common/src/services/organization/updateOrganizationUser.ts
+++ b/packages/common/src/services/organization/updateOrganizationUser.ts
@@ -41,12 +41,11 @@ export async function updateOrganizationUser({
   assertAccess({ admin: permission.UPDATE }, orgUser?.roles || []);
 
   // Check if the organization user to update exists
-  const targetOrgUser = await db._query.organizationUsers.findFirst({
-    where: (table, { eq, and }) =>
-      and(
-        eq(table.id, organizationUserId),
-        eq(table.organizationId, organizationId),
-      ),
+  const targetOrgUser = await db.query.organizationUsers.findFirst({
+    where: {
+      id: organizationUserId,
+      organizationId,
+    },
   });
 
   if (!targetOrgUser) {
@@ -113,8 +112,8 @@ export async function updateOrganizationUser({
   }
 
   // Return the updated user with roles
-  const updatedUserWithRoles = await db._query.organizationUsers.findFirst({
-    where: (table, { eq }) => eq(table.id, organizationUserId),
+  const updatedUserWithRoles = await db.query.organizationUsers.findFirst({
+    where: { id: organizationUserId },
     with: {
       roles: {
         with: {

--- a/packages/common/src/utils/db.ts
+++ b/packages/common/src/utils/db.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, lt, or, sql } from 'drizzle-orm';
+import { SQL, and, eq, gt, lt, or, sql } from 'drizzle-orm';
 import { PgColumn } from 'drizzle-orm/pg-core';
 
 import { CommonError } from './error';
@@ -58,7 +58,19 @@ type Cursor = {
  * If tieBreakerColumn is not provided, only the primary column comparison is used.
  * This is suitable for columns with high cardinality (like timestamps) where collisions are rare.
  */
-export const getCursorCondition = ({
+export function getCursorCondition(args: {
+  column: PgColumn;
+  tieBreakerColumn?: PgColumn;
+  cursor: Cursor;
+  direction: 'asc' | 'desc';
+}): SQL;
+export function getCursorCondition(args: {
+  column: PgColumn;
+  tieBreakerColumn?: PgColumn;
+  cursor?: Cursor;
+  direction: 'asc' | 'desc';
+}): SQL | undefined;
+export function getCursorCondition({
   column,
   tieBreakerColumn,
   cursor,
@@ -68,14 +80,13 @@ export const getCursorCondition = ({
   tieBreakerColumn?: PgColumn;
   cursor?: Cursor;
   direction: 'asc' | 'desc';
-}) => {
+}): SQL | undefined {
   if (!cursor) {
     return undefined;
   }
 
   const compareFn = direction === 'asc' ? gt : lt;
 
-  // If no tiebreaker, use simple comparison
   if (!tieBreakerColumn || !cursor.id) {
     return compareFn(column, cursor.value);
   }
@@ -83,8 +94,8 @@ export const getCursorCondition = ({
   return or(
     compareFn(column, cursor.value),
     and(eq(column, cursor.value), compareFn(tieBreakerColumn, cursor.id)),
-  );
-};
+  )!;
+}
 
 export const constructTextSearch = ({
   column,

--- a/services/api/src/routers/organization/checkMembership.ts
+++ b/services/api/src/routers/organization/checkMembership.ts
@@ -32,12 +32,11 @@ export const checkMembershipRouter = router({
       assertAccess({ profile: permission.ADMIN }, orgUser?.roles ?? []);
 
       // Check if the target email is a member of the organization
-      const membershipExists = await db._query.organizationUsers.findFirst({
-        where: (table, { and, eq }) =>
-          and(
-            eq(table.email, email.toLowerCase()),
-            eq(table.organizationId, organizationId),
-          ),
+      const membershipExists = await db.query.organizationUsers.findFirst({
+        where: {
+          email: email.toLowerCase(),
+          organizationId,
+        },
       });
 
       return {

--- a/services/api/src/routers/organization/inviteUser.ts
+++ b/services/api/src/routers/organization/inviteUser.ts
@@ -79,9 +79,8 @@ export const inviteUserRouter = router({
         // Invalidate caches for users who were successfully added to the organization
         if (result.details?.successful.length > 0) {
           // Find existing users by email to get their auth user IDs
-          const existingUsers = await db._query.users.findMany({
-            where: (table, { inArray }) =>
-              inArray(table.email, result.details.successful),
+          const existingUsers = await db.query.users.findMany({
+            where: { email: { in: result.details.successful } },
             columns: { authUserId: true },
           });
 

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -416,6 +416,19 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   /**
+   * Organizations strategies (join to taxonomy terms).
+   */
+  organizationsStrategies: {
+    // @ts-expect-error - taxonomyTerms self-referential parentId breaks inference
+    term: r.one.taxonomyTerms({
+      from: r.organizationsStrategies.taxonomyTermId,
+      // @ts-expect-error - see above
+      to: r.taxonomyTerms.id,
+      optional: false,
+    }),
+  },
+
+  /**
    * Organization user relations
    *
    * organizationId is NOT NULL. authUserId links to the service user.

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -401,6 +401,31 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.organizations.id,
       to: r.organizationsWhereWeWork.organizationId,
     }),
+    projects: r.many.projects({
+      from: r.organizations.id,
+      to: r.projects.organizationId,
+    }),
+    links: r.many.links({
+      from: r.organizations.id,
+      to: r.links.organizationId,
+    }),
+    strategies: r.many.organizationsStrategies({
+      from: r.organizations.id,
+      to: r.organizationsStrategies.organizationId,
+    }),
+  },
+
+  /**
+   * Organizations strategies (join to taxonomy terms).
+   */
+  organizationsStrategies: {
+    // @ts-expect-error - taxonomyTerms self-referential parentId breaks inference
+    term: r.one.taxonomyTerms({
+      from: r.organizationsStrategies.taxonomyTermId,
+      // @ts-expect-error - see above
+      to: r.taxonomyTerms.id,
+      optional: false,
+    }),
   },
 
   /**
@@ -457,6 +482,26 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   /**
+   * Organization relationship relations
+   *
+   * Self-referential edges between two organizations (source/target).
+   */
+  organizationRelationships: {
+    sourceOrganization: r.one.organizations({
+      from: r.organizationRelationships.sourceOrganizationId,
+      to: r.organizations.id,
+      alias: 'organizationRelationship_source',
+      optional: false,
+    }),
+    targetOrganization: r.one.organizations({
+      from: r.organizationRelationships.targetOrganizationId,
+      to: r.organizations.id,
+      alias: 'organizationRelationship_target',
+      optional: false,
+    }),
+  },
+
+  /**
    * Allow list relations
    */
   allowList: {
@@ -487,20 +532,30 @@ export const relations = defineRelations(schema, (r) => ({
   /**
    * User relations
    *
-   * profileId is nullable.
+   * profileId, currentProfileId, and lastOrgId are nullable.
    */
   users: {
     profile: r.one.profiles({
       from: r.users.profileId,
       to: r.profiles.id,
+      alias: 'user_profile',
     }),
-    avatarImage: r.one.objectsInStorage({
-      from: r.users.avatarImageId,
-      to: r.objectsInStorage.id,
+    currentProfile: r.one.profiles({
+      from: r.users.currentProfileId,
+      to: r.profiles.id,
+      alias: 'user_currentProfile',
+    }),
+    currentOrganization: r.one.organizations({
+      from: r.users.lastOrgId,
+      to: r.organizations.id,
     }),
     organizationUsers: r.many.organizationUsers({
       from: r.users.authUserId,
       to: r.organizationUsers.authUserId,
+    }),
+    avatarImage: r.one.objectsInStorage({
+      from: r.users.avatarImageId,
+      to: r.objectsInStorage.id,
     }),
     authUser: r.one.authUsers({
       from: r.users.authUserId,

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -416,19 +416,6 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   /**
-   * Organizations strategies (join to taxonomy terms).
-   */
-  organizationsStrategies: {
-    // @ts-expect-error - taxonomyTerms self-referential parentId breaks inference
-    term: r.one.taxonomyTerms({
-      from: r.organizationsStrategies.taxonomyTermId,
-      // @ts-expect-error - see above
-      to: r.taxonomyTerms.id,
-      optional: false,
-    }),
-  },
-
-  /**
    * Organization user relations
    *
    * organizationId is NOT NULL. authUserId links to the service user.


### PR DESCRIPTION
Continues retiring v1 db._query so we can drop the legacy relations and the dual API.