### PR TITLE
chore: Update db client and tx consistency

### DIFF
--- a/packages/common/src/services/assert/assertGlobalRole.ts
+++ b/packages/common/src/services/assert/assertGlobalRole.ts
@@ -1,8 +1,4 @@
-import {
-  type DatabaseType,
-  type TransactionType,
-  db as defaultDb,
-} from '@op/db/client';
+import { type DbClient, db as defaultDb } from '@op/db/client';
 import type { AccessRole } from '@op/db/schema';
 
 import { NotFoundError } from '../../utils';
@@ -20,7 +16,7 @@ import { NotFoundError } from '../../utils';
  */
 export async function assertGlobalRole(
   name: string,
-  db?: DatabaseType | TransactionType,
+  db?: DbClient,
 ): Promise<AccessRole> {
   const client = db ?? defaultDb;
 

--- a/packages/common/src/services/assert/assertOrganization.ts
+++ b/packages/common/src/services/assert/assertOrganization.ts
@@ -1,4 +1,4 @@
-import { db } from '@op/db/client';
+import { type DbClient, db as defaultDb } from '@op/db/client';
 import type { Organization } from '@op/db/schema';
 
 import { NotFoundError } from '../../utils';
@@ -8,11 +8,13 @@ import { NotFoundError } from '../../utils';
  *
  * @param id - The organization ID to look up
  * @param error - Custom error to throw if not found (defaults to NotFoundError)
+ * @param db - Optional database client or transaction to use
  * @throws The provided error or NotFoundError if organization is not found
  */
 export async function assertOrganization(
   id: string,
   error: Error = new NotFoundError('Organization', id),
+  db: DbClient = defaultDb,
 ): Promise<Organization> {
   const organization = await db._query.organizations.findFirst({
     where: (table, { eq }) => eq(table.id, id),
@@ -30,11 +32,13 @@ export async function assertOrganization(
  *
  * @param profileId - The profile ID to look up the organization by
  * @param error - Custom error to throw if not found (defaults to NotFoundError)
+ * @param db - Optional database client or transaction to use
  * @throws The provided error or NotFoundError if organization is not found
  */
 export async function assertOrganizationByProfileId(
   profileId: string,
   error: Error = new NotFoundError('Organization', profileId),
+  db: DbClient = defaultDb,
 ): Promise<Organization> {
   const organization = await db._query.organizations.findFirst({
     where: (table, { eq }) => eq(table.profileId, profileId),

--- a/packages/common/src/services/assert/assertProfile.ts
+++ b/packages/common/src/services/assert/assertProfile.ts
@@ -1,4 +1,4 @@
-import { db } from '@op/db/client';
+import { type DbClient, db as defaultDb } from '@op/db/client';
 import type { Profile } from '@op/db/schema';
 
 import { NotFoundError } from '../../utils';
@@ -8,11 +8,13 @@ import { NotFoundError } from '../../utils';
  *
  * @param id - The profile ID to look up
  * @param error - Custom error to throw if not found (defaults to NotFoundError)
+ * @param db - Optional database client or transaction to use
  * @throws The provided error or NotFoundError if profile is not found
  */
 export async function assertProfile(
   id: string,
   error: Error = new NotFoundError('Profile', id),
+  db: DbClient = defaultDb,
 ): Promise<Profile> {
   const profile = await db._query.profiles.findFirst({
     where: (table, { eq }) => eq(table.id, id),
@@ -30,11 +32,13 @@ export async function assertProfile(
  *
  * @param slug - The profile slug to look up
  * @param error - Custom error to throw if not found (defaults to NotFoundError)
+ * @param db - Optional database client or transaction to use
  * @throws The provided error or NotFoundError if profile is not found
  */
 export async function assertProfileBySlug(
   slug: string,
   error: Error = new NotFoundError('Profile', slug),
+  db: DbClient = defaultDb,
 ): Promise<Profile> {
   const profile = await db._query.profiles.findFirst({
     where: (table, { eq }) => eq(table.slug, slug),

--- a/packages/common/src/services/assert/assertProfileUser.ts
+++ b/packages/common/src/services/assert/assertProfileUser.ts
@@ -1,4 +1,4 @@
-import { db } from '@op/db/client';
+import { type DbClient, db as defaultDb } from '@op/db/client';
 import type { ProfileUser } from '@op/db/schema';
 
 import { NotFoundError } from '../../utils';
@@ -9,6 +9,7 @@ import { NotFoundError } from '../../utils';
 export async function assertProfileUser(
   id: string,
   error: Error = new NotFoundError('User not found', id),
+  db: DbClient = defaultDb,
 ): Promise<ProfileUser> {
   const profileUser = await db._query.profileUsers.findFirst({
     where: (table, { eq }) => eq(table.id, id),

--- a/packages/common/src/services/assert/assertUser.ts
+++ b/packages/common/src/services/assert/assertUser.ts
@@ -1,4 +1,4 @@
-import { db } from '@op/db/client';
+import { type DbClient, db as defaultDb } from '@op/db/client';
 import type { CommonUser } from '@op/db/schema';
 
 import { NotFoundError } from '../../utils';
@@ -8,11 +8,13 @@ import { NotFoundError } from '../../utils';
  *
  * @param id - The user ID to look up
  * @param error - Custom error to throw if not found (defaults to NotFoundError)
+ * @param db - Optional database client or transaction to use
  * @throws The provided error or NotFoundError if user is not found
  */
 export async function assertUser(
   id: string,
   error: Error = new NotFoundError('User', id),
+  db: DbClient = defaultDb,
 ): Promise<CommonUser> {
   const user = await db.query.users.findFirst({
     where: { id },
@@ -30,11 +32,13 @@ export async function assertUser(
  *
  * @param authUserId - The auth user ID to look up
  * @param error - Custom error to throw if not found (defaults to NotFoundError)
+ * @param db - Optional database client or transaction to use
  * @throws The provided error or NotFoundError if user is not found
  */
 export async function assertUserByAuthId(
   authUserId: string,
   error: Error = new NotFoundError('User', authUserId),
+  db: DbClient = defaultDb,
 ): Promise<CommonUser> {
   const user = await db.query.users.findFirst({
     where: { authUserId },

--- a/packages/common/src/services/decision/advancePhase.ts
+++ b/packages/common/src/services/decision/advancePhase.ts
@@ -1,5 +1,4 @@
-import { and, desc, eq, inArray, isNull } from '@op/db/client';
-import type { DbClient } from '@op/db/client';
+import { type DbClient, and, desc, eq, inArray, isNull } from '@op/db/client';
 import {
   ProcessStatus,
   decisionProcessTransitions,
@@ -22,7 +21,7 @@ import {
 import type { ExecutionContext } from './selectionPipeline/types';
 
 export interface AdvancePhaseInput {
-  tx: DbClient;
+  db: DbClient;
   /** Pre-loaded instance row. Stale snapshots are safe — writes use optimistic locks. */
   instance: {
     id: string;
@@ -68,7 +67,7 @@ export async function advancePhase(
   input: AdvancePhaseInput,
 ): Promise<AdvancePhaseResult> {
   const {
-    tx,
+    db,
     instance,
     fromPhaseId,
     toPhaseId,
@@ -92,7 +91,7 @@ export async function advancePhase(
 
   // Lock the instance row so a concurrent submitManualSelection can't
   // attach proposals to the inbound transition while we're advancing out.
-  const [lockedInstance] = await tx
+  const [lockedInstance] = await db
     .select({
       currentStateId: processInstances.currentStateId,
       status: processInstances.status,
@@ -114,13 +113,13 @@ export async function advancePhase(
 
   const allProposals = await getProposalsForPhase({
     instanceId,
-    dbClient: tx,
+    db,
   });
 
   let selectedProposalIds: string[] = allProposals.map((p) => p.id);
 
   if (selectionPipeline) {
-    const proposalMetrics = await aggregateProposalMetrics(allProposals, tx);
+    const proposalMetrics = await aggregateProposalMetrics(allProposals, db);
     const context: ExecutionContext = {
       proposals: allProposals,
       voteData: proposalMetrics,
@@ -132,7 +131,7 @@ export async function advancePhase(
   }
 
   // Optimistic lock: only succeeds if currentStateId still matches fromPhaseId.
-  const updated = await tx
+  const updated = await db
     .update(processInstances)
     .set({
       currentStateId: toPhaseId,
@@ -151,7 +150,7 @@ export async function advancePhase(
     return { conflict: true };
   }
 
-  await tx
+  await db
     .update(decisionProcessTransitions)
     .set({ completedAt: now })
     .where(
@@ -162,7 +161,7 @@ export async function advancePhase(
       ),
     );
 
-  const [insertedTransition] = await tx
+  const [insertedTransition] = await db
     .insert(stateTransitionHistory)
     .values({
       processInstanceId: instanceId,
@@ -180,7 +179,7 @@ export async function advancePhase(
   }
 
   if (selectedProposalIds.length > 0) {
-    const latestHistoryRows = await tx
+    const latestHistoryRows = await db
       .selectDistinctOn([proposalHistory.id], {
         proposalId: proposalHistory.id,
         historyId: proposalHistory.historyId,
@@ -200,7 +199,7 @@ export async function advancePhase(
       );
     }
 
-    await tx.insert(decisionTransitionProposals).values(
+    await db.insert(decisionTransitionProposals).values(
       latestHistoryRows.map(({ proposalId, historyId }) => ({
         processInstanceId: instanceId,
         transitionHistoryId: insertedTransition.id,

--- a/packages/common/src/services/decision/createInstanceFromTemplate.ts
+++ b/packages/common/src/services/decision/createInstanceFromTemplate.ts
@@ -81,7 +81,7 @@ export const createDecisionInstance = async ({
 
     const { admin: adminRole } = await createDefaultDecisionRoles({
       profileId: instanceProfile.id,
-      tx,
+      db: tx,
     });
 
     // Add the creator as a profile user with Admin role

--- a/packages/common/src/services/decision/createProposal.ts
+++ b/packages/common/src/services/decision/createProposal.ts
@@ -240,7 +240,7 @@ export const createProposal = async ({
         // Process proposal content to replace temporary URLs with permanent ones
         try {
           await processProposalContent({
-            conn: tx,
+            db: tx,
             proposalId: insertedProposal.id,
           });
         } catch (error) {

--- a/packages/common/src/services/decision/createTransitionsForProcess.ts
+++ b/packages/common/src/services/decision/createTransitionsForProcess.ts
@@ -1,4 +1,4 @@
-import { type TransactionType, db } from '@op/db/client';
+import { type DbClient, db as defaultDb } from '@op/db/client';
 import { decisionProcessTransitions } from '@op/db/schema';
 import type { ProcessInstance } from '@op/db/schema';
 
@@ -14,10 +14,10 @@ import { buildExpectedTransitions } from './buildExpectedTransitions';
  */
 export async function createTransitionsForProcess({
   processInstance,
-  tx,
+  db = defaultDb,
 }: {
   processInstance: ProcessInstance;
-  tx?: TransactionType;
+  db?: DbClient;
 }): Promise<{
   transitions: Array<{
     id: string;
@@ -26,8 +26,6 @@ export async function createTransitionsForProcess({
     scheduledDate: Date;
   }>;
 }> {
-  const dbClient = tx ?? db;
-
   try {
     const transitionsToCreate = buildExpectedTransitions(processInstance);
 
@@ -35,7 +33,7 @@ export async function createTransitionsForProcess({
       return { transitions: [] };
     }
 
-    const createdTransitions = await dbClient
+    const createdTransitions = await db
       .insert(decisionProcessTransitions)
       .values(transitionsToCreate)
       .returning();

--- a/packages/common/src/services/decision/decisionRoles.ts
+++ b/packages/common/src/services/decision/decisionRoles.ts
@@ -1,4 +1,4 @@
-import { type TransactionType, db } from '@op/db/client';
+import { type DbClient, db as defaultDb } from '@op/db/client';
 import { accessRolePermissionsOnAccessZones, accessRoles } from '@op/db/schema';
 import { permission, toBitField } from 'access-zones';
 import { eq } from 'drizzle-orm';
@@ -48,15 +48,14 @@ export async function createDecisionRole({
   profileId,
   permissions,
   description,
-  tx,
+  db = defaultDb,
 }: {
   name: string;
   profileId: string;
   permissions: Record<string, ZonePermission>;
   description?: string;
-  tx?: TransactionType;
+  db?: DbClient;
 }) {
-  const client = tx ?? db;
 
   // Scoped roles on a decision process always get profile READ
   if (permissions['profile']) {
@@ -86,7 +85,7 @@ export async function createDecisionRole({
   const zoneNames = Object.keys(permissions);
   const zones = await Promise.all(
     zoneNames.map((zoneName) =>
-      client.query.accessZones.findFirst({ where: { name: zoneName } }),
+      db.query.accessZones.findFirst({ where: { name: zoneName } }),
     ),
   );
 
@@ -100,7 +99,7 @@ export async function createDecisionRole({
     }),
   );
 
-  const [role] = await client
+  const [role] = await db
     .insert(accessRoles)
     .values({ name, description, profileId })
     .returning();
@@ -109,7 +108,7 @@ export async function createDecisionRole({
     throw new CommonError('Failed to create decision role');
   }
 
-  await client.insert(accessRolePermissionsOnAccessZones).values(
+  await db.insert(accessRolePermissionsOnAccessZones).values(
     zoneNames.map((zoneName) => ({
       accessRoleId: role.id,
       accessZoneId: zoneMap.get(zoneName)!.id,
@@ -126,10 +125,10 @@ export async function createDecisionRole({
  */
 export async function createDefaultDecisionRoles({
   profileId,
-  tx,
+  db = defaultDb,
 }: {
   profileId: string;
-  tx?: TransactionType;
+  db?: DbClient;
 }) {
   const [admin, participant] = await Promise.all([
     createDecisionRole({
@@ -161,7 +160,7 @@ export async function createDefaultDecisionRoles({
           },
         },
       },
-      tx,
+      db,
     }),
     createDecisionRole({
       name: 'Participant',
@@ -192,7 +191,7 @@ export async function createDefaultDecisionRoles({
           },
         },
       },
-      tx,
+      db,
     }),
   ]);
 
@@ -207,7 +206,7 @@ export async function getDecisionRole({
 }: {
   roleId: string;
 }): Promise<DecisionRolePermissions> {
-  const zone = await db.query.accessZones.findFirst({
+  const zone = await defaultDb.query.accessZones.findFirst({
     where: { name: 'decisions' },
   });
 
@@ -215,9 +214,10 @@ export async function getDecisionRole({
     throw new NotFoundError('Zone', 'decisions');
   }
 
-  const existing = await db.query.accessRolePermissionsOnAccessZones.findFirst({
-    where: { accessRoleId: roleId, accessZoneId: zone.id },
-  });
+  const existing =
+    await defaultDb.query.accessRolePermissionsOnAccessZones.findFirst({
+      where: { accessRoleId: roleId, accessZoneId: zone.id },
+    });
 
   return fromDecisionBitField(existing?.permission ?? 0);
 }
@@ -236,10 +236,10 @@ export async function updateDecisionRoles({
   user: { id: string };
 }) {
   const [zone, role] = await Promise.all([
-    db.query.accessZones.findFirst({
+    defaultDb.query.accessZones.findFirst({
       where: { name: 'decisions' },
     }),
-    db.query.accessRoles.findFirst({
+    defaultDb.query.accessRoles.findFirst({
       where: { id: roleId },
     }),
   ]);
@@ -258,19 +258,20 @@ export async function updateDecisionRoles({
 
   await assertProfileAdmin(user, role.profileId);
 
-  const existing = await db.query.accessRolePermissionsOnAccessZones.findFirst({
-    where: { accessRoleId: roleId, accessZoneId: zone.id },
-  });
+  const existing =
+    await defaultDb.query.accessRolePermissionsOnAccessZones.findFirst({
+      where: { accessRoleId: roleId, accessZoneId: zone.id },
+    });
 
   const bitfield = toDecisionBitField(decisionPermissions) | permission.READ;
 
   if (existing) {
-    await db
+    await defaultDb
       .update(accessRolePermissionsOnAccessZones)
       .set({ permission: bitfield })
       .where(eq(accessRolePermissionsOnAccessZones.id, existing.id));
   } else {
-    await db.insert(accessRolePermissionsOnAccessZones).values({
+    await defaultDb.insert(accessRolePermissionsOnAccessZones).values({
       accessRoleId: roleId,
       accessZoneId: zone.id,
       permission: bitfield,

--- a/packages/common/src/services/decision/decisionRoles.ts
+++ b/packages/common/src/services/decision/decisionRoles.ts
@@ -56,7 +56,6 @@ export async function createDecisionRole({
   description?: string;
   db?: DbClient;
 }) {
-
   // Scoped roles on a decision process always get profile READ
   if (permissions['profile']) {
     const existing = permissions['profile'];

--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -1,4 +1,4 @@
-import { type TransactionType, db, eq } from '@op/db/client';
+import { type DbClient, db as defaultDb, eq } from '@op/db/client';
 import { accessRolePermissionsOnAccessZones, accessRoles } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 import { assertAccess, permission } from 'access-zones';
@@ -60,7 +60,7 @@ export const duplicateInstance = async ({
   }
 
   // Fetch source instance
-  const sourceInstance = await db.query.processInstances.findFirst({
+  const sourceInstance = await defaultDb.query.processInstances.findFirst({
     where: { id: instanceId },
   });
 
@@ -218,16 +218,14 @@ function buildInstanceData(
 async function copyCustomRoles({
   sourceProfileId,
   targetProfileId,
-  tx,
+  db = defaultDb,
 }: {
   sourceProfileId: string;
   targetProfileId: string;
-  tx?: TransactionType;
+  db?: DbClient;
 }) {
-  const client = tx ?? db;
-
   // Fetch all roles for the source profile with their zone permissions
-  const sourceRoles = await client._query.accessRoles.findMany({
+  const sourceRoles = await db._query.accessRoles.findMany({
     where: eq(accessRoles.profileId, sourceProfileId),
     with: {
       zonePermissions: true,
@@ -241,7 +239,7 @@ async function copyCustomRoles({
 
   for (const role of customRoles) {
     // Create the role on the new profile
-    const [newRole] = await client
+    const [newRole] = await db
       .insert(accessRoles)
       .values({
         name: role.name,
@@ -256,7 +254,7 @@ async function copyCustomRoles({
 
     // Copy zone permissions
     if (role.zonePermissions.length > 0) {
-      await client.insert(accessRolePermissionsOnAccessZones).values(
+      await db.insert(accessRolePermissionsOnAccessZones).values(
         role.zonePermissions.map((zp) => ({
           accessRoleId: newRole.id,
           accessZoneId: zp.accessZoneId,

--- a/packages/common/src/services/decision/getProposalsForPhase.ts
+++ b/packages/common/src/services/decision/getProposalsForPhase.ts
@@ -1,7 +1,8 @@
 import {
+  type DbClient,
   and,
   asc,
-  db,
+  db as defaultDb,
   desc,
   eq,
   gt,
@@ -10,7 +11,6 @@ import {
   lt,
   ne,
 } from '@op/db/client';
-import type { DbClient } from '@op/db/client';
 import type { Proposal } from '@op/db/schema';
 import {
   ProposalStatus,
@@ -28,9 +28,9 @@ import { isLegacyInstanceData } from './isLegacyInstance';
  */
 async function getInstanceContext(
   instanceId: string,
-  dbClient: DbClient,
+  db: DbClient,
 ): Promise<{ isLegacy: boolean; currentPhaseId?: string | null } | null> {
-  const [row] = await dbClient
+  const [row] = await db
     .select({
       instanceData: processInstances.instanceData,
       currentStateId: processInstances.currentStateId,
@@ -71,9 +71,9 @@ async function resolvePhaseWindow(
   instanceId: string,
   phaseId: string,
   currentPhaseId: string | null | undefined,
-  dbClient: DbClient,
+  db: DbClient,
 ): Promise<PhaseWindow> {
-  const [inbound] = await dbClient
+  const [inbound] = await db
     .select({
       id: stateTransitionHistory.id,
       transitionedAt: stateTransitionHistory.transitionedAt,
@@ -88,7 +88,7 @@ async function resolvePhaseWindow(
     .orderBy(desc(stateTransitionHistory.transitionedAt))
     .limit(1);
 
-  const [outbound] = await dbClient
+  const [outbound] = await db
     .select({ transitionedAt: stateTransitionHistory.transitionedAt })
     .from(stateTransitionHistory)
     .where(
@@ -122,9 +122,9 @@ async function resolvePhaseWindow(
 /** Proposal ids attached to a specific inbound transition, filtered to still-active rows. */
 async function attachmentIdsFor(
   transitionHistoryId: string,
-  dbClient: DbClient,
+  db: DbClient,
 ): Promise<string[]> {
-  const rows = await dbClient
+  const rows = await db
     .select({ id: decisionTransitionProposals.proposalId })
     .from(decisionTransitionProposals)
     .innerJoin(
@@ -149,7 +149,7 @@ async function submittedDuringIds(
   instanceId: string,
   inboundAt: Date | undefined,
   outboundAt: Date | undefined,
-  dbClient: DbClient,
+  db: DbClient,
 ): Promise<string[]> {
   const conditions = [
     eq(proposals.processInstanceId, instanceId),
@@ -163,7 +163,7 @@ async function submittedDuringIds(
     conditions.push(lt(proposals.createdAt, outboundAt.toISOString()));
   }
 
-  const rows = await dbClient
+  const rows = await db
     .select({ id: proposals.id })
     .from(proposals)
     .where(and(...conditions));
@@ -172,9 +172,9 @@ async function submittedDuringIds(
 
 async function allActiveIds(
   instanceId: string,
-  dbClient: DbClient,
+  db: DbClient,
 ): Promise<string[]> {
-  const rows = await dbClient
+  const rows = await db
     .select({ id: proposals.id })
     .from(proposals)
     .where(
@@ -203,32 +203,32 @@ async function allActiveIds(
 export async function getProposalIdsForPhase({
   instanceId,
   phaseId,
-  dbClient = db,
+  db = defaultDb,
 }: {
   instanceId: string;
   phaseId?: string;
-  dbClient?: DbClient;
+  db?: DbClient;
 }): Promise<string[]> {
-  const ctx = await getInstanceContext(instanceId, dbClient);
+  const ctx = await getInstanceContext(instanceId, db);
 
   if (!ctx) {
     return [];
   }
 
   if (ctx.isLegacy) {
-    return allActiveIds(instanceId, dbClient);
+    return allActiveIds(instanceId, db);
   }
 
   const resolvedPhaseId = phaseId ?? ctx.currentPhaseId;
   if (!resolvedPhaseId) {
-    return allActiveIds(instanceId, dbClient);
+    return allActiveIds(instanceId, db);
   }
 
   const window = await resolvePhaseWindow(
     instanceId,
     resolvedPhaseId,
     ctx.currentPhaseId,
-    dbClient,
+    db,
   );
 
   if (window.kind === 'unreached') {
@@ -236,14 +236,14 @@ export async function getProposalIdsForPhase({
   }
 
   const attachmentIds = window.inbound
-    ? await attachmentIdsFor(window.inbound.id, dbClient)
+    ? await attachmentIdsFor(window.inbound.id, db)
     : [];
 
   const duringIds = await submittedDuringIds(
     instanceId,
     window.inbound?.transitionedAt,
     window.outboundTransitionedAt,
-    dbClient,
+    db,
   );
 
   return [...new Set([...attachmentIds, ...duringIds])];
@@ -256,18 +256,18 @@ export async function getProposalIdsForPhase({
 export async function getProposalsForPhase({
   instanceId,
   phaseId,
-  dbClient = db,
+  db = defaultDb,
 }: {
   instanceId: string;
   phaseId?: string;
-  dbClient?: DbClient;
+  db?: DbClient;
 }): Promise<Proposal[]> {
-  const ids = await getProposalIdsForPhase({ instanceId, phaseId, dbClient });
+  const ids = await getProposalIdsForPhase({ instanceId, phaseId, db });
   if (ids.length === 0) {
     return [];
   }
 
-  return dbClient
+  return db
     .select()
     .from(proposals)
     .where(inArray(proposals.id, ids))

--- a/packages/common/src/services/decision/isLegacyInstance.ts
+++ b/packages/common/src/services/decision/isLegacyInstance.ts
@@ -1,5 +1,4 @@
-import { db, eq } from '@op/db/client';
-import type { DbClient } from '@op/db/client';
+import { type DbClient, db as defaultDb, eq } from '@op/db/client';
 import { processInstances } from '@op/db/schema';
 
 /**
@@ -27,9 +26,9 @@ export function isLegacyInstanceData(instanceData: unknown): boolean {
  */
 export async function isLegacyInstance(
   instanceId: string,
-  dbClient: DbClient = db,
+  db: DbClient = defaultDb,
 ): Promise<boolean> {
-  const [row] = await dbClient
+  const [row] = await db
     .select({ instanceData: processInstances.instanceData })
     .from(processInstances)
     .where(eq(processInstances.id, instanceId))

--- a/packages/common/src/services/decision/listSelectionCandidates.ts
+++ b/packages/common/src/services/decision/listSelectionCandidates.ts
@@ -1,5 +1,4 @@
-import { db, eq } from '@op/db/client';
-import type { DbClient } from '@op/db/client';
+import { type DbClient, db as defaultDb, eq } from '@op/db/client';
 import { proposalCategories } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 import { assertAccess, permission } from 'access-zones';
@@ -22,7 +21,7 @@ interface ListSelectionCandidatesInput {
   /** Filter via the canonical `proposalCategories` join, not `proposalData.category`. */
   categoryId?: string;
   sortOrder?: 'newest' | 'oldest';
-  dbClient?: DbClient;
+  db?: DbClient;
 }
 
 /**
@@ -35,9 +34,9 @@ export async function listSelectionCandidates({
   user,
   categoryId,
   sortOrder = 'newest',
-  dbClient = db,
+  db = defaultDb,
 }: ListSelectionCandidatesInput): Promise<SelectionCandidates> {
-  const instance = await dbClient.query.processInstances.findFirst({
+  const instance = await db.query.processInstances.findFirst({
     where: { id: processInstanceId },
   });
 
@@ -65,7 +64,7 @@ export async function listSelectionCandidates({
 
   let categoryProposalIds: Set<string> | undefined;
   if (categoryId) {
-    const rows = await dbClient
+    const rows = await db
       .select({ proposalId: proposalCategories.proposalId })
       .from(proposalCategories)
       .where(eq(proposalCategories.taxonomyTermId, categoryId));
@@ -78,7 +77,7 @@ export async function listSelectionCandidates({
   const phaseCandidateIds = await getProposalIdsForPhase({
     instanceId: processInstanceId,
     phaseId: previousPhaseId,
-    dbClient,
+    db,
   });
 
   const candidateIds = categoryProposalIds

--- a/packages/common/src/services/decision/proposalContentProcessor.ts
+++ b/packages/common/src/services/decision/proposalContentProcessor.ts
@@ -179,11 +179,11 @@ export async function getProposalAttachmentUrls(
 ): Promise<Record<string, string>> {
   const proposalAttachmentJoins =
     await defaultDb._query.proposalAttachments.findMany({
-    where: eq(proposalAttachments.proposalId, proposalId),
-    with: {
-      attachment: true,
-    },
-  });
+      where: eq(proposalAttachments.proposalId, proposalId),
+      with: {
+        attachment: true,
+      },
+    });
 
   if (proposalAttachmentJoins.length === 0) {
     return {};

--- a/packages/common/src/services/decision/proposalContentProcessor.ts
+++ b/packages/common/src/services/decision/proposalContentProcessor.ts
@@ -1,4 +1,4 @@
-import { db, eq } from '@op/db/client';
+import { type DbClient, db as defaultDb, eq } from '@op/db/client';
 import { attachments, proposalAttachments, proposals } from '@op/db/schema';
 
 /**
@@ -15,15 +15,15 @@ const getPublicUrl = (key?: string | null) => {
  * Process proposal content to replace temporary image URLs with permanent attachment references
  */
 export async function processProposalContent({
-  conn,
+  db,
   proposalId,
 }: {
-  conn: typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
+  db: DbClient;
   proposalId: string;
 }): Promise<void> {
   try {
     // Get the proposal content
-    const proposal = await conn._query.proposals.findFirst({
+    const proposal = await db._query.proposals.findFirst({
       where: eq(proposals.id, proposalId),
     });
 
@@ -42,7 +42,7 @@ export async function processProposalContent({
 
     // Get all attachments for this proposal through the join table
     const proposalAttachmentJoins =
-      await conn._query.proposalAttachments.findMany({
+      await db._query.proposalAttachments.findMany({
         where: eq(proposalAttachments.proposalId, proposalId),
         with: {
           attachment: true,
@@ -119,7 +119,7 @@ export async function processProposalContent({
         content: processedContent,
       };
 
-      await conn
+      await db
         .update(proposals)
         .set({
           proposalData: updatedProposalData,
@@ -132,7 +132,7 @@ export async function processProposalContent({
     // Update attachment metadata
     if (updatedAttachments.length > 0) {
       for (const attachmentUpdate of updatedAttachments) {
-        await conn
+        await db
           .update(attachments)
           .set({
             fileName: attachmentUpdate.fileName,
@@ -177,7 +177,8 @@ function extractImageUrlsFromContent(htmlContent: string): string[] {
 export async function getProposalAttachmentUrls(
   proposalId: string,
 ): Promise<Record<string, string>> {
-  const proposalAttachmentJoins = await db._query.proposalAttachments.findMany({
+  const proposalAttachmentJoins =
+    await defaultDb._query.proposalAttachments.findMany({
     where: eq(proposalAttachments.proposalId, proposalId),
     with: {
       attachment: true,

--- a/packages/common/src/services/decision/selectionPipeline/proposalMetrics.ts
+++ b/packages/common/src/services/decision/selectionPipeline/proposalMetrics.ts
@@ -1,5 +1,4 @@
-import { db, eq, inArray } from '@op/db/client';
-import type { DbClient } from '@op/db/client';
+import { type DbClient, db as defaultDb, eq, inArray } from '@op/db/client';
 import type { Proposal } from '@op/db/schema';
 import {
   ProfileRelationshipType,
@@ -12,12 +11,12 @@ import type { VoteAggregation } from './types';
 
 /**
  * Aggregate voting data for the given proposals.
- * Accepts an optional dbClient so this can be called within a transaction
+ * Accepts an optional db so this can be called within a transaction
  * for a consistent snapshot.
  */
 export async function aggregateProposalMetrics(
   phaseProposals: Proposal[],
-  dbClient: DbClient = db,
+  db: DbClient = defaultDb,
 ): Promise<Record<string, VoteAggregation>> {
   if (phaseProposals.length === 0) {
     return {};
@@ -28,7 +27,7 @@ export async function aggregateProposalMetrics(
 
   // Fetch votes and profile relationships in parallel
   const [voteRows, relationships] = await Promise.all([
-    dbClient
+    db
       .select({
         submissionId: decisionsVoteSubmissions.id,
         voteData: decisionsVoteSubmissions.voteData,
@@ -44,7 +43,7 @@ export async function aggregateProposalMetrics(
       )
       .where(inArray(decisionsVoteProposals.proposalId, proposalIds)),
 
-    dbClient
+    db
       .select()
       .from(profileRelationships)
       .where(inArray(profileRelationships.targetProfileId, profileIds)),

--- a/packages/common/src/services/decision/submitManualSelection.ts
+++ b/packages/common/src/services/decision/submitManualSelection.ts
@@ -188,7 +188,7 @@ export async function submitManualSelection({
       await getProposalIdsForPhase({
         instanceId: processInstanceId,
         phaseId: previousPhaseId,
-        dbClient: tx,
+        db: tx,
       }),
     );
     for (const id of uniqueProposalIds) {

--- a/packages/common/src/services/decision/transitionMonitor.ts
+++ b/packages/common/src/services/decision/transitionMonitor.ts
@@ -176,7 +176,7 @@ async function advanceInstanceTransitions({
 
       const advanceResult = await db.transaction(async (tx) =>
         advancePhase({
-          tx,
+          db: tx,
           instance: {
             id: processInstanceId,
             instanceData: currentInstanceData,

--- a/packages/common/src/services/decision/triggerPhaseAdvancement.ts
+++ b/packages/common/src/services/decision/triggerPhaseAdvancement.ts
@@ -108,7 +108,7 @@ export async function triggerPhaseAdvancement({
 
   const advanceResult = await db.transaction(async (tx) => {
     const result = await advancePhase({
-      tx,
+      db: tx,
       instance: {
         id: instance.id,
         instanceData,

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -276,13 +276,13 @@ export const updateDecisionInstance = async ({
       // When publishing a draft, create transitions for all date-based phases
       await createTransitionsForProcess({
         processInstance: updatedInstance,
-        tx,
+        db: tx,
       });
     } else if (phases && phases.length > 0) {
       // If phases were updated and already published, update the corresponding transitions
       await updateTransitionsForProcess({
         processInstance: updatedInstance,
-        tx,
+        db: tx,
       });
     }
   });

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -1,5 +1,5 @@
 import { getTipTapClient } from '@op/collab';
-import { type TransactionType, and, db, eq } from '@op/db/client';
+import { type DbClient, and, db, eq } from '@op/db/client';
 import {
   ProposalStatus,
   type Visibility,
@@ -30,11 +30,11 @@ import { type DecisionInstanceData, isLastPhase } from './schemas/instanceData';
 import { validateProposalAgainstTemplate } from './validateProposalAgainstTemplate';
 
 async function updateProposalCategoryLink(
-  tx: TransactionType,
+  db: DbClient,
   proposalId: string,
   newCategoryLabels: string[],
 ): Promise<void> {
-  await tx
+  await db
     .delete(proposalCategories)
     .where(eq(proposalCategories.proposalId, proposalId));
 
@@ -42,7 +42,7 @@ async function updateProposalCategoryLink(
     return;
   }
 
-  const proposalTaxonomy = await tx._query.taxonomies.findFirst({
+  const proposalTaxonomy = await db._query.taxonomies.findFirst({
     where: eq(taxonomies.name, 'proposal'),
   });
 
@@ -58,7 +58,7 @@ async function updateProposalCategoryLink(
       continue;
     }
 
-    const taxonomyTerm = await tx._query.taxonomyTerms.findFirst({
+    const taxonomyTerm = await db._query.taxonomyTerms.findFirst({
       where: and(
         eq(taxonomyTerms.label, categoryLabel.trim()),
         eq(taxonomyTerms.taxonomyId, proposalTaxonomy.id),
@@ -74,7 +74,7 @@ async function updateProposalCategoryLink(
   }
 
   if (taxonomyTermIds.length > 0) {
-    await tx.insert(proposalCategories).values(
+    await db.insert(proposalCategories).values(
       taxonomyTermIds.map((taxonomyTermId) => ({
         proposalId,
         taxonomyTermId,

--- a/packages/common/src/services/decision/updateTransitionsForProcess.ts
+++ b/packages/common/src/services/decision/updateTransitionsForProcess.ts
@@ -1,4 +1,4 @@
-import { type TransactionType, db, eq, inArray } from '@op/db/client';
+import { type DbClient, db as defaultDb, eq, inArray } from '@op/db/client';
 import { decisionProcessTransitions } from '@op/db/schema';
 import type { ProcessInstance } from '@op/db/schema';
 
@@ -7,7 +7,7 @@ import { buildExpectedTransitions } from './buildExpectedTransitions';
 
 export interface UpdateTransitionsInput {
   processInstance: ProcessInstance;
-  tx?: TransactionType;
+  db?: DbClient;
 }
 
 export interface UpdateTransitionsResult {
@@ -27,16 +27,15 @@ export interface UpdateTransitionsResult {
  */
 export async function updateTransitionsForProcess({
   processInstance,
-  tx,
+  db = defaultDb,
 }: UpdateTransitionsInput): Promise<UpdateTransitionsResult> {
-  const dbClient = tx ?? db;
 
   try {
     const expectedTransitions = buildExpectedTransitions(processInstance);
 
     // Get existing transitions
     const existingTransitions =
-      await dbClient._query.decisionProcessTransitions.findMany({
+      await db._query.decisionProcessTransitions.findMany({
         where: eq(
           decisionProcessTransitions.processInstanceId,
           processInstance.id,
@@ -100,7 +99,7 @@ export async function updateTransitionsForProcess({
     if (transitionsToDelete.length > 0) {
       const idsToDelete = transitionsToDelete.map((t) => t.id);
       ops.push(
-        dbClient
+        db
           .delete(decisionProcessTransitions)
           .where(inArray(decisionProcessTransitions.id, idsToDelete))
           .then(() => {}),
@@ -110,7 +109,7 @@ export async function updateTransitionsForProcess({
     // Batch insert
     if (toCreate.length > 0) {
       ops.push(
-        dbClient
+        db
           .insert(decisionProcessTransitions)
           .values(toCreate)
           .then(() => {}),
@@ -120,7 +119,7 @@ export async function updateTransitionsForProcess({
     // Updates must remain individual (different values per row)
     for (const update of toUpdate) {
       ops.push(
-        dbClient
+        db
           .update(decisionProcessTransitions)
           .set({ scheduledDate: update.scheduledDate })
           .where(eq(decisionProcessTransitions.id, update.id))

--- a/packages/common/src/services/decision/updateTransitionsForProcess.ts
+++ b/packages/common/src/services/decision/updateTransitionsForProcess.ts
@@ -29,7 +29,6 @@ export async function updateTransitionsForProcess({
   processInstance,
   db = defaultDb,
 }: UpdateTransitionsInput): Promise<UpdateTransitionsResult> {
-
   try {
     const expectedTransitions = buildExpectedTransitions(processInstance);
 

--- a/packages/common/src/services/organization/createOrganization.ts
+++ b/packages/common/src/services/organization/createOrganization.ts
@@ -129,15 +129,15 @@ export const createOrganization = async ({
     }
   }
 
-  return db.transaction(async (db) => {
+  return db.transaction(async (tx) => {
     // Create an org profile
-    const [profile] = await db
+    const [profile] = await tx
       .insert(profiles)
       .values({
         name: data.name! ?? 'New Organization',
         slug: await generateUniqueProfileSlug({
           name: data.name ?? 'org',
-          db,
+          db: tx,
         }),
         email: data.email,
         bio: data.bio,
@@ -152,7 +152,7 @@ export const createOrganization = async ({
       throw new CommonError('Failed to create profile');
     }
 
-    const [newOrg] = await db
+    const [newOrg] = await tx
       .insert(organizations)
       .values({
         ...orgInputs,
@@ -167,7 +167,7 @@ export const createOrganization = async ({
 
     // Insert organizationUser linking the user to organization, with a default role of owner
     const [[newOrgUser], adminRole] = await Promise.all([
-      db
+      tx
         .insert(organizationUsers)
         .values({
           organizationId: newOrg.id,
@@ -175,8 +175,8 @@ export const createOrganization = async ({
           email: user.email!,
         })
         .returning(),
-      assertGlobalRole('Admin', db),
-      db
+      assertGlobalRole('Admin', tx),
+      tx
         .update(users)
         .set({ lastOrgId: newOrg.id, currentProfileId: profile.id })
         .where(eq(users.authUserId, user.id)),
@@ -186,7 +186,7 @@ export const createOrganization = async ({
       throw new CommonError('Failed to create organization');
     }
 
-    await db.insert(organizationUserToAccessRoles).values({
+    await tx.insert(organizationUserToAccessRoles).values({
       organizationUserId: newOrgUser.id,
       accessRoleId: adminRole.id,
     });
@@ -195,7 +195,7 @@ export const createOrganization = async ({
     await Promise.all([
       ...(data.receivingFundsLink
         ? [
-            db.insert(links).values({
+            tx.insert(links).values({
               organizationId: newOrg.id,
               href: data.receivingFundsLink,
               description: data.receivingFundsDescription,
@@ -205,7 +205,7 @@ export const createOrganization = async ({
         : []),
       ...(data.offeringFundsLink
         ? [
-            db.insert(links).values({
+            tx.insert(links).values({
               organizationId: newOrg.id,
               href: data.offeringFundsLink,
               description: data.offeringFundsDescription,
@@ -224,7 +224,7 @@ export const createOrganization = async ({
             : null;
 
           // Create location record
-          const [location] = await db
+          const [location] = await tx
             .insert(locations)
             .values({
               name: whereWeWork.label,
@@ -253,7 +253,7 @@ export const createOrganization = async ({
 
           if (location) {
             // Link location to organization
-            await db
+            await tx
               .insert(organizationsWhereWeWork)
               .values({
                 organizationId: newOrg.id,
@@ -276,7 +276,7 @@ export const createOrganization = async ({
     if (strategies) {
       await Promise.all(
         strategies.map((strategy) =>
-          db
+          tx
             .insert(organizationsStrategies)
             .values({
               organizationId: newOrg.id,
@@ -302,7 +302,7 @@ export const createOrganization = async ({
 
       await Promise.all(
         terms.map((term) =>
-          db
+          tx
             .insert(organizationsTerms)
             .values({
               organizationId: newOrg.id,

--- a/packages/common/src/services/organization/createOrganization.ts
+++ b/packages/common/src/services/organization/createOrganization.ts
@@ -1,9 +1,4 @@
-import {
-  type DbClient,
-  db as defaultDb,
-  eq,
-  sql,
-} from '@op/db/client';
+import { type DbClient, db as defaultDb, eq, sql } from '@op/db/client';
 import {
   links,
   locations,

--- a/packages/common/src/services/organization/createOrganization.ts
+++ b/packages/common/src/services/organization/createOrganization.ts
@@ -1,4 +1,9 @@
-import { db, eq, sql } from '@op/db/client';
+import {
+  type DbClient,
+  db as defaultDb,
+  eq,
+  sql,
+} from '@op/db/client';
 import {
   links,
   locations,
@@ -89,6 +94,7 @@ const broadDomains = [
 export const createOrganization = async ({
   data,
   user,
+  db = defaultDb,
 }: {
   data: OrganizationInput &
     FundingLinksInput & {
@@ -96,6 +102,7 @@ export const createOrganization = async ({
       orgBannerImageId?: string;
     };
   user: User;
+  db?: DbClient;
 }) => {
   const orgInputs = OrganizationInputParser.parse({
     ...data,
@@ -122,68 +129,68 @@ export const createOrganization = async ({
     }
   }
 
-  // Create an org profile
-  const [profile] = await db
-    .insert(profiles)
-    .values({
-      name: data.name! ?? 'New Organization',
-      slug: await generateUniqueProfileSlug({
-        name: data.name ?? 'org',
-      }),
-      email: data.email,
-      bio: data.bio,
-      website: data.website,
-      mission: data.mission,
-      headerImageId: data.orgBannerImageId,
-      avatarImageId: data.orgAvatarImageId,
-    })
-    .returning();
-
-  if (!profile) {
-    throw new CommonError('Failed to create profile');
-  }
-
-  const [newOrg] = await db
-    .insert(organizations)
-    .values({
-      ...orgInputs,
-      profileId: profile.id,
-      domain,
-    })
-    .returning();
-
-  if (!newOrg) {
-    throw new NotFoundError('Failed to create organization');
-  }
-
-  // Insert organizationUser linking the user to organization, with a default role of owner
-  const [[newOrgUser], adminRole] = await Promise.all([
-    db
-      .insert(organizationUsers)
+  return db.transaction(async (db) => {
+    // Create an org profile
+    const [profile] = await db
+      .insert(profiles)
       .values({
-        organizationId: newOrg.id,
-        authUserId: user.id,
-        email: user.email!,
+        name: data.name! ?? 'New Organization',
+        slug: await generateUniqueProfileSlug({
+          name: data.name ?? 'org',
+          db,
+        }),
+        email: data.email,
+        bio: data.bio,
+        website: data.website,
+        mission: data.mission,
+        headerImageId: data.orgBannerImageId,
+        avatarImageId: data.orgAvatarImageId,
       })
-      .returning(),
-    assertGlobalRole('Admin'),
-    db
-      .update(users)
-      .set({ lastOrgId: newOrg.id, currentProfileId: profile.id })
-      .where(eq(users.authUserId, user.id)),
-  ]);
+      .returning();
 
-  // Add admin role to the user creating the organization
-  if (!newOrgUser) {
-    throw new CommonError('Failed to create organization');
-  }
+    if (!profile) {
+      throw new CommonError('Failed to create profile');
+    }
 
-  await db.insert(organizationUserToAccessRoles).values({
-    organizationUserId: newOrgUser.id,
-    accessRoleId: adminRole.id,
-  });
+    const [newOrg] = await db
+      .insert(organizations)
+      .values({
+        ...orgInputs,
+        profileId: profile.id,
+        domain,
+      })
+      .returning();
 
-  try {
+    if (!newOrg) {
+      throw new NotFoundError('Failed to create organization');
+    }
+
+    // Insert organizationUser linking the user to organization, with a default role of owner
+    const [[newOrgUser], adminRole] = await Promise.all([
+      db
+        .insert(organizationUsers)
+        .values({
+          organizationId: newOrg.id,
+          authUserId: user.id,
+          email: user.email!,
+        })
+        .returning(),
+      assertGlobalRole('Admin', db),
+      db
+        .update(users)
+        .set({ lastOrgId: newOrg.id, currentProfileId: profile.id })
+        .where(eq(users.authUserId, user.id)),
+    ]);
+
+    if (!newOrgUser) {
+      throw new CommonError('Failed to create organization');
+    }
+
+    await db.insert(organizationUserToAccessRoles).values({
+      organizationUserId: newOrgUser.id,
+      accessRoleId: adminRole.id,
+    });
+
     // Add funding links
     await Promise.all([
       ...(data.receivingFundsLink
@@ -266,9 +273,6 @@ export const createOrganization = async ({
       offeringFundsTerms,
     } = data;
 
-    // add all stategy terms to the org (strategy terms already exist in the DB)
-    // TODO: parallelize this
-
     if (strategies) {
       await Promise.all(
         strategies.map((strategy) =>
@@ -283,7 +287,6 @@ export const createOrganization = async ({
       );
     }
 
-    // TODO: this was changed quickly in the process. We are transitioning to this way of doing terms.
     if (
       focusAreas ||
       communitiesServed ||
@@ -310,14 +313,6 @@ export const createOrganization = async ({
       );
     }
 
-    if (!newOrgUser) {
-      throw new CommonError('Failed to associate organization with user');
-    }
-
-    // @ts-ignore
     return { ...newOrg, profile };
-  } catch (e) {
-    console.error(e);
-    throw new CommonError('Failed to create organization');
-  }
+  });
 };

--- a/packages/common/src/services/organization/joinOrganization.ts
+++ b/packages/common/src/services/organization/joinOrganization.ts
@@ -1,11 +1,5 @@
 import { cache } from '@op/cache';
-import {
-  type DatabaseType,
-  type TransactionType,
-  and,
-  db as defaultDb,
-  eq,
-} from '@op/db/client';
+import { type DbClient, and, db as defaultDb, eq } from '@op/db/client';
 import {
   type AccessRole,
   type CommonUser,
@@ -28,13 +22,13 @@ export const joinOrganization = async ({
   user,
   organization,
   roleId,
-  db,
+  db = defaultDb,
 }: {
   user: CommonUser;
   organization: Organization;
   /** If provided the allowlist checks are skipped and this role is assigned */
   roleId?: AccessRole['id'];
-  db?: DatabaseType | TransactionType;
+  db?: DbClient;
 }): Promise<OrganizationUser> => {
   const userEmailDomainPart = user.email.split('@')[1];
   if (!userEmailDomainPart) {
@@ -43,11 +37,9 @@ export const joinOrganization = async ({
 
   const userEmailDomain = userEmailDomainPart.toLowerCase();
 
-  const client = db ?? defaultDb;
-
   // Check if user is already a member of this organization and if they are on the allow list
   const [existingMembership, allowListUser] = await Promise.all([
-    client
+    db
       .select()
       .from(organizationUsers)
       .where(
@@ -89,11 +81,11 @@ export const joinOrganization = async ({
 
   const targetRole = await determineTargetRole(
     roleId ?? allowListUser?.metadata?.roleId,
-    client,
+    db,
   );
 
-  return await client.transaction<OrganizationUser>(async (innerTx) => {
-    const [newOrgUser] = await innerTx
+  return await db.transaction<OrganizationUser>(async (tx) => {
+    const [newOrgUser] = await tx
       .insert(organizationUsers)
       .values({
         organizationId: organization.id,
@@ -107,7 +99,7 @@ export const joinOrganization = async ({
       throw new CommonError('Failed to add user to organization');
     }
 
-    await innerTx.insert(organizationUserToAccessRoles).values({
+    await tx.insert(organizationUserToAccessRoles).values({
       organizationUserId: newOrgUser.id,
       accessRoleId: targetRole.id,
     });
@@ -123,10 +115,10 @@ export const joinOrganization = async ({
  */
 const determineTargetRole = async (
   roleId: AccessRole['id'] | undefined,
-  client: DatabaseType | TransactionType,
+  db: DbClient,
 ): Promise<AccessRole> => {
   if (roleId) {
-    const role = await client.query.accessRoles.findFirst({
+    const role = await db.query.accessRoles.findFirst({
       where: { id: roleId },
     });
 
@@ -135,5 +127,5 @@ const determineTargetRole = async (
     }
   }
 
-  return assertGlobalRole('Member', client);
+  return assertGlobalRole('Member', db);
 };

--- a/packages/common/src/services/profile/requests/createProfileJoinRequest.ts
+++ b/packages/common/src/services/profile/requests/createProfileJoinRequest.ts
@@ -1,11 +1,4 @@
-import {
-  type DatabaseType,
-  type TransactionType,
-  and,
-  db,
-  eq,
-  sql,
-} from '@op/db/client';
+import { type DbClient, and, db, eq, sql } from '@op/db/client';
 import {
   JoinProfileRequestStatus,
   joinProfileRequests,
@@ -179,9 +172,9 @@ async function performAutoJoin(
   user: User,
   organization: Organization,
   roleId: string,
-  tx: DatabaseType | TransactionType,
+  db: DbClient,
 ): Promise<void> {
-  const commonUser = await tx.query.users.findFirst({
+  const commonUser = await db.query.users.findFirst({
     where: { authUserId: user.id },
   });
 
@@ -193,6 +186,6 @@ async function performAutoJoin(
     user: commonUser,
     organization,
     roleId,
-    db: tx,
+    db,
   });
 }

--- a/packages/common/src/services/profile/utils.ts
+++ b/packages/common/src/services/profile/utils.ts
@@ -1,4 +1,4 @@
-import { DatabaseType, TransactionType, db as database } from '@op/db/client';
+import { type DbClient, db as defaultDb } from '@op/db/client';
 import { profiles } from '@op/db/schema';
 import { randomUUID } from 'crypto';
 import { inArray } from 'drizzle-orm';
@@ -9,17 +9,13 @@ import slugify from 'slugify';
  */
 export const generateUniqueProfileSlug = async ({
   name,
-  db,
+  db = defaultDb,
 }: {
   name: string;
-  db?: DatabaseType | TransactionType;
+  db?: DbClient;
 }): Promise<string> => {
   const MAX_ATTEMPTS = 10;
   const MAX_SLUG_LENGTH = 50; // Rough good practice of max slug length
-
-  if (!db) {
-    db = database;
-  }
 
   // Generate base slug from name
   let baseSlug = slugify(name, {

--- a/services/api/src/routers/decision/instances/advancePhase.test.ts
+++ b/services/api/src/routers/decision/instances/advancePhase.test.ts
@@ -67,7 +67,7 @@ async function callAdvancePhase(
   const { dbInstance } = loaded;
   return db.transaction(async (tx) =>
     advancePhase({
-      tx,
+      db: tx,
       instance: {
         id: dbInstance.id,
         instanceData: dbInstance.instanceData as DecisionInstanceData,

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -130,7 +130,7 @@ async function advanceToReviewPhase(instanceId: string) {
 
   const result = await db.transaction(async (tx) =>
     advancePhase({
-      tx,
+      db: tx,
       instance: {
         id: dbInstance.id,
         instanceData: dbInstance.instanceData as DecisionInstanceData,

--- a/services/api/src/routers/organization/organization.test.ts
+++ b/services/api/src/routers/organization/organization.test.ts
@@ -186,16 +186,30 @@ describe.concurrent('Organization Integration Tests', () => {
         users: { admin: 1 },
       });
 
-      const seededTerms = await db
-        .select({ id: taxonomyTerms.id })
-        .from(taxonomyTerms)
-        .limit(2);
-      const [strategyTerm, focusTerm] = seededTerms;
+      // Insert taxonomy term fixtures so the test doesn't depend on seed state.
+      const [strategyTerm, focusTerm] = await db
+        .insert(taxonomyTerms)
+        .values([
+          {
+            termUri: `test:strategy:${task.id}`,
+            label: `Test Strategy ${task.id}`,
+            facet: 'strategy',
+          },
+          {
+            termUri: `test:focus:${task.id}`,
+            label: `Test Focus ${task.id}`,
+            facet: 'focusArea',
+          },
+        ])
+        .returning({ id: taxonomyTerms.id });
       if (!strategyTerm || !focusTerm) {
-        throw new Error(
-          'Expected at least 2 seeded taxonomy terms; check test DB seed',
-        );
+        throw new Error('Failed to insert taxonomy term fixtures');
       }
+      onTestFinished(async () => {
+        await db
+          .delete(taxonomyTerms)
+          .where(inArray(taxonomyTerms.id, [strategyTerm.id, focusTerm.id]));
+      });
 
       const { session } = await createIsolatedSession(adminUser.email);
       const caller = createCaller(await createTestContextWithSession(session));
@@ -215,6 +229,12 @@ describe.concurrent('Organization Integration Tests', () => {
         focusAreas: [{ id: focusTerm.id, label: 'Test Focus' }],
       });
 
+      onTestFinished(async () => {
+        if (result.profile?.id) {
+          await db.delete(profiles).where(eq(profiles.id, result.profile.id));
+        }
+      });
+
       const strategyRows = await db
         .select()
         .from(organizationsStrategies)
@@ -228,12 +248,6 @@ describe.concurrent('Organization Integration Tests', () => {
         .where(eq(organizationsTerms.organizationId, result.id));
       expect(termRows).toHaveLength(1);
       expect(termRows[0]?.taxonomyTermId).toBe(focusTerm.id);
-
-      onTestFinished(async () => {
-        if (result.profile?.id) {
-          await db.delete(profiles).where(eq(profiles.id, result.profile.id));
-        }
-      });
     });
 
     it('should roll back all inserts when a downstream insert fails', async ({

--- a/services/api/src/routers/organization/organization.test.ts
+++ b/services/api/src/routers/organization/organization.test.ts
@@ -1,5 +1,11 @@
 import { db } from '@op/db/client';
-import { locations, profiles } from '@op/db/schema';
+import {
+  locations,
+  organizationsStrategies,
+  organizationsTerms,
+  profiles,
+  taxonomyTerms,
+} from '@op/db/schema';
 import { eq, inArray } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
@@ -169,6 +175,107 @@ describe.concurrent('Organization Integration Tests', () => {
       };
 
       await expect(() => caller.create(invalidData)).rejects.toThrow();
+    });
+
+    it('should persist strategies and focus areas', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestOrganizationDataManager(task.id, onTestFinished);
+      const { adminUser } = await testData.createOrganization({
+        users: { admin: 1 },
+      });
+
+      const seededTerms = await db
+        .select({ id: taxonomyTerms.id })
+        .from(taxonomyTerms)
+        .limit(2);
+      const [strategyTerm, focusTerm] = seededTerms;
+      if (!strategyTerm || !focusTerm) {
+        throw new Error(
+          'Expected at least 2 seeded taxonomy terms; check test DB seed',
+        );
+      }
+
+      const { session } = await createIsolatedSession(adminUser.email);
+      const caller = createCaller(await createTestContextWithSession(session));
+
+      const result = await caller.create({
+        name: `Strategies Test Org ${task.id}`,
+        website: 'https://strategies-test.example.com',
+        email: 'contact@strategies-test.example.com',
+        orgType: 'nonprofit' as const,
+        bio: 'Strategies test',
+        mission: 'Strategies test',
+        networkOrganization: false,
+        isReceivingFunds: false,
+        isOfferingFunds: false,
+        acceptingApplications: false,
+        strategies: [{ id: strategyTerm.id, label: 'Test Strategy' }],
+        focusAreas: [{ id: focusTerm.id, label: 'Test Focus' }],
+      });
+
+      const strategyRows = await db
+        .select()
+        .from(organizationsStrategies)
+        .where(eq(organizationsStrategies.organizationId, result.id));
+      expect(strategyRows).toHaveLength(1);
+      expect(strategyRows[0]?.taxonomyTermId).toBe(strategyTerm.id);
+
+      const termRows = await db
+        .select()
+        .from(organizationsTerms)
+        .where(eq(organizationsTerms.organizationId, result.id));
+      expect(termRows).toHaveLength(1);
+      expect(termRows[0]?.taxonomyTermId).toBe(focusTerm.id);
+
+      onTestFinished(async () => {
+        if (result.profile?.id) {
+          await db.delete(profiles).where(eq(profiles.id, result.profile.id));
+        }
+      });
+    });
+
+    it('should roll back all inserts when a downstream insert fails', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestOrganizationDataManager(task.id, onTestFinished);
+      const { adminUser } = await testData.createOrganization({
+        users: { admin: 1 },
+      });
+
+      const { session } = await createIsolatedSession(adminUser.email);
+      const caller = createCaller(await createTestContextWithSession(session));
+
+      const orgName = `Rollback Test Org ${task.id}`;
+      const fakeTaxonomyTermId = '00000000-0000-0000-0000-000000000000';
+
+      await expect(() =>
+        caller.create({
+          name: orgName,
+          website: 'https://rollback-test.example.com',
+          email: 'contact@rollback-test.example.com',
+          orgType: 'nonprofit' as const,
+          bio: 'Rollback test',
+          mission: 'Rollback test',
+          networkOrganization: false,
+          isReceivingFunds: false,
+          isOfferingFunds: false,
+          acceptingApplications: false,
+          strategies: [{ id: fakeTaxonomyTermId, label: 'fake' }],
+        }),
+      ).rejects.toThrow();
+
+      // The transaction should have rolled back the profile, organization,
+      // organizationUser, and role-grant rows that were inserted before the
+      // failing strategies insert. Verify by name (uniqueness comes from the
+      // task-id suffix above).
+      const orphanProfiles = await db
+        .select({ id: profiles.id })
+        .from(profiles)
+        .where(eq(profiles.name, orgName));
+      expect(orphanProfiles).toHaveLength(0);
     });
   });
 

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -649,7 +649,7 @@ export class TestDecisionsDataManager {
     }
     return db.transaction(async (tx) =>
       advancePhase({
-        tx,
+        db: tx,
         instance: {
           ...processInstance,
           instanceData: processInstance.instanceData as DecisionInstanceData,


### PR DESCRIPTION
Unifies a lot of the database client usage to support transactions. This is partially to make sure that we're using it consistently across the board, but also that it's easy for us to pass in a transaction when we can to avoid things like deadlocks or pool exhaustion as a result of database clients being created within a transaction.
