### PR TITLE
feat(reviews): add review summary page for proposals

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/reviews/loading.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/reviews/loading.tsx
@@ -1,0 +1,5 @@
+import { ReviewSummarySkeleton } from '@/components/decisions/ReviewSummary/ReviewSummarySkeleton';
+
+export default function Loading() {
+  return <ReviewSummarySkeleton />;
+}

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/reviews/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/reviews/page.tsx
@@ -1,0 +1,16 @@
+import { ReviewSummaryLayout } from '@/components/decisions/ReviewSummary/ReviewSummaryLayout';
+
+export default async function ReviewSummaryPage({
+  params,
+}: {
+  params: Promise<{ slug: string; profileId: string }>;
+}) {
+  const { slug, profileId: proposalProfileId } = await params;
+
+  return (
+    <ReviewSummaryLayout
+      decisionSlug={slug}
+      proposalProfileId={proposalProfileId}
+    />
+  );
+}

--- a/apps/app/src/components/decisions/DecisionSubpageHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionSubpageHeader.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import { LuArrowLeft } from 'react-icons/lu';
+
+import { Link } from '@/lib/i18n';
+
+interface DecisionSubpageHeaderProps {
+  backHref: string;
+  backLabel: ReactNode;
+  children?: ReactNode;
+}
+
+export function DecisionSubpageHeader({
+  backHref,
+  backLabel,
+  children,
+}: DecisionSubpageHeaderProps) {
+  return (
+    <header className="sticky top-0 z-20 flex h-14 shrink-0 items-center justify-between border-b bg-white px-6 md:px-8">
+      <Link
+        href={backHref}
+        className="flex items-center gap-2 text-base text-primary-teal"
+      >
+        <LuArrowLeft className="size-4" />
+        {backLabel}
+      </Link>
+      {children}
+    </header>
+  );
+}

--- a/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewNavbar.tsx
@@ -3,10 +3,11 @@
 import { Button } from '@op/ui/Button';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { useState } from 'react';
-import { LuArrowLeft, LuCheck } from 'react-icons/lu';
+import { LuCheck } from 'react-icons/lu';
 
-import { Link, useTranslations } from '@/lib/i18n';
+import { useTranslations } from '@/lib/i18n';
 
+import { DecisionSubpageHeader } from '../DecisionSubpageHeader';
 import { RequestRevisionModal } from './RequestRevisionModal';
 import { useReviewForm } from './ReviewFormContext';
 
@@ -28,14 +29,10 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
 
   return (
     <>
-      <header className="sticky top-0 z-20 flex h-14 shrink-0 items-center justify-between border-b bg-white px-6 md:px-8">
-        <Link
-          href={`/decisions/${decisionSlug}`}
-          className="flex items-center gap-2 text-base text-primary-teal"
-        >
-          <LuArrowLeft className="size-4" />
-          {t('Back to proposals')}
-        </Link>
+      <DecisionSubpageHeader
+        backHref={`/decisions/${decisionSlug}`}
+        backLabel={t('Back to proposals')}
+      >
         <div className="flex items-center gap-4">
           {canRequestRevision && (
             <Button
@@ -61,7 +58,7 @@ export function ReviewNavbar({ decisionSlug }: ReviewNavbarProps) {
             {t('Submit review')}
           </Button>
         </div>
-      </header>
+      </DecisionSubpageHeader>
 
       <RequestRevisionModal
         isOpen={isRequestModalOpen}

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -1,8 +1,8 @@
 import {
   type ProposalReview,
   type RubricTemplateSchema,
+  findSchemaOption,
   isOverallRecommendationField,
-  parseSchemaOptions,
 } from '@op/common/client';
 import type { ReactNode } from 'react';
 
@@ -124,10 +124,7 @@ function RubricFieldResult({
       return <ResultCard value={label} description={rationale} />;
     }
 
-    const options = parseSchemaOptions(field.schema);
-    const selected = options.find(
-      (option) => String(option.value) === String(value),
-    );
+    const selected = findSchemaOption(field.schema, value);
 
     if (isOverallRecommendationField(field.key)) {
       return (

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryAdvanceFooter.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryAdvanceFooter.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Button } from '@op/ui/Button';
+import { FooterBar } from '@op/ui/FooterBar';
+import { LuCheck } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+import { useManualSelection } from '../useManualSelection';
+
+interface ReviewSummaryAdvanceFooterProps {
+  instanceId: string;
+  proposalId: string;
+  phaseId: string | undefined;
+}
+
+export function ReviewSummaryAdvanceFooter({
+  instanceId,
+  proposalId,
+  phaseId,
+}: ReviewSummaryAdvanceFooterProps) {
+  const t = useTranslations();
+  const [selectedIds, setSelectedIds] = useManualSelection(
+    instanceId,
+    phaseId ?? '',
+  );
+
+  const isAdvancing = selectedIds.includes(proposalId);
+  const count = selectedIds.length;
+
+  const toggle = () => {
+    setSelectedIds(
+      isAdvancing
+        ? selectedIds.filter((id) => id !== proposalId)
+        : [...selectedIds, proposalId],
+    );
+  };
+
+  return (
+    <FooterBar position="fixed" className="bg-neutral-offWhite/95">
+      <FooterBar.Start>
+        <span className="text-base text-neutral-black">
+          {t('{count} proposals advancing', { count })}
+        </span>
+      </FooterBar.Start>
+      <FooterBar.Center />
+      <FooterBar.End>
+        <Button
+          size="small"
+          color="secondary"
+          onPress={toggle}
+          className={
+            isAdvancing
+              ? 'border-primary-teal bg-primary-tealWhite text-primary-tealBlack hover:bg-primary-tealWhite'
+              : undefined
+          }
+        >
+          {isAdvancing ? <LuCheck className="size-4" /> : null}
+          {isAdvancing ? t('Advancing proposal') : t('Advance proposal')}
+        </Button>
+      </FooterBar.End>
+    </FooterBar>
+  );
+}

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
@@ -1,0 +1,118 @@
+import {
+  HydrationBoundary,
+  createServerUtils,
+  dehydrate,
+} from '@op/api/server';
+import { createClient } from '@op/api/serverClient';
+import { CommonError } from '@op/common';
+import { forbidden, notFound } from 'next/navigation';
+
+import { ReviewSummaryView } from './ReviewSummaryView';
+
+interface ReviewSummaryLayoutProps {
+  decisionSlug: string;
+  proposalProfileId: string;
+}
+
+export async function ReviewSummaryLayout({
+  decisionSlug,
+  proposalProfileId,
+}: ReviewSummaryLayoutProps) {
+  const client = await createClient();
+
+  let decisionProfile;
+  try {
+    decisionProfile = await client.decision.getDecisionBySlug({
+      slug: decisionSlug,
+    });
+  } catch (error) {
+    const cause = error instanceof Error ? error.cause : null;
+    if (cause instanceof CommonError && cause.statusCode === 403) {
+      forbidden();
+    }
+    if (cause instanceof CommonError && cause.statusCode === 404) {
+      notFound();
+    }
+    throw error;
+  }
+
+  if (!decisionProfile?.processInstance) {
+    notFound();
+  }
+
+  if (!decisionProfile.processInstance.access?.admin) {
+    forbidden();
+  }
+
+  const instanceId = decisionProfile.processInstance.id;
+
+  const { utils, queryClient } = await createServerUtils();
+
+  const [proposal, instance] = await Promise.all([
+    (async () => {
+      try {
+        return await utils.decision.getProposal.fetch({
+          profileId: proposalProfileId,
+        });
+      } catch (error) {
+        const cause = error instanceof Error ? error.cause : null;
+        if (cause instanceof CommonError && cause.statusCode === 404) {
+          notFound();
+        }
+        throw error;
+      }
+    })(),
+    utils.decision.getInstance.fetch({ instanceId }),
+  ]);
+
+  if (proposal.processInstanceId !== instanceId) {
+    notFound();
+  }
+
+  const proposalId = proposal.id;
+  const phaseId = resolveReviewPhaseId(instance);
+
+  await utils.decision.getProposalWithReviewAggregates.prefetch({
+    processInstanceId: instanceId,
+    proposalId,
+    phaseId,
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ReviewSummaryView
+        decisionSlug={decisionSlug}
+        instanceId={instanceId}
+        proposalId={proposalId}
+        proposalProfileId={proposalProfileId}
+        phaseId={phaseId}
+      />
+    </HydrationBoundary>
+  );
+}
+
+// Walk back from the current phase to find the most recent review phase —
+// after a review phase ends, currentStateId no longer points at it but the
+// review assignments are still pinned to the original review phase id.
+function resolveReviewPhaseId(instance: {
+  currentStateId: string | null;
+  instanceData?: {
+    phases?: Array<{
+      phaseId: string;
+      rules?: { proposals?: { review?: boolean } };
+    }>;
+  } | null;
+}): string | undefined {
+  const phases = instance.instanceData?.phases ?? [];
+  const currentIdx = phases.findIndex(
+    (p) => p.phaseId === instance.currentStateId,
+  );
+  const startIdx = currentIdx === -1 ? phases.length - 1 : currentIdx;
+  for (let i = startIdx; i >= 0; i--) {
+    const phase = phases[i];
+    if (phase?.rules?.proposals?.review === true) {
+      return phase.phaseId;
+    }
+  }
+  return instance.currentStateId ?? undefined;
+}

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryPanel.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryPanel.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import {
+  OVERALL_RECOMMENDATION_KEY,
+  type ProposalWithSubmittedReviews,
+  type RubricTemplateSchema,
+  getRubricScoringInfo,
+} from '@op/common/client';
+import { useMemo } from 'react';
+
+import { ReviewerDetail } from './ReviewerDetail';
+import { ReviewerList } from './ReviewerList';
+
+export interface RubricSummary {
+  totalPoints: number;
+  hasScoring: boolean;
+  hasOverallRecommendation: boolean;
+}
+
+interface ReviewSummaryPanelProps {
+  proposalWithReviews: ProposalWithSubmittedReviews;
+  rubricTemplate: RubricTemplateSchema | null;
+  selectedAssignmentId: string | null;
+  onSelectAssignment: (assignmentId: string | null) => void;
+}
+
+export function ReviewSummaryPanel({
+  proposalWithReviews,
+  rubricTemplate,
+  selectedAssignmentId,
+  onSelectAssignment,
+}: ReviewSummaryPanelProps) {
+  const rubricSummary = useMemo<RubricSummary>(() => {
+    if (!rubricTemplate) {
+      return {
+        totalPoints: 0,
+        hasScoring: false,
+        hasOverallRecommendation: false,
+      };
+    }
+    const info = getRubricScoringInfo(rubricTemplate);
+    const hasOverallRecommendation = Boolean(
+      rubricTemplate.properties?.[OVERALL_RECOMMENDATION_KEY],
+    );
+    return {
+      totalPoints: info.totalPoints,
+      hasScoring: info.criteria.some((c) => c.scored),
+      hasOverallRecommendation,
+    };
+  }, [rubricTemplate]);
+
+  const selectedReview = selectedAssignmentId
+    ? (proposalWithReviews.reviews.find(
+        (r) => r.review.assignmentId === selectedAssignmentId,
+      ) ?? null)
+    : null;
+
+  if (selectedReview && rubricTemplate) {
+    return (
+      <ReviewerDetail
+        item={selectedReview}
+        rubricTemplate={rubricTemplate}
+        rubricSummary={rubricSummary}
+        onBack={() => onSelectAssignment(null)}
+      />
+    );
+  }
+
+  return (
+    <ReviewerList
+      proposalWithReviews={proposalWithReviews}
+      rubricTemplate={rubricTemplate}
+      rubricSummary={rubricSummary}
+      onSelectAssignment={onSelectAssignment}
+    />
+  );
+}

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummarySkeleton.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummarySkeleton.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from '@op/ui/Skeleton';
+
+export function ReviewSummarySkeleton() {
+  return (
+    <div className="flex h-dvh flex-col bg-white">
+      <div className="flex h-14 shrink-0 items-center justify-between border-b px-6 md:px-8">
+        <Skeleton className="h-5 w-24" />
+      </div>
+      <div className="mx-auto hidden min-h-0 w-full max-w-6xl flex-1 sm:flex">
+        <div className="flex-1 border-r p-12">
+          <div className="space-y-4">
+            <Skeleton className="h-10 w-3/4" />
+            <Skeleton className="h-4 w-1/3" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+          </div>
+        </div>
+        <div className="flex-1 px-12 pt-12">
+          <div className="space-y-6">
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-14 w-full" />
+            <Skeleton className="h-14 w-full" />
+            <Skeleton className="h-14 w-full" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { trpc } from '@op/api/client';
+import { SplitPane } from '@op/ui/SplitPane';
+import { useQueryState } from 'nuqs';
+
+import { useTranslations } from '@/lib/i18n';
+
+import { TranslatedText } from '@/components/TranslatedText';
+
+import { DecisionSubpageHeader } from '../DecisionSubpageHeader';
+import { ProposalPreview } from '../ProposalPreview';
+import { ReviewSummaryAdvanceFooter } from './ReviewSummaryAdvanceFooter';
+import { ReviewSummaryPanel } from './ReviewSummaryPanel';
+
+interface ReviewSummaryViewProps {
+  decisionSlug: string;
+  instanceId: string;
+  proposalId: string;
+  proposalProfileId: string;
+  phaseId: string | undefined;
+}
+
+export function ReviewSummaryView({
+  decisionSlug,
+  instanceId,
+  proposalId,
+  proposalProfileId,
+  phaseId,
+}: ReviewSummaryViewProps) {
+  const t = useTranslations();
+  const [[instance, proposalWithReviews, proposal]] = trpc.useSuspenseQueries(
+    (t) => [
+      t.decision.getInstance({ instanceId }),
+      t.decision.getProposalWithReviewAggregates({
+        processInstanceId: instanceId,
+        proposalId,
+        phaseId,
+      }),
+      t.decision.getProposal({ profileId: proposalProfileId }),
+    ],
+  );
+
+  const rubricTemplate = instance.instanceData?.rubricTemplate ?? null;
+
+  const [selectedAssignmentId, setSelectedAssignmentId] = useQueryState(
+    'assignment',
+    { history: 'push' },
+  );
+
+  return (
+    <div className="flex h-dvh flex-col bg-white pb-14">
+      <DecisionSubpageHeader
+        backHref={`/decisions/${decisionSlug}`}
+        backLabel={t('Back')}
+      />
+
+      <SplitPane className="mx-auto max-w-6xl" defaultMobileTabId="summary">
+        <SplitPane.Pane
+          id="proposal"
+          label={<TranslatedText text="Proposal" />}
+        >
+          <ProposalPreview proposal={proposal} />
+        </SplitPane.Pane>
+        <SplitPane.Pane
+          id="summary"
+          label={<TranslatedText text="Review Summary" />}
+        >
+          <ReviewSummaryPanel
+            proposalWithReviews={proposalWithReviews}
+            rubricTemplate={rubricTemplate}
+            selectedAssignmentId={selectedAssignmentId}
+            onSelectAssignment={setSelectedAssignmentId}
+          />
+        </SplitPane.Pane>
+      </SplitPane>
+
+      <ReviewSummaryAdvanceFooter
+        instanceId={instanceId}
+        proposalId={proposalId}
+        phaseId={phaseId}
+      />
+    </div>
+  );
+}

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewerDetail.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewerDetail.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import {
+  OVERALL_RECOMMENDATION_KEY,
+  type RubricTemplateSchema,
+  type SubmittedReviewItem,
+  findSchemaOption,
+} from '@op/common/client';
+import { Button } from '@op/ui/Button';
+import { Header3 } from '@op/ui/Header';
+import { StatusDot } from '@op/ui/StatusDot';
+import { LuArrowLeft } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+import { ProfileAvatar } from '../../ProfileAvatar';
+import { SubmittedReviewView } from '../Review/SubmittedReviewView';
+import type { RubricSummary } from './ReviewSummaryPanel';
+import { recommendationIntent } from './recommendationIntent';
+
+interface ReviewerDetailProps {
+  item: SubmittedReviewItem;
+  rubricTemplate: RubricTemplateSchema;
+  rubricSummary: RubricSummary;
+  onBack: () => void;
+}
+
+export function ReviewerDetail({
+  item,
+  rubricTemplate,
+  rubricSummary,
+  onBack,
+}: ReviewerDetailProps) {
+  const t = useTranslations();
+  const { hasOverallRecommendation, hasScoring, totalPoints } = rubricSummary;
+
+  const recommendationLabel = (() => {
+    if (!hasOverallRecommendation || !item.overallRecommendation) {
+      return null;
+    }
+    const match = findSchemaOption(
+      rubricTemplate.properties?.[OVERALL_RECOMMENDATION_KEY],
+      item.overallRecommendation,
+    );
+    return match?.title ?? item.overallRecommendation;
+  })();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Button
+        variant="link"
+        size="inline"
+        onPress={onBack}
+        className="inline-flex items-center gap-1 self-start text-base"
+      >
+        <LuArrowLeft className="size-4" />
+        {t('Back to all reviewers')}
+      </Button>
+
+      <div className="flex items-center justify-between border-b border-neutral-gray1 pb-4">
+        <div className="flex items-center gap-2">
+          <ProfileAvatar
+            profile={item.reviewer}
+            withLink={false}
+            className="size-6"
+          />
+          <Header3 className="font-serif">
+            {item.reviewer.name ?? item.reviewer.slug}
+          </Header3>
+        </div>
+        {(recommendationLabel || hasScoring) && (
+          <div className="flex items-center gap-1">
+            {recommendationLabel && (
+              <StatusDot
+                intent={recommendationIntent(item.overallRecommendation)}
+              >
+                <span className="text-sm text-neutral-black">
+                  {recommendationLabel}
+                </span>
+              </StatusDot>
+            )}
+            {hasScoring && (
+              <span className="text-sm text-neutral-gray4">
+                ({item.score}/{totalPoints}pts)
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      <SubmittedReviewView
+        rubricTemplate={rubricTemplate}
+        review={item.review}
+      />
+    </div>
+  );
+}

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewerList.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewerList.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import {
+  OVERALL_RECOMMENDATION_KEY,
+  type ProposalWithSubmittedReviews,
+  type RubricTemplateSchema,
+  type SubmittedReviewItem,
+  parseSchemaOptions,
+} from '@op/common/client';
+import { Button } from '@op/ui/Button';
+import { Header3 } from '@op/ui/Header';
+import { StatusDot } from '@op/ui/StatusDot';
+import { useMemo } from 'react';
+import { LuChevronRight } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+import { ProfileAvatar } from '../../ProfileAvatar';
+import type { RubricSummary } from './ReviewSummaryPanel';
+import { recommendationIntent } from './recommendationIntent';
+
+interface ReviewerListProps {
+  proposalWithReviews: ProposalWithSubmittedReviews;
+  rubricTemplate: RubricTemplateSchema | null;
+  rubricSummary: RubricSummary;
+  onSelectAssignment: (assignmentId: string) => void;
+}
+
+export function ReviewerList({
+  proposalWithReviews,
+  rubricTemplate,
+  rubricSummary,
+  onSelectAssignment,
+}: ReviewerListProps) {
+  const t = useTranslations();
+  const { reviewsSubmittedCount, assignmentsCount, averageScore } =
+    proposalWithReviews.aggregates;
+  const { hasScoring, hasOverallRecommendation, totalPoints } = rubricSummary;
+
+  const recommendationOptions = useMemo(
+    () =>
+      hasOverallRecommendation && rubricTemplate
+        ? parseSchemaOptions(
+            rubricTemplate.properties?.[OVERALL_RECOMMENDATION_KEY],
+          )
+        : [],
+    [hasOverallRecommendation, rubricTemplate],
+  );
+
+  const groups = useMemo(() => {
+    if (!hasOverallRecommendation) {
+      return null;
+    }
+    return getReviewsGroupedByRecommendation(
+      proposalWithReviews.reviews,
+      recommendationOptions,
+    );
+  }, [
+    proposalWithReviews.reviews,
+    hasOverallRecommendation,
+    recommendationOptions,
+  ]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-2">
+        <Header3 className="font-serif">{t('Review Summary')}</Header3>
+        <p className="text-base text-neutral-charcoal">
+          {t(
+            '{submitted} out of {total} reviewers submitted a review for this proposal',
+            { submitted: reviewsSubmittedCount, total: assignmentsCount },
+          )}
+        </p>
+      </header>
+
+      {hasScoring && (
+        <div className="flex items-center justify-between rounded-lg bg-neutral-offWhite p-4">
+          <span className="font-serif text-title-sm text-neutral-black">
+            {t('Average Score')}
+          </span>
+          <span className="font-serif text-title-sm text-neutral-black">
+            {formatScore(averageScore)}
+            <span className="text-neutral-gray4">/{totalPoints}pts</span>
+          </span>
+        </div>
+      )}
+
+      {groups ? (
+        <div className="flex flex-col gap-6">
+          {groups.map((group) => (
+            <RecommendationGroup
+              key={group.value}
+              label={group.label}
+              count={group.items.length}
+              value={group.value}
+            >
+              {group.items.map((item) => (
+                <ReviewerRow
+                  key={item.review.assignmentId}
+                  item={item}
+                  showScore={hasScoring}
+                  totalPoints={totalPoints}
+                  onSelect={onSelectAssignment}
+                />
+              ))}
+            </RecommendationGroup>
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <Header3 className="font-serif !text-title-sm">
+            {t('Submitted Reviews')}
+          </Header3>
+          <div className="flex flex-col gap-2">
+            {proposalWithReviews.reviews.map((item) => (
+              <ReviewerRow
+                key={item.review.assignmentId}
+                item={item}
+                showScore={hasScoring}
+                totalPoints={totalPoints}
+                onSelect={onSelectAssignment}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ReviewerGroup {
+  value: string;
+  label: string;
+  items: SubmittedReviewItem[];
+}
+
+function getReviewsGroupedByRecommendation(
+  reviews: SubmittedReviewItem[],
+  options: ReturnType<typeof parseSchemaOptions>,
+): ReviewerGroup[] {
+  const order = options.map((o) => String(o.value));
+  const titles = new Map(options.map((o) => [String(o.value), o.title]));
+
+  const buckets = new Map<string, SubmittedReviewItem[]>();
+  for (const value of order) {
+    buckets.set(value, []);
+  }
+
+  for (const review of reviews) {
+    const value = review.overallRecommendation ?? '';
+    if (!value) continue;
+    const bucket = buckets.get(value) ?? [];
+    bucket.push(review);
+    buckets.set(value, bucket);
+  }
+
+  return Array.from(buckets.entries())
+    .filter(([, items]) => items.length > 0)
+    .map(([value, items]) => ({
+      value,
+      label: titles.get(value) ?? value,
+      items,
+    }));
+}
+
+function formatScore(value: number): string {
+  return Number.isInteger(value) ? `${value}` : value.toFixed(1);
+}
+
+function RecommendationGroup({
+  label,
+  count,
+  value,
+  children,
+}: {
+  label: string;
+  count: number;
+  value: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <StatusDot intent={recommendationIntent(value)} className="gap-2">
+        <span className="font-serif !text-title-sm14 text-neutral-black">
+          {label} ({count})
+        </span>
+      </StatusDot>
+      <div className="flex flex-col gap-2">{children}</div>
+    </div>
+  );
+}
+
+function ReviewerRow({
+  item,
+  showScore,
+  totalPoints,
+  onSelect,
+}: {
+  item: SubmittedReviewItem;
+  showScore: boolean;
+  totalPoints: number;
+  onSelect: (assignmentId: string) => void;
+}) {
+  const t = useTranslations();
+  return (
+    <Button
+      unstyled
+      onPress={() => onSelect(item.review.assignmentId)}
+      className="flex h-14 w-full cursor-pointer items-center justify-between rounded-lg border border-neutral-gray1 bg-white px-3 py-2 text-left outline-0 outline-transparent transition-colors duration-200 hover:bg-neutral-offWhite focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue"
+      aria-label={t('View review by {name}', {
+        name: item.reviewer.name ?? item.reviewer.slug,
+      })}
+    >
+      <div className="flex items-center gap-2">
+        <ProfileAvatar
+          profile={item.reviewer}
+          withLink={false}
+          className="size-6"
+        />
+        <div className="flex flex-col">
+          <span className="text-base text-neutral-black">
+            {item.reviewer.name ?? item.reviewer.slug}
+          </span>
+          {showScore && (
+            <span className="text-sm text-neutral-black">
+              {item.score}
+              <span className="text-neutral-gray4">/{totalPoints}pts</span>
+            </span>
+          )}
+        </div>
+      </div>
+      <LuChevronRight className="size-4 text-neutral-gray4" />
+    </Button>
+  );
+}

--- a/apps/app/src/components/decisions/ReviewSummary/recommendationIntent.ts
+++ b/apps/app/src/components/decisions/ReviewSummary/recommendationIntent.ts
@@ -1,0 +1,20 @@
+import { RECOMMENDATION_OPTION } from '@op/common/client';
+import type { StatusDotIntent } from '@op/ui/StatusDot';
+
+export function recommendationIntent(
+  value: string | null | undefined,
+): StatusDotIntent {
+  if (!value) {
+    return 'neutral';
+  }
+  if (value === RECOMMENDATION_OPTION.YES.value) {
+    return 'success';
+  }
+  if (value === RECOMMENDATION_OPTION.NO.value) {
+    return 'danger';
+  }
+  if (value === RECOMMENDATION_OPTION.MAYBE.value) {
+    return 'warning';
+  }
+  return 'neutral';
+}

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1151,6 +1151,8 @@
   "PROPOSALS TO ADVANCE": "অগ্রসর করার প্রস্তাব",
   "Advance": "অগ্রসর",
   "Advancing": "অগ্রসর হচ্ছে",
+  "Advance proposal": "প্রস্তাব অগ্রসর করুন",
+  "Advancing proposal": "প্রস্তাব অগ্রসর হচ্ছে",
   "Confirm decisions": "সিদ্ধান্ত নিশ্চিত করুন",
   "{count} proposals advancing": "{count, plural, other {# প্রস্তাব অগ্রসর হচ্ছে}}",
   "Eligible proposals": "যোগ্য প্রস্তাব",
@@ -1172,5 +1174,11 @@
   "Score ({pts}pts)": "স্কোর ({pts}পয়েন্ট)",
   "{pts} pts": "{pts} পয়েন্ট",
   "No proposals to review yet": "পর্যালোচনার জন্য এখনও কোন প্রস্তাব নেই",
-  "Proposals will appear here once they are submitted.": "প্রস্তাবগুলি জমা দেওয়ার পর এখানে দেখা যাবে।"
+  "Proposals will appear here once they are submitted.": "প্রস্তাবগুলি জমা দেওয়ার পর এখানে দেখা যাবে।",
+  "Review Summary": "পর্যালোচনার সারসংক্ষেপ",
+  "Average Score": "গড় স্কোর",
+  "Submitted Reviews": "জমা দেওয়া পর্যালোচনা",
+  "Back to all reviewers": "সমস্ত পর্যালোচকের কাছে ফিরে যান",
+  "{submitted} out of {total} reviewers submitted a review for this proposal": "{total} জন পর্যালোচকের মধ্যে {submitted} জন এই প্রস্তাবের জন্য একটি পর্যালোচনা জমা দিয়েছেন",
+  "View review by {name}": "{name} এর পর্যালোচনা দেখুন"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1189,6 +1189,8 @@
   "Publish": "Publish",
   "Advance": "Advance",
   "Advancing": "Advancing",
+  "Advance proposal": "Advance proposal",
+  "Advancing proposal": "Advancing proposal",
   "Confirm decisions": "Confirm decisions",
   "{count} proposals advancing": "{count, plural, one {# proposal advancing} other {# proposals advancing}}",
   "Eligible proposals": "Eligible proposals",
@@ -1213,5 +1215,11 @@
   "Score ({pts}pts)": "Score ({pts}pts)",
   "{pts} pts": "{pts} pts",
   "No proposals to review yet": "No proposals to review yet",
-  "Proposals will appear here once they are submitted.": "Proposals will appear here once they are submitted."
+  "Proposals will appear here once they are submitted.": "Proposals will appear here once they are submitted.",
+  "Review Summary": "Review Summary",
+  "Average Score": "Average Score",
+  "Submitted Reviews": "Submitted Reviews",
+  "Back to all reviewers": "Back to all reviewers",
+  "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} out of {total} reviewers submitted a review for this proposal",
+  "View review by {name}": "View review by {name}"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1150,6 +1150,8 @@
   "PROPOSALS TO ADVANCE": "PROPUESTAS A AVANZAR",
   "Advance": "Avanzar",
   "Advancing": "Avanzando",
+  "Advance proposal": "Avanzar propuesta",
+  "Advancing proposal": "Propuesta avanzando",
   "Confirm decisions": "Confirmar decisiones",
   "{count} proposals advancing": "{count, plural, one {# propuesta avanzando} other {# propuestas avanzando}}",
   "Eligible proposals": "Propuestas elegibles",
@@ -1171,5 +1173,11 @@
   "Score ({pts}pts)": "Puntuación ({pts}pts)",
   "{pts} pts": "{pts} pts",
   "No proposals to review yet": "Aún no hay propuestas para revisar",
-  "Proposals will appear here once they are submitted.": "Las propuestas aparecerán aquí una vez que sean enviadas."
+  "Proposals will appear here once they are submitted.": "Las propuestas aparecerán aquí una vez que sean enviadas.",
+  "Review Summary": "Resumen de revisión",
+  "Average Score": "Puntuación media",
+  "Submitted Reviews": "Revisiones enviadas",
+  "Back to all reviewers": "Volver a todos los revisores",
+  "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} de {total} revisores enviaron una revisión para esta propuesta",
+  "View review by {name}": "Ver revisión de {name}"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1150,6 +1150,8 @@
   "PROPOSALS TO ADVANCE": "PROPOSITIONS À FAIRE AVANCER",
   "Advance": "Avancer",
   "Advancing": "En cours",
+  "Advance proposal": "Faire avancer la proposition",
+  "Advancing proposal": "Proposition en cours",
   "Confirm decisions": "Confirmer les décisions",
   "{count} proposals advancing": "{count, plural, one {# proposition en cours} other {# propositions en cours}}",
   "Eligible proposals": "Propositions éligibles",
@@ -1171,5 +1173,11 @@
   "Score ({pts}pts)": "Score ({pts}pts)",
   "{pts} pts": "{pts} pts",
   "No proposals to review yet": "Aucune proposition à examiner pour l'instant",
-  "Proposals will appear here once they are submitted.": "Les propositions apparaîtront ici une fois soumises."
+  "Proposals will appear here once they are submitted.": "Les propositions apparaîtront ici une fois soumises.",
+  "Review Summary": "Résumé de la révision",
+  "Average Score": "Score moyen",
+  "Submitted Reviews": "Révisions soumises",
+  "Back to all reviewers": "Retour à tous les évaluateurs",
+  "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} évaluateurs sur {total} ont soumis une révision pour cette proposition",
+  "View review by {name}": "Voir la révision de {name}"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1150,6 +1150,8 @@
   "PROPOSALS TO ADVANCE": "PROPOSTAS A AVANÇAR",
   "Advance": "Avançar",
   "Advancing": "Avançando",
+  "Advance proposal": "Avançar proposta",
+  "Advancing proposal": "Proposta avançando",
   "Confirm decisions": "Confirmar decisões",
   "{count} proposals advancing": "{count, plural, one {# proposta avançando} other {# propostas avançando}}",
   "Eligible proposals": "Propostas elegíveis",
@@ -1171,5 +1173,11 @@
   "Score ({pts}pts)": "Pontuação ({pts}pts)",
   "{pts} pts": "{pts} pts",
   "No proposals to review yet": "Ainda não há propostas para revisar",
-  "Proposals will appear here once they are submitted.": "As propostas aparecerão aqui assim que forem enviadas."
+  "Proposals will appear here once they are submitted.": "As propostas aparecerão aqui assim que forem enviadas.",
+  "Review Summary": "Resumo da avaliação",
+  "Average Score": "Pontuação média",
+  "Submitted Reviews": "Avaliações enviadas",
+  "Back to all reviewers": "Voltar a todos os avaliadores",
+  "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} de {total} avaliadores enviaram uma avaliação para esta proposta",
+  "View review by {name}": "Ver avaliação de {name}"
 }

--- a/packages/common/src/services/decision/proposalDataSchema.ts
+++ b/packages/common/src/services/decision/proposalDataSchema.ts
@@ -312,6 +312,24 @@ export function schemaHasOptions(
   return parseSchemaOptions(schema).length > 0;
 }
 
+/**
+ * Find the option in a JSON Schema property whose `value` matches the given
+ * stored value. Stringifies both sides so callers don't have to worry about
+ * `string` vs `number` consts in `oneOf`.
+ */
+export function findSchemaOption(
+  schema: XFormatPropertySchema | null | undefined,
+  value: unknown,
+): SchemaOption | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  const stringified = String(value);
+  return parseSchemaOptions(schema).find(
+    (option) => String(option.value) === stringified,
+  );
+}
+
 export function schemaAllowsMultipleSelection(
   schema: XFormatPropertySchema | null | undefined,
 ): boolean {

--- a/tests/e2e/tests/decision-review-selection.spec.ts
+++ b/tests/e2e/tests/decision-review-selection.spec.ts
@@ -288,4 +288,83 @@ test.describe('Decision Review Selection — review → voting flow', () => {
       }),
     ).not.toBeVisible();
   });
+
+  // Per-proposal Review Summary has its own sticky footer with an
+  // "Advance proposal" CTA that writes into the same persisted draft the
+  // parent ReviewSelectionList reads. This is the contract: toggle on the
+  // detail page, walk back to the list, see the row reflect the selection.
+  test('selecting a proposal from its review summary footer propagates back to the parent list', async ({
+    authenticatedPage: page,
+    org,
+  }) => {
+    const { instance } = await seedOnReviewPhase(org, [
+      'Proposal Alpha',
+      'Proposal Beta',
+    ]);
+
+    await page.goto(`/en/decisions/${instance.slug}`, {
+      waitUntil: 'networkidle',
+    });
+
+    // Drive the instance into the review→voting selection state — same path
+    // as the full-flow test. Once it lands, ReviewSelectionList renders and
+    // the proposal title links navigate to the per-proposal Review Summary.
+    await page.getByRole('button', { name: 'Start Voting' }).first().click();
+    const advanceDialog = page.getByRole('dialog');
+    await advanceDialog.getByRole('button', { name: 'Advance Phase' }).click();
+
+    await expect(
+      page.getByRole('columnheader', { name: 'Overall recommendation' }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Sanity: footer starts at zero before any cross-page selection.
+    await expect(page.getByText('0 proposals advancing')).toBeVisible();
+
+    // The proposal title is rendered as a link to the review summary.
+    // `exact: true` keeps this from matching the row's "Advance Proposal
+    // Alpha" toggle button, which contains the same accessible name as a
+    // substring.
+    await page
+      .getByRole('link', { name: 'Proposal Alpha', exact: true })
+      .click();
+    await page.waitForURL(/\/proposal\/.*\/reviews$/, { timeout: 15_000 });
+
+    // Footer "Advance proposal" CTA is the unselected state. `exact: true`
+    // disambiguates from the per-row "Advance Proposal Alpha" toggles, which
+    // would otherwise match by substring.
+    const advanceButton = page.getByRole('button', {
+      name: 'Advance proposal',
+      exact: true,
+    });
+    await expect(advanceButton).toBeVisible({ timeout: 15_000 });
+    await advanceButton.click();
+
+    // Same button flips to "Advancing proposal" + count picks up the entry.
+    await expect(
+      page.getByRole('button', { name: 'Advancing proposal', exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText('1 proposal advancing')).toBeVisible();
+
+    // Walk back to the parent list. The list should reflect the selection
+    // that was just made on the detail page — this is what the persisted
+    // draft buys us across the navigation boundary.
+    await page.getByRole('link', { name: 'Back', exact: true }).click();
+    await expect(page).toHaveURL(new RegExp(`/decisions/${instance.slug}$`), {
+      timeout: 10_000,
+    });
+
+    // Row toggle aria-label flips to "Don't advance ..." once selected.
+    await expect(
+      page.getByRole('button', { name: "Don't advance Proposal Alpha" }),
+    ).toBeVisible({ timeout: 15_000 });
+    // The other proposal stays unselected.
+    await expect(
+      page.getByRole('button', { name: 'Advance Proposal Beta' }),
+    ).toBeVisible();
+    // Footer count + Confirm CTA reflect the persisted draft.
+    await expect(page.getByText('1 proposal advancing')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Confirm decisions' }),
+    ).toBeEnabled();
+  });
 });

--- a/tests/e2e/tests/review-summary.spec.ts
+++ b/tests/e2e/tests/review-summary.spec.ts
@@ -1,0 +1,440 @@
+import type {
+  DecisionSchemaDefinition,
+  RubricTemplateSchema,
+} from '@op/common';
+import { ProposalReviewState, processInstances } from '@op/db/schema';
+import { db, eq } from '@op/db/test';
+import {
+  createDecisionInstance,
+  createInstanceMember,
+  createProposalReview,
+  createReviewAssignment,
+  createReviewScenario,
+  getSeededTemplate,
+} from '@op/test';
+
+import {
+  TEST_USER_DEFAULT_PASSWORD,
+  authenticateAsUser,
+  expect,
+  test,
+} from '../fixtures/index.js';
+
+// Mirrors OVERALL_RECOMMENDATION_KEY from @op/common/client. Inlined to
+// sidestep CJS/ESM interop when loading @op/common from the e2e runner.
+const OVERALL_RECOMMENDATION_KEY = '__overall_recommendation';
+
+const REVIEW_SCHEMA = {
+  id: 'review-summary-e2e',
+  version: '1.0.0',
+  name: 'Review Summary E2E',
+  description: 'Schema for the per-proposal review summary page e2e tests.',
+  proposalTemplate: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        title: 'Proposal title',
+        'x-format': 'short-text',
+      },
+    },
+    'x-field-order': ['title'],
+    required: ['title'],
+  },
+  phases: [
+    {
+      id: 'submission',
+      name: 'Proposal Submission',
+      description: 'Members submit proposals.',
+      rules: {
+        proposals: { submit: true },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'review',
+      name: 'Review',
+      description: 'Reviewers evaluate proposals.',
+      rules: {
+        proposals: { submit: false, review: true },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'results',
+      name: 'Results',
+      description: 'Final results.',
+      rules: {
+        proposals: { submit: false },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+  ],
+} satisfies DecisionSchemaDefinition;
+
+/**
+ * Two scored criteria + an overall recommendation. Total possible per
+ * review = max(innovation) + max(feasibility) = 5 + 3 = 8.
+ */
+const RUBRIC_TEMPLATE = {
+  type: 'object',
+  required: ['innovation', 'feasibility', OVERALL_RECOMMENDATION_KEY],
+  'x-field-order': ['innovation', 'feasibility', OVERALL_RECOMMENDATION_KEY],
+  properties: {
+    innovation: {
+      type: 'integer',
+      title: 'Innovation',
+      'x-format': 'dropdown',
+      minimum: 1,
+      maximum: 5,
+      oneOf: [
+        { const: 1, title: '1' },
+        { const: 2, title: '2' },
+        { const: 3, title: '3' },
+        { const: 4, title: '4' },
+        { const: 5, title: '5' },
+      ],
+    },
+    feasibility: {
+      type: 'integer',
+      title: 'Feasibility',
+      'x-format': 'dropdown',
+      minimum: 1,
+      maximum: 3,
+      oneOf: [
+        { const: 1, title: '1' },
+        { const: 2, title: '2' },
+        { const: 3, title: '3' },
+      ],
+    },
+    [OVERALL_RECOMMENDATION_KEY]: {
+      type: 'string',
+      title: 'Overall Recommendation',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 'yes', title: 'Yes' },
+        { const: 'maybe', title: 'Maybe' },
+        { const: 'no', title: 'No' },
+      ],
+    },
+  },
+} as const satisfies RubricTemplateSchema;
+
+const PROPOSAL_TITLE = 'Community Solar Initiative';
+
+test.describe('Review Summary page', () => {
+  test('admin sees aggregated reviews grouped by recommendation, deep-link round-trips', async ({
+    authenticatedPage: page,
+    org,
+    supabaseAdmin,
+  }, testInfo) => {
+    const testId = `review-summary-${testInfo.workerIndex}-${Date.now()}`;
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: REVIEW_SCHEMA,
+    });
+
+    // Inject rubricTemplate and put the instance in the review phase.
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...(instance.instance.instanceData as Record<string, unknown>),
+          rubricTemplate: RUBRIC_TEMPLATE,
+        },
+        currentStateId: 'review',
+      })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    // Four reviewers — two "Yes" voters, one "Maybe", one unsubmitted (no
+    // review row, just an assignment).
+    const { user: reviewerYes1 } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-yes1`,
+      instanceProfileId: instance.profileId,
+    });
+    const { user: reviewerYes2 } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-yes2`,
+      instanceProfileId: instance.profileId,
+    });
+    const { user: reviewerMaybe } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-maybe`,
+      instanceProfileId: instance.profileId,
+    });
+    const { user: reviewerUnsubmitted } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-unsubmitted`,
+      instanceProfileId: instance.profileId,
+    });
+
+    // First reviewer + proposal in one go. createReviewScenario flips the
+    // proposal to SUBMITTED, which fires the AFTER UPDATE trigger that
+    // writes the proposalHistory row used as assignedProposalHistoryId.
+    const {
+      proposal,
+      assignedProposalHistoryId,
+      assignment: yes1Assignment,
+    } = await createReviewScenario({
+      instance: { id: instance.instance.id },
+      author: {
+        profileId: org.organizationProfile.id,
+        authUserId: org.adminUser.authUserId,
+        email: org.adminUser.email,
+      },
+      reviewer: { profileId: reviewerYes1.profileId },
+      proposalData: {
+        title: PROPOSAL_TITLE,
+        collaborationDocId: 'test-proposal-view-doc',
+      },
+    });
+
+    // The other three assignments share the same proposalHistory snapshot.
+    const yes2Assignment = await createReviewAssignment({
+      processInstanceId: instance.instance.id,
+      proposalId: proposal.id,
+      reviewerProfileId: reviewerYes2.profileId,
+      assignedProposalHistoryId,
+    });
+    const maybeAssignment = await createReviewAssignment({
+      processInstanceId: instance.instance.id,
+      proposalId: proposal.id,
+      reviewerProfileId: reviewerMaybe.profileId,
+      assignedProposalHistoryId,
+    });
+    await createReviewAssignment({
+      processInstanceId: instance.instance.id,
+      proposalId: proposal.id,
+      reviewerProfileId: reviewerUnsubmitted.profileId,
+      assignedProposalHistoryId,
+    });
+
+    // Submitted reviews — Yes1: 8, Yes2: 7, Maybe: 4. Avg = (8+7+4)/3 = 6.333…
+    // → formatted as "6.3". No two row scores collide with the average string.
+    const submittedAt = new Date().toISOString();
+    await createProposalReview({
+      assignmentId: yes1Assignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          innovation: 5,
+          feasibility: 3,
+          [OVERALL_RECOMMENDATION_KEY]: 'yes',
+        },
+        rationales: { innovation: 'Strong vision' },
+      },
+      submittedAt,
+    });
+    await createProposalReview({
+      assignmentId: yes2Assignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          innovation: 4,
+          feasibility: 3,
+          [OVERALL_RECOMMENDATION_KEY]: 'yes',
+        },
+        rationales: {},
+      },
+      submittedAt,
+    });
+    await createProposalReview({
+      assignmentId: maybeAssignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          innovation: 2,
+          feasibility: 2,
+          [OVERALL_RECOMMENDATION_KEY]: 'maybe',
+        },
+        rationales: {},
+      },
+      submittedAt,
+    });
+
+    const summaryUrl = `/en/decisions/${instance.slug}/proposal/${proposal.profileId}/reviews`;
+
+    await page.goto(summaryUrl, { waitUntil: 'domcontentloaded' });
+
+    // ====================================================================
+    // Step 1: Header reflects submitted/total + Average Score
+    // ====================================================================
+
+    await expect(
+      page.getByRole('heading', { name: 'Review Summary' }),
+    ).toBeVisible({ timeout: 36_000 });
+
+    await expect(
+      page.getByText(
+        '3 out of 4 reviewers submitted a review for this proposal',
+      ),
+    ).toBeVisible();
+
+    const averageScoreSection = page
+      .getByText('Average Score', { exact: true })
+      .locator('..');
+    await expect(averageScoreSection).toContainText('6.3');
+    await expect(averageScoreSection).toContainText('/8pts');
+
+    // ====================================================================
+    // Step 2: Recommendation groups — Yes (2), Maybe (1); No is filtered out
+    // ====================================================================
+
+    await expect(page.getByText('Yes (2)')).toBeVisible();
+    await expect(page.getByText('Maybe (1)')).toBeVisible();
+    await expect(page.getByText(/^No \(\d+\)$/)).toHaveCount(0);
+
+    // Submitted-only — the unsubmitted assignment must not surface as a row.
+    // Three reviewer rows total (one per submitted review).
+    const reviewerRows = page.getByRole('button', {
+      name: /^View review by /,
+    });
+    await expect(reviewerRows).toHaveCount(3);
+
+    // ====================================================================
+    // Step 3: Click the top-scoring row (Yes1, 8/8pts) → ReviewerDetail mounts
+    //          and the assignment ID is pushed into the URL
+    // ====================================================================
+
+    const yes1Row = reviewerRows.filter({ hasText: '8/8pts' });
+    await expect(yes1Row).toHaveCount(1);
+    await yes1Row.click();
+
+    await expect(page).toHaveURL(
+      new RegExp(`assignment=${yes1Assignment.id}`),
+      { timeout: 10_000 },
+    );
+
+    await expect(
+      page.getByRole('button', { name: 'Back to all reviewers' }),
+    ).toBeVisible();
+    // Detail header shows the score in parentheses; the list rows do not.
+    await expect(page.getByText('(8/8pts)')).toBeVisible();
+    // The submitted rubric content renders below the header.
+    await expect(
+      page.getByRole('heading', { name: 'Innovation' }),
+    ).toBeVisible();
+
+    // ====================================================================
+    // Step 4: Back to all reviewers — assignment param drops, list returns
+    // ====================================================================
+
+    await page.getByRole('button', { name: 'Back to all reviewers' }).click();
+
+    await expect(page).toHaveURL(
+      (url) => !new URL(url).searchParams.has('assignment'),
+      { timeout: 10_000 },
+    );
+    await expect(page.getByText('Yes (2)')).toBeVisible();
+
+    // ====================================================================
+    // Step 5: Deep link with ?assignment=<id> renders detail on first paint
+    // ====================================================================
+
+    await page.goto(`${summaryUrl}?assignment=${maybeAssignment.id}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await expect(
+      page.getByRole('button', { name: 'Back to all reviewers' }),
+    ).toBeVisible({ timeout: 36_000 });
+    // Streaming SSR leaves a hidden Suspense fallback (`<div hidden id="S:0">`)
+    // alongside the live tabpanel until React finishes hydrating, so duplicates
+    // of every text node are present briefly. `.first()` targets the visible copy.
+    await expect(page.getByText('(4/8pts)').first()).toBeVisible();
+    await expect(page.getByText('Maybe').first()).toBeVisible();
+
+    // ====================================================================
+    // Step 6: Navbar "Back" link returns to the decision page
+    // ====================================================================
+
+    await page.getByRole('link', { name: 'Back', exact: true }).click();
+    await expect(page).toHaveURL(new RegExp(`/decisions/${instance.slug}$`), {
+      timeout: 10_000,
+    });
+  });
+
+  test('non-admin member of the instance is forbidden from the summary page', async ({
+    browser,
+    org,
+    supabaseAdmin,
+  }, testInfo) => {
+    const testId = `review-summary-forbidden-${testInfo.workerIndex}-${Date.now()}`;
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: REVIEW_SCHEMA,
+    });
+
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...(instance.instance.instanceData as Record<string, unknown>),
+          rubricTemplate: RUBRIC_TEMPLATE,
+        },
+        currentStateId: 'review',
+      })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    const { proposal } = await createReviewScenario({
+      instance: { id: instance.instance.id },
+      author: {
+        profileId: org.organizationProfile.id,
+        authUserId: org.adminUser.authUserId,
+        email: org.adminUser.email,
+      },
+      // Reviewer == the org admin so we don't need a separate reviewer here.
+      reviewer: { profileId: org.adminUser.profileId },
+      proposalData: {
+        title: PROPOSAL_TITLE,
+        collaborationDocId: 'test-proposal-view-doc',
+      },
+    });
+
+    // Member-level access: READ on decisions zone, no ADMIN. Page should
+    // resolve `decisionProfile.processInstance.access.admin === false` and
+    // call forbidden().
+    const { user: member } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-member`,
+      instanceProfileId: instance.profileId,
+    });
+
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await authenticateAsUser(page, {
+      email: member.email,
+      password: TEST_USER_DEFAULT_PASSWORD,
+    });
+
+    await page.goto(
+      `/en/decisions/${instance.slug}/proposal/${proposal.profileId}/reviews`,
+      { waitUntil: 'domcontentloaded' },
+    );
+
+    // The route lives under /decisions/[slug]/..., so Next.js resolves the
+    // nearest forbidden.tsx — the decision-scoped one, not the root locale
+    // one. Its copy is "You don't have access to this page".
+    await expect(
+      page.getByRole('heading', {
+        name: "You don't have access to this page",
+      }),
+    ).toBeVisible({ timeout: 36_000 });
+
+    await ctx.close();
+  });
+});


### PR DESCRIPTION
Surfaces per-proposal review aggregates and individual reviewer detail at `/decisions/[slug]/proposal/[slug]/reviews`
