### PR TITLE
refactor(reviews): centralize rubric review-data parsing

### DIFF
--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -1,7 +1,9 @@
 import {
   type ProposalReview,
+  type RubricAnswerValue,
   type RubricTemplateSchema,
   isOverallRecommendationField,
+  parseRubricReviewData,
   parseSchemaOptions,
 } from '@op/common/client';
 import type { ReactNode } from 'react';
@@ -22,7 +24,10 @@ export function SubmittedReviewView({
 }) {
   const t = useTranslations();
   const fields = compileRubricSchema(rubricTemplate);
-  const { answers, rationales } = review.reviewData;
+  const { answers, rationales } = parseRubricReviewData(
+    rubricTemplate,
+    review.reviewData,
+  );
 
   return (
     <div className="flex flex-col gap-6">
@@ -112,7 +117,7 @@ function RubricFieldResult({
   rationale,
 }: {
   field: FieldDescriptor;
-  value: unknown;
+  value: RubricAnswerValue | undefined;
   rationale?: string;
 }) {
   const t = useTranslations();

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -42,8 +42,6 @@ export {
 } from './services/decision/getRubricScoringInfo';
 export {
   parseRubricReviewData,
-  readRubricNumber,
-  readRubricString,
   type ParsedRubricReviewData,
   type RubricAnswerValue,
 } from './services/decision/parseRubricReviewData';

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -40,6 +40,13 @@ export {
   OVERALL_RECOMMENDATION_KEY,
   isOverallRecommendationField,
 } from './services/decision/getRubricScoringInfo';
+export {
+  parseRubricReviewData,
+  readRubricNumber,
+  readRubricString,
+  type ParsedRubricReviewData,
+  type RubricAnswerValue,
+} from './services/decision/parseRubricReviewData';
 export { REVIEWS_POLICIES } from './services/decision/schemas/types';
 export { isLastPhase } from './services/decision/schemas/instanceData';
 export {

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -80,6 +80,7 @@ export * from './assembleProposalData';
 export * from './resolveProposalTemplate';
 export * from './getProposalTemplateFieldOrder';
 export * from './getRubricScoringInfo';
+export * from './parseRubricReviewData';
 export * from './tiptapExtensions';
 
 // Proposal attachments

--- a/packages/common/src/services/decision/listProposalsWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/listProposalsWithReviewAggregates.ts
@@ -21,11 +21,13 @@ import {
   OVERALL_RECOMMENDATION_KEY,
   getRubricScoringInfo,
 } from './getRubricScoringInfo';
+import { parseRubricReviewData } from './parseRubricReviewData';
 import {
   type ProposalCategoryItem,
   type ProposalsWithReviewAggregatesList,
   proposalsWithReviewAggregatesListSchema,
 } from './schemas/reviews';
+import type { RubricTemplateSchema } from './types';
 
 // ── Input schema ───────────────────────────────────────────────────────
 
@@ -77,12 +79,7 @@ export async function listProposalsWithReviewAggregates(
     );
   }
 
-  const rubricTemplate = instance.instanceData.rubricTemplate;
-  const scoredCriterionKeys = rubricTemplate
-    ? getRubricScoringInfo(rubricTemplate)
-        .criteria.filter((c) => c.scored)
-        .map((c) => c.key)
-    : [];
+  const rubricTemplate = instance.instanceData.rubricTemplate ?? null;
 
   const phaseId = input.phaseId ?? instance.currentStateId ?? undefined;
   const phaseProposalIds = await getProposalIdsForPhase({
@@ -96,7 +93,7 @@ export async function listProposalsWithReviewAggregates(
       phaseProposalIds,
       processInstanceId,
       phaseId,
-      scoredCriterionKeys,
+      rubricTemplate,
     });
   }
 
@@ -106,7 +103,7 @@ export async function listProposalsWithReviewAggregates(
     phaseProposalIds,
     limit: input.limit,
     cursor: input.cursor,
-    scoredCriterionKeys,
+    rubricTemplate,
   });
 }
 
@@ -117,13 +114,13 @@ async function listProposalsFiltered({
   phaseProposalIds,
   processInstanceId,
   phaseId,
-  scoredCriterionKeys,
+  rubricTemplate,
 }: {
   proposalIds: string[];
   phaseProposalIds: string[];
   processInstanceId: string;
   phaseId: string | undefined;
-  scoredCriterionKeys: string[];
+  rubricTemplate: RubricTemplateSchema | null;
 }): Promise<ProposalsWithReviewAggregatesList> {
   const phaseProposalIdSet = new Set(phaseProposalIds);
   const filteredProposalIds = proposalIds.filter((id) =>
@@ -146,7 +143,7 @@ async function listProposalsFiltered({
     proposal,
     aggregates: getComputedReviewAggregates(
       proposal.reviewAssignments,
-      scoredCriterionKeys,
+      rubricTemplate,
     ),
     categories: categoriesByProposalId.get(proposal.id) ?? [],
   }));
@@ -166,14 +163,14 @@ async function listProposalsPaginated({
   phaseProposalIds,
   limit,
   cursor,
-  scoredCriterionKeys,
+  rubricTemplate,
 }: {
   processInstanceId: string;
   phaseId: string | undefined;
   phaseProposalIds: string[];
   limit: number;
   cursor: string | undefined;
-  scoredCriterionKeys: string[];
+  rubricTemplate: RubricTemplateSchema | null;
 }): Promise<ProposalsWithReviewAggregatesList> {
   if (phaseProposalIds.length === 0) {
     return { items: [], total: 0, next: null };
@@ -222,7 +219,7 @@ async function listProposalsPaginated({
     proposal,
     aggregates: getComputedReviewAggregates(
       proposal.reviewAssignments,
-      scoredCriterionKeys,
+      rubricTemplate,
     ),
     categories: categoriesByProposalId.get(proposal.id) ?? [],
   }));
@@ -310,6 +307,10 @@ async function getCategoriesByProposalIds(
  *
  * `proposal_reviews_assignment_unique` makes `reviews` 0-or-1; we read just
  * the first row even though the relation is declared as many.
+ *
+ * Rubric answers are parsed once via `parseRubricReviewData` so the loop
+ * works against typed values (`number` for scored criteria, `string` for the
+ * overall-recommendation enum) instead of casting and coercing per access.
  */
 function getComputedReviewAggregates(
   reviewAssignments: Array<{
@@ -317,12 +318,18 @@ function getComputedReviewAggregates(
     reviewer: unknown;
     reviews: Array<{ state: string; reviewData: unknown }>;
   }>,
-  scoredCriterionKeys: string[],
+  rubricTemplate: RubricTemplateSchema | null,
 ) {
   const reviewers = reviewAssignments.map((a) => ({
     profile: a.reviewer,
     status: a.status,
   }));
+
+  const scoredCriterionKeys = rubricTemplate
+    ? getRubricScoringInfo(rubricTemplate)
+        .criteria.filter((c) => c.scored)
+        .map((c) => c.key)
+    : [];
 
   let reviewsSubmittedCount = 0;
   let totalScore = 0;
@@ -335,23 +342,22 @@ function getComputedReviewAggregates(
     }
     reviewsSubmittedCount += 1;
 
-    const data = review.reviewData as {
-      answers?: Record<string, unknown>;
-    } | null;
-    const answers = data?.answers ?? {};
+    const { answers } = parseRubricReviewData(
+      rubricTemplate,
+      review.reviewData,
+    );
 
     for (const key of scoredCriterionKeys) {
-      const value = Number(answers[key]);
-      if (Number.isFinite(value)) {
+      const value = answers[key];
+      if (typeof value === 'number') {
         totalScore += value;
       }
     }
 
     const recommendation = answers[OVERALL_RECOMMENDATION_KEY];
-    if (recommendation != null) {
-      const recommendationKey = String(recommendation);
-      overallRecommendationCount[recommendationKey] =
-        (overallRecommendationCount[recommendationKey] ?? 0) + 1;
+    if (typeof recommendation === 'string') {
+      overallRecommendationCount[recommendation] =
+        (overallRecommendationCount[recommendation] ?? 0) + 1;
     }
   }
 

--- a/packages/common/src/services/decision/parseRubricReviewData.test.ts
+++ b/packages/common/src/services/decision/parseRubricReviewData.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseRubricReviewData } from './parseRubricReviewData';
+import type { RubricTemplateSchema } from './types';
+
+const seiRubricTemplate = {
+  type: 'object',
+  properties: {
+    innovation: {
+      type: 'integer',
+      title: 'Innovation',
+      'x-format': 'dropdown',
+      minimum: 1,
+      maximum: 5,
+      oneOf: [
+        { const: 1, title: 'Poor' },
+        { const: 2, title: 'Below Average' },
+        { const: 3, title: 'Average' },
+        { const: 4, title: 'Good' },
+        { const: 5, title: 'Excellent' },
+      ],
+    },
+    meetsEligibility: {
+      type: 'string',
+      title: 'Meets Eligibility',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 'yes', title: 'Yes' },
+        { const: 'no', title: 'No' },
+      ],
+    },
+    strengthsSummary: {
+      type: 'string',
+      title: 'Key Strengths',
+      'x-format': 'short-text',
+    },
+    __overall_recommendation: {
+      type: 'string',
+      title: 'Overall Recommendation',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 'yes', title: 'Yes' },
+        { const: 'maybe', title: 'Maybe' },
+        { const: 'no', title: 'No' },
+      ],
+    },
+  },
+} as const satisfies RubricTemplateSchema;
+
+describe('parseRubricReviewData', () => {
+  it('parses scored integer answers as numbers', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { innovation: 4 },
+      rationales: {},
+    });
+
+    expect(parsed.answers.innovation).toBe(4);
+    expect(typeof parsed.answers.innovation).toBe('number');
+  });
+
+  it('parses dropdown const enums as their literal value', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { meetsEligibility: 'yes' },
+      rationales: {},
+    });
+
+    expect(parsed.answers.meetsEligibility).toBe('yes');
+  });
+
+  it('parses the __overall_recommendation enum', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { __overall_recommendation: 'maybe' },
+      rationales: {},
+    });
+
+    expect(parsed.answers.__overall_recommendation).toBe('maybe');
+  });
+
+  it('parses free-text criteria as strings', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { strengthsSummary: 'Solid plan' },
+      rationales: {},
+    });
+
+    expect(parsed.answers.strengthsSummary).toBe('Solid plan');
+  });
+
+  it('drops a single malformed answer without losing siblings', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: {
+        // out-of-range integer
+        innovation: 99,
+        // valid sibling
+        meetsEligibility: 'yes',
+      },
+      rationales: {},
+    });
+
+    expect(parsed.answers.innovation).toBeUndefined();
+    expect(parsed.answers.meetsEligibility).toBe('yes');
+  });
+
+  it('drops dropdown values that are not in the allowed consts', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { meetsEligibility: 'kinda' },
+      rationales: {},
+    });
+
+    expect(parsed.answers.meetsEligibility).toBeUndefined();
+  });
+
+  it('coerces a stringified integer? no — keeps types strict', () => {
+    // Number criteria reject string-encoded numbers; the storage layer is
+    // expected to hold real JSON numbers.
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { innovation: '4' },
+      rationales: {},
+    });
+
+    expect(parsed.answers.innovation).toBeUndefined();
+  });
+
+  it('preserves rationales when valid', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { innovation: 3 },
+      rationales: { innovation: 'Good fit' },
+    });
+
+    expect(parsed.rationales).toEqual({ innovation: 'Good fit' });
+  });
+
+  it('returns empty halves when reviewData is missing entirely', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, null);
+
+    expect(parsed).toEqual({ answers: {}, rationales: {} });
+  });
+
+  it('returns empty halves when reviewData has the wrong wrapper shape', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      // rationales should be Record<string, string>
+      answers: {},
+      rationales: { innovation: 42 },
+    });
+
+    expect(parsed).toEqual({ answers: {}, rationales: {} });
+  });
+
+  it('preserves unknown primitive keys when the criterion was removed from the template', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { legacyCriterion: 'kept' },
+      rationales: {},
+    });
+
+    expect(parsed.answers.legacyCriterion).toBe('kept');
+  });
+
+  it('drops unknown keys whose value is non-primitive', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { legacyCriterion: { nested: true } },
+      rationales: {},
+    });
+
+    expect(parsed.answers.legacyCriterion).toBeUndefined();
+  });
+
+  it('treats a null template as an empty-template parse (primitives preserved)', () => {
+    const parsed = parseRubricReviewData(null, {
+      answers: { __overall_recommendation: 'yes', score: 4 },
+      rationales: { __overall_recommendation: 'good' },
+    });
+
+    expect(parsed.answers.__overall_recommendation).toBe('yes');
+    expect(parsed.answers.score).toBe(4);
+    expect(parsed.rationales).toEqual({ __overall_recommendation: 'good' });
+  });
+});

--- a/packages/common/src/services/decision/parseRubricReviewData.test.ts
+++ b/packages/common/src/services/decision/parseRubricReviewData.test.ts
@@ -48,85 +48,58 @@ const seiRubricTemplate = {
 } as const satisfies RubricTemplateSchema;
 
 describe('parseRubricReviewData', () => {
-  it('parses scored integer answers as numbers', () => {
-    const parsed = parseRubricReviewData(seiRubricTemplate, {
-      answers: { innovation: 4 },
-      rationales: {},
-    });
-
-    expect(parsed.answers.innovation).toBe(4);
-    expect(typeof parsed.answers.innovation).toBe('number');
-  });
-
-  it('parses dropdown const enums as their literal value', () => {
-    const parsed = parseRubricReviewData(seiRubricTemplate, {
-      answers: { meetsEligibility: 'yes' },
-      rationales: {},
-    });
-
-    expect(parsed.answers.meetsEligibility).toBe('yes');
-  });
-
-  it('parses the __overall_recommendation enum', () => {
-    const parsed = parseRubricReviewData(seiRubricTemplate, {
-      answers: { __overall_recommendation: 'maybe' },
-      rationales: {},
-    });
-
-    expect(parsed.answers.__overall_recommendation).toBe('maybe');
-  });
-
-  it('parses free-text criteria as strings', () => {
-    const parsed = parseRubricReviewData(seiRubricTemplate, {
-      answers: { strengthsSummary: 'Solid plan' },
-      rationales: {},
-    });
-
-    expect(parsed.answers.strengthsSummary).toBe('Solid plan');
-  });
-
-  it('drops a single malformed answer without losing siblings', () => {
+  it('parses a fully-populated wrapper with primitive narrowing', () => {
     const parsed = parseRubricReviewData(seiRubricTemplate, {
       answers: {
-        // out-of-range integer
-        innovation: 99,
-        // valid sibling
+        innovation: 4,
         meetsEligibility: 'yes',
+        strengthsSummary: 'Solid plan',
+        __overall_recommendation: 'maybe',
       },
-      rationales: {},
+      rationales: { innovation: 'Good fit' },
     });
 
-    expect(parsed.answers.innovation).toBeUndefined();
-    expect(parsed.answers.meetsEligibility).toBe('yes');
+    expect(parsed).toEqual({
+      answers: {
+        innovation: 4,
+        meetsEligibility: 'yes',
+        strengthsSummary: 'Solid plan',
+        __overall_recommendation: 'maybe',
+      },
+      rationales: { innovation: 'Good fit' },
+    });
+    expect(typeof parsed.answers.innovation).toBe('number');
+    expect(typeof parsed.answers.meetsEligibility).toBe('string');
   });
 
-  it('drops dropdown values that are not in the allowed consts', () => {
+  it('drops all answers (kept rationales) when Ajv rejects the payload', () => {
+    // out-of-range integer → Ajv rejects the whole answer payload, so we
+    // drop every answer rather than silently surfacing a malformed row
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { innovation: 99, meetsEligibility: 'yes' },
+      rationales: { innovation: 'questionable' },
+    });
+
+    expect(parsed.answers).toEqual({});
+    expect(parsed.rationales).toEqual({ innovation: 'questionable' });
+  });
+
+  it('drops all answers when a dropdown value is not in the allowed consts', () => {
     const parsed = parseRubricReviewData(seiRubricTemplate, {
       answers: { meetsEligibility: 'kinda' },
       rationales: {},
     });
 
-    expect(parsed.answers.meetsEligibility).toBeUndefined();
+    expect(parsed.answers).toEqual({});
   });
 
-  it('coerces a stringified integer? no — keeps types strict', () => {
-    // Number criteria reject string-encoded numbers; the storage layer is
-    // expected to hold real JSON numbers.
+  it('rejects stringified numbers (Ajv coerceTypes is off)', () => {
     const parsed = parseRubricReviewData(seiRubricTemplate, {
       answers: { innovation: '4' },
       rationales: {},
     });
 
-    expect(parsed.answers.innovation).toBeUndefined();
-  });
-
-  it('preserves rationales when valid', () => {
-    const parsed = parseRubricReviewData(seiRubricTemplate, {
-      answers: { innovation: 3 },
-      rationales: { innovation: 'Good fit' },
-    });
-
-    expect(parsed.rationales).toEqual({ innovation: 'Good fit' });
+    expect(parsed.answers).toEqual({});
   });
 
   it('returns empty halves when reviewData is missing entirely', () => {
@@ -135,17 +108,25 @@ describe('parseRubricReviewData', () => {
     expect(parsed).toEqual({ answers: {}, rationales: {} });
   });
 
-  it('returns empty halves when reviewData has the wrong wrapper shape', () => {
+  it('returns empty halves when the wrapper shape is wrong', () => {
     const parsed = parseRubricReviewData(seiRubricTemplate, {
-      // rationales should be Record<string, string>
       answers: {},
-      rationales: { innovation: 42 },
+      rationales: { innovation: 42 }, // rationales must be Record<string, string>
     });
 
     expect(parsed).toEqual({ answers: {}, rationales: {} });
   });
 
-  it('preserves unknown primitive keys when the criterion was removed from the template', () => {
+  it('preserves a partial answer set (Ajv allows missing keys by default)', () => {
+    const parsed = parseRubricReviewData(seiRubricTemplate, {
+      answers: { innovation: 3 },
+      rationales: {},
+    });
+
+    expect(parsed.answers).toEqual({ innovation: 3 });
+  });
+
+  it('preserves keys for criteria removed from the template (additionalProperties default)', () => {
     const parsed = parseRubricReviewData(seiRubricTemplate, {
       answers: { legacyCriterion: 'kept' },
       rationales: {},
@@ -154,23 +135,25 @@ describe('parseRubricReviewData', () => {
     expect(parsed.answers.legacyCriterion).toBe('kept');
   });
 
-  it('drops unknown keys whose value is non-primitive', () => {
+  it('drops the answers when a value is non-primitive (Zod narrow rejects)', () => {
     const parsed = parseRubricReviewData(seiRubricTemplate, {
       answers: { legacyCriterion: { nested: true } },
       rationales: {},
     });
 
-    expect(parsed.answers.legacyCriterion).toBeUndefined();
+    expect(parsed.answers).toEqual({});
   });
 
-  it('treats a null template as an empty-template parse (primitives preserved)', () => {
+  it('skips Ajv when the template is null and narrows primitives via Zod', () => {
     const parsed = parseRubricReviewData(null, {
       answers: { __overall_recommendation: 'yes', score: 4 },
       rationales: { __overall_recommendation: 'good' },
     });
 
-    expect(parsed.answers.__overall_recommendation).toBe('yes');
-    expect(parsed.answers.score).toBe(4);
+    expect(parsed.answers).toEqual({
+      __overall_recommendation: 'yes',
+      score: 4,
+    });
     expect(parsed.rationales).toEqual({ __overall_recommendation: 'good' });
   });
 });

--- a/packages/common/src/services/decision/parseRubricReviewData.ts
+++ b/packages/common/src/services/decision/parseRubricReviewData.ts
@@ -1,0 +1,121 @@
+import { schemaValidator } from './schemaValidator';
+import { rubricReviewDataSchema } from './schemas/reviews';
+import type { RubricTemplateSchema, XFormatPropertySchema } from './types';
+
+/**
+ * Possible values a single rubric answer can hold once parsed against the
+ * template.
+ *
+ * The rubric template is loaded at runtime, so per-key static narrowing
+ * isn't possible — `z.infer` only resolves when the schema is known at
+ * compile time. The best static type we can give is the union of value
+ * shapes that JSON Schema can express here. Per-key narrowing comes from
+ * helpers (`readRubricNumber` / `readRubricString`) that take the criterion
+ * key.
+ */
+export type RubricAnswerValue = number | string | null;
+
+export interface ParsedRubricReviewData {
+  answers: Record<string, RubricAnswerValue>;
+  rationales: Record<string, string>;
+}
+
+/**
+ * Validate a single rubric answer against its criterion's JSON Schema using
+ * Ajv (via the shared `schemaValidator`). Centralised so the read path uses
+ * the same validator — and the same vendor-extension keywords (`x-format`,
+ * `x-field-order`) — that the write path goes through.
+ */
+function isAnswerValid(
+  propSchema: XFormatPropertySchema,
+  value: unknown,
+): boolean {
+  return schemaValidator.validate(propSchema, value).valid;
+}
+
+/**
+ * Narrow an arbitrary stored answer to a `RubricAnswerValue`. Anything that
+ * isn't a primitive JSON scalar is dropped — answers persisted as objects or
+ * arrays don't fit any current rubric criterion shape and would only confuse
+ * downstream consumers.
+ */
+function asAnswerValue(value: unknown): RubricAnswerValue | undefined {
+  if (typeof value === 'number' || typeof value === 'string') {
+    return value;
+  }
+  if (value === null) {
+    return null;
+  }
+  return undefined;
+}
+
+/**
+ * Parse persisted review data against the rubric template.
+ *
+ * Two passes:
+ *   1. Wrapper — `{ answers, rationales }` via Zod (`rubricReviewDataSchema`).
+ *      A wrapper-shape failure (legacy/malformed row) falls back to
+ *      `{ answers: {}, rationales: {} }` so a single bad row never breaks
+ *      an entire admin list.
+ *   2. Per-criterion answers — each known key is validated against its JSON
+ *      Schema property via Ajv. A failing key is dropped while siblings parse
+ *      cleanly. Keys whose criterion was removed from the template are kept
+ *      when the value is a primitive scalar.
+ *
+ * Static type stays a union (`RubricAnswerValue`) because the template is
+ * dynamic. Use `readRubricNumber` / `readRubricString` when a caller wants
+ * narrowed access for a specific criterion.
+ */
+export function parseRubricReviewData(
+  template: RubricTemplateSchema | null | undefined,
+  raw: unknown,
+): ParsedRubricReviewData {
+  const wrapper = rubricReviewDataSchema.safeParse(raw);
+  const { answers: rawAnswers, rationales } = wrapper.success
+    ? wrapper.data
+    : { answers: {}, rationales: {} };
+
+  const properties = template?.properties ?? {};
+  const answers: Record<string, RubricAnswerValue> = {};
+
+  for (const [key, value] of Object.entries(rawAnswers)) {
+    const propSchema = properties[key];
+
+    if (propSchema && !isAnswerValid(propSchema, value)) {
+      continue;
+    }
+
+    const narrowed = asAnswerValue(value);
+    if (narrowed === undefined) {
+      continue;
+    }
+    answers[key] = narrowed;
+  }
+
+  return { answers, rationales };
+}
+
+/**
+ * Read a numeric answer for a criterion. Returns `undefined` when the key is
+ * absent or the stored value isn't a number — callers don't need to repeat
+ * the `typeof value === 'number'` check.
+ */
+export function readRubricNumber(
+  answers: Record<string, RubricAnswerValue>,
+  key: string,
+): number | undefined {
+  const value = answers[key];
+  return typeof value === 'number' ? value : undefined;
+}
+
+/**
+ * Read a string answer for a criterion. Returns `undefined` when the key is
+ * absent or the stored value isn't a string.
+ */
+export function readRubricString(
+  answers: Record<string, RubricAnswerValue>,
+  key: string,
+): string | undefined {
+  const value = answers[key];
+  return typeof value === 'string' ? value : undefined;
+}

--- a/packages/common/src/services/decision/parseRubricReviewData.ts
+++ b/packages/common/src/services/decision/parseRubricReviewData.ts
@@ -1,19 +1,24 @@
+import { z } from 'zod';
+
 import { schemaValidator } from './schemaValidator';
 import { rubricReviewDataSchema } from './schemas/reviews';
-import type { RubricTemplateSchema, XFormatPropertySchema } from './types';
+import type { RubricTemplateSchema } from './types';
 
 /**
- * Possible values a single rubric answer can hold once parsed against the
- * template.
- *
- * The rubric template is loaded at runtime, so per-key static narrowing
- * isn't possible — `z.infer` only resolves when the schema is known at
- * compile time. The best static type we can give is the union of value
- * shapes that JSON Schema can express here. Per-key narrowing comes from
- * helpers (`readRubricNumber` / `readRubricString`) that take the criterion
- * key.
+ * Possible values a single rubric answer can hold once parsed. The rubric
+ * template is loaded at runtime so per-key static narrowing isn't possible
+ * via `z.infer` — the union is the strongest static type. Per-criterion
+ * narrowing comes from inline `typeof` checks in callers.
  */
 export type RubricAnswerValue = number | string | null;
+
+const rubricAnswerValueSchema: z.ZodType<RubricAnswerValue> = z.union([
+  z.number(),
+  z.string(),
+  z.null(),
+]);
+
+const rubricAnswersSchema = z.record(z.string(), rubricAnswerValueSchema);
 
 export interface ParsedRubricReviewData {
   answers: Record<string, RubricAnswerValue>;
@@ -21,101 +26,37 @@ export interface ParsedRubricReviewData {
 }
 
 /**
- * Validate a single rubric answer against its criterion's JSON Schema using
- * Ajv (via the shared `schemaValidator`). Centralised so the read path uses
- * the same validator — and the same vendor-extension keywords (`x-format`,
- * `x-field-order`) — that the write path goes through.
- */
-function isAnswerValid(
-  propSchema: XFormatPropertySchema,
-  value: unknown,
-): boolean {
-  return schemaValidator.validate(propSchema, value).valid;
-}
-
-/**
- * Narrow an arbitrary stored answer to a `RubricAnswerValue`. Anything that
- * isn't a primitive JSON scalar is dropped — answers persisted as objects or
- * arrays don't fit any current rubric criterion shape and would only confuse
- * downstream consumers.
- */
-function asAnswerValue(value: unknown): RubricAnswerValue | undefined {
-  if (typeof value === 'number' || typeof value === 'string') {
-    return value;
-  }
-  if (value === null) {
-    return null;
-  }
-  return undefined;
-}
-
-/**
- * Parse persisted review data against the rubric template.
+ * Read-path entry for review data — the rubric counterpart to
+ * `parseProposalData`. Three steps:
+ *   1. Zod parses the wrapper shape (`{ answers, rationales }`).
+ *   2. Ajv validates the answer payload against the rubric template — same
+ *      validator the write path uses (`schemaValidator.assertRubricData`).
+ *   3. Zod narrows the answer values from `unknown` to `RubricAnswerValue`,
+ *      so callers don't have to cast.
  *
- * Two passes:
- *   1. Wrapper — `{ answers, rationales }` via Zod (`rubricReviewDataSchema`).
- *      A wrapper-shape failure (legacy/malformed row) falls back to
- *      `{ answers: {}, rationales: {} }` so a single bad row never breaks
- *      an entire admin list.
- *   2. Per-criterion answers — each known key is validated against its JSON
- *      Schema property via Ajv. A failing key is dropped while siblings parse
- *      cleanly. Keys whose criterion was removed from the template are kept
- *      when the value is a primitive scalar.
- *
- * Static type stays a union (`RubricAnswerValue`) because the template is
- * dynamic. Use `readRubricNumber` / `readRubricString` when a caller wants
- * narrowed access for a specific criterion.
+ * Tolerant on every step: a wrapper-shape failure or an Ajv mismatch returns
+ * empty answers (rationales preserved when available) so a single legacy
+ * row can't break an admin list. Errors that need surfacing happen at the
+ * write path; reads stay defensive.
  */
 export function parseRubricReviewData(
   template: RubricTemplateSchema | null | undefined,
   raw: unknown,
 ): ParsedRubricReviewData {
   const wrapper = rubricReviewDataSchema.safeParse(raw);
-  const { answers: rawAnswers, rationales } = wrapper.success
-    ? wrapper.data
-    : { answers: {}, rationales: {} };
-
-  const properties = template?.properties ?? {};
-  const answers: Record<string, RubricAnswerValue> = {};
-
-  for (const [key, value] of Object.entries(rawAnswers)) {
-    const propSchema = properties[key];
-
-    if (propSchema && !isAnswerValid(propSchema, value)) {
-      continue;
-    }
-
-    const narrowed = asAnswerValue(value);
-    if (narrowed === undefined) {
-      continue;
-    }
-    answers[key] = narrowed;
+  if (!wrapper.success) {
+    return { answers: {}, rationales: {} };
   }
 
-  return { answers, rationales };
-}
+  const { answers: rawAnswers, rationales } = wrapper.data;
 
-/**
- * Read a numeric answer for a criterion. Returns `undefined` when the key is
- * absent or the stored value isn't a number — callers don't need to repeat
- * the `typeof value === 'number'` check.
- */
-export function readRubricNumber(
-  answers: Record<string, RubricAnswerValue>,
-  key: string,
-): number | undefined {
-  const value = answers[key];
-  return typeof value === 'number' ? value : undefined;
-}
+  if (template && !schemaValidator.validate(template, rawAnswers).valid) {
+    return { answers: {}, rationales };
+  }
 
-/**
- * Read a string answer for a criterion. Returns `undefined` when the key is
- * absent or the stored value isn't a string.
- */
-export function readRubricString(
-  answers: Record<string, RubricAnswerValue>,
-  key: string,
-): string | undefined {
-  const value = answers[key];
-  return typeof value === 'string' ? value : undefined;
+  const narrowed = rubricAnswersSchema.safeParse(rawAnswers);
+  return {
+    answers: narrowed.success ? narrowed.data : {},
+    rationales,
+  };
 }


### PR DESCRIPTION
Kills the ad-hoc cast and Number()/String() coercions on stored rubric answers in the admin aggregates path (and the submitted-review view) by routing reads through a single Ajv-backed parser.