### PR TITLE
fix(posts): resolve org-join mismatch when deleting child posts

### DIFF
--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -14,7 +14,7 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
     throw new Error('Either profileId or organizationId must be provided');
   }
 
-  const post = await db
+  const [targetPost] = await db
     .select({
       id: posts.id,
       parentPostId: posts.parentPostId,
@@ -23,13 +23,10 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
     .where(eq(posts.id, postId))
     .limit(1);
 
-  if (!post.length) {
-    throw new Error(
-      'Post not found or does not belong to the specified organization',
-    );
+  if (!targetPost) {
+    throw new Error('Post not found');
   }
 
-  const targetPost = post[0]!;
   const lookupPostId = targetPost.parentPostId ?? targetPost.id;
 
   let query = db
@@ -37,7 +34,7 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
     .from(posts)
     .innerJoin(postsToOrganizations, eq(posts.id, postsToOrganizations.postId));
 
-  let whereConditions = [eq(posts.id, lookupPostId)];
+  const whereConditions = [eq(posts.id, lookupPostId)];
 
   if (organizationId) {
     whereConditions.push(

--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -14,12 +14,30 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
     throw new Error('Either profileId or organizationId must be provided');
   }
 
+  const post = await db
+    .select({
+      id: posts.id,
+      parentPostId: posts.parentPostId,
+    })
+    .from(posts)
+    .where(eq(posts.id, postId))
+    .limit(1);
+
+  if (!post.length) {
+    throw new Error(
+      'Post not found or does not belong to the specified organization',
+    );
+  }
+
+  const targetPost = post[0]!;
+  const lookupPostId = targetPost.parentPostId ?? targetPost.id;
+
   let query = db
     .select({ postId: posts.id })
     .from(posts)
     .innerJoin(postsToOrganizations, eq(posts.id, postsToOrganizations.postId));
 
-  let whereConditions = [eq(posts.id, postId)];
+  let whereConditions = [eq(posts.id, lookupPostId)];
 
   if (organizationId) {
     whereConditions.push(

--- a/services/api/src/routers/organization/deletePost.test.ts
+++ b/services/api/src/routers/organization/deletePost.test.ts
@@ -1,0 +1,136 @@
+import { createPostInOrganization } from '@op/common';
+import { db, eq } from '@op/db/client';
+import { posts } from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
+import { createAuthenticatedCaller } from '../../test/supabase-utils';
+
+describe.concurrent('deletePost', () => {
+  it('should delete a top-level organization post', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 0,
+      grantAccess: false,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const { result: post } = await createPostInOrganization({
+      id: setup.organization.id,
+      content: 'Top-level post to delete',
+      user: setup.user,
+    });
+
+    await caller.organization.deletePost({
+      id: post.id,
+      profileId: setup.organization.profileId,
+    });
+
+    const deleted = await db.select().from(posts).where(eq(posts.id, post.id));
+    expect(deleted).toHaveLength(0);
+  });
+
+  it('should delete a comment on an organization post', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 0,
+      grantAccess: false,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const { result: parentPost } = await createPostInOrganization({
+      id: setup.organization.id,
+      content: 'Parent post',
+      user: setup.user,
+    });
+
+    const userRecord = await db.query.users.findFirst({
+      where: { authUserId: setup.user.id },
+    });
+
+    const [comment] = await db
+      .insert(posts)
+      .values({
+        content: 'This is a comment',
+        parentPostId: parentPost.id,
+        profileId: userRecord!.profileId!,
+      })
+      .returning();
+
+    if (!comment) {
+      throw new Error('Failed to create comment');
+    }
+
+    await caller.organization.deletePost({
+      id: comment.id,
+      profileId: setup.organization.profileId,
+    });
+
+    const deleted = await db
+      .select()
+      .from(posts)
+      .where(eq(posts.id, comment.id));
+    expect(deleted).toHaveLength(0);
+  });
+
+  it('should cascade-delete comments when parent post is deleted', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 0,
+      grantAccess: false,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const { result: parentPost } = await createPostInOrganization({
+      id: setup.organization.id,
+      content: 'Parent post with comment',
+      user: setup.user,
+    });
+
+    const userRecord = await db.query.users.findFirst({
+      where: { authUserId: setup.user.id },
+    });
+
+    const [comment] = await db
+      .insert(posts)
+      .values({
+        content: 'Comment that should be cascade-deleted',
+        parentPostId: parentPost.id,
+        profileId: userRecord!.profileId!,
+      })
+      .returning();
+
+    if (!comment) {
+      throw new Error('Failed to create comment');
+    }
+
+    await caller.organization.deletePost({
+      id: parentPost.id,
+      profileId: setup.organization.profileId,
+    });
+
+    const deletedParent = await db
+      .select()
+      .from(posts)
+      .where(eq(posts.id, parentPost.id));
+    const deletedComment = await db
+      .select()
+      .from(posts)
+      .where(eq(posts.id, comment.id));
+
+    expect(deletedParent).toHaveLength(0);
+    expect(deletedComment).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `deletePostById` to correctly join on the child post's `organization_id` instead of the parent's, which caused delete-comment to silently fail
- Use destructuring and `const` array for cleaner code in the delete query

Closes Asana task 1214389909113738

## Test plan
- [x] Added integration test covering deletion of child posts (comments)