### PR TITLE
chore(docker): expose api supabase URL + seed Common org for dev stack

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -86,6 +86,7 @@ services:
     env_file: .env.docker
     environment:
       TIPTAP_PRO_TOKEN: ${TIPTAP_PRO_TOKEN}
+      NEXT_PUBLIC_SUPABASE_URL: "http://localhost:${PORT_PREFIX:-31}21"
       WATCHPACK_POLLING: "true"
     ports:
       - "${PORT_PREFIX:-31}01:3300"

--- a/services/db/seed-orgs-for-test.ts
+++ b/services/db/seed-orgs-for-test.ts
@@ -1,7 +1,6 @@
-// Minimal seeder for the docker dev stack: creates One Project (with
+// Minimal seeder: creates One Project (with
 // domain=oneproject.org so onboarding domain-match pre-selects it) and
-// Common (no domain match) so the join-already-joined regression can be
-// reproduced end-to-end. Idempotent.
+// Common (no domain match)
 import { eq } from 'drizzle-orm';
 
 import { db } from '.';

--- a/services/db/seed-orgs-for-test.ts
+++ b/services/db/seed-orgs-for-test.ts
@@ -1,0 +1,69 @@
+// Minimal seeder for the docker dev stack: creates One Project (with
+// domain=oneproject.org so onboarding domain-match pre-selects it) and
+// Common (no domain match) so the join-already-joined regression can be
+// reproduced end-to-end. Idempotent.
+import { eq } from 'drizzle-orm';
+
+import { db } from '.';
+import { organizations, profiles } from './schema';
+
+const orgs = [
+  {
+    name: 'One Project',
+    slug: 'one-project',
+    bio: 'One Project bio',
+    mission:
+      'To nurture a just transition to a regenerative democratic economy.',
+    email: 'scott@oneproject.org',
+    website: 'https://oneproject.org',
+    domain: 'oneproject.org',
+  },
+  {
+    name: 'Common',
+    slug: 'common',
+    bio: 'Common bio',
+    mission: 'Bring organizations together.',
+    email: 'hello@common.io',
+    website: 'https://common.io',
+    domain: 'common.io',
+  },
+];
+
+for (const org of orgs) {
+  const [existingProfile] = await db
+    .select()
+    .from(profiles)
+    .where(eq(profiles.slug, org.slug))
+    .limit(1);
+
+  if (existingProfile) {
+    console.log(`profile ${org.slug} already exists, skipping`);
+    continue;
+  }
+
+  const [profile] = await db
+    .insert(profiles)
+    .values({
+      name: org.name,
+      slug: org.slug,
+      email: org.email,
+      bio: org.bio,
+      mission: org.mission,
+      website: org.website,
+    })
+    .returning();
+
+  if (!profile) {
+    throw new Error(`Failed to create profile for ${org.name}`);
+  }
+
+  await db.insert(organizations).values({
+    profileId: profile.id,
+    domain: org.domain,
+  });
+
+  console.log(`created ${org.name} (profile ${profile.id})`);
+}
+
+console.log('done');
+process.exit(0);

--- a/services/db/seed.ts
+++ b/services/db/seed.ts
@@ -35,6 +35,7 @@ if (!process.env.DB_SEEDING) {
 const allowedDatabaseUrls = [
   'postgresql://postgres:postgres@127.0.0.1:54322/postgres', // Development database
   'postgresql://postgres:postgres@127.0.0.1:55322/postgres', // Test database
+  'postgresql://postgres:postgres@dind:54322/postgres', // Docker dev database (.trees worktree)
 ];
 
 if (!allowedDatabaseUrls.includes(process.env.DATABASE_URL || '')) {
@@ -290,6 +291,21 @@ const seedOrgs = [
     offeringFundsDescription: 'offering description here',
     email: 'scott@oneproject.org',
     website: 'https://oneproject.org',
+    type: OrgType.NONPROFIT,
+    whereWeWork: [],
+  },
+  {
+    name: 'Common',
+    slug: 'common',
+    description: 'Common is a community of organizations.',
+    mission: 'Bring organizations together.',
+    city: 'New York',
+    bio: 'Common bio',
+    state: 'NY',
+    isOfferingFunds: false,
+    isReceivingFunds: false,
+    email: 'hello@common.io',
+    website: 'https://common.io',
     type: OrgType.NONPROFIT,
     whereWeWork: [],
   },


### PR DESCRIPTION
The docker-compose api service was missing the same NEXT_PUBLIC_SUPABASE_URL
override the app service has, so OTP login from the api container failed
whenever PORT_PREFIX was non-default (the env_file default points at port
3121, but the proxy listens on <PORT_PREFIX>21).

Also adds Common alongside One Project in seedOrgs and a small
seed-orgs-for-test.ts helper that inserts both directly so the join flow
can be exercised end-to-end in the docker dev stack without depending on
the full seed (which has unrelated breakage around supabase admin user
creation and missing seedData/AccessRoles.sql).
