### PR TITLE
refactor(common): migrate decision services to drizzle v2 query api

### DIFF
--- a/packages/common/src/services/decision/createProposal.ts
+++ b/packages/common/src/services/decision/createProposal.ts
@@ -1,8 +1,7 @@
-import { db, eq } from '@op/db/client';
+import { db } from '@op/db/client';
 import {
   EntityType,
   ProposalStatus,
-  processInstances,
   profileUserToAccessRoles,
   profileUsers,
   profiles,
@@ -48,8 +47,8 @@ export const createProposal = async ({
 
   try {
     // Verify the process instance exists
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, data.processInstanceId),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: data.processInstanceId },
     });
 
     if (!instance) {
@@ -240,7 +239,7 @@ export const createProposal = async ({
         // Process proposal content to replace temporary URLs with permanent ones
         try {
           await processProposalContent({
-            db: tx,
+            conn: tx,
             proposalId: insertedProposal.id,
           });
         } catch (error) {

--- a/packages/common/src/services/decision/deleteProposal.ts
+++ b/packages/common/src/services/decision/deleteProposal.ts
@@ -21,8 +21,8 @@ export const deleteProposal = async ({
   try {
     const [sessionUser, existingProposal] = await Promise.all([
       getUserSession({ authUserId: user.id }),
-      db._query.proposals.findFirst({
-        where: eq(proposals.id, proposalId),
+      db.query.proposals.findFirst({
+        where: { id: proposalId },
         with: {
           processInstance: true,
         },

--- a/packages/common/src/services/decision/getDecisionBySlug.ts
+++ b/packages/common/src/services/decision/getDecisionBySlug.ts
@@ -32,7 +32,7 @@ const decisionProfileQueryConfig = {
 
 type DecisionProfileQueryResult = Awaited<
   ReturnType<
-    typeof db._query.profiles.findFirst<typeof decisionProfileQueryConfig>
+    typeof db.query.profiles.findFirst<typeof decisionProfileQueryConfig>
   >
 >;
 
@@ -94,11 +94,8 @@ export const getDecisionBySlug = async ({
         return rows[0];
       }),
     // Full profile data
-    db._query.profiles.findFirst({
-      where: and(
-        eq(profiles.slug, slug),
-        eq(profiles.type, EntityType.DECISION),
-      ),
+    db.query.profiles.findFirst({
+      where: { slug, type: EntityType.DECISION },
       ...decisionProfileQueryConfig,
     }),
   ]);

--- a/packages/common/src/services/decision/getProcess.ts
+++ b/packages/common/src/services/decision/getProcess.ts
@@ -1,12 +1,11 @@
-import { db, eq } from '@op/db/client';
-import { decisionProcesses } from '@op/db/schema';
+import { db } from '@op/db/client';
 
 import { NotFoundError } from '../../utils';
 
 export const getProcess = async (processId: string) => {
   try {
-    const process = await db._query.decisionProcesses.findFirst({
-      where: eq(decisionProcesses.id, processId),
+    const process = await db.query.decisionProcesses.findFirst({
+      where: { id: processId },
       with: {
         createdBy: true,
       },

--- a/packages/common/src/services/decision/getResults.ts
+++ b/packages/common/src/services/decision/getResults.ts
@@ -1,7 +1,6 @@
-import { and, asc, db, desc, eq, gt, inArray, or } from '@op/db/client';
+import { and, asc, db, eq, gt, inArray, or } from '@op/db/client';
 import {
   decisionProcessResultSelections,
-  decisionProcessResults,
   decisionsVoteProposals,
   decisionsVoteSubmissions,
   processInstances,
@@ -63,9 +62,9 @@ export const getLatestResultWithProposals = async ({
   });
 
   // Get the latest result (without loading all selections)
-  const result = await db._query.decisionProcessResults.findFirst({
-    where: eq(decisionProcessResults.processInstanceId, processInstanceId),
-    orderBy: [desc(decisionProcessResults.executedAt)],
+  const result = await db.query.decisionProcessResults.findFirst({
+    where: { processInstanceId },
+    orderBy: (table, { desc }) => [desc(table.executedAt)],
   });
 
   if (!result) {

--- a/packages/common/src/services/decision/getResultsStats.ts
+++ b/packages/common/src/services/decision/getResultsStats.ts
@@ -1,7 +1,6 @@
-import { db, desc, eq } from '@op/db/client';
+import { db, eq } from '@op/db/client';
 import {
   decisionProcessResultSelections,
-  decisionProcessResults,
   processInstances,
   proposals,
 } from '@op/db/schema';
@@ -48,9 +47,9 @@ export const getResultsStats = async ({
     orgFallbackPermissions: [{ decisions: permission.READ }],
   });
 
-  const result = await db._query.decisionProcessResults.findFirst({
-    where: eq(decisionProcessResults.processInstanceId, instanceId),
-    orderBy: [desc(decisionProcessResults.executedAt)],
+  const result = await db.query.decisionProcessResults.findFirst({
+    where: { processInstanceId: instanceId },
+    orderBy: (table, { desc }) => [desc(table.executedAt)],
   });
 
   if (!result) {

--- a/packages/common/src/services/decision/getTemplate.ts
+++ b/packages/common/src/services/decision/getTemplate.ts
@@ -1,5 +1,4 @@
-import { db, eq } from '@op/db/client';
-import { decisionProcesses } from '@op/db/schema';
+import { db } from '@op/db/client';
 
 import { NotFoundError } from '../../utils';
 import type { DecisionSchemaDefinition } from './schemas/types';
@@ -11,8 +10,8 @@ import type { DecisionSchemaDefinition } from './schemas/types';
 export const getTemplate = async (
   templateId: string,
 ): Promise<DecisionSchemaDefinition> => {
-  const templateRecord = await db._query.decisionProcesses.findFirst({
-    where: eq(decisionProcesses.id, templateId),
+  const templateRecord = await db.query.decisionProcesses.findFirst({
+    where: { id: templateId },
   });
 
   if (!templateRecord) {

--- a/packages/common/src/services/decision/listInstances.ts
+++ b/packages/common/src/services/decision/listInstances.ts
@@ -1,4 +1,4 @@
-import { and, asc, db, desc, eq, sql } from '@op/db/client';
+import { and, db, eq, sql } from '@op/db/client';
 import { ProcessStatus, processInstances } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 import { assertAccess, permission } from 'access-zones';
@@ -88,14 +88,17 @@ export const listInstances = async ({
     const count = countResult[0]?.count || 0;
 
     // Get process instances with relations
-    const orderColumn = orderBy
-      ? processInstances[orderBy]
-      : processInstances.createdAt;
-
-    const orderFn = orderDirection === 'asc' ? asc : desc;
-
-    const instanceList = await db._query.processInstances.findMany({
-      where: whereClause,
+    const instanceList = await db.query.processInstances.findMany({
+      where: {
+        ...(ownerProfileId && { ownerProfileId }),
+        ...(stewardProfileId && { stewardProfileId }),
+        ...(processId && { processId }),
+        ...(status && { status }),
+        ...(search && {
+          RAW: (table, { sql }) =>
+            sql`${table.search} @@ plainto_tsquery('english', ${search})`,
+        }),
+      },
       with: {
         process: true,
         owner: true,
@@ -108,7 +111,10 @@ export const listInstances = async ({
       },
       limit,
       offset,
-      orderBy: orderFn(orderColumn),
+      orderBy: (table, { asc, desc }) => {
+        const col = table[orderBy];
+        return orderDirection === 'asc' ? asc(col) : desc(col);
+      },
     });
 
     // Transform instances to include proposal and participant counts

--- a/packages/common/src/services/decision/listLegacyInstances.ts
+++ b/packages/common/src/services/decision/listLegacyInstances.ts
@@ -1,5 +1,5 @@
-import { db, desc, eq } from '@op/db/client';
-import { ProposalStatus, organizations, processInstances } from '@op/db/schema';
+import { db, eq } from '@op/db/client';
+import { ProposalStatus, organizations } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 import { assertAccess, permission } from 'access-zones';
 
@@ -29,8 +29,8 @@ export const listLegacyInstances = async ({
 
   assertAccess({ decisions: permission.READ }, orgUser?.roles ?? []);
 
-  const instanceList = await db._query.processInstances.findMany({
-    where: eq(processInstances.ownerProfileId, ownerProfileId),
+  const instanceList = await db.query.processInstances.findMany({
+    where: { ownerProfileId },
     with: {
       process: true,
       owner: {
@@ -46,7 +46,7 @@ export const listLegacyInstances = async ({
         },
       },
     },
-    orderBy: desc(processInstances.createdAt),
+    orderBy: (table, { desc }) => desc(table.createdAt),
   });
 
   return instanceList.map((instance) => {

--- a/packages/common/src/services/decision/listProcesses.ts
+++ b/packages/common/src/services/decision/listProcesses.ts
@@ -1,4 +1,4 @@
-import { and, db, desc, eq, ilike, sql } from '@op/db/client';
+import { and, db, eq, ilike, sql } from '@op/db/client';
 import { decisionProcesses } from '@op/db/schema';
 
 export interface ListProcessesInput {
@@ -40,12 +40,27 @@ export const listProcesses = async ({
     const whereClause = and(...conditions);
 
     const [processes, totalResult] = await Promise.all([
-      db._query.decisionProcesses.findMany({
-        where: whereClause,
+      db.query.decisionProcesses.findMany({
+        where: {
+          RAW: (table) => {
+            const parts = [
+              sql`${table.processSchema}->>'id' IS NOT NULL`,
+              sql`${table.processSchema}->>'version' IS NOT NULL`,
+              sql`${table.processSchema}->'phases' IS NOT NULL`,
+            ];
+            if (search) {
+              parts.push(ilike(table.name, `%${search}%`));
+            }
+            if (createdByProfileId) {
+              parts.push(eq(table.createdByProfileId, createdByProfileId));
+            }
+            return sql.join(parts, sql` AND `);
+          },
+        },
         with: {
           createdBy: true,
         },
-        orderBy: [desc(decisionProcesses.createdAt)],
+        orderBy: (table, { desc }) => [desc(table.createdAt)],
         limit: limit + 1, // Get one extra to check if there are more
         offset,
       }),

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -1,15 +1,4 @@
-import {
-  and,
-  asc,
-  db,
-  desc,
-  eq,
-  ilike,
-  inArray,
-  ne,
-  or,
-  sql,
-} from '@op/db/client';
+import { and, db, eq, ilike, inArray, ne, or, sql } from '@op/db/client';
 import {
   ProfileRelationshipType,
   ProposalStatus,
@@ -126,25 +115,30 @@ const resolveExplicitScope = async ({
   return votedRows.map((r) => r.proposalId);
 };
 
-// Shared function to build WHERE conditions for both count and data queries
-const buildWhereConditions = (input: ListProposalsInput) => {
+// Shared function to build WHERE conditions for both count and data queries.
+// Accepts a table reference so the relational query API can pass an aliased
+// version while the v1 select can pass the schema table directly.
+const buildWhereConditions = (
+  input: ListProposalsInput,
+  t: typeof proposals = proposals,
+) => {
   const { processInstanceId, submittedByProfileId, status, search } = input;
 
   const conditions = [];
 
-  conditions.push(eq(proposals.processInstanceId, processInstanceId));
+  conditions.push(eq(t.processInstanceId, processInstanceId));
 
   if (submittedByProfileId) {
-    conditions.push(eq(proposals.submittedByProfileId, submittedByProfileId));
+    conditions.push(eq(t.submittedByProfileId, submittedByProfileId));
   }
 
   if (status) {
-    conditions.push(eq(proposals.status, status));
+    conditions.push(eq(t.status, status));
   }
 
   if (search) {
     // Search in proposal data (JSONB) - convert to text for searching
-    conditions.push(ilike(sql`${proposals.proposalData}::text`, `%${search}%`));
+    conditions.push(ilike(sql`${t.proposalData}::text`, `%${search}%`));
   }
 
   return conditions.length > 0 ? and(...conditions) : undefined;
@@ -243,23 +237,6 @@ export const listProposals = async ({
 
   const { limit = 20, offset = 0, orderBy = 'createdAt', dir = 'desc' } = input;
 
-  // Build shared WHERE clause using the extracted function
-  const baseWhereClause = buildWhereConditions(input);
-
-  // When the caller provided an explicit scope (proposalIds or votedByProfileId),
-  // constrain the entire query to that ID set. This prevents the draft branch
-  // (below) from independently surfacing drafts the user owns but didn't ask for.
-  let whereClause = baseWhereClause;
-  if (explicitScopeIds !== undefined) {
-    const explicitScopeFilter =
-      explicitScopeIds.length > 0
-        ? inArray(proposals.id, explicitScopeIds)
-        : sql`false`;
-    whereClause = whereClause
-      ? and(whereClause, explicitScopeFilter)
-      : explicitScopeFilter;
-  }
-
   // Handle category filtering separately to avoid table reference issues
   const { categoryId } = input;
   let categoryProposalIds: string[] = [];
@@ -282,73 +259,81 @@ export const listProposals = async ({
         canManageProposals,
       };
     }
-
-    // Add category filter to WHERE clause (composed with any earlier filters)
-    const categoryFilter = inArray(proposals.id, categoryProposalIds);
-    whereClause = whereClause
-      ? and(whereClause, categoryFilter)
-      : categoryFilter;
   }
 
-  // Phase scoping applies to non-draft proposals only. Drafts are user-private
-  // and not part of any phase transition snapshot, so they bypass phaseProposalIds.
-  // When phaseProposalIds is empty (e.g. instance has no submitted proposals yet),
-  // the non-draft branch must short-circuit to false rather than emit an empty IN ().
-  const phaseScopedNonDraftIdFilter =
-    phaseProposalIds.length > 0
-      ? and(
-          ne(proposals.status, ProposalStatus.DRAFT),
-          inArray(proposals.id, phaseProposalIds),
-        )
-      : sql`false`;
+  // Build the full WHERE clause against the supplied table reference. Used by
+  // the v1 select count below (passing the schema table) and the v2 relational
+  // findMany (passing the aliased table from the RAW callback).
+  const buildFullWhere = (t: typeof proposals = proposals) => {
+    let whereClause = buildWhereConditions(input, t);
 
-  if (skipAccessCheck) {
-    // Trusted contexts get all phase-scoped non-draft proposals.
-    whereClause = whereClause
-      ? and(whereClause, phaseScopedNonDraftIdFilter)
-      : phaseScopedNonDraftIdFilter;
-  } else {
-    // Draft proposals: only visible to users with proposal-level access
-    // (the creator and invited collaborators with a profileUsers record on the proposal's profile).
-    // Drafts are not phase-scoped and remain visible regardless of phaseId so that
-    // creators continue to see their own in-progress work alongside the current phase.
-    const draftFilter = and(
-      eq(proposals.status, ProposalStatus.DRAFT),
-      inArray(
-        proposals.profileId,
-        db
-          .select({ profileId: profileUsers.profileId })
-          .from(profileUsers)
-          .where(eq(profileUsers.authUserId, input.authUserId)),
-      ),
-    );
+    if (explicitScopeIds !== undefined) {
+      const explicitScopeFilter =
+        explicitScopeIds.length > 0
+          ? inArray(t.id, explicitScopeIds)
+          : sql`false`;
+      whereClause = whereClause
+        ? and(whereClause, explicitScopeFilter)
+        : explicitScopeFilter;
+    }
 
-    // Non-draft proposals: phase-scoped, plus the HIDDEN visibility filter for
-    // non-admins (admins and the owning profile still see hidden proposals).
-    const nonDraftVisibilityFilter = canManageProposals
-      ? phaseScopedNonDraftIdFilter
-      : and(
-          phaseScopedNonDraftIdFilter,
-          or(
-            eq(proposals.visibility, Visibility.VISIBLE),
-            eq(proposals.submittedByProfileId, currentProfileId),
-          ),
-        );
+    if (categoryId && categoryProposalIds.length > 0) {
+      const categoryFilter = inArray(t.id, categoryProposalIds);
+      whereClause = whereClause
+        ? and(whereClause, categoryFilter)
+        : categoryFilter;
+    }
 
-    const permissionFilter = or(draftFilter, nonDraftVisibilityFilter);
-    whereClause = whereClause
-      ? and(whereClause, permissionFilter)
-      : permissionFilter;
-  }
+    // Phase scoping applies to non-draft proposals only. Drafts are user-private
+    // and not part of any phase transition snapshot, so they bypass phaseProposalIds.
+    // When phaseProposalIds is empty (e.g. instance has no submitted proposals yet),
+    // the non-draft branch must short-circuit to false rather than emit an empty IN ().
+    const phaseScopedNonDraftIdFilter =
+      phaseProposalIds.length > 0
+        ? and(
+            ne(t.status, ProposalStatus.DRAFT),
+            inArray(t.id, phaseProposalIds),
+          )
+        : sql`false`;
 
-  // Get proposals with optimized ordering
-  const orderColumn = proposals[orderBy] ?? proposals.createdAt;
+    if (skipAccessCheck) {
+      whereClause = whereClause
+        ? and(whereClause, phaseScopedNonDraftIdFilter)
+        : phaseScopedNonDraftIdFilter;
+    } else {
+      const draftFilter = and(
+        eq(t.status, ProposalStatus.DRAFT),
+        inArray(
+          t.profileId,
+          db
+            .select({ profileId: profileUsers.profileId })
+            .from(profileUsers)
+            .where(eq(profileUsers.authUserId, input.authUserId)),
+        ),
+      );
 
-  const orderFn = dir === 'asc' ? asc : desc;
+      const nonDraftVisibilityFilter = canManageProposals
+        ? phaseScopedNonDraftIdFilter
+        : and(
+            phaseScopedNonDraftIdFilter,
+            or(
+              eq(t.visibility, Visibility.VISIBLE),
+              eq(t.submittedByProfileId, currentProfileId),
+            ),
+          );
+
+      const permissionFilter = or(draftFilter, nonDraftVisibilityFilter);
+      whereClause = whereClause
+        ? and(whereClause, permissionFilter)
+        : permissionFilter;
+    }
+
+    return whereClause;
+  };
 
   const [proposalList, countResult] = await Promise.all([
-    db._query.proposals.findMany({
-      where: whereClause,
+    db.query.proposals.findMany({
+      where: { RAW: (t) => buildFullWhere(t)! },
       with: {
         submittedBy: {
           with: {
@@ -359,10 +344,13 @@ export const listProposals = async ({
       },
       limit,
       offset,
-      orderBy: orderFn(orderColumn),
+      orderBy: (t, { asc, desc }) => {
+        const col = t[orderBy] ?? t.createdAt;
+        return dir === 'asc' ? asc(col) : desc(col);
+      },
     }),
     // Get count using Drizzle's count function instead of raw SQL
-    db.select({ count: countFn() }).from(proposals).where(whereClause),
+    db.select({ count: countFn() }).from(proposals).where(buildFullWhere()),
   ]);
 
   const count = countResult[0]?.count || 0;

--- a/packages/common/src/services/decision/proposalContentProcessor.ts
+++ b/packages/common/src/services/decision/proposalContentProcessor.ts
@@ -1,5 +1,5 @@
-import { type DbClient, db as defaultDb, eq } from '@op/db/client';
-import { attachments, proposalAttachments, proposals } from '@op/db/schema';
+import { db, eq } from '@op/db/client';
+import { attachments, proposals } from '@op/db/schema';
 
 /**
  * Generate public URL for asset using Next.js rewrite
@@ -15,16 +15,16 @@ const getPublicUrl = (key?: string | null) => {
  * Process proposal content to replace temporary image URLs with permanent attachment references
  */
 export async function processProposalContent({
-  db,
+  conn,
   proposalId,
 }: {
-  db: DbClient;
+  conn: typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
   proposalId: string;
 }): Promise<void> {
   try {
     // Get the proposal content
-    const proposal = await db._query.proposals.findFirst({
-      where: eq(proposals.id, proposalId),
+    const proposal = await conn.query.proposals.findFirst({
+      where: { id: proposalId },
     });
 
     if (!proposal) {
@@ -42,8 +42,8 @@ export async function processProposalContent({
 
     // Get all attachments for this proposal through the join table
     const proposalAttachmentJoins =
-      await db._query.proposalAttachments.findMany({
-        where: eq(proposalAttachments.proposalId, proposalId),
+      await conn.query.proposalAttachments.findMany({
+        where: { proposalId },
         with: {
           attachment: true,
         },
@@ -119,7 +119,7 @@ export async function processProposalContent({
         content: processedContent,
       };
 
-      await db
+      await conn
         .update(proposals)
         .set({
           proposalData: updatedProposalData,
@@ -132,7 +132,7 @@ export async function processProposalContent({
     // Update attachment metadata
     if (updatedAttachments.length > 0) {
       for (const attachmentUpdate of updatedAttachments) {
-        await db
+        await conn
           .update(attachments)
           .set({
             fileName: attachmentUpdate.fileName,
@@ -177,13 +177,12 @@ function extractImageUrlsFromContent(htmlContent: string): string[] {
 export async function getProposalAttachmentUrls(
   proposalId: string,
 ): Promise<Record<string, string>> {
-  const proposalAttachmentJoins =
-    await defaultDb._query.proposalAttachments.findMany({
-      where: eq(proposalAttachments.proposalId, proposalId),
-      with: {
-        attachment: true,
-      },
-    });
+  const proposalAttachmentJoins = await db.query.proposalAttachments.findMany({
+    where: { proposalId },
+    with: {
+      attachment: true,
+    },
+  });
 
   if (proposalAttachmentJoins.length === 0) {
     return {};

--- a/packages/common/src/services/decision/proposalTaxonomy.ts
+++ b/packages/common/src/services/decision/proposalTaxonomy.ts
@@ -50,7 +50,7 @@ export async function ensureProposalTaxonomyTerms(
       trim: true,
     });
 
-    // taxonomyTerms V2 types are broken due to self-referential parentId
+    // taxonomyTerms self-referential parentId breaks v2 where typing.
     let existingTerm = await db._query.taxonomyTerms.findFirst({
       where: eq(taxonomyTerms.termUri, termUri),
     });

--- a/packages/common/src/services/decision/updateProcess.ts
+++ b/packages/common/src/services/decision/updateProcess.ts
@@ -31,8 +31,8 @@ export const updateProcess = async ({
     }
 
     // Check if process exists and user has permission to update it
-    const existingProcess = await db._query.decisionProcesses.findFirst({
-      where: eq(decisionProcesses.id, processId),
+    const existingProcess = await db.query.decisionProcesses.findFirst({
+      where: { id: processId },
     });
 
     if (!existingProcess) {

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -1,12 +1,11 @@
 import { getTipTapClient } from '@op/collab';
-import { type DbClient, and, db, eq } from '@op/db/client';
+import { type TransactionType, and, db, eq } from '@op/db/client';
 import {
   ProposalStatus,
   type Visibility,
   profiles,
   proposalCategories,
   proposals,
-  taxonomies,
   taxonomyTerms,
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
@@ -30,11 +29,11 @@ import { type DecisionInstanceData, isLastPhase } from './schemas/instanceData';
 import { validateProposalAgainstTemplate } from './validateProposalAgainstTemplate';
 
 async function updateProposalCategoryLink(
-  db: DbClient,
+  tx: TransactionType,
   proposalId: string,
   newCategoryLabels: string[],
 ): Promise<void> {
-  await db
+  await tx
     .delete(proposalCategories)
     .where(eq(proposalCategories.proposalId, proposalId));
 
@@ -42,8 +41,8 @@ async function updateProposalCategoryLink(
     return;
   }
 
-  const proposalTaxonomy = await db._query.taxonomies.findFirst({
-    where: eq(taxonomies.name, 'proposal'),
+  const proposalTaxonomy = await tx.query.taxonomies.findFirst({
+    where: { name: 'proposal' },
   });
 
   if (!proposalTaxonomy) {
@@ -58,7 +57,8 @@ async function updateProposalCategoryLink(
       continue;
     }
 
-    const taxonomyTerm = await db._query.taxonomyTerms.findFirst({
+    // taxonomyTerms self-referential parentId breaks v2 where typing.
+    const taxonomyTerm = await tx._query.taxonomyTerms.findFirst({
       where: and(
         eq(taxonomyTerms.label, categoryLabel.trim()),
         eq(taxonomyTerms.taxonomyId, proposalTaxonomy.id),
@@ -74,7 +74,7 @@ async function updateProposalCategoryLink(
   }
 
   if (taxonomyTermIds.length > 0) {
-    await db.insert(proposalCategories).values(
+    await tx.insert(proposalCategories).values(
       taxonomyTermIds.map((taxonomyTermId) => ({
         proposalId,
         taxonomyTermId,

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -1,10 +1,8 @@
-import { and, db, eq } from '@op/db/client';
+import { db } from '@op/db/client';
 import {
   type VoteData,
   decisionsVoteProposals,
   decisionsVoteSubmissions,
-  processInstances,
-  proposals,
 } from '@op/db/schema';
 import { assertAccess, permission } from 'access-zones';
 
@@ -149,8 +147,8 @@ export const submitVote = async ({
     const profileId = await getIndividualProfileId(authUserId);
 
     // Get process instance and schema
-    const processInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, data.processInstanceId),
+    const processInstance = await db.query.processInstances.findFirst({
+      where: { id: data.processInstanceId },
       columns: {
         id: true,
         profileId: true,
@@ -216,11 +214,11 @@ export const submitVote = async ({
     }
 
     // Check if user has already voted
-    const existingVote = await db._query.decisionsVoteSubmissions.findFirst({
-      where: and(
-        eq(decisionsVoteSubmissions.processInstanceId, data.processInstanceId),
-        eq(decisionsVoteSubmissions.submittedByProfileId, profileId),
-      ),
+    const existingVote = await db.query.decisionsVoteSubmissions.findFirst({
+      where: {
+        processInstanceId: data.processInstanceId,
+        submittedByProfileId: profileId,
+      },
     });
 
     if (existingVote) {
@@ -230,8 +228,8 @@ export const submitVote = async ({
     }
 
     // Get available proposals for this process instance
-    const availableProposals = await db._query.proposals.findMany({
-      where: eq(proposals.processInstanceId, data.processInstanceId),
+    const availableProposals = await db.query.proposals.findMany({
+      where: { processInstanceId: data.processInstanceId },
     });
 
     // Filter to eligible proposals for voting
@@ -346,8 +344,8 @@ export const getVotingStatus = async ({
     const profileId = await getIndividualProfileId(authUserId);
 
     // Get process instance and schema
-    const processInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, data.processInstanceId),
+    const processInstance = await db.query.processInstances.findFirst({
+      where: { id: data.processInstanceId },
       columns: {
         id: true,
         profileId: true,
@@ -398,11 +396,11 @@ export const getVotingStatus = async ({
     const { votingConfig } = schemaResult;
 
     // Check if user has voted
-    const voteSubmission = await db._query.decisionsVoteSubmissions.findFirst({
-      where: and(
-        eq(decisionsVoteSubmissions.processInstanceId, data.processInstanceId),
-        eq(decisionsVoteSubmissions.submittedByProfileId, profileId),
-      ),
+    const voteSubmission = await db.query.decisionsVoteSubmissions.findFirst({
+      where: {
+        processInstanceId: data.processInstanceId,
+        submittedByProfileId: profileId,
+      },
       with: {
         voteProposals: {
           with: {

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -502,6 +502,44 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   /**
+   * Decision vote submission relations
+   */
+  decisionsVoteSubmissions: {
+    voteProposals: r.many.decisionsVoteProposals({
+      from: r.decisionsVoteSubmissions.id,
+      to: r.decisionsVoteProposals.voteSubmissionId,
+    }),
+  },
+
+  /**
+   * Decision vote proposal relations (junction table)
+   */
+  decisionsVoteProposals: {
+    proposal: r.one.proposals({
+      from: r.decisionsVoteProposals.proposalId,
+      to: r.proposals.id,
+      alias: 'decisionsVoteProposal_proposal',
+      optional: false,
+    }),
+  },
+
+  /**
+   * Decision process relations
+   */
+  decisionProcesses: {
+    createdBy: r.one.profiles({
+      from: r.decisionProcesses.createdByProfileId,
+      to: r.profiles.id,
+      alias: 'decisionProcess_createdBy',
+      optional: false,
+    }),
+    instances: r.many.processInstances({
+      from: r.decisionProcesses.id,
+      to: r.processInstances.processId,
+    }),
+  },
+
+  /**
    * Allow list relations
    */
   allowList: {


### PR DESCRIPTION
Continues retiring v1 db._query so we can drop the legacy relations and the dual API.