### PR TITLE
feat(decisions): default selection pipeline to pass-none

### DIFF
--- a/packages/common/src/services/decision/advancePhase.ts
+++ b/packages/common/src/services/decision/advancePhase.ts
@@ -116,7 +116,8 @@ export async function advancePhase(
     db,
   });
 
-  let selectedProposalIds: string[] = allProposals.map((p) => p.id);
+  // Default to pass-none; phases opt into pass-all via an empty-blocks pipeline.
+  let selectedProposalIds: string[] = [];
 
   if (selectionPipeline) {
     const proposalMetrics = await aggregateProposalMetrics(allProposals, db);

--- a/packages/common/src/services/decision/schemas/definitions.ts
+++ b/packages/common/src/services/decision/schemas/definitions.ts
@@ -51,7 +51,7 @@ export const simpleVoting: DecisionSchemaDefinition = {
       rules: {
         proposals: { submit: true },
         voting: { submit: false },
-        advancement: { method: 'date', endDate: '2026-01-01' },
+        advancement: { method: 'manual', endDate: '2026-01-01' },
       },
       // User-configurable settings, available as variables in selectionPipeline
       settings: {
@@ -82,6 +82,13 @@ export const simpleVoting: DecisionSchemaDefinition = {
           },
         },
       },
+      // Pass-all: every submitted proposal advances into review.
+      // Expressed as an empty pipeline (no blocks) which short-circuits to
+      // returning the full input set.
+      selectionPipeline: {
+        version: '1.0.0',
+        blocks: [],
+      },
     },
     {
       id: 'review',
@@ -90,7 +97,7 @@ export const simpleVoting: DecisionSchemaDefinition = {
       rules: {
         proposals: { submit: false },
         voting: { submit: false },
-        advancement: { method: 'date', endDate: '2026-01-02' },
+        advancement: { method: 'manual', endDate: '2026-01-02' },
       },
       settings: {
         type: 'object',
@@ -109,6 +116,8 @@ export const simpleVoting: DecisionSchemaDefinition = {
           },
         },
       },
+      // No selectionPipeline → falls back to pass-none, requiring an admin
+      // to manually pick which proposals advance to voting.
     },
     {
       id: 'voting',
@@ -117,7 +126,7 @@ export const simpleVoting: DecisionSchemaDefinition = {
       rules: {
         proposals: { submit: false },
         voting: { submit: true },
-        advancement: { method: 'date', endDate: '2026-01-03' },
+        advancement: { method: 'manual', endDate: '2026-01-03' },
       },
       // Phase-specific settings
       settings: {
@@ -175,7 +184,7 @@ export const simpleVoting: DecisionSchemaDefinition = {
       rules: {
         proposals: { submit: false },
         voting: { submit: false },
-        advancement: { method: 'date', endDate: '2026-01-04' },
+        advancement: { method: 'manual', endDate: '2026-01-04' },
       },
       settings: {
         type: 'object',

--- a/packages/common/src/services/decision/schemas/definitions.ts
+++ b/packages/common/src/services/decision/schemas/definitions.ts
@@ -82,13 +82,6 @@ export const simpleVoting: DecisionSchemaDefinition = {
           },
         },
       },
-      // Pass-all: every submitted proposal advances into review.
-      // Expressed as an empty pipeline (no blocks) which short-circuits to
-      // returning the full input set.
-      selectionPipeline: {
-        version: '1.0.0',
-        blocks: [],
-      },
     },
     {
       id: 'review',
@@ -116,8 +109,6 @@ export const simpleVoting: DecisionSchemaDefinition = {
           },
         },
       },
-      // No selectionPipeline → falls back to pass-none, requiring an admin
-      // to manually pick which proposals advance to voting.
     },
     {
       id: 'voting',

--- a/packages/common/src/services/decision/schemas/definitions.ts
+++ b/packages/common/src/services/decision/schemas/definitions.ts
@@ -51,7 +51,14 @@ export const simpleVoting: DecisionSchemaDefinition = {
       rules: {
         proposals: { submit: true },
         voting: { submit: false },
-        advancement: { method: 'manual', endDate: '2026-01-01' },
+        advancement: { method: 'date', endDate: '2026-01-01' },
+      },
+      // Pass-all: every submitted proposal advances into review.
+      // Expressed as an empty pipeline (no blocks) which short-circuits to
+      // returning the full input set.
+      selectionPipeline: {
+        version: '1.0.0',
+        blocks: [],
       },
       // User-configurable settings, available as variables in selectionPipeline
       settings: {

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -38,6 +38,9 @@ const decisionSchemaWithReview = {
         proposals: { submit: true },
         advancement: { method: 'manual' as const },
       },
+      // Pass-all: every submitted proposal advances into review so the
+      // assignment generator has proposals to fan out to reviewers.
+      selectionPipeline: { version: '1.0.0', blocks: [] },
     },
     {
       id: 'review',

--- a/services/api/src/routers/decision/instances/transitionMonitor.test.ts
+++ b/services/api/src/routers/decision/instances/transitionMonitor.test.ts
@@ -1,4 +1,7 @@
-import { processDecisionsTransitions, simpleVoting } from '@op/common';
+import {
+  type DecisionSchemaDefinition,
+  processDecisionsTransitions,
+} from '@op/common';
 import { db, eq } from '@op/db/client';
 import {
   ProcessStatus,
@@ -29,8 +32,54 @@ async function createAuthenticatedCaller(email: string) {
   return createCaller(await createTestContextWithSession(session));
 }
 
+// Four-phase schema for transition-monitor tests: every phase uses
+// date-based advancement so the monitor schedules transitions, and every
+// phase carries a pass-all selectionPipeline so proposals flow forward.
+const monitorTestSchema: DecisionSchemaDefinition = {
+  id: 'monitor-test',
+  version: '1.0.0',
+  name: 'Monitor Test Schema',
+  description: 'Date-based pass-all schema used for transition monitor tests.',
+  phases: [
+    {
+      id: 'submission',
+      name: 'Submission',
+      rules: {
+        proposals: { submit: true },
+        advancement: { method: 'date' },
+      },
+      selectionPipeline: { version: '1.0.0', blocks: [] },
+    },
+    {
+      id: 'review',
+      name: 'Review',
+      rules: {
+        advancement: { method: 'date' },
+      },
+      selectionPipeline: { version: '1.0.0', blocks: [] },
+    },
+    {
+      id: 'voting',
+      name: 'Voting',
+      rules: {
+        voting: { submit: true },
+        advancement: { method: 'date' },
+      },
+      selectionPipeline: { version: '1.0.0', blocks: [] },
+    },
+    {
+      id: 'results',
+      name: 'Results',
+      rules: {
+        advancement: { method: 'date' },
+      },
+    },
+  ],
+};
+
 /**
- * Helper to create a template using the simpleVoting schema (4 phases, date-based advancement).
+ * Helper to create a template using the monitor test schema (4 phases,
+ * date-based advancement, pass-all selection pipelines).
  * Returns the template ID and user email.
  */
 async function createSimpleTemplate(
@@ -52,8 +101,8 @@ async function createSimpleTemplate(
     .insert(decisionProcesses)
     .values({
       name: `Simple Template ${taskId}`,
-      description: simpleVoting.description,
-      processSchema: simpleVoting,
+      description: monitorTestSchema.description,
+      processSchema: monitorTestSchema,
       createdByProfileId: userRecord.profileId,
     })
     .returning();

--- a/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
+++ b/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from 'vitest';
 
 import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
 import {
+  schemaMissingPipeline,
   schemaWithPipeline,
   schemaWithThreePhasesAndPipelines,
   schemaWithoutPipeline,
@@ -128,7 +129,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
     }
   });
 
-  it('creates join rows for ALL proposals when no selectionPipeline is defined', async ({
+  it('creates join rows for ALL proposals with an explicit pass-all pipeline (empty blocks)', async ({
     task,
     onTestFinished,
   }) => {
@@ -174,6 +175,53 @@ describe.concurrent('Transition pipeline: join table population', () => {
       );
 
     expect(joinRows).toHaveLength(3);
+  });
+
+  it('creates zero join rows when no selectionPipeline is defined (pass-none default)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      processSchema: schemaMissingPipeline,
+      instanceCount: 1,
+      status: ProcessStatus.PUBLISHED,
+    });
+    const instanceId = setup.instances[0]!.instance.id;
+    const { userEmail } = setup;
+
+    for (let i = 1; i <= 3; i++) {
+      await testData.createProposal({
+        userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal ${i} ${task.id}` },
+        status: ProposalStatus.SUBMITTED,
+      });
+    }
+
+    await testData.advancePhase({
+      instanceId,
+      fromPhaseId: 'submission',
+      toPhaseId: 'review',
+    });
+
+    const [transition] = await db
+      .select()
+      .from(stateTransitionHistory)
+      .where(eq(stateTransitionHistory.processInstanceId, instanceId))
+      .limit(1);
+
+    expect(transition).toBeDefined();
+
+    const joinRows = await db
+      .select()
+      .from(decisionTransitionProposals)
+      .where(
+        eq(decisionTransitionProposals.transitionHistoryId, transition!.id),
+      );
+
+    expect(joinRows).toHaveLength(0);
   });
 
   it('returns empty when pipeline eliminates every proposal (no legacy fallback for new instances)', async ({

--- a/services/api/src/test/helpers/pipelineSchemas.ts
+++ b/services/api/src/test/helpers/pipelineSchemas.ts
@@ -59,9 +59,31 @@ export const schemaWithThreePhasesAndPipelines = {
 };
 
 /**
- * Same schema without any selectionPipeline — all proposals survive the transition.
+ * Same shape as schemaWithPipeline but with an explicit pass-all selectionPipeline
+ * (empty blocks) on the submission phase. Use this when a test wants every
+ * proposal to survive the transition. Named "withoutPipeline" historically because
+ * it predates the pass-none default; the explicit empty pipeline now expresses the
+ * same intent.
  */
 export const schemaWithoutPipeline = {
+  ...schemaWithPipeline,
+  phases: [
+    {
+      id: 'submission',
+      name: 'Submission',
+      rules: {},
+      selectionPipeline: { version: '1.0.0', blocks: [] },
+    },
+    { id: 'review', name: 'Review', rules: {} },
+  ],
+};
+
+/**
+ * Schema with no selectionPipeline at all. Use this to exercise the pass-none
+ * default fallback in advancePhase — proposals are NOT carried into the next phase
+ * and the admin is expected to manually pick the survivors.
+ */
+export const schemaMissingPipeline = {
   ...schemaWithPipeline,
   phases: [
     { id: 'submission', name: 'Submission', rules: {} },

--- a/services/db/seedData/decisionTemplates.ts
+++ b/services/db/seedData/decisionTemplates.ts
@@ -77,10 +77,6 @@ export const simpleVoting = {
           },
         },
       },
-      selectionPipeline: {
-        version: '1.0.0',
-        blocks: [],
-      },
     },
     {
       id: 'review',

--- a/services/db/seedData/decisionTemplates.ts
+++ b/services/db/seedData/decisionTemplates.ts
@@ -50,7 +50,7 @@ export const simpleVoting = {
       rules: {
         proposals: { submit: true },
         voting: { submit: false },
-        advancement: { method: 'date', endDate: '2026-01-01' },
+        advancement: { method: 'manual', endDate: '2026-01-01' },
       },
       settings: {
         type: 'object',
@@ -77,6 +77,10 @@ export const simpleVoting = {
           },
         },
       },
+      selectionPipeline: {
+        version: '1.0.0',
+        blocks: [],
+      },
     },
     {
       id: 'review',
@@ -85,7 +89,7 @@ export const simpleVoting = {
       rules: {
         proposals: { submit: false },
         voting: { submit: false },
-        advancement: { method: 'date', endDate: '2026-01-02' },
+        advancement: { method: 'manual', endDate: '2026-01-02' },
       },
       settings: {
         type: 'object',
@@ -109,7 +113,7 @@ export const simpleVoting = {
       rules: {
         proposals: { submit: false },
         voting: { submit: true },
-        advancement: { method: 'date', endDate: '2026-01-03' },
+        advancement: { method: 'manual', endDate: '2026-01-03' },
       },
       settings: {
         type: 'object',
@@ -162,7 +166,7 @@ export const simpleVoting = {
       rules: {
         proposals: { submit: false },
         voting: { submit: false },
-        advancement: { method: 'date', endDate: '2026-01-04' },
+        advancement: { method: 'manual', endDate: '2026-01-04' },
       },
       settings: {
         type: 'object',

--- a/services/db/seedData/decisionTemplates.ts
+++ b/services/db/seedData/decisionTemplates.ts
@@ -50,7 +50,12 @@ export const simpleVoting = {
       rules: {
         proposals: { submit: true },
         voting: { submit: false },
-        advancement: { method: 'manual', endDate: '2026-01-01' },
+        advancement: { method: 'date', endDate: '2026-01-01' },
+      },
+      // Pass-all: every submitted proposal advances into review.
+      selectionPipeline: {
+        version: '1.0.0',
+        blocks: [],
       },
       settings: {
         type: 'object',

--- a/tests/core/src/decision-data.ts
+++ b/tests/core/src/decision-data.ts
@@ -131,6 +131,9 @@ export const testMinimalSchema = {
         voting: { submit: false },
         advancement: { method: 'manual' as const },
       },
+      // Explicit pass-all so every submitted proposal advances on transition.
+      // (advancePhase defaults to pass-none when no pipeline is configured.)
+      selectionPipeline: { version: '1.0.0' as const, blocks: [] },
     },
     {
       id: 'final',


### PR DESCRIPTION
## Summary

- Flip the implicit selection-pipeline fallback in `advancePhase` from pass-all to **pass-none**. Phases without an explicit `selectionPipeline` no longer auto-advance every proposal — they require a manual selection (or an explicit pipeline) instead.
- Phases that should still let everything through opt in via an empty pipeline: `selectionPipeline: { version: '1.0.0', blocks: [] }`.