### PR TITLE
feat: add v2 relations for posts and assertProfileTypeAccess helper

### DIFF
--- a/packages/common/src/services/access/assertProfileTypeAccess.ts
+++ b/packages/common/src/services/access/assertProfileTypeAccess.ts
@@ -4,6 +4,7 @@ import type { AccessZonePermission, NormalizedRole } from 'access-zones';
 import { assertAccess, permission } from 'access-zones';
 import { inArray } from 'drizzle-orm';
 
+import { UnauthorizedError } from '../../utils/error';
 import { type RoleJunction, getNormalizedRoles } from './utils';
 
 // Per-profile-type permission policy. Omitting a type from the record means
@@ -29,14 +30,19 @@ export const assertProfileTypeAccess = async ({
   profileIds,
   policies,
 }: AssertProfileTypeAccessOptions) => {
-  if (profileIds.length === 0) {
+  const uniqueProfileIds = [...new Set(profileIds)];
+  if (uniqueProfileIds.length === 0) {
     return;
   }
 
   const profileRows = await db
     .select({ id: profiles.id, type: profiles.type })
     .from(profiles)
-    .where(inArray(profiles.id, profileIds));
+    .where(inArray(profiles.id, uniqueProfileIds));
+
+  if (profileRows.length !== uniqueProfileIds.length) {
+    throw new UnauthorizedError("You don't have access to do this");
+  }
 
   const gatedRows = profileRows.flatMap((row) => {
     const requiredPermission = policies[row.type as EntityType];

--- a/packages/common/src/services/access/assertProfileTypeAccess.ts
+++ b/packages/common/src/services/access/assertProfileTypeAccess.ts
@@ -1,10 +1,10 @@
 import { db } from '@op/db/client';
 import { EntityType, profiles } from '@op/db/schema';
-import type { AccessZonePermission } from 'access-zones';
+import type { AccessZonePermission, NormalizedRole } from 'access-zones';
 import { assertAccess, permission } from 'access-zones';
 import { inArray } from 'drizzle-orm';
 
-import { getProfileAccessUser } from './index';
+import { type RoleJunction, getNormalizedRoles } from './utils';
 
 // Per-profile-type permission policy. Omitting a type from the record means
 // that type is NOT gated — the caller is opting into lenient pass-through
@@ -20,9 +20,10 @@ export type AssertProfileTypeAccessOptions = {
 };
 
 // Authorizes a user against a list of profiles, dispatching on profile type.
-// One batched type lookup, then per-profile permission assertion using the
-// caller-supplied policy for that type. Profile ADMIN always satisfies the
-// check. Types not present in `policies` are treated as no-op (lenient).
+// Two batched queries: one for profile types, one for the user's profileUser
+// rows (with role graph) across every gated profile. Profile ADMIN always
+// satisfies the check. Types not present in `policies` are treated as no-op
+// (lenient).
 export const assertProfileTypeAccess = async ({
   user,
   profileIds,
@@ -37,20 +38,47 @@ export const assertProfileTypeAccess = async ({
     .from(profiles)
     .where(inArray(profiles.id, profileIds));
 
-  await Promise.all(
-    profileRows.map(async (row) => {
-      const requiredPermission = policies[row.type as EntityType];
-      if (!requiredPermission) {
-        return;
-      }
-      const profileUser = await getProfileAccessUser({
-        user,
-        profileId: row.id,
-      });
-      assertAccess(
-        [{ profile: permission.ADMIN }, requiredPermission],
-        profileUser?.roles ?? [],
-      );
-    }),
+  const gatedRows = profileRows.flatMap((row) => {
+    const requiredPermission = policies[row.type as EntityType];
+    return requiredPermission ? [{ id: row.id, requiredPermission }] : [];
+  });
+  if (gatedRows.length === 0) {
+    return;
+  }
+
+  const profileUsers = await db.query.profileUsers.findMany({
+    where: {
+      authUserId: user.id,
+      profileId: { in: gatedRows.map((row) => row.id) },
+    },
+    with: {
+      roles: {
+        with: {
+          accessRole: {
+            with: {
+              zonePermissions: {
+                with: { accessZone: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const rolesByProfileId = new Map<string, NormalizedRole[]>(
+    profileUsers.map((profileUser) => [
+      profileUser.profileId,
+      getNormalizedRoles(
+        profileUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
+      ),
+    ]),
   );
+
+  for (const row of gatedRows) {
+    assertAccess(
+      [{ profile: permission.ADMIN }, row.requiredPermission],
+      rolesByProfileId.get(row.id) ?? [],
+    );
+  }
 };

--- a/packages/common/src/services/access/assertProfileTypeAccess.ts
+++ b/packages/common/src/services/access/assertProfileTypeAccess.ts
@@ -45,6 +45,8 @@ export const assertProfileTypeAccess = async ({
   }
 
   const gatedRows = profileRows.flatMap((row) => {
+    // `enumToPgEnum` widens enum columns to `string`; narrowing here until
+    // the helper preserves literal types.
     const requiredPermission = policies[row.type as EntityType];
     return requiredPermission ? [{ id: row.id, requiredPermission }] : [];
   });

--- a/packages/common/src/services/access/assertProfileTypeAccess.ts
+++ b/packages/common/src/services/access/assertProfileTypeAccess.ts
@@ -1,0 +1,56 @@
+import { db } from '@op/db/client';
+import { EntityType, profiles } from '@op/db/schema';
+import type { AccessZonePermission } from 'access-zones';
+import { assertAccess, permission } from 'access-zones';
+import { inArray } from 'drizzle-orm';
+
+import { getProfileAccessUser } from './index';
+
+// Per-profile-type permission policy. Omitting a type from the record means
+// that type is NOT gated — the caller is opting into lenient pass-through
+// for, e.g., regular org or individual profiles.
+export type ProfileTypePolicies = Partial<
+  Record<EntityType, AccessZonePermission>
+>;
+
+export type AssertProfileTypeAccessOptions = {
+  user: { id: string };
+  profileIds: string[];
+  policies: ProfileTypePolicies;
+};
+
+// Authorizes a user against a list of profiles, dispatching on profile type.
+// One batched type lookup, then per-profile permission assertion using the
+// caller-supplied policy for that type. Profile ADMIN always satisfies the
+// check. Types not present in `policies` are treated as no-op (lenient).
+export const assertProfileTypeAccess = async ({
+  user,
+  profileIds,
+  policies,
+}: AssertProfileTypeAccessOptions) => {
+  if (profileIds.length === 0) {
+    return;
+  }
+
+  const profileRows = await db
+    .select({ id: profiles.id, type: profiles.type })
+    .from(profiles)
+    .where(inArray(profiles.id, profileIds));
+
+  await Promise.all(
+    profileRows.map(async (row) => {
+      const requiredPermission = policies[row.type as EntityType];
+      if (!requiredPermission) {
+        return;
+      }
+      const profileUser = await getProfileAccessUser({
+        user,
+        profileId: row.id,
+      });
+      assertAccess(
+        [{ profile: permission.ADMIN }, requiredPermission],
+        profileUser?.roles ?? [],
+      );
+    }),
+  );
+};

--- a/packages/common/src/services/access/assertProfileTypeAccess.ts
+++ b/packages/common/src/services/access/assertProfileTypeAccess.ts
@@ -4,8 +4,8 @@ import type { AccessZonePermission, NormalizedRole } from 'access-zones';
 import { assertAccess, permission } from 'access-zones';
 import { inArray } from 'drizzle-orm';
 
-import { UnauthorizedError } from '../../utils/error';
-import { type RoleJunction, getNormalizedRoles } from './utils';
+import { ValidationError } from '../../utils/error';
+import { getNormalizedRoles } from './utils';
 
 // Per-profile-type permission policy. Omitting a type from the record means
 // that type is NOT gated — the caller is opting into lenient pass-through
@@ -41,7 +41,7 @@ export const assertProfileTypeAccess = async ({
     .where(inArray(profiles.id, uniqueProfileIds));
 
   if (profileRows.length !== uniqueProfileIds.length) {
-    throw new UnauthorizedError("You don't have access to do this");
+    throw new ValidationError('One or more profileIds do not exist');
   }
 
   const gatedRows = profileRows.flatMap((row) => {
@@ -75,9 +75,7 @@ export const assertProfileTypeAccess = async ({
   const rolesByProfileId = new Map<string, NormalizedRole[]>(
     profileUsers.map((profileUser) => [
       profileUser.profileId,
-      getNormalizedRoles(
-        profileUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
-      ),
+      getNormalizedRoles(profileUser.roles),
     ]),
   );
 

--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -371,6 +371,7 @@ export const getUserSession = async ({
   }
 };
 
+export * from './assertProfileTypeAccess';
 export * from './getRoles';
 export * from './permissions';
 export * from './utils';

--- a/services/api/src/access/assertProfileTypeAccess.test.ts
+++ b/services/api/src/access/assertProfileTypeAccess.test.ts
@@ -1,0 +1,371 @@
+import { assertProfileTypeAccess } from '@op/common';
+import { db } from '@op/db/client';
+import { EntityType } from '@op/db/schema';
+import { permission } from 'access-zones';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../test/helpers/TestDecisionsDataManager';
+
+describe.concurrent('assertProfileTypeAccess', () => {
+  describe('input handling', () => {
+    it('returns without throwing when profileIds is empty', async () => {
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: randomUUID() },
+          profileIds: [],
+          policies: { [EntityType.ORG]: { decisions: permission.ADMIN } },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws ValidationError when a profileId does not exist', async () => {
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: randomUUID() },
+          profileIds: [randomUUID()],
+          policies: { [EntityType.ORG]: { decisions: permission.ADMIN } },
+        }),
+      ).rejects.toThrow(/do not exist/);
+    });
+
+    it('treats a profile type not present in policies as a no-op', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+      // ORG profile, but the policy only gates DECISION → lenient pass-through.
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: randomUUID() },
+          profileIds: [setup.organization.profileId],
+          policies: {
+            [EntityType.DECISION]: { decisions: permission.ADMIN },
+          },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('dedups duplicate profileIds before checking', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const { profileId } = setup.instances[0]!;
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: setup.user.id },
+          profileIds: [profileId, profileId],
+          policies: { [EntityType.DECISION]: { decisions: permission.ADMIN } },
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ORG profiles are gated through `organizationUsers`, not `profileUsers`, so
+  // this helper has no visibility into org-admin status when ORG is included in
+  // `policies`. Confirm the behaviour: gating ORG rejects even an org admin.
+  describe('ORG profiles', () => {
+    it('rejects an org admin because the helper only consults profileUsers', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: setup.user.id },
+          profileIds: [setup.organization.profileId],
+          policies: { [EntityType.ORG]: { decisions: permission.ADMIN } },
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('outsider with no profileUser row fails any non-lenient policy', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: randomUUID() },
+          profileIds: [setup.organization.profileId],
+          policies: { [EntityType.ORG]: { decisions: permission.ADMIN } },
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('DECISION profiles', () => {
+    it('admin passes a decisions ADMIN policy', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const { profileId } = setup.instances[0]!;
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: setup.user.id },
+          profileIds: [profileId],
+          policies: { [EntityType.DECISION]: { decisions: permission.ADMIN } },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('member fails a decisions ADMIN policy but passes a decisions READ policy', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: false,
+      });
+      const { profileId } = setup.instances[0]!;
+      const member = await testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [profileId],
+      });
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: member.authUserId },
+          profileIds: [profileId],
+          policies: { [EntityType.DECISION]: { decisions: permission.ADMIN } },
+        }),
+      ).rejects.toThrow();
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: member.authUserId },
+          profileIds: [profileId],
+          policies: { [EntityType.DECISION]: { decisions: permission.READ } },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('outsider fails a decisions ADMIN policy', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: false,
+      });
+      const { profileId } = setup.instances[0]!;
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: randomUUID() },
+          profileIds: [profileId],
+          policies: { [EntityType.DECISION]: { decisions: permission.ADMIN } },
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('PROPOSAL profiles', () => {
+    it('creator (proposal-profile admin) passes an admin policy', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const proposal = await testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: setup.instances[0]!.instance.id,
+        proposalData: { title: `Proposal ${task.id}` },
+      });
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: setup.user.id },
+          profileIds: [proposal.profileId],
+          policies: { [EntityType.PROPOSAL]: { decisions: permission.ADMIN } },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('non-creator org member fails an admin policy on a proposal profile', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const proposal = await testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: setup.instances[0]!.instance.id,
+        proposalData: { title: `Proposal ${task.id}` },
+      });
+      const other = await testData.createMemberUser({
+        organization: setup.organization,
+      });
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: other.authUserId },
+          profileIds: [proposal.profileId],
+          policies: { [EntityType.PROPOSAL]: { decisions: permission.ADMIN } },
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('INDIVIDUAL profiles', () => {
+    it('owner of an individual profile passes a profile ADMIN policy', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+      const individualProfileId = await getIndividualProfileId(setup.user.id);
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: setup.user.id },
+          profileIds: [individualProfileId],
+          policies: {
+            [EntityType.INDIVIDUAL]: { profile: permission.ADMIN },
+          },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('another user cannot satisfy a policy on someone else’s individual profile', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+      const individualProfileId = await getIndividualProfileId(setup.user.id);
+      const stranger = await testData.createMemberUser({
+        organization: setup.organization,
+      });
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: stranger.authUserId },
+          profileIds: [individualProfileId],
+          policies: {
+            [EntityType.INDIVIDUAL]: { profile: permission.ADMIN },
+          },
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('multiple profiles', () => {
+    it('passes when the user has access on every gated profile', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const { profileId: decisionProfileId } = setup.instances[0]!;
+      const individualProfileId = await getIndividualProfileId(setup.user.id);
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: setup.user.id },
+          profileIds: [individualProfileId, decisionProfileId],
+          policies: {
+            [EntityType.INDIVIDUAL]: { profile: permission.ADMIN },
+            [EntityType.DECISION]: { decisions: permission.ADMIN },
+          },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws when the user fails the policy on any one gated profile', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: false,
+      });
+      const { profileId: decisionProfileId } = setup.instances[0]!;
+      // Member gets decision READ but no admin; expect to fail when policy
+      // requires decisions.ADMIN on the decision profile.
+      const member = await testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [decisionProfileId],
+      });
+      const memberIndividualProfileId = await getIndividualProfileId(
+        member.authUserId,
+      );
+
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: member.authUserId },
+          profileIds: [memberIndividualProfileId, decisionProfileId],
+          policies: {
+            [EntityType.INDIVIDUAL]: { profile: permission.ADMIN },
+            [EntityType.DECISION]: { decisions: permission.ADMIN },
+          },
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('checks only gated types when a mix of gated and non-gated profiles is passed', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const { profileId: decisionProfileId } = setup.instances[0]!;
+
+      // ORG profile would reject this user (no profileUser row), but ORG is
+      // not gated by the policy → only the DECISION check runs.
+      await expect(
+        assertProfileTypeAccess({
+          user: { id: setup.user.id },
+          profileIds: [setup.organization.profileId, decisionProfileId],
+          policies: {
+            [EntityType.DECISION]: { decisions: permission.READ },
+          },
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});
+
+async function getIndividualProfileId(authUserId: string): Promise<string> {
+  const user = await db.query.users.findFirst({
+    where: { authUserId },
+    columns: { profileId: true },
+  });
+  if (!user?.profileId) {
+    throw new Error(`No individual profile for authUserId=${authUserId}`);
+  }
+  return user.profileId;
+}

--- a/services/api/src/access/assertProfileTypeAccess.test.ts
+++ b/services/api/src/access/assertProfileTypeAccess.test.ts
@@ -1,4 +1,4 @@
-import { assertProfileTypeAccess } from '@op/common';
+import { ValidationError, assertProfileTypeAccess } from '@op/common';
 import { db } from '@op/db/client';
 import { EntityType } from '@op/db/schema';
 import { permission } from 'access-zones';
@@ -26,7 +26,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
           profileIds: [randomUUID()],
           policies: { [EntityType.ORG]: { decisions: permission.ADMIN } },
         }),
-      ).rejects.toThrow(/do not exist/);
+      ).rejects.toThrow(ValidationError);
     });
 
     it('treats a profile type not present in policies as a no-op', async ({

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -162,6 +162,98 @@ export const relations = defineRelations(schema, (r) => ({
       to: r.objectsInStorage.id,
       optional: false,
     }),
+    post: r.one.posts({
+      from: r.attachments.postId,
+      to: r.posts.id,
+    }),
+  },
+
+  /**
+   * Post relations
+   *
+   * profileId is nullable in the schema. parentPostId is also nullable
+   * (top-level posts have no parent). The self-referential parent/children
+   * relations share an alias so v2 can pair them as inverses.
+   */
+  posts: {
+    profile: r.one.profiles({
+      from: r.posts.profileId,
+      to: r.profiles.id,
+    }),
+    parentPost: r.one.posts({
+      from: r.posts.parentPostId,
+      to: r.posts.id,
+      alias: 'post_parent_child',
+    }),
+    childPosts: r.many.posts({
+      from: r.posts.id,
+      to: r.posts.parentPostId,
+      alias: 'post_parent_child',
+    }),
+    attachments: r.many.attachments({
+      from: r.posts.id,
+      to: r.attachments.postId,
+    }),
+    reactions: r.many.postReactions({
+      from: r.posts.id,
+      to: r.postReactions.postId,
+    }),
+    postsToProfiles: r.many.postsToProfiles({
+      from: r.posts.id,
+      to: r.postsToProfiles.postId,
+    }),
+    postsToOrganizations: r.many.postsToOrganizations({
+      from: r.posts.id,
+      to: r.postsToOrganizations.postId,
+    }),
+  },
+
+  /**
+   * Posts-to-profiles join relations
+   */
+  postsToProfiles: {
+    post: r.one.posts({
+      from: r.postsToProfiles.postId,
+      to: r.posts.id,
+      optional: false,
+    }),
+    profile: r.one.profiles({
+      from: r.postsToProfiles.profileId,
+      to: r.profiles.id,
+      optional: false,
+    }),
+  },
+
+  /**
+   * Posts-to-organizations join relations
+   */
+  postsToOrganizations: {
+    post: r.one.posts({
+      from: r.postsToOrganizations.postId,
+      to: r.posts.id,
+      optional: false,
+    }),
+    organization: r.one.organizations({
+      from: r.postsToOrganizations.organizationId,
+      to: r.organizations.id,
+      optional: false,
+    }),
+  },
+
+  /**
+   * Post reaction relations
+   */
+  postReactions: {
+    post: r.one.posts({
+      from: r.postReactions.postId,
+      to: r.posts.id,
+      optional: false,
+    }),
+    profile: r.one.profiles({
+      from: r.postReactions.profileId,
+      to: r.profiles.id,
+      optional: false,
+    }),
   },
 
   /**


### PR DESCRIPTION
## Summary

Precursor extracted from #1060 to make review tractable. Two pieces, both purely additive:

1. **`services/db/relations.ts`**: declares Drizzle v2 relations for `posts`, `postsToProfiles`, `postsToOrganizations`, `postReactions`, and the `attachments → post` side. Self-referential parent/child uses a shared alias. Existing v1 queries continue to work unchanged.
2. **`packages/common/src/services/access/assertProfileTypeAccess.ts`**: profile-type-dispatch authorization helper. Caller passes a policy keyed by `EntityType`; the helper resolves each profile and applies the matching policy via `assertAccess`. No callers in this PR — wiring lands in #1060.

#1060 is now stacked on this PR; #1085 (frontend) is stacked on #1060.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] No behavior change — existing post / reaction flows unchanged (no callers of the new helper yet)