### PR TITLE
refactor(common): migrate posts/profile/user/access services to drizzle v2 query api

### DIFF
--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -1,5 +1,5 @@
 import { cache } from '@op/cache';
-import { and, db, eq } from '@op/db/client';
+import { db, eq } from '@op/db/client';
 import type { Profile, ProfileUser } from '@op/db/schema';
 import { organizations, users } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
@@ -37,12 +37,11 @@ export const getOrgAccessUser = async ({
   organizationId: string;
 }): Promise<OrgUserWithNormalizedRoles | undefined> => {
   const getOrgUser = async () => {
-    const orgUser = await db._query.organizationUsers.findFirst({
-      where: (table, { eq }) =>
-        and(
-          eq(table.organizationId, organizationId),
-          eq(table.authUserId, user.id),
-        ),
+    const orgUser = await db.query.organizationUsers.findFirst({
+      where: {
+        organizationId,
+        authUserId: user.id,
+      },
       with: {
         roles: {
           with: {
@@ -97,9 +96,11 @@ export const getProfileAccessUser = async ({
   user: { id: string };
   profileId: string;
 }): Promise<ProfileUserWithNormalizedRoles | undefined> => {
-  const profileUser = await db._query.profileUsers.findFirst({
-    where: (table, { eq }) =>
-      and(eq(table.profileId, profileId), eq(table.authUserId, user.id)),
+  const profileUser = await db.query.profileUsers.findFirst({
+    where: {
+      profileId,
+      authUserId: user.id,
+    },
     with: {
       profile: true,
       roles: {
@@ -328,8 +329,8 @@ export const getUserSession = async ({
   const validatedAuthUserId = validateAuthUserId(authUserId);
 
   try {
-    const dbUser = await db._query.users.findFirst({
-      where: (table, { eq }) => eq(table.authUserId, validatedAuthUserId),
+    const dbUser = await db.query.users.findFirst({
+      where: { authUserId: validatedAuthUserId },
       with: {
         organizationUsers: true,
       },

--- a/packages/common/src/services/assert/assertOrganization.ts
+++ b/packages/common/src/services/assert/assertOrganization.ts
@@ -16,8 +16,8 @@ export async function assertOrganization(
   error: Error = new NotFoundError('Organization', id),
   db: DbClient = defaultDb,
 ): Promise<Organization> {
-  const organization = await db._query.organizations.findFirst({
-    where: (table, { eq }) => eq(table.id, id),
+  const organization = await db.query.organizations.findFirst({
+    where: { id },
   });
 
   if (!organization) {
@@ -40,8 +40,8 @@ export async function assertOrganizationByProfileId(
   error: Error = new NotFoundError('Organization', profileId),
   db: DbClient = defaultDb,
 ): Promise<Organization> {
-  const organization = await db._query.organizations.findFirst({
-    where: (table, { eq }) => eq(table.profileId, profileId),
+  const organization = await db.query.organizations.findFirst({
+    where: { profileId },
   });
 
   if (!organization) {

--- a/packages/common/src/services/assert/assertProfile.ts
+++ b/packages/common/src/services/assert/assertProfile.ts
@@ -16,8 +16,8 @@ export async function assertProfile(
   error: Error = new NotFoundError('Profile', id),
   db: DbClient = defaultDb,
 ): Promise<Profile> {
-  const profile = await db._query.profiles.findFirst({
-    where: (table, { eq }) => eq(table.id, id),
+  const profile = await db.query.profiles.findFirst({
+    where: { id },
   });
 
   if (!profile) {
@@ -40,8 +40,8 @@ export async function assertProfileBySlug(
   error: Error = new NotFoundError('Profile', slug),
   db: DbClient = defaultDb,
 ): Promise<Profile> {
-  const profile = await db._query.profiles.findFirst({
-    where: (table, { eq }) => eq(table.slug, slug),
+  const profile = await db.query.profiles.findFirst({
+    where: { slug },
   });
 
   if (!profile) {

--- a/packages/common/src/services/assert/assertProfileUser.ts
+++ b/packages/common/src/services/assert/assertProfileUser.ts
@@ -11,8 +11,8 @@ export async function assertProfileUser(
   error: Error = new NotFoundError('User not found', id),
   db: DbClient = defaultDb,
 ): Promise<ProfileUser> {
-  const profileUser = await db._query.profileUsers.findFirst({
-    where: (table, { eq }) => eq(table.id, id),
+  const profileUser = await db.query.profileUsers.findFirst({
+    where: { id },
   });
 
   if (!profileUser) {

--- a/packages/common/src/services/decision/createProposal.ts
+++ b/packages/common/src/services/decision/createProposal.ts
@@ -1,8 +1,7 @@
-import { db, eq } from '@op/db/client';
+import { db } from '@op/db/client';
 import {
   EntityType,
   ProposalStatus,
-  processInstances,
   profileUserToAccessRoles,
   profileUsers,
   profiles,
@@ -48,8 +47,8 @@ export const createProposal = async ({
 
   try {
     // Verify the process instance exists
-    const instance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, data.processInstanceId),
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: data.processInstanceId },
     });
 
     if (!instance) {
@@ -240,7 +239,7 @@ export const createProposal = async ({
         // Process proposal content to replace temporary URLs with permanent ones
         try {
           await processProposalContent({
-            db: tx,
+            conn: tx,
             proposalId: insertedProposal.id,
           });
         } catch (error) {

--- a/packages/common/src/services/decision/deleteProposal.ts
+++ b/packages/common/src/services/decision/deleteProposal.ts
@@ -21,8 +21,8 @@ export const deleteProposal = async ({
   try {
     const [sessionUser, existingProposal] = await Promise.all([
       getUserSession({ authUserId: user.id }),
-      db._query.proposals.findFirst({
-        where: eq(proposals.id, proposalId),
+      db.query.proposals.findFirst({
+        where: { id: proposalId },
         with: {
           processInstance: true,
         },

--- a/packages/common/src/services/decision/getDecisionBySlug.ts
+++ b/packages/common/src/services/decision/getDecisionBySlug.ts
@@ -32,7 +32,7 @@ const decisionProfileQueryConfig = {
 
 type DecisionProfileQueryResult = Awaited<
   ReturnType<
-    typeof db._query.profiles.findFirst<typeof decisionProfileQueryConfig>
+    typeof db.query.profiles.findFirst<typeof decisionProfileQueryConfig>
   >
 >;
 
@@ -94,11 +94,8 @@ export const getDecisionBySlug = async ({
         return rows[0];
       }),
     // Full profile data
-    db._query.profiles.findFirst({
-      where: and(
-        eq(profiles.slug, slug),
-        eq(profiles.type, EntityType.DECISION),
-      ),
+    db.query.profiles.findFirst({
+      where: { slug, type: EntityType.DECISION },
       ...decisionProfileQueryConfig,
     }),
   ]);

--- a/packages/common/src/services/decision/getProcess.ts
+++ b/packages/common/src/services/decision/getProcess.ts
@@ -1,12 +1,11 @@
-import { db, eq } from '@op/db/client';
-import { decisionProcesses } from '@op/db/schema';
+import { db } from '@op/db/client';
 
 import { NotFoundError } from '../../utils';
 
 export const getProcess = async (processId: string) => {
   try {
-    const process = await db._query.decisionProcesses.findFirst({
-      where: eq(decisionProcesses.id, processId),
+    const process = await db.query.decisionProcesses.findFirst({
+      where: { id: processId },
       with: {
         createdBy: true,
       },

--- a/packages/common/src/services/decision/getResults.ts
+++ b/packages/common/src/services/decision/getResults.ts
@@ -1,7 +1,6 @@
-import { and, asc, db, desc, eq, gt, inArray, or } from '@op/db/client';
+import { and, asc, db, eq, gt, inArray, or } from '@op/db/client';
 import {
   decisionProcessResultSelections,
-  decisionProcessResults,
   decisionsVoteProposals,
   decisionsVoteSubmissions,
   processInstances,
@@ -63,9 +62,9 @@ export const getLatestResultWithProposals = async ({
   });
 
   // Get the latest result (without loading all selections)
-  const result = await db._query.decisionProcessResults.findFirst({
-    where: eq(decisionProcessResults.processInstanceId, processInstanceId),
-    orderBy: [desc(decisionProcessResults.executedAt)],
+  const result = await db.query.decisionProcessResults.findFirst({
+    where: { processInstanceId },
+    orderBy: (table, { desc }) => [desc(table.executedAt)],
   });
 
   if (!result) {

--- a/packages/common/src/services/decision/getResultsStats.ts
+++ b/packages/common/src/services/decision/getResultsStats.ts
@@ -1,7 +1,6 @@
-import { db, desc, eq } from '@op/db/client';
+import { db, eq } from '@op/db/client';
 import {
   decisionProcessResultSelections,
-  decisionProcessResults,
   processInstances,
   proposals,
 } from '@op/db/schema';
@@ -48,9 +47,9 @@ export const getResultsStats = async ({
     orgFallbackPermissions: [{ decisions: permission.READ }],
   });
 
-  const result = await db._query.decisionProcessResults.findFirst({
-    where: eq(decisionProcessResults.processInstanceId, instanceId),
-    orderBy: [desc(decisionProcessResults.executedAt)],
+  const result = await db.query.decisionProcessResults.findFirst({
+    where: { processInstanceId: instanceId },
+    orderBy: (table, { desc }) => [desc(table.executedAt)],
   });
 
   if (!result) {

--- a/packages/common/src/services/decision/getTemplate.ts
+++ b/packages/common/src/services/decision/getTemplate.ts
@@ -1,5 +1,4 @@
-import { db, eq } from '@op/db/client';
-import { decisionProcesses } from '@op/db/schema';
+import { db } from '@op/db/client';
 
 import { NotFoundError } from '../../utils';
 import type { DecisionSchemaDefinition } from './schemas/types';
@@ -11,8 +10,8 @@ import type { DecisionSchemaDefinition } from './schemas/types';
 export const getTemplate = async (
   templateId: string,
 ): Promise<DecisionSchemaDefinition> => {
-  const templateRecord = await db._query.decisionProcesses.findFirst({
-    where: eq(decisionProcesses.id, templateId),
+  const templateRecord = await db.query.decisionProcesses.findFirst({
+    where: { id: templateId },
   });
 
   if (!templateRecord) {

--- a/packages/common/src/services/decision/listInstances.ts
+++ b/packages/common/src/services/decision/listInstances.ts
@@ -1,4 +1,4 @@
-import { and, asc, db, desc, eq, sql } from '@op/db/client';
+import { and, db, eq, sql } from '@op/db/client';
 import { ProcessStatus, processInstances } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 import { assertAccess, permission } from 'access-zones';
@@ -88,14 +88,17 @@ export const listInstances = async ({
     const count = countResult[0]?.count || 0;
 
     // Get process instances with relations
-    const orderColumn = orderBy
-      ? processInstances[orderBy]
-      : processInstances.createdAt;
-
-    const orderFn = orderDirection === 'asc' ? asc : desc;
-
-    const instanceList = await db._query.processInstances.findMany({
-      where: whereClause,
+    const instanceList = await db.query.processInstances.findMany({
+      where: {
+        ...(ownerProfileId && { ownerProfileId }),
+        ...(stewardProfileId && { stewardProfileId }),
+        ...(processId && { processId }),
+        ...(status && { status }),
+        ...(search && {
+          RAW: (table, { sql }) =>
+            sql`${table.search} @@ plainto_tsquery('english', ${search})`,
+        }),
+      },
       with: {
         process: true,
         owner: true,
@@ -108,7 +111,10 @@ export const listInstances = async ({
       },
       limit,
       offset,
-      orderBy: orderFn(orderColumn),
+      orderBy: (table, { asc, desc }) => {
+        const col = table[orderBy];
+        return orderDirection === 'asc' ? asc(col) : desc(col);
+      },
     });
 
     // Transform instances to include proposal and participant counts

--- a/packages/common/src/services/decision/listLegacyInstances.ts
+++ b/packages/common/src/services/decision/listLegacyInstances.ts
@@ -1,5 +1,5 @@
-import { db, desc, eq } from '@op/db/client';
-import { ProposalStatus, organizations, processInstances } from '@op/db/schema';
+import { db, eq } from '@op/db/client';
+import { ProposalStatus, organizations } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 import { assertAccess, permission } from 'access-zones';
 
@@ -29,8 +29,8 @@ export const listLegacyInstances = async ({
 
   assertAccess({ decisions: permission.READ }, orgUser?.roles ?? []);
 
-  const instanceList = await db._query.processInstances.findMany({
-    where: eq(processInstances.ownerProfileId, ownerProfileId),
+  const instanceList = await db.query.processInstances.findMany({
+    where: { ownerProfileId },
     with: {
       process: true,
       owner: {
@@ -46,7 +46,7 @@ export const listLegacyInstances = async ({
         },
       },
     },
-    orderBy: desc(processInstances.createdAt),
+    orderBy: (table, { desc }) => desc(table.createdAt),
   });
 
   return instanceList.map((instance) => {

--- a/packages/common/src/services/decision/listProcesses.ts
+++ b/packages/common/src/services/decision/listProcesses.ts
@@ -1,4 +1,4 @@
-import { and, db, desc, eq, ilike, sql } from '@op/db/client';
+import { and, db, eq, ilike, sql } from '@op/db/client';
 import { decisionProcesses } from '@op/db/schema';
 
 export interface ListProcessesInput {
@@ -40,12 +40,27 @@ export const listProcesses = async ({
     const whereClause = and(...conditions);
 
     const [processes, totalResult] = await Promise.all([
-      db._query.decisionProcesses.findMany({
-        where: whereClause,
+      db.query.decisionProcesses.findMany({
+        where: {
+          RAW: (table) => {
+            const parts = [
+              sql`${table.processSchema}->>'id' IS NOT NULL`,
+              sql`${table.processSchema}->>'version' IS NOT NULL`,
+              sql`${table.processSchema}->'phases' IS NOT NULL`,
+            ];
+            if (search) {
+              parts.push(ilike(table.name, `%${search}%`));
+            }
+            if (createdByProfileId) {
+              parts.push(eq(table.createdByProfileId, createdByProfileId));
+            }
+            return sql.join(parts, sql` AND `);
+          },
+        },
         with: {
           createdBy: true,
         },
-        orderBy: [desc(decisionProcesses.createdAt)],
+        orderBy: (table, { desc }) => [desc(table.createdAt)],
         limit: limit + 1, // Get one extra to check if there are more
         offset,
       }),

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -1,15 +1,4 @@
-import {
-  and,
-  asc,
-  db,
-  desc,
-  eq,
-  ilike,
-  inArray,
-  ne,
-  or,
-  sql,
-} from '@op/db/client';
+import { and, db, eq, ilike, inArray, ne, or, sql } from '@op/db/client';
 import {
   ProfileRelationshipType,
   ProposalStatus,
@@ -126,25 +115,30 @@ const resolveExplicitScope = async ({
   return votedRows.map((r) => r.proposalId);
 };
 
-// Shared function to build WHERE conditions for both count and data queries
-const buildWhereConditions = (input: ListProposalsInput) => {
+// Shared function to build WHERE conditions for both count and data queries.
+// Accepts a table reference so the relational query API can pass an aliased
+// version while the v1 select can pass the schema table directly.
+const buildWhereConditions = (
+  input: ListProposalsInput,
+  t: typeof proposals = proposals,
+) => {
   const { processInstanceId, submittedByProfileId, status, search } = input;
 
   const conditions = [];
 
-  conditions.push(eq(proposals.processInstanceId, processInstanceId));
+  conditions.push(eq(t.processInstanceId, processInstanceId));
 
   if (submittedByProfileId) {
-    conditions.push(eq(proposals.submittedByProfileId, submittedByProfileId));
+    conditions.push(eq(t.submittedByProfileId, submittedByProfileId));
   }
 
   if (status) {
-    conditions.push(eq(proposals.status, status));
+    conditions.push(eq(t.status, status));
   }
 
   if (search) {
     // Search in proposal data (JSONB) - convert to text for searching
-    conditions.push(ilike(sql`${proposals.proposalData}::text`, `%${search}%`));
+    conditions.push(ilike(sql`${t.proposalData}::text`, `%${search}%`));
   }
 
   return conditions.length > 0 ? and(...conditions) : undefined;
@@ -243,23 +237,6 @@ export const listProposals = async ({
 
   const { limit = 20, offset = 0, orderBy = 'createdAt', dir = 'desc' } = input;
 
-  // Build shared WHERE clause using the extracted function
-  const baseWhereClause = buildWhereConditions(input);
-
-  // When the caller provided an explicit scope (proposalIds or votedByProfileId),
-  // constrain the entire query to that ID set. This prevents the draft branch
-  // (below) from independently surfacing drafts the user owns but didn't ask for.
-  let whereClause = baseWhereClause;
-  if (explicitScopeIds !== undefined) {
-    const explicitScopeFilter =
-      explicitScopeIds.length > 0
-        ? inArray(proposals.id, explicitScopeIds)
-        : sql`false`;
-    whereClause = whereClause
-      ? and(whereClause, explicitScopeFilter)
-      : explicitScopeFilter;
-  }
-
   // Handle category filtering separately to avoid table reference issues
   const { categoryId } = input;
   let categoryProposalIds: string[] = [];
@@ -282,73 +259,81 @@ export const listProposals = async ({
         canManageProposals,
       };
     }
-
-    // Add category filter to WHERE clause (composed with any earlier filters)
-    const categoryFilter = inArray(proposals.id, categoryProposalIds);
-    whereClause = whereClause
-      ? and(whereClause, categoryFilter)
-      : categoryFilter;
   }
 
-  // Phase scoping applies to non-draft proposals only. Drafts are user-private
-  // and not part of any phase transition snapshot, so they bypass phaseProposalIds.
-  // When phaseProposalIds is empty (e.g. instance has no submitted proposals yet),
-  // the non-draft branch must short-circuit to false rather than emit an empty IN ().
-  const phaseScopedNonDraftIdFilter =
-    phaseProposalIds.length > 0
-      ? and(
-          ne(proposals.status, ProposalStatus.DRAFT),
-          inArray(proposals.id, phaseProposalIds),
-        )
-      : sql`false`;
+  // Build the full WHERE clause against the supplied table reference. Used by
+  // the v1 select count below (passing the schema table) and the v2 relational
+  // findMany (passing the aliased table from the RAW callback).
+  const buildFullWhere = (t: typeof proposals = proposals) => {
+    let whereClause = buildWhereConditions(input, t);
 
-  if (skipAccessCheck) {
-    // Trusted contexts get all phase-scoped non-draft proposals.
-    whereClause = whereClause
-      ? and(whereClause, phaseScopedNonDraftIdFilter)
-      : phaseScopedNonDraftIdFilter;
-  } else {
-    // Draft proposals: only visible to users with proposal-level access
-    // (the creator and invited collaborators with a profileUsers record on the proposal's profile).
-    // Drafts are not phase-scoped and remain visible regardless of phaseId so that
-    // creators continue to see their own in-progress work alongside the current phase.
-    const draftFilter = and(
-      eq(proposals.status, ProposalStatus.DRAFT),
-      inArray(
-        proposals.profileId,
-        db
-          .select({ profileId: profileUsers.profileId })
-          .from(profileUsers)
-          .where(eq(profileUsers.authUserId, input.authUserId)),
-      ),
-    );
+    if (explicitScopeIds !== undefined) {
+      const explicitScopeFilter =
+        explicitScopeIds.length > 0
+          ? inArray(t.id, explicitScopeIds)
+          : sql`false`;
+      whereClause = whereClause
+        ? and(whereClause, explicitScopeFilter)
+        : explicitScopeFilter;
+    }
 
-    // Non-draft proposals: phase-scoped, plus the HIDDEN visibility filter for
-    // non-admins (admins and the owning profile still see hidden proposals).
-    const nonDraftVisibilityFilter = canManageProposals
-      ? phaseScopedNonDraftIdFilter
-      : and(
-          phaseScopedNonDraftIdFilter,
-          or(
-            eq(proposals.visibility, Visibility.VISIBLE),
-            eq(proposals.submittedByProfileId, currentProfileId),
-          ),
-        );
+    if (categoryId && categoryProposalIds.length > 0) {
+      const categoryFilter = inArray(t.id, categoryProposalIds);
+      whereClause = whereClause
+        ? and(whereClause, categoryFilter)
+        : categoryFilter;
+    }
 
-    const permissionFilter = or(draftFilter, nonDraftVisibilityFilter);
-    whereClause = whereClause
-      ? and(whereClause, permissionFilter)
-      : permissionFilter;
-  }
+    // Phase scoping applies to non-draft proposals only. Drafts are user-private
+    // and not part of any phase transition snapshot, so they bypass phaseProposalIds.
+    // When phaseProposalIds is empty (e.g. instance has no submitted proposals yet),
+    // the non-draft branch must short-circuit to false rather than emit an empty IN ().
+    const phaseScopedNonDraftIdFilter =
+      phaseProposalIds.length > 0
+        ? and(
+            ne(t.status, ProposalStatus.DRAFT),
+            inArray(t.id, phaseProposalIds),
+          )
+        : sql`false`;
 
-  // Get proposals with optimized ordering
-  const orderColumn = proposals[orderBy] ?? proposals.createdAt;
+    if (skipAccessCheck) {
+      whereClause = whereClause
+        ? and(whereClause, phaseScopedNonDraftIdFilter)
+        : phaseScopedNonDraftIdFilter;
+    } else {
+      const draftFilter = and(
+        eq(t.status, ProposalStatus.DRAFT),
+        inArray(
+          t.profileId,
+          db
+            .select({ profileId: profileUsers.profileId })
+            .from(profileUsers)
+            .where(eq(profileUsers.authUserId, input.authUserId)),
+        ),
+      );
 
-  const orderFn = dir === 'asc' ? asc : desc;
+      const nonDraftVisibilityFilter = canManageProposals
+        ? phaseScopedNonDraftIdFilter
+        : and(
+            phaseScopedNonDraftIdFilter,
+            or(
+              eq(t.visibility, Visibility.VISIBLE),
+              eq(t.submittedByProfileId, currentProfileId),
+            ),
+          );
+
+      const permissionFilter = or(draftFilter, nonDraftVisibilityFilter);
+      whereClause = whereClause
+        ? and(whereClause, permissionFilter)
+        : permissionFilter;
+    }
+
+    return whereClause;
+  };
 
   const [proposalList, countResult] = await Promise.all([
-    db._query.proposals.findMany({
-      where: whereClause,
+    db.query.proposals.findMany({
+      where: { RAW: (t) => buildFullWhere(t)! },
       with: {
         submittedBy: {
           with: {
@@ -359,10 +344,13 @@ export const listProposals = async ({
       },
       limit,
       offset,
-      orderBy: orderFn(orderColumn),
+      orderBy: (t, { asc, desc }) => {
+        const col = t[orderBy] ?? t.createdAt;
+        return dir === 'asc' ? asc(col) : desc(col);
+      },
     }),
     // Get count using Drizzle's count function instead of raw SQL
-    db.select({ count: countFn() }).from(proposals).where(whereClause),
+    db.select({ count: countFn() }).from(proposals).where(buildFullWhere()),
   ]);
 
   const count = countResult[0]?.count || 0;

--- a/packages/common/src/services/decision/proposalContentProcessor.ts
+++ b/packages/common/src/services/decision/proposalContentProcessor.ts
@@ -1,5 +1,5 @@
-import { type DbClient, db as defaultDb, eq } from '@op/db/client';
-import { attachments, proposalAttachments, proposals } from '@op/db/schema';
+import { db, eq } from '@op/db/client';
+import { attachments, proposals } from '@op/db/schema';
 
 /**
  * Generate public URL for asset using Next.js rewrite
@@ -15,16 +15,16 @@ const getPublicUrl = (key?: string | null) => {
  * Process proposal content to replace temporary image URLs with permanent attachment references
  */
 export async function processProposalContent({
-  db,
+  conn,
   proposalId,
 }: {
-  db: DbClient;
+  conn: typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
   proposalId: string;
 }): Promise<void> {
   try {
     // Get the proposal content
-    const proposal = await db._query.proposals.findFirst({
-      where: eq(proposals.id, proposalId),
+    const proposal = await conn.query.proposals.findFirst({
+      where: { id: proposalId },
     });
 
     if (!proposal) {
@@ -42,8 +42,8 @@ export async function processProposalContent({
 
     // Get all attachments for this proposal through the join table
     const proposalAttachmentJoins =
-      await db._query.proposalAttachments.findMany({
-        where: eq(proposalAttachments.proposalId, proposalId),
+      await conn.query.proposalAttachments.findMany({
+        where: { proposalId },
         with: {
           attachment: true,
         },
@@ -119,7 +119,7 @@ export async function processProposalContent({
         content: processedContent,
       };
 
-      await db
+      await conn
         .update(proposals)
         .set({
           proposalData: updatedProposalData,
@@ -132,7 +132,7 @@ export async function processProposalContent({
     // Update attachment metadata
     if (updatedAttachments.length > 0) {
       for (const attachmentUpdate of updatedAttachments) {
-        await db
+        await conn
           .update(attachments)
           .set({
             fileName: attachmentUpdate.fileName,
@@ -177,13 +177,12 @@ function extractImageUrlsFromContent(htmlContent: string): string[] {
 export async function getProposalAttachmentUrls(
   proposalId: string,
 ): Promise<Record<string, string>> {
-  const proposalAttachmentJoins =
-    await defaultDb._query.proposalAttachments.findMany({
-      where: eq(proposalAttachments.proposalId, proposalId),
-      with: {
-        attachment: true,
-      },
-    });
+  const proposalAttachmentJoins = await db.query.proposalAttachments.findMany({
+    where: { proposalId },
+    with: {
+      attachment: true,
+    },
+  });
 
   if (proposalAttachmentJoins.length === 0) {
     return {};

--- a/packages/common/src/services/decision/proposalTaxonomy.ts
+++ b/packages/common/src/services/decision/proposalTaxonomy.ts
@@ -50,7 +50,7 @@ export async function ensureProposalTaxonomyTerms(
       trim: true,
     });
 
-    // taxonomyTerms V2 types are broken due to self-referential parentId
+    // taxonomyTerms self-referential parentId breaks v2 where typing.
     let existingTerm = await db._query.taxonomyTerms.findFirst({
       where: eq(taxonomyTerms.termUri, termUri),
     });

--- a/packages/common/src/services/decision/updateProcess.ts
+++ b/packages/common/src/services/decision/updateProcess.ts
@@ -31,8 +31,8 @@ export const updateProcess = async ({
     }
 
     // Check if process exists and user has permission to update it
-    const existingProcess = await db._query.decisionProcesses.findFirst({
-      where: eq(decisionProcesses.id, processId),
+    const existingProcess = await db.query.decisionProcesses.findFirst({
+      where: { id: processId },
     });
 
     if (!existingProcess) {

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -1,12 +1,11 @@
 import { getTipTapClient } from '@op/collab';
-import { type DbClient, and, db, eq } from '@op/db/client';
+import { type TransactionType, and, db, eq } from '@op/db/client';
 import {
   ProposalStatus,
   type Visibility,
   profiles,
   proposalCategories,
   proposals,
-  taxonomies,
   taxonomyTerms,
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
@@ -30,11 +29,11 @@ import { type DecisionInstanceData, isLastPhase } from './schemas/instanceData';
 import { validateProposalAgainstTemplate } from './validateProposalAgainstTemplate';
 
 async function updateProposalCategoryLink(
-  db: DbClient,
+  tx: TransactionType,
   proposalId: string,
   newCategoryLabels: string[],
 ): Promise<void> {
-  await db
+  await tx
     .delete(proposalCategories)
     .where(eq(proposalCategories.proposalId, proposalId));
 
@@ -42,8 +41,8 @@ async function updateProposalCategoryLink(
     return;
   }
 
-  const proposalTaxonomy = await db._query.taxonomies.findFirst({
-    where: eq(taxonomies.name, 'proposal'),
+  const proposalTaxonomy = await tx.query.taxonomies.findFirst({
+    where: { name: 'proposal' },
   });
 
   if (!proposalTaxonomy) {
@@ -58,7 +57,8 @@ async function updateProposalCategoryLink(
       continue;
     }
 
-    const taxonomyTerm = await db._query.taxonomyTerms.findFirst({
+    // taxonomyTerms self-referential parentId breaks v2 where typing.
+    const taxonomyTerm = await tx._query.taxonomyTerms.findFirst({
       where: and(
         eq(taxonomyTerms.label, categoryLabel.trim()),
         eq(taxonomyTerms.taxonomyId, proposalTaxonomy.id),
@@ -74,7 +74,7 @@ async function updateProposalCategoryLink(
   }
 
   if (taxonomyTermIds.length > 0) {
-    await db.insert(proposalCategories).values(
+    await tx.insert(proposalCategories).values(
       taxonomyTermIds.map((taxonomyTermId) => ({
         proposalId,
         taxonomyTermId,

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -1,10 +1,8 @@
-import { and, db, eq } from '@op/db/client';
+import { db } from '@op/db/client';
 import {
   type VoteData,
   decisionsVoteProposals,
   decisionsVoteSubmissions,
-  processInstances,
-  proposals,
 } from '@op/db/schema';
 import { assertAccess, permission } from 'access-zones';
 
@@ -149,8 +147,8 @@ export const submitVote = async ({
     const profileId = await getIndividualProfileId(authUserId);
 
     // Get process instance and schema
-    const processInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, data.processInstanceId),
+    const processInstance = await db.query.processInstances.findFirst({
+      where: { id: data.processInstanceId },
       columns: {
         id: true,
         profileId: true,
@@ -216,11 +214,11 @@ export const submitVote = async ({
     }
 
     // Check if user has already voted
-    const existingVote = await db._query.decisionsVoteSubmissions.findFirst({
-      where: and(
-        eq(decisionsVoteSubmissions.processInstanceId, data.processInstanceId),
-        eq(decisionsVoteSubmissions.submittedByProfileId, profileId),
-      ),
+    const existingVote = await db.query.decisionsVoteSubmissions.findFirst({
+      where: {
+        processInstanceId: data.processInstanceId,
+        submittedByProfileId: profileId,
+      },
     });
 
     if (existingVote) {
@@ -230,8 +228,8 @@ export const submitVote = async ({
     }
 
     // Get available proposals for this process instance
-    const availableProposals = await db._query.proposals.findMany({
-      where: eq(proposals.processInstanceId, data.processInstanceId),
+    const availableProposals = await db.query.proposals.findMany({
+      where: { processInstanceId: data.processInstanceId },
     });
 
     // Filter to eligible proposals for voting
@@ -346,8 +344,8 @@ export const getVotingStatus = async ({
     const profileId = await getIndividualProfileId(authUserId);
 
     // Get process instance and schema
-    const processInstance = await db._query.processInstances.findFirst({
-      where: eq(processInstances.id, data.processInstanceId),
+    const processInstance = await db.query.processInstances.findFirst({
+      where: { id: data.processInstanceId },
       columns: {
         id: true,
         profileId: true,
@@ -398,11 +396,11 @@ export const getVotingStatus = async ({
     const { votingConfig } = schemaResult;
 
     // Check if user has voted
-    const voteSubmission = await db._query.decisionsVoteSubmissions.findFirst({
-      where: and(
-        eq(decisionsVoteSubmissions.processInstanceId, data.processInstanceId),
-        eq(decisionsVoteSubmissions.submittedByProfileId, profileId),
-      ),
+    const voteSubmission = await db.query.decisionsVoteSubmissions.findFirst({
+      where: {
+        processInstanceId: data.processInstanceId,
+        submittedByProfileId: profileId,
+      },
       with: {
         voteProposals: {
           with: {

--- a/packages/common/src/services/organization/deleteOrganization.ts
+++ b/packages/common/src/services/organization/deleteOrganization.ts
@@ -15,8 +15,8 @@ export async function deleteOrganization({
   user: User;
 }) {
   // First, find the organization by its profile ID to get the organization ID
-  const organization = await db._query.organizations.findFirst({
-    where: (table, { eq }) => eq(table.profileId, organizationProfileId),
+  const organization = await db.query.organizations.findFirst({
+    where: { profileId: organizationProfileId },
   });
 
   if (!organization) {

--- a/packages/common/src/services/organization/deleteOrganizationUser.ts
+++ b/packages/common/src/services/organization/deleteOrganizationUser.ts
@@ -28,12 +28,11 @@ export async function deleteOrganizationUser({
   assertAccess({ admin: permission.UPDATE }, orgUser?.roles || []);
 
   // Check if the organization user to delete exists
-  const targetOrgUser = await db._query.organizationUsers.findFirst({
-    where: (table, { eq, and }) =>
-      and(
-        eq(table.id, organizationUserId),
-        eq(table.organizationId, organizationId),
-      ),
+  const targetOrgUser = await db.query.organizationUsers.findFirst({
+    where: {
+      id: organizationUserId,
+      organizationId,
+    },
   });
 
   if (!targetOrgUser) {

--- a/packages/common/src/services/organization/getOrganization.ts
+++ b/packages/common/src/services/organization/getOrganization.ts
@@ -1,5 +1,5 @@
-import { db, eq, sql } from '@op/db/client';
-import { locations, profiles } from '@op/db/schema';
+import { db, eq } from '@op/db/client';
+import { profiles } from '@op/db/schema';
 
 import { NotFoundError } from '../../utils';
 
@@ -20,8 +20,8 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
     throw new NotFoundError('Could not find organization');
   }
 
-  const org = await db._query.organizations.findFirst({
-    where: (table, { eq }) => eq(table.profileId, profileId),
+  const org = await db.query.organizations.findFirst({
+    where: { profileId },
     with: {
       projects: true,
       links: true,
@@ -35,8 +35,10 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
         with: {
           location: {
             extras: {
-              x: sql<number>`ST_X(${locations.location})`.as('x'),
-              y: sql<number>`ST_Y(${locations.location})`.as('y'),
+              x: (table, { sql }) =>
+                sql<number>`ST_X(${table.location})`.as('x'),
+              y: (table, { sql }) =>
+                sql<number>`ST_Y(${table.location})`.as('y'),
             },
             columns: {
               id: true,
@@ -45,7 +47,6 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
               countryCode: true,
               countryName: true,
               metadata: true,
-              latLng: false,
             },
           },
         },
@@ -63,8 +64,9 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
     throw new NotFoundError('Could not find organization');
   }
 
-  org.whereWeWork = org.whereWeWork.map((record) => record.location);
-  org.strategies = org.strategies.map((record) => record.term);
-
-  return org;
+  return {
+    ...org,
+    whereWeWork: org.whereWeWork.map((record) => record.location),
+    strategies: org.strategies.map((record) => record.term),
+  };
 };

--- a/packages/common/src/services/organization/getOrganizationUsers.ts
+++ b/packages/common/src/services/organization/getOrganizationUsers.ts
@@ -28,8 +28,8 @@ export const getOrganizationUsers = async ({
   assertAccess({ admin: permission.READ }, orgUser?.roles || []);
 
   // Fetch all users in the organization with their roles and avatar images
-  const organizationUsers = await db._query.organizationUsers.findMany({
-    where: (table, { eq }) => eq(table.organizationId, organization.id),
+  const organizationUsers = await db.query.organizationUsers.findMany({
+    where: { organizationId: organization.id },
     with: {
       roles: {
         with: {

--- a/packages/common/src/services/organization/getOrganizationsByProfile.ts
+++ b/packages/common/src/services/organization/getOrganizationsByProfile.ts
@@ -1,12 +1,12 @@
-import { db, sql } from '@op/db/client';
-import { locations } from '@op/db/schema';
+import { db } from '@op/db/client';
 
 export const getOrganizationsByProfile = async (profileId: string) => {
   // Find all users who have access to this profile
   // Either as their personal profile or as their current profile
-  const usersWithProfile = await db._query.users.findMany({
-    where: (table, { eq, or }) =>
-      or(eq(table.profileId, profileId), eq(table.currentProfileId, profileId)),
+  const usersWithProfile = await db.query.users.findMany({
+    where: {
+      OR: [{ profileId }, { currentProfileId: profileId }],
+    },
     with: {
       organizationUsers: {
         with: {
@@ -24,8 +24,10 @@ export const getOrganizationsByProfile = async (profileId: string) => {
                 with: {
                   location: {
                     extras: {
-                      x: sql<number>`ST_X(${locations.location})`.as('x'),
-                      y: sql<number>`ST_Y(${locations.location})`.as('y'),
+                      x: (table, { sql }) =>
+                        sql<number>`ST_X(${table.location})`.as('x'),
+                      y: (table, { sql }) =>
+                        sql<number>`ST_Y(${table.location})`.as('y'),
                     },
                     columns: {
                       id: true,
@@ -34,7 +36,6 @@ export const getOrganizationsByProfile = async (profileId: string) => {
                       countryCode: true,
                       countryName: true,
                       metadata: true,
-                      latLng: false,
                     },
                   },
                 },

--- a/packages/common/src/services/organization/inviteUsers.ts
+++ b/packages/common/src/services/organization/inviteUsers.ts
@@ -69,8 +69,8 @@ export const inviteUsersToOrganization = async (
 
   assertAccess({ profile: permission.ADMIN }, orgUser.roles || []);
 
-  const authUser = (await db._query.users.findFirst({
-    where: (table, { eq }) => eq(table.authUserId, user.id),
+  const authUser = (await db.query.users.findFirst({
+    where: { authUserId: user.id },
     with: {
       currentOrganization: {
         with: {
@@ -99,11 +99,11 @@ export const inviteUsersToOrganization = async (
     const email = rawEmail.toLowerCase();
     try {
       // Check if user already exists in the system
-      const existingUser = await db._query.users.findFirst({
-        where: (table, { eq }) => eq(table.email, email),
+      const existingUser = await db.query.users.findFirst({
+        where: { email },
         with: {
           organizationUsers: {
-            where: (table, { eq }) => eq(table.organizationId, organizationId),
+            where: { organizationId },
           },
         },
       });
@@ -165,8 +165,8 @@ export const inviteUsersToOrganization = async (
       }
 
       // Check if email is already in the allowList
-      const existingEntry = await db._query.allowList.findFirst({
-        where: (table, { eq }) => eq(table.email, email),
+      const existingEntry = await db.query.allowList.findFirst({
+        where: { email },
       });
 
       if (!existingEntry) {
@@ -259,8 +259,8 @@ export const inviteNewUsers = async (input: InviteNewUsersInput) => {
   const { emails, personalMessage, user } = input;
 
   // Get the current user's database record with profile details
-  const authUser = (await db._query.users.findFirst({
-    where: (table, { eq }) => eq(table.authUserId, user.id),
+  const authUser = (await db.query.users.findFirst({
+    where: { authUserId: user.id },
     with: {
       currentOrganization: {
         with: {
@@ -301,8 +301,8 @@ export const inviteNewUsers = async (input: InviteNewUsersInput) => {
     const email = rawEmail.toLowerCase();
     try {
       // Check if email is already in the allowList
-      const existingEntry = await db._query.allowList.findFirst({
-        where: (table, { eq }) => eq(table.email, email),
+      const existingEntry = await db.query.allowList.findFirst({
+        where: { email },
       });
 
       if (!existingEntry) {

--- a/packages/common/src/services/organization/listOrganizations.ts
+++ b/packages/common/src/services/organization/listOrganizations.ts
@@ -1,12 +1,6 @@
-import { db, sql } from '@op/db/client';
-import { locations, organizations } from '@op/db/schema';
+import { db } from '@op/db/client';
 
-import {
-  NotFoundError,
-  decodeCursor,
-  encodeCursor,
-  getCursorCondition,
-} from '../../utils';
+import { NotFoundError, decodeCursor, encodeCursor } from '../../utils';
 
 export const listOrganizations = async ({
   cursor,
@@ -20,22 +14,18 @@ export const listOrganizations = async ({
   dir?: 'asc' | 'desc';
 }) => {
   try {
-    const orderByColumn =
-      orderBy === 'createdAt'
-        ? organizations.createdAt
-        : organizations.updatedAt;
-
-    // Build cursor condition for unfiltered query
-    const cursorCondition = cursor
-      ? getCursorCondition({
-          column: orderByColumn,
-          cursor: decodeCursor<{ value: string | Date }>(cursor),
-          direction: dir,
-        })
+    const decodedCursor = cursor
+      ? decodeCursor<{ value: string | Date }>(cursor)
       : undefined;
 
-    const result = await db._query.organizations.findMany({
-      where: cursorCondition,
+    const cursorOp = decodedCursor
+      ? dir === 'asc'
+        ? { gt: decodedCursor.value }
+        : { lt: decodedCursor.value }
+      : undefined;
+
+    const result = await db.query.organizations.findMany({
+      where: cursorOp ? { [orderBy]: cursorOp } : undefined,
       with: {
         projects: true,
         links: true,
@@ -49,8 +39,10 @@ export const listOrganizations = async ({
           with: {
             location: {
               extras: {
-                x: sql<number>`ST_X(${locations.location})`.as('x'),
-                y: sql<number>`ST_Y(${locations.location})`.as('y'),
+                x: (table, { sql }) =>
+                  sql<number>`ST_X(${table.location})`.as('x'),
+                y: (table, { sql }) =>
+                  sql<number>`ST_Y(${table.location})`.as('y'),
               },
               columns: {
                 id: true,
@@ -59,14 +51,15 @@ export const listOrganizations = async ({
                 countryCode: true,
                 countryName: true,
                 metadata: true,
-                latLng: false,
               },
             },
           },
         },
       },
-      orderBy: (_, { asc, desc }) =>
-        dir === 'asc' ? asc(orderByColumn) : desc(orderByColumn),
+      orderBy: (table, { asc, desc }) => {
+        const col = orderBy === 'createdAt' ? table.createdAt : table.updatedAt;
+        return dir === 'asc' ? asc(col) : desc(col);
+      },
       limit: limit + 1, // Fetch one extra to check hasMore
     });
 
@@ -74,12 +67,13 @@ export const listOrganizations = async ({
       throw new NotFoundError('Organizations not found');
     }
 
-    result.forEach((org) => {
-      org.whereWeWork = org.whereWeWork.map((item) => item.location);
-    });
+    const flattened = result.map((org) => ({
+      ...org,
+      whereWeWork: org.whereWeWork.map((item) => item.location),
+    }));
 
-    const hasMore = result.length > limit;
-    const items = result.slice(0, limit);
+    const hasMore = flattened.length > limit;
+    const items = flattened.slice(0, limit);
     const lastItem = items[items.length - 1];
 
     const orderByValue =

--- a/packages/common/src/services/organization/relationships.ts
+++ b/packages/common/src/services/organization/relationships.ts
@@ -1,13 +1,11 @@
 import { OPURLConfig } from '@op/core';
-import { and, db, eq, inArray, or } from '@op/db/client';
+import { and, db, eq, inArray } from '@op/db/client';
 import {
   Organization,
   Profile,
   accessRoles,
   organizationRelationships,
   organizationUserToAccessRoles,
-  organizationUsers,
-  organizations,
 } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 import { relationshipMap } from '@op/types';
@@ -88,12 +86,12 @@ export const sendRelationshipNotification = async ({
   relationships: Array<string>;
 }) => {
   const [sourceOrg, targetOrg] = await Promise.all([
-    db._query.organizations.findFirst({
-      where: eq(organizations.id, from),
+    db.query.organizations.findFirst({
+      where: { id: from },
       with: { profile: true },
     }),
-    db._query.organizations.findFirst({
-      where: eq(organizations.id, to),
+    db.query.organizations.findFirst({
+      where: { id: to },
       with: { profile: true },
     }),
   ]);
@@ -104,23 +102,24 @@ export const sendRelationshipNotification = async ({
 
   // Send email notifications to target organization admin users only
   try {
-    const adminUsers = await db._query.organizationUsers.findMany({
-      where: and(
-        eq(organizationUsers.organizationId, to),
-        inArray(
-          organizationUsers.id,
-          db
-            .select({
-              userId: organizationUserToAccessRoles.organizationUserId,
-            })
-            .from(organizationUserToAccessRoles)
-            .leftJoin(
-              accessRoles,
-              eq(organizationUserToAccessRoles.accessRoleId, accessRoles.id),
-            )
-            .where(eq(accessRoles.name, 'Admin')),
-        ),
-      ),
+    const adminUsers = await db.query.organizationUsers.findMany({
+      where: {
+        organizationId: to,
+        RAW: (table) =>
+          inArray(
+            table.id,
+            db
+              .select({
+                userId: organizationUserToAccessRoles.organizationUserId,
+              })
+              .from(organizationUserToAccessRoles)
+              .leftJoin(
+                accessRoles,
+                eq(organizationUserToAccessRoles.accessRoleId, accessRoles.id),
+              )
+              .where(eq(accessRoles.name, 'Admin')),
+          ),
+      },
     });
 
     const appUrlConfig = OPURLConfig('APP');
@@ -174,19 +173,11 @@ export const getRelatedOrganizations = async ({
   // }
   //
 
-  const where = () =>
-    and(
-      or(
-        eq(organizationRelationships.sourceOrganizationId, orgId),
-        eq(organizationRelationships.targetOrganizationId, orgId),
-      ),
-      ...(pending !== null
-        ? [eq(organizationRelationships.pending, pending)]
-        : []),
-    );
-
-  const relationships = await db._query.organizationRelationships.findMany({
-    where,
+  const relationships = await db.query.organizationRelationships.findMany({
+    where: {
+      OR: [{ sourceOrganizationId: orgId }, { targetOrganizationId: orgId }],
+      ...(pending !== null && { pending }),
+    },
     with: {
       targetOrganization: {
         with: {
@@ -285,25 +276,18 @@ export const getDirectedRelationships = async ({
   // }
   //
   const allRelationshipsFromDb =
-    await db._query.organizationRelationships.findMany({
-      where: () =>
-        and(
-          or(
-            eq(organizationRelationships.sourceOrganizationId, from),
-            eq(organizationRelationships.targetOrganizationId, from),
-          ),
-          ...(to
-            ? [
-                or(
-                  eq(organizationRelationships.targetOrganizationId, to),
-                  eq(organizationRelationships.sourceOrganizationId, to),
-                ),
-              ]
-            : []),
-          ...(pending !== null
-            ? [eq(organizationRelationships.pending, pending)]
-            : []),
-        ),
+    await db.query.organizationRelationships.findMany({
+      where: {
+        OR: [{ sourceOrganizationId: from }, { targetOrganizationId: from }],
+        ...(to && {
+          AND: [
+            {
+              OR: [{ targetOrganizationId: to }, { sourceOrganizationId: to }],
+            },
+          ],
+        }),
+        ...(pending !== null && { pending }),
+      },
       with: {
         targetOrganization: {
           with: {
@@ -365,15 +349,12 @@ export const getPendingRelationships = async ({
     throw new UnauthorizedError('You are not a member of this organization');
   }
 
-  const where = () =>
-    and(
-      eq(organizationRelationships.targetOrganizationId, orgId),
-      eq(organizationRelationships.pending, true),
-    );
-
   const [relationships] = await Promise.all([
-    db._query.organizationRelationships.findMany({
-      where,
+    db.query.organizationRelationships.findMany({
+      where: {
+        targetOrganizationId: orgId,
+        pending: true,
+      },
       with: {
         targetOrganization: {
           with: {

--- a/packages/common/src/services/organization/updateOrganization.ts
+++ b/packages/common/src/services/organization/updateOrganization.ts
@@ -291,11 +291,11 @@ export const updateOrganization = async ({
 
   // Fetch the updated organization and profile separately to ensure proper typing
   const [updatedOrg, updatedProfile] = await Promise.all([
-    db._query.organizations.findFirst({
-      where: eq(organizations.id, organizationId),
+    db.query.organizations.findFirst({
+      where: { id: organizationId },
     }),
-    db._query.profiles.findFirst({
-      where: eq(profiles.id, existingOrg.profileId),
+    db.query.profiles.findFirst({
+      where: { id: existingOrg.profileId },
       with: {
         headerImage: true,
         avatarImage: true,

--- a/packages/common/src/services/organization/updateOrganizationUser.ts
+++ b/packages/common/src/services/organization/updateOrganizationUser.ts
@@ -41,12 +41,11 @@ export async function updateOrganizationUser({
   assertAccess({ admin: permission.UPDATE }, orgUser?.roles || []);
 
   // Check if the organization user to update exists
-  const targetOrgUser = await db._query.organizationUsers.findFirst({
-    where: (table, { eq, and }) =>
-      and(
-        eq(table.id, organizationUserId),
-        eq(table.organizationId, organizationId),
-      ),
+  const targetOrgUser = await db.query.organizationUsers.findFirst({
+    where: {
+      id: organizationUserId,
+      organizationId,
+    },
   });
 
   if (!targetOrgUser) {
@@ -113,8 +112,8 @@ export async function updateOrganizationUser({
   }
 
   // Return the updated user with roles
-  const updatedUserWithRoles = await db._query.organizationUsers.findFirst({
-    where: (table, { eq }) => eq(table.id, organizationUserId),
+  const updatedUserWithRoles = await db.query.organizationUsers.findFirst({
+    where: { id: organizationUserId },
     with: {
       roles: {
         with: {

--- a/packages/common/src/services/posts/createPost.ts
+++ b/packages/common/src/services/posts/createPost.ts
@@ -29,8 +29,8 @@ const sendPostCommentNotification = async (
 ) => {
   try {
     // Get parent post and author information, including organization associations
-    const parentPostToOrg = (await db._query.postsToOrganizations.findFirst({
-      where: (table, { eq }) => eq(table.postId, parentPostId),
+    const parentPostToOrg = (await db.query.postsToOrganizations.findFirst({
+      where: { postId: parentPostId },
       with: {
         organization: {
           with: {
@@ -51,8 +51,8 @@ const sendPostCommentNotification = async (
 
     if (parentProfileId) {
       // Parallelize commenter and post author queries
-      const commenterProfile = await db._query.profiles.findFirst({
-        where: (table, { eq }) => eq(table.id, commenterProfileId),
+      const commenterProfile = await db.query.profiles.findFirst({
+        where: { id: commenterProfileId },
       });
 
       if (commenterProfile && parentProfile.email) {
@@ -114,11 +114,11 @@ const sendProposalCommentNotification = async (
     if (proposal && proposal.profileId) {
       // Parallelize commenter and proposal author queries
       const [commenterProfile, proposalAuthorProfile] = await Promise.all([
-        db._query.profiles.findFirst({
-          where: (table, { eq }) => eq(table.id, commenterProfileId),
+        db.query.profiles.findFirst({
+          where: { id: commenterProfileId },
         }),
-        db._query.profiles.findFirst({
-          where: (table, { eq }) => eq(table.id, proposal.submittedByProfileId),
+        db.query.profiles.findFirst({
+          where: { id: proposal.submittedByProfileId },
         }),
       ]);
 
@@ -214,8 +214,8 @@ export const createPost = async (input: CreatePostServiceInput) => {
       // Get all storage objects that were attached to the post (inside transaction)
       const allStorageObjects =
         attachmentIds.length > 0
-          ? await tx._query.objectsInStorage.findMany({
-              where: (table, { inArray }) => inArray(table.id, attachmentIds),
+          ? await tx.query.objectsInStorage.findMany({
+              where: { id: { in: attachmentIds } },
             })
           : [];
 

--- a/packages/common/src/services/posts/createPostInOrganization.ts
+++ b/packages/common/src/services/posts/createPostInOrganization.ts
@@ -29,8 +29,8 @@ export const createPostInOrganization = async (
   // Get all storage objects that were attached to the post
   const allStorageObjects =
     attachmentIds.length > 0
-      ? await db._query.objectsInStorage.findMany({
-          where: (table, { inArray }) => inArray(table.id, attachmentIds),
+      ? await db.query.objectsInStorage.findMany({
+          where: { id: { in: attachmentIds } },
         })
       : [];
 

--- a/packages/common/src/services/posts/getOrganizationPosts.ts
+++ b/packages/common/src/services/posts/getOrganizationPosts.ts
@@ -1,7 +1,5 @@
 import { db } from '@op/db/client';
-import { posts, postsToOrganizations } from '@op/db/schema';
 import type { GetOrganizationPostsInput } from '@op/types';
-import { and, desc, eq, isNull } from 'drizzle-orm';
 
 import { getCurrentProfileId } from '../access';
 import { getItemsWithReactionsAndComments } from './listPosts';
@@ -29,25 +27,21 @@ export const getOrganizationPosts = async (
   }
 
   try {
-    // Build where conditions
-    const conditions = [];
-
-    // Filter by parent post
-    if (parentPostId === null) {
-      // Top-level posts only (no parent) - these are "posts"
-      conditions.push(isNull(posts.parentPostId));
-    } else if (parentPostId) {
-      // Children of specific parent - these are "comments"
-      conditions.push(eq(posts.parentPostId, parentPostId));
-    }
-    // If parentPostId is undefined, we get all posts regardless of parent
+    // Filter by parent post: null = top-level only, set = comments under that
+    // parent, undefined = all regardless of parent.
+    const postWhere =
+      parentPostId === null
+        ? { parentPostId: { isNull: true as const } }
+        : parentPostId
+          ? { parentPostId }
+          : undefined;
 
     // Organization posts are filtered through postsToOrganizations
-    const orgPosts = await db._query.postsToOrganizations.findMany({
-      where: eq(postsToOrganizations.organizationId, organizationId),
+    const orgPosts = await db.query.postsToOrganizations.findMany({
+      where: { organizationId },
       with: {
         post: {
-          where: conditions.length > 0 ? and(...conditions) : undefined,
+          ...(postWhere && { where: postWhere }),
           with: {
             profile: {
               with: {
@@ -68,7 +62,7 @@ export const getOrganizationPosts = async (
               ? {
                   childPosts: {
                     limit: 50,
-                    orderBy: [desc(posts.createdAt)],
+                    orderBy: (table, { desc }) => [desc(table.createdAt)],
                     with: {
                       profile: {
                         with: {
@@ -103,7 +97,7 @@ export const getOrganizationPosts = async (
       },
       limit,
       offset,
-      orderBy: [desc(postsToOrganizations.createdAt)],
+      orderBy: (table, { desc }) => [desc(table.createdAt)],
     });
 
     // Transform to match expected format and add reaction data

--- a/packages/common/src/services/posts/getPost.ts
+++ b/packages/common/src/services/posts/getPost.ts
@@ -1,6 +1,4 @@
 import { db } from '@op/db/client';
-import { posts } from '@op/db/schema';
-import { desc, eq } from 'drizzle-orm';
 
 import { getCurrentProfileId } from '../access';
 import { getItemsWithReactionsAndComments } from './listPosts';
@@ -26,8 +24,8 @@ export const getPost = async ({
   try {
     // Query post directly by ID
     const [post, actorProfileId] = await Promise.all([
-      db._query.posts.findFirst({
-        where: eq(posts.id, postId),
+      db.query.posts.findFirst({
+        where: { id: postId },
         with: {
           profile: {
             with: {
@@ -48,7 +46,7 @@ export const getPost = async ({
             ? {
                 childPosts: {
                   limit: 50,
-                  orderBy: [desc(posts.createdAt)],
+                  orderBy: (table, { desc }) => [desc(table.createdAt)],
                   with: {
                     profile: {
                       with: {

--- a/packages/common/src/services/posts/getPosts.ts
+++ b/packages/common/src/services/posts/getPosts.ts
@@ -1,6 +1,4 @@
 import { db } from '@op/db/client';
-import { posts, postsToProfiles } from '@op/db/schema';
-import { and, desc, eq, isNull } from 'drizzle-orm';
 
 import { getCurrentProfileId } from '../access';
 import { getItemsWithReactionsAndComments } from './listPosts';
@@ -37,28 +35,24 @@ export const getPosts = async (input: GetPostsInput) => {
       return []; // Return empty array if neither profileId nor parentPostId provided
     }
 
-    // Build where conditions for posts within the profile
-    const conditions = [];
-
-    // Filter by parent post
-    if (parentPostId === null) {
-      // Top-level posts only (no parent) - these are "posts"
-      conditions.push(isNull(posts.parentPostId));
-    } else if (parentPostId) {
-      // Children of specific parent - these are "comments"
-      conditions.push(eq(posts.parentPostId, parentPostId));
-    }
-    // If parentPostId is undefined, we get all posts regardless of parent
+    // Filter by parent post: null = top-level only, set = comments under that
+    // parent, undefined = all regardless of parent.
+    const postWhere =
+      parentPostId === null
+        ? { parentPostId: { isNull: true as const } }
+        : parentPostId
+          ? { parentPostId }
+          : undefined;
 
     let postsData: any[];
 
     if (profileId) {
       // Query by profile through postsToProfiles
-      const profilePosts = await db._query.postsToProfiles.findMany({
-        where: eq(postsToProfiles.profileId, profileId),
+      const profilePosts = await db.query.postsToProfiles.findMany({
+        where: { profileId },
         with: {
           post: {
-            where: conditions.length > 0 ? and(...conditions) : undefined,
+            ...(postWhere && { where: postWhere }),
             with: {
               profile: {
                 with: {
@@ -79,7 +73,7 @@ export const getPosts = async (input: GetPostsInput) => {
                 ? {
                     childPosts: {
                       limit: 50,
-                      orderBy: [desc(posts.createdAt)],
+                      orderBy: (table, { desc }) => [desc(table.createdAt)],
                       with: {
                         profile: {
                           with: {
@@ -105,13 +99,13 @@ export const getPosts = async (input: GetPostsInput) => {
         },
         limit,
         offset,
-        orderBy: [desc(postsToProfiles.createdAt)],
+        orderBy: (table, { desc }) => [desc(table.createdAt)],
       });
       postsData = profilePosts;
     } else {
       // Query comments directly from posts table when no profileId but parentPostId exists
-      const directPosts = await db._query.posts.findMany({
-        where: conditions.length > 0 ? and(...conditions) : undefined,
+      const directPosts = await db.query.posts.findMany({
+        ...(postWhere && { where: postWhere }),
         with: {
           profile: {
             with: {
@@ -132,7 +126,7 @@ export const getPosts = async (input: GetPostsInput) => {
             ? {
                 childPosts: {
                   limit: 50,
-                  orderBy: [desc(posts.createdAt)],
+                  orderBy: (table, { desc }) => [desc(table.createdAt)],
                   with: {
                     profile: {
                       with: {
@@ -156,7 +150,7 @@ export const getPosts = async (input: GetPostsInput) => {
         },
         limit,
         offset,
-        orderBy: [desc(posts.createdAt)],
+        orderBy: (table, { desc }) => [desc(table.createdAt)],
       });
       // Transform to match postsToProfiles format
       postsData = directPosts.map((post) => ({ post }));

--- a/packages/common/src/services/posts/getProfilePosts.ts
+++ b/packages/common/src/services/posts/getProfilePosts.ts
@@ -1,6 +1,4 @@
-import { db, eq } from '@op/db/client';
-import { posts, postsToProfiles } from '@op/db/schema';
-import { desc, isNull } from 'drizzle-orm';
+import { db } from '@op/db/client';
 
 export interface GetProfilePostsInput {
   profileId: string;
@@ -14,11 +12,11 @@ export const getProfilePosts = async (input: GetProfilePostsInput) => {
 
   try {
     // Get posts attached to this profile via postsToProfiles junction table
-    const profilePosts = await db._query.postsToProfiles.findMany({
-      where: eq(postsToProfiles.profileId, input.profileId),
+    const profilePosts = await db.query.postsToProfiles.findMany({
+      where: { profileId: input.profileId },
       with: {
         post: {
-          where: isNull(posts.parentPostId), // Only top-level posts
+          where: { parentPostId: { isNull: true } }, // Only top-level posts
           with: {
             profile: {
               with: {
@@ -37,7 +35,7 @@ export const getProfilePosts = async (input: GetProfilePostsInput) => {
             },
             childPosts: {
               limit: 50,
-              orderBy: [desc(posts.createdAt)],
+              orderBy: (table, { desc }) => [desc(table.createdAt)],
               with: {
                 profile: {
                   with: {
@@ -54,7 +52,7 @@ export const getProfilePosts = async (input: GetProfilePostsInput) => {
           },
         },
       },
-      orderBy: [desc(postsToProfiles.createdAt)],
+      orderBy: (table, { desc }) => [desc(table.createdAt)],
       limit,
       offset,
     });

--- a/packages/common/src/services/posts/listPosts.ts
+++ b/packages/common/src/services/posts/listPosts.ts
@@ -1,10 +1,5 @@
 import { and, count, db, eq, inArray, isNotNull } from '@op/db/client';
-import {
-  organizations,
-  posts,
-  postsToOrganizations,
-  profiles,
-} from '@op/db/schema';
+import { posts, profiles } from '@op/db/schema';
 
 import {
   NotFoundError,
@@ -26,16 +21,7 @@ export const listPosts = async ({
   cursor?: string | null;
 }) => {
   try {
-    // Build cursor condition for pagination
-    const cursorCondition = cursor
-      ? getGenericCursorCondition({
-          columns: {
-            id: postsToOrganizations.postId,
-            date: postsToOrganizations.createdAt,
-          },
-          cursor: decodeCursor(cursor),
-        })
-      : undefined;
+    const decodedCursor = cursor ? decodeCursor(cursor) : undefined;
 
     const profile = slug
       ? await db
@@ -51,8 +37,8 @@ export const listPosts = async ({
       throw new NotFoundError('Could not find organization');
     }
 
-    const org = await db._query.organizations.findFirst({
-      where: (_, { eq }) => eq(organizations.profileId, profileId),
+    const org = await db.query.organizations.findFirst({
+      where: { profileId },
     });
 
     if (!org) {
@@ -63,13 +49,20 @@ export const listPosts = async ({
       throw new NotFoundError('Organization not found');
     }
 
-    const result = await db._query.postsToOrganizations.findMany({
-      where: cursorCondition
-        ? and(eq(postsToOrganizations.organizationId, org.id), cursorCondition)
-        : (table, { eq }) => eq(table.organizationId, org.id),
+    const result = await db.query.postsToOrganizations.findMany({
+      where: {
+        organizationId: org.id,
+        ...(decodedCursor && {
+          RAW: (table) =>
+            getGenericCursorCondition({
+              columns: { id: table.postId, date: table.createdAt },
+              cursor: decodedCursor,
+            })!,
+        }),
+      },
       with: {
         post: {
-          where: (table, { isNull }) => isNull(table.parentPostId), // Only show top-level posts
+          where: { parentPostId: { isNull: true } }, // Only show top-level posts
           with: {
             attachments: {
               with: {

--- a/packages/common/src/services/posts/listRelatedOrganizationPosts.ts
+++ b/packages/common/src/services/posts/listRelatedOrganizationPosts.ts
@@ -1,5 +1,5 @@
-import { and, db, eq, exists, inArray, isNull } from '@op/db/client';
-import { posts, postsToOrganizations } from '@op/db/schema';
+import { and, db, eq, exists, isNull } from '@op/db/client';
+import { posts } from '@op/db/schema';
 import type { User } from '@supabase/supabase-js';
 
 import {
@@ -29,32 +29,33 @@ export const listAllRelatedOrganizationPosts = async (
 ) => {
   const { limit = 20, cursor } = options;
 
-  // Build cursor condition for pagination
-  const cursorCondition = cursor
-    ? getGenericCursorCondition({
-        columns: {
-          id: postsToOrganizations.postId,
-          date: postsToOrganizations.createdAt,
-        },
-        cursor: decodeCursor(cursor),
-      })
-    : undefined;
+  const decodedCursor = cursor ? decodeCursor(cursor) : undefined;
 
   // Fetch posts for all organizations with pagination
   const [result, profileId] = await Promise.all([
-    db._query.postsToOrganizations.findMany({
-      where: (table) => {
-        // Filter to only include top-level posts (no parentPostId)
-        const topLevelPostFilter = exists(
-          db
-            .select({ id: posts.id })
-            .from(posts)
-            .where(and(eq(posts.id, table.postId), isNull(posts.parentPostId))),
-        );
+    db.query.postsToOrganizations.findMany({
+      where: {
+        RAW: (table) => {
+          // Filter to only include top-level posts (no parentPostId)
+          const topLevelPostFilter = exists(
+            db
+              .select({ id: posts.id })
+              .from(posts)
+              .where(
+                and(eq(posts.id, table.postId), isNull(posts.parentPostId)),
+              ),
+          );
 
-        return cursorCondition
-          ? and(cursorCondition, topLevelPostFilter)
-          : topLevelPostFilter;
+          if (!decodedCursor) {
+            return topLevelPostFilter;
+          }
+
+          const cursorCondition = getGenericCursorCondition({
+            columns: { id: table.postId, date: table.createdAt },
+            cursor: decodedCursor,
+          });
+          return and(cursorCondition, topLevelPostFilter)!;
+        },
       },
       with: {
         post: {
@@ -122,20 +123,16 @@ export const listRelatedOrganizationPosts = async (
   orgIds.push(organizationId); // Add our own org so we see our own posts
 
   // Fetch posts for all related organizations
-  const result = await db._query.postsToOrganizations.findMany({
-    where: (table) => {
-      // Filter to only include top-level posts (no parentPostId)
-      const topLevelPostFilter = exists(
-        db
-          .select({ id: posts.id })
-          .from(posts)
-          .where(and(eq(posts.id, table.postId), isNull(posts.parentPostId))),
-      );
-
-      return and(
-        inArray(postsToOrganizations.organizationId, orgIds),
-        topLevelPostFilter,
-      );
+  const result = await db.query.postsToOrganizations.findMany({
+    where: {
+      organizationId: { in: orgIds },
+      RAW: (table) =>
+        exists(
+          db
+            .select({ id: posts.id })
+            .from(posts)
+            .where(and(eq(posts.id, table.postId), isNull(posts.parentPostId))),
+        ),
     },
     with: {
       post: {

--- a/packages/common/src/services/profile/getProfile.ts
+++ b/packages/common/src/services/profile/getProfile.ts
@@ -1,5 +1,5 @@
-import { db, eq } from '@op/db/client';
-import { EntityType, profiles } from '@op/db/schema';
+import { db } from '@op/db/client';
+import { EntityType } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 import { z } from 'zod';
 
@@ -49,8 +49,8 @@ export const getProfile = async ({
   slug,
   user: _user, // Currently unused but kept for future extensibility
 }: GetProfileParams) => {
-  const profile = await db._query.profiles.findFirst({
-    where: eq(profiles.slug, slug),
+  const profile = await db.query.profiles.findFirst({
+    where: { slug },
     with: {
       avatarImage: true,
       headerImage: true,

--- a/packages/common/src/services/profile/getProfileUserWithRelations.ts
+++ b/packages/common/src/services/profile/getProfileUserWithRelations.ts
@@ -1,10 +1,9 @@
-import { db, eq } from '@op/db/client';
-import {
-  type AccessRole,
-  type ObjectsInStorage,
-  type Profile,
-  type ProfileUser,
-  profileUsers,
+import { db } from '@op/db/client';
+import type {
+  AccessRole,
+  ObjectsInStorage,
+  Profile,
+  ProfileUser,
 } from '@op/db/schema';
 
 /**
@@ -36,8 +35,8 @@ export type ProfileUserWithRelations = ProfileUser & {
 export const getProfileUserWithRelations = async (
   profileUserId: string,
 ): Promise<ProfileUserWithRelations | null> => {
-  const profileUser = await db._query.profileUsers.findFirst({
-    where: eq(profileUsers.id, profileUserId),
+  const profileUser = await db.query.profileUsers.findFirst({
+    where: { id: profileUserId },
     with: {
       serviceUser: {
         with: {

--- a/packages/common/src/services/profile/inviteUsersToProfile.ts
+++ b/packages/common/src/services/profile/inviteUsersToProfile.ts
@@ -138,11 +138,11 @@ export const inviteUsersToProfile = async ({
       },
     }),
     // Get all users with their profile memberships for this profile
-    db._query.users.findMany({
-      where: (table, { inArray }) => inArray(table.email, normalizedEmails),
+    db.query.users.findMany({
+      where: { email: { in: normalizedEmails } },
       with: {
         profileUsers: {
-          where: (table, { eq }) => eq(table.profileId, profileId),
+          where: { profileId },
         },
       },
     }),

--- a/packages/common/src/services/profile/listProfileUsers.ts
+++ b/packages/common/src/services/profile/listProfileUsers.ts
@@ -1,5 +1,5 @@
 import { and, db, eq, gt, lt, or, sql } from '@op/db/client';
-import { profileUsers, profiles, users } from '@op/db/schema';
+import { profiles, users } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 import { assertAccess, permission } from 'access-zones';
 
@@ -64,35 +64,6 @@ export const listProfileUsers = async ({
 
   assertAccess({ profile: permission.ADMIN }, profileAccessUser.roles ?? []);
 
-  // Build where clause with optional search filter (minimum 2 characters)
-  // Uses ILIKE for substring matching and trigram word_similarity for fuzzy matching
-  // The <% operator uses GIN trigram indexes for efficient fuzzy searching
-  const searchFilter =
-    query && query.length >= 2
-      ? (() => {
-          const ilikePattern = `%${query}%`;
-
-          // Email: ILIKE for substring + trigram for typo tolerance
-          const emailMatch = sql`(
-            ${profileUsers.email} ILIKE ${ilikePattern}
-            OR ${query} <% ${profileUsers.email}
-          )`;
-
-          return or(
-            emailMatch,
-            // Check profileUsers.name directly (for users without a linked profile)
-            sql`${profileUsers.name} ILIKE ${ilikePattern}`,
-            // Check via users → profiles join for users with a full profile
-            sql`${profileUsers.authUserId} IN (
-              SELECT u.auth_user_id FROM ${users} u
-              INNER JOIN ${profiles} p ON p.id = u.profile_id
-              WHERE p.name ILIKE ${ilikePattern} OR ${query} <% p.name
-            )`,
-          );
-        })()
-      : undefined;
-
-  // Build cursor condition for pagination
   // The cursor must match the ORDER BY columns for correct pagination
   type ProfileUserCursor = { value: string; tiebreaker?: string };
   const decodedCursor = cursor
@@ -101,50 +72,60 @@ export const listProfileUsers = async ({
 
   const compareFn = dir === 'asc' ? gt : lt;
 
-  const buildCursorCondition = () => {
-    if (!decodedCursor) {
-      return undefined;
-    }
-
-    if (orderBy === 'email') {
-      // Email is unique, no tiebreaker needed
-      return compareFn(profileUsers.email, decodedCursor.value);
-    }
-
-    if (orderBy === 'name') {
-      // ORDER BY name, email - compound condition
-      return or(
-        compareFn(profileUsers.name, decodedCursor.value),
-        and(
-          eq(profileUsers.name, decodedCursor.value),
-          compareFn(profileUsers.email, decodedCursor.tiebreaker ?? ''),
-        ),
-      );
-    }
-
-    // orderBy === 'role' - uses shared subquery helper
-    const roleSubquery = buildRoleNameSubquery(profileUsers.id);
-    const compareOp = dir === 'asc' ? sql`>` : sql`<`;
-    return sql`(
-      ${roleSubquery} ${compareOp} ${decodedCursor.value}
-      OR (${roleSubquery} = ${decodedCursor.value} AND ${profileUsers.email} ${compareOp} ${decodedCursor.tiebreaker ?? ''})
-    )`;
-  };
-
-  const cursorCondition = buildCursorCondition();
-
-  // Combine all conditions
-  const baseCondition = eq(profileUsers.profileId, profileId);
-  const conditions = [baseCondition, searchFilter, cursorCondition].filter(
-    Boolean,
-  );
-  const whereClause =
-    conditions.length > 1 ? and(...conditions) : baseCondition;
-
   // Fetch profile users with their roles and user profiles
   // Request one extra to check if there are more results
-  const profileUserResults = await db._query.profileUsers.findMany({
-    where: whereClause,
+  const profileUserResults = await db.query.profileUsers.findMany({
+    where: {
+      profileId,
+      RAW: (table) => {
+        const conditions = [];
+
+        // Search filter (minimum 2 characters): ILIKE for substring matching
+        // and trigram word_similarity for typo tolerance.
+        if (query && query.length >= 2) {
+          const ilikePattern = `%${query}%`;
+          const searchFilter = or(
+            sql`(${table.email} ILIKE ${ilikePattern} OR ${query} <% ${table.email})`,
+            sql`${table.name} ILIKE ${ilikePattern}`,
+            sql`${table.authUserId} IN (
+              SELECT u.auth_user_id FROM ${users} u
+              INNER JOIN ${profiles} p ON p.id = u.profile_id
+              WHERE p.name ILIKE ${ilikePattern} OR ${query} <% p.name
+            )`,
+          );
+          if (searchFilter) {
+            conditions.push(searchFilter);
+          }
+        }
+
+        if (decodedCursor) {
+          if (orderBy === 'email') {
+            conditions.push(compareFn(table.email, decodedCursor.value));
+          } else if (orderBy === 'name') {
+            const compoundName = or(
+              compareFn(table.name, decodedCursor.value),
+              and(
+                eq(table.name, decodedCursor.value),
+                compareFn(table.email, decodedCursor.tiebreaker ?? ''),
+              ),
+            );
+            if (compoundName) {
+              conditions.push(compoundName);
+            }
+          } else {
+            // orderBy === 'role' — uses shared subquery helper.
+            const roleSubquery = buildRoleNameSubquery(table.id);
+            const compareOp = dir === 'asc' ? sql`>` : sql`<`;
+            conditions.push(sql`(
+              ${roleSubquery} ${compareOp} ${decodedCursor.value}
+              OR (${roleSubquery} = ${decodedCursor.value} AND ${table.email} ${compareOp} ${decodedCursor.tiebreaker ?? ''})
+            )`);
+          }
+        }
+
+        return conditions.length > 0 ? and(...conditions)! : sql`TRUE`;
+      },
+    },
     with: {
       roles: {
         with: {

--- a/packages/common/src/services/profile/listProfiles.ts
+++ b/packages/common/src/services/profile/listProfiles.ts
@@ -1,6 +1,6 @@
 import { match } from '@op/core';
-import { and, db, inArray, sql } from '@op/db/client';
-import { type EntityType, locations, profiles } from '@op/db/schema';
+import { db } from '@op/db/client';
+import { type EntityType } from '@op/db/schema';
 
 import {
   NotFoundError,
@@ -23,36 +23,30 @@ export const listProfiles = async ({
   types?: EntityType[];
 }) => {
   try {
-    const orderByColumn = match(orderBy, {
-      name: profiles.name,
-      createdAt: profiles.createdAt,
-      _: profiles.updatedAt,
-    });
-
-    // Build cursor condition for pagination
-    const cursorCondition = cursor
-      ? getCursorCondition({
-          column: orderByColumn,
-          tieBreakerColumn: orderBy === 'name' ? profiles.id : undefined,
-          cursor: decodeCursor<{ value: string | Date; id?: string }>(cursor),
-          direction: dir,
-        })
+    const decodedCursor = cursor
+      ? decodeCursor<{ value: string | Date; id?: string }>(cursor)
       : undefined;
 
-    // Build type filter condition
-    const typeCondition =
-      types && types.length > 0 ? inArray(profiles.type, types) : undefined;
-
-    const whereConditions = [cursorCondition, typeCondition].filter(Boolean);
-    const whereClause =
-      whereConditions.length > 0
-        ? whereConditions.length === 1
-          ? whereConditions[0]
-          : and(...whereConditions)
-        : undefined;
-
-    const result = await db._query.profiles.findMany({
-      where: whereClause,
+    const result = await db.query.profiles.findMany({
+      where: {
+        ...(types && types.length > 0 && { type: { in: types } }),
+        ...(decodedCursor && {
+          RAW: (table) => {
+            const col = match(orderBy, {
+              name: table.name,
+              createdAt: table.createdAt,
+              _: table.updatedAt,
+            });
+            const tieBreaker = orderBy === 'name' ? table.id : undefined;
+            return getCursorCondition({
+              column: col,
+              tieBreakerColumn: tieBreaker,
+              cursor: decodedCursor,
+              direction: dir,
+            })!;
+          },
+        }),
+      },
       with: {
         headerImage: true,
         avatarImage: true,
@@ -64,8 +58,10 @@ export const listProfiles = async ({
               with: {
                 location: {
                   extras: {
-                    x: sql<number>`ST_X(${locations.location})`.as('x'),
-                    y: sql<number>`ST_Y(${locations.location})`.as('y'),
+                    x: (table, { sql }) =>
+                      sql<number>`ST_X(${table.location})`.as('x'),
+                    y: (table, { sql }) =>
+                      sql<number>`ST_Y(${table.location})`.as('y'),
                   },
                   columns: {
                     id: true,
@@ -74,7 +70,6 @@ export const listProfiles = async ({
                     countryCode: true,
                     countryName: true,
                     metadata: true,
-                    latLng: false,
                   },
                 },
               },
@@ -82,25 +77,35 @@ export const listProfiles = async ({
           },
         },
       },
-      orderBy: (_, { asc, desc }) =>
-        dir === 'asc' ? asc(orderByColumn) : desc(orderByColumn),
+      orderBy: (table, { asc, desc }) => {
+        const col = match(orderBy, {
+          name: table.name,
+          createdAt: table.createdAt,
+          _: table.updatedAt,
+        });
+        return dir === 'asc' ? asc(col) : desc(col);
+      },
       limit: limit + 1, // Fetch one extra to check hasMore
-    });
-
-    result.forEach((profile) => {
-      if (profile.organization) {
-        // @ts-expect-error - transitionary issue from org to profiles
-        profile.organization.whereWeWork = // @ts-ignore - transitionary issue from org to profiles
-          profile.organization?.whereWeWork.map((item: any) => item.location);
-      }
     });
 
     if (!result) {
       throw new NotFoundError('Profiles not found');
     }
 
-    const hasMore = result.length > limit;
-    const items = result.slice(0, limit);
+    const flattened = result.map((profile) => ({
+      ...profile,
+      organization: profile.organization
+        ? {
+            ...profile.organization,
+            whereWeWork: profile.organization.whereWeWork.map(
+              (item) => item.location,
+            ),
+          }
+        : null,
+    }));
+
+    const hasMore = flattened.length > limit;
+    const items = flattened.slice(0, limit);
     const lastItem = items[items.length - 1];
 
     const cursorValue = match(orderBy, {

--- a/packages/common/src/services/profile/requests/assertTargetProfileAdminAccess.ts
+++ b/packages/common/src/services/profile/requests/assertTargetProfileAdminAccess.ts
@@ -1,8 +1,7 @@
 import { db } from '@op/db/client';
-import { type Organization, type Profile, organizations } from '@op/db/schema';
+import type { Organization, Profile } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 import { assertAccess, permission } from 'access-zones';
-import { eq } from 'drizzle-orm';
 
 import { UnauthorizedError } from '../../../utils';
 import { getOrgAccessUser } from '../../access';
@@ -29,8 +28,8 @@ export const assertTargetProfileAdminAccess = async ({
 }): Promise<TargetProfileAdminContext> => {
   const [targetProfile, organization] = await Promise.all([
     assertProfile(targetProfileId),
-    db._query.organizations.findFirst({
-      where: eq(organizations.profileId, targetProfileId),
+    db.query.organizations.findFirst({
+      where: { profileId: targetProfileId },
     }),
   ]);
 

--- a/packages/common/src/services/profile/requests/deleteProfileJoinRequest.ts
+++ b/packages/common/src/services/profile/requests/deleteProfileJoinRequest.ts
@@ -20,8 +20,8 @@ export const deleteProfileJoinRequest = async ({
   requestId: string;
 }): Promise<JoinProfileRequestWithProfiles> => {
   // Find the existing request by ID with profiles
-  const existingRequest = await db._query.joinProfileRequests.findFirst({
-    where: (table, { eq }) => eq(table.id, requestId),
+  const existingRequest = await db.query.joinProfileRequests.findFirst({
+    where: { id: requestId },
     with: {
       requestProfile: true,
       targetProfile: true,
@@ -38,12 +38,11 @@ export const deleteProfileJoinRequest = async ({
   }
 
   // Check authorization - user must own the requesting profile
-  const requestingUser = await db._query.users.findFirst({
-    where: (table, { and, eq }) =>
-      and(
-        eq(table.authUserId, user.id),
-        eq(table.profileId, existingRequest.requestProfileId),
-      ),
+  const requestingUser = await db.query.users.findFirst({
+    where: {
+      authUserId: user.id,
+      profileId: existingRequest.requestProfileId,
+    },
   });
 
   if (!requestingUser) {

--- a/packages/common/src/services/profile/requests/listProfileJoinRequests.ts
+++ b/packages/common/src/services/profile/requests/listProfileJoinRequests.ts
@@ -1,7 +1,6 @@
 import { db } from '@op/db/client';
-import { JoinProfileRequestStatus, joinProfileRequests } from '@op/db/schema';
+import { JoinProfileRequestStatus } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
-import { and, eq } from 'drizzle-orm';
 
 import {
   type PaginatedResult,
@@ -36,27 +35,26 @@ export const listProfileJoinRequests = async ({
   limit?: number;
   dir?: 'asc' | 'desc';
 }): Promise<PaginatedResult<JoinProfileRequestWithProfiles>> => {
-  // Build cursor condition for pagination
-  const cursorCondition = cursor
-    ? getCursorCondition({
-        column: joinProfileRequests.createdAt,
-        tieBreakerColumn: joinProfileRequests.id,
-        cursor: decodeCursor<ListJoinProfileRequestsCursor>(cursor),
-        direction: dir,
-      })
+  const decodedCursor = cursor
+    ? decodeCursor<ListJoinProfileRequestsCursor>(cursor)
     : undefined;
-
-  // Build where clause
-  const whereClause = and(
-    eq(joinProfileRequests.targetProfileId, targetProfileId),
-    status ? eq(joinProfileRequests.status, status) : undefined,
-    cursorCondition,
-  );
 
   const [, results] = await Promise.all([
     assertTargetProfileAdminAccess({ user, targetProfileId }),
-    db._query.joinProfileRequests.findMany({
-      where: whereClause,
+    db.query.joinProfileRequests.findMany({
+      where: {
+        targetProfileId,
+        ...(status && { status }),
+        ...(decodedCursor && {
+          RAW: (table) =>
+            getCursorCondition({
+              column: table.createdAt,
+              tieBreakerColumn: table.id,
+              cursor: decodedCursor,
+              direction: dir,
+            })!,
+        }),
+      },
       with: {
         requestProfile: true,
         targetProfile: true,

--- a/packages/common/src/services/profile/requests/updateProfileJoinRequest.ts
+++ b/packages/common/src/services/profile/requests/updateProfileJoinRequest.ts
@@ -29,8 +29,8 @@ export const updateProfileJoinRequest = async ({
   status: JoinProfileRequestStatus.APPROVED | JoinProfileRequestStatus.REJECTED;
 }): Promise<JoinProfileRequestWithProfiles> => {
   // Find the existing request by ID
-  const existingRequest = await db._query.joinProfileRequests.findFirst({
-    where: (table, { eq }) => eq(table.id, requestId),
+  const existingRequest = await db.query.joinProfileRequests.findFirst({
+    where: { id: requestId },
   });
 
   if (!existingRequest) {
@@ -85,9 +85,8 @@ export const updateProfileJoinRequest = async ({
     }
 
     // Get the owner of the requesting profile (their authUserId)
-    const requestingUser = await db._query.users.findFirst({
-      where: (table, { eq }) =>
-        eq(table.profileId, existingRequest.requestProfileId),
+    const requestingUser = await db.query.users.findFirst({
+      where: { profileId: existingRequest.requestProfileId },
     });
 
     if (requestingUser) {
@@ -95,12 +94,11 @@ export const updateProfileJoinRequest = async ({
       // NOTE: We're using organizationUsers instead of profileUsers because we're in between
       // memberships - the profile user membership (new) and the organization user membership (old).
       // After we migrate to profile users, this code should be changed to use profileUsers.
-      const existingMembership = await db._query.organizationUsers.findFirst({
-        where: (table, { and, eq }) =>
-          and(
-            eq(table.authUserId, requestingUser.authUserId),
-            eq(table.organizationId, organization.id),
-          ),
+      const existingMembership = await db.query.organizationUsers.findFirst({
+        where: {
+          authUserId: requestingUser.authUserId,
+          organizationId: organization.id,
+        },
       });
 
       // Only create membership if it doesn't already exist

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -2,7 +2,6 @@ import { and, db, eq, sql } from '@op/db/client';
 import {
   allowList,
   organizationUsers,
-  organizations,
   users,
   usersUsedStorage,
 } from '@op/db/schema';
@@ -10,6 +9,7 @@ import { type UserWithRoles, getGlobalPermissions } from 'access-zones';
 
 import { NotFoundError, UnauthorizedError } from '../../utils/error';
 import { getNormalizedRoles, getOrgAccessUser } from '../access';
+import type { RoleJunction } from '../access/utils';
 import { AllowListUser, allowListMetadataSchema } from './validators';
 
 export interface User {
@@ -61,8 +61,8 @@ export const getUserByAuthId = async ({
   authUserId: string;
   includePermissions?: boolean;
 }) => {
-  const user = await db._query.users.findFirst({
-    where: (table, { eq }) => eq(table.authUserId, authUserId),
+  const user = await db.query.users.findFirst({
+    where: { authUserId },
     with: {
       avatarImage: true,
       organizationUsers: {
@@ -157,8 +157,11 @@ export const getUserByAuthId = async ({
           return orgUser;
         }
 
-        // Transform the relational data into normalized format for access-zones library
-        const normalizedRoles = getNormalizedRoles(orgUser.roles);
+        // Transform the relational data into normalized format for access-zones library.
+        // The role-with-accessRole shape is only present when includePermissions=true.
+        const normalizedRoles = getNormalizedRoles(
+          orgUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
+        );
 
         // Transform the user to the format expected by access-zones
         const userForTransformation: UserWithRoles = {
@@ -184,7 +187,9 @@ export const getUserByAuthId = async ({
           return profileUser;
         }
 
-        const normalizedRoles = getNormalizedRoles(profileUser.roles);
+        const normalizedRoles = getNormalizedRoles(
+          profileUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
+        );
 
         const userForTransformation: UserWithRoles = {
           id: profileUser.id,
@@ -233,8 +238,8 @@ export const getUserWithProfiles = async ({
   authUserId: string;
   includeRoles?: boolean;
 }) => {
-  return await db._query.users.findFirst({
-    where: (table, { eq }) => eq(table.authUserId, authUserId),
+  return await db.query.users.findFirst({
+    where: { authUserId },
     with: {
       profile: {
         with: {
@@ -270,8 +275,8 @@ export const getUserForProfileSwitch = async ({
 }: {
   authUserId: string;
 }) => {
-  return await db._query.users.findFirst({
-    where: (table, { eq }) => eq(table.authUserId, authUserId),
+  return await db.query.users.findFirst({
+    where: { authUserId },
     with: {
       profile: true,
       organizationUsers: {
@@ -303,7 +308,7 @@ export const getUserForProfileSwitch = async ({
 export interface UpdateUserCurrentProfileOptions {
   authUserId: string;
   profileId: string;
-  orgId?: number;
+  orgId?: string;
 }
 
 export const updateUserCurrentProfile = async (
@@ -314,11 +319,7 @@ export const updateUserCurrentProfile = async (
     .update(users)
     .set({
       currentProfileId: profileId,
-      ...(orgId
-        ? { lastOrgId: orgId.toString() }
-        : {
-            lastOrgId: null,
-          }),
+      lastOrgId: orgId ?? null,
     })
     .where(eq(users.authUserId, authUserId))
     .returning();
@@ -378,8 +379,8 @@ export const switchUserOrganization = async (
 ) => {
   const { authUserId, organizationId } = options;
   // First, get the organization to find its profile ID
-  const organization = await db._query.organizations.findFirst({
-    where: eq(organizations.id, organizationId),
+  const organization = await db.query.organizations.findFirst({
+    where: { id: organizationId },
   });
 
   if (!organization) {

--- a/services/api/src/routers/organization/checkMembership.ts
+++ b/services/api/src/routers/organization/checkMembership.ts
@@ -32,12 +32,11 @@ export const checkMembershipRouter = router({
       assertAccess({ profile: permission.ADMIN }, orgUser?.roles ?? []);
 
       // Check if the target email is a member of the organization
-      const membershipExists = await db._query.organizationUsers.findFirst({
-        where: (table, { and, eq }) =>
-          and(
-            eq(table.email, email.toLowerCase()),
-            eq(table.organizationId, organizationId),
-          ),
+      const membershipExists = await db.query.organizationUsers.findFirst({
+        where: {
+          email: email.toLowerCase(),
+          organizationId,
+        },
       });
 
       return {

--- a/services/api/src/routers/organization/inviteUser.ts
+++ b/services/api/src/routers/organization/inviteUser.ts
@@ -79,9 +79,8 @@ export const inviteUserRouter = router({
         // Invalidate caches for users who were successfully added to the organization
         if (result.details?.successful.length > 0) {
           // Find existing users by email to get their auth user IDs
-          const existingUsers = await db._query.users.findMany({
-            where: (table, { inArray }) =>
-              inArray(table.email, result.details.successful),
+          const existingUsers = await db.query.users.findMany({
+            where: { email: { in: result.details.successful } },
             columns: { authUserId: true },
           });
 

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -401,6 +401,31 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.organizations.id,
       to: r.organizationsWhereWeWork.organizationId,
     }),
+    projects: r.many.projects({
+      from: r.organizations.id,
+      to: r.projects.organizationId,
+    }),
+    links: r.many.links({
+      from: r.organizations.id,
+      to: r.links.organizationId,
+    }),
+    strategies: r.many.organizationsStrategies({
+      from: r.organizations.id,
+      to: r.organizationsStrategies.organizationId,
+    }),
+  },
+
+  /**
+   * Organizations strategies (join to taxonomy terms).
+   */
+  organizationsStrategies: {
+    // @ts-expect-error - taxonomyTerms self-referential parentId breaks inference
+    term: r.one.taxonomyTerms({
+      from: r.organizationsStrategies.taxonomyTermId,
+      // @ts-expect-error - see above
+      to: r.taxonomyTerms.id,
+      optional: false,
+    }),
   },
 
   /**
@@ -457,6 +482,26 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   /**
+   * Organization relationship relations
+   *
+   * Self-referential edges between two organizations (source/target).
+   */
+  organizationRelationships: {
+    sourceOrganization: r.one.organizations({
+      from: r.organizationRelationships.sourceOrganizationId,
+      to: r.organizations.id,
+      alias: 'organizationRelationship_source',
+      optional: false,
+    }),
+    targetOrganization: r.one.organizations({
+      from: r.organizationRelationships.targetOrganizationId,
+      to: r.organizations.id,
+      alias: 'organizationRelationship_target',
+      optional: false,
+    }),
+  },
+
+  /**
    * Allow list relations
    */
   allowList: {
@@ -487,20 +532,30 @@ export const relations = defineRelations(schema, (r) => ({
   /**
    * User relations
    *
-   * profileId is nullable.
+   * profileId, currentProfileId, and lastOrgId are nullable.
    */
   users: {
     profile: r.one.profiles({
       from: r.users.profileId,
       to: r.profiles.id,
+      alias: 'user_profile',
     }),
-    avatarImage: r.one.objectsInStorage({
-      from: r.users.avatarImageId,
-      to: r.objectsInStorage.id,
+    currentProfile: r.one.profiles({
+      from: r.users.currentProfileId,
+      to: r.profiles.id,
+      alias: 'user_currentProfile',
+    }),
+    currentOrganization: r.one.organizations({
+      from: r.users.lastOrgId,
+      to: r.organizations.id,
     }),
     organizationUsers: r.many.organizationUsers({
       from: r.users.authUserId,
       to: r.organizationUsers.authUserId,
+    }),
+    avatarImage: r.one.objectsInStorage({
+      from: r.users.avatarImageId,
+      to: r.objectsInStorage.id,
     }),
     authUser: r.one.authUsers({
       from: r.users.authUserId,

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -186,6 +186,10 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.profiles.id,
       to: r.organizations.profileId,
     }),
+    individual: r.one.individuals({
+      from: r.profiles.id,
+      to: r.individuals.profileId,
+    }),
     profileUsers: r.many.profileUsers({
       from: r.profiles.id,
       to: r.profileUsers.profileId,
@@ -336,6 +340,17 @@ export const relations = defineRelations(schema, (r) => ({
     roles: r.many.profileUserToAccessRoles({
       from: r.profileUsers.id,
       to: r.profileUserToAccessRoles.profileUserId,
+    }),
+    serviceUser: r.one.users({
+      from: r.profileUsers.authUserId,
+      to: r.users.authUserId,
+      alias: 'profileUser_serviceUser',
+    }),
+    profile: r.one.profiles({
+      from: r.profileUsers.profileId,
+      to: r.profiles.id,
+      alias: 'profileUser_profile',
+      optional: false,
     }),
   },
 
@@ -540,6 +555,88 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   /**
+   * Post relations
+   *
+   * `parentPost`/`childPosts` is the self-referential thread tree.
+   */
+  posts: {
+    profile: r.one.profiles({
+      from: r.posts.profileId,
+      to: r.profiles.id,
+      alias: 'post_profile',
+      optional: false,
+    }),
+    attachments: r.many.attachments({
+      from: r.posts.id,
+      to: r.attachments.postId,
+    }),
+    reactions: r.many.postReactions({
+      from: r.posts.id,
+      to: r.postReactions.postId,
+    }),
+    parentPost: r.one.posts({
+      from: r.posts.parentPostId,
+      to: r.posts.id,
+      alias: 'post_parent',
+    }),
+    childPosts: r.many.posts({
+      from: r.posts.id,
+      to: r.posts.parentPostId,
+      alias: 'post_children',
+    }),
+  },
+
+  /**
+   * Posts-to-organizations join table relations.
+   */
+  postsToOrganizations: {
+    post: r.one.posts({
+      from: r.postsToOrganizations.postId,
+      to: r.posts.id,
+      optional: false,
+    }),
+    organization: r.one.organizations({
+      from: r.postsToOrganizations.organizationId,
+      to: r.organizations.id,
+      optional: false,
+    }),
+  },
+
+  /**
+   * Posts-to-profiles join table relations.
+   */
+  postsToProfiles: {
+    post: r.one.posts({
+      from: r.postsToProfiles.postId,
+      to: r.posts.id,
+      optional: false,
+    }),
+    profile: r.one.profiles({
+      from: r.postsToProfiles.profileId,
+      to: r.profiles.id,
+      alias: 'postsToProfiles_profile',
+      optional: false,
+    }),
+  },
+
+  /**
+   * Post reaction relations.
+   */
+  postReactions: {
+    post: r.one.posts({
+      from: r.postReactions.postId,
+      to: r.posts.id,
+      optional: false,
+    }),
+    profile: r.one.profiles({
+      from: r.postReactions.profileId,
+      to: r.profiles.id,
+      alias: 'postReaction_profile',
+      optional: false,
+    }),
+  },
+
+  /**
    * Allow list relations
    */
   allowList: {
@@ -591,14 +688,14 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.users.authUserId,
       to: r.organizationUsers.authUserId,
     }),
+    profileUsers: r.many.profileUsers({
+      from: r.users.authUserId,
+      to: r.profileUsers.authUserId,
+    }),
     avatarImage: r.one.objectsInStorage({
       from: r.users.avatarImageId,
       to: r.objectsInStorage.id,
-    }),
-    authUser: r.one.authUsers({
-      from: r.users.authUserId,
-      to: r.authUsers.id,
-      optional: false,
+      alias: 'user_avatarImage',
     }),
   },
 

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -502,6 +502,44 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   /**
+   * Decision vote submission relations
+   */
+  decisionsVoteSubmissions: {
+    voteProposals: r.many.decisionsVoteProposals({
+      from: r.decisionsVoteSubmissions.id,
+      to: r.decisionsVoteProposals.voteSubmissionId,
+    }),
+  },
+
+  /**
+   * Decision vote proposal relations (junction table)
+   */
+  decisionsVoteProposals: {
+    proposal: r.one.proposals({
+      from: r.decisionsVoteProposals.proposalId,
+      to: r.proposals.id,
+      alias: 'decisionsVoteProposal_proposal',
+      optional: false,
+    }),
+  },
+
+  /**
+   * Decision process relations
+   */
+  decisionProcesses: {
+    createdBy: r.one.profiles({
+      from: r.decisionProcesses.createdByProfileId,
+      to: r.profiles.id,
+      alias: 'decisionProcess_createdBy',
+      optional: false,
+    }),
+    instances: r.many.processInstances({
+      from: r.decisionProcesses.id,
+      to: r.processInstances.processId,
+    }),
+  },
+
+  /**
    * Allow list relations
    */
   allowList: {


### PR DESCRIPTION
Continues retiring v1 db._query so we can drop the legacy relations and the dual API.