### PR TITLE
feat(analytics): add tracking events for manual transitions

### DIFF
--- a/apps/app/src/components/decisions/DecisionProcessStepper.tsx
+++ b/apps/app/src/components/decisions/DecisionProcessStepper.tsx
@@ -10,7 +10,8 @@ import { type Phase, PhaseStepper } from '@op/ui/PhaseStepper';
 import { Sheet, SheetBody } from '@op/ui/Sheet';
 import { toast } from '@op/ui/Toast';
 import { useLocale } from 'next-intl';
-import { useMemo, useState } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { useRouter, useTranslations } from '@/lib/i18n';
 
@@ -41,6 +42,7 @@ export function DecisionProcessStepper({
     [translation],
   );
 
+  const posthog = usePostHog();
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const isMobile = useMediaQuery(`(max-width: ${screens.sm})`);
 
@@ -62,6 +64,7 @@ export function DecisionProcessStepper({
     currentPhaseName,
     nextPhaseName,
     currentPhaseAdvancement,
+    currentPhaseEndDate,
   } = useMemo(() => {
     const idx = phases.findIndex((p) => p.id === currentStateId);
     const nextId =
@@ -77,6 +80,8 @@ export function DecisionProcessStepper({
         : '',
       currentPhaseAdvancement:
         idx >= 0 ? phases[idx]!.advancementMethod : undefined,
+      currentPhaseEndDate:
+        idx >= 0 ? phases[idx]!.phase?.endDate : undefined,
     };
   }, [phases, currentStateId, translatedPhaseNames]);
 
@@ -111,10 +116,23 @@ export function DecisionProcessStepper({
     ],
   );
 
+  const trackingProps = useCallback(
+    () => ({
+      process_instance_id: instanceId,
+      from_phase_id: currentStateId,
+      to_phase_id: nextPhaseId,
+      before_end_date: currentPhaseEndDate
+        ? new Date() < new Date(currentPhaseEndDate)
+        : null,
+    }),
+    [instanceId, currentStateId, nextPhaseId, currentPhaseEndDate],
+  );
+
   const handleAdvancePhase = () => {
     if (!instanceId || transitionMutation.isPending) {
       return;
     }
+    posthog.capture('manual_transition_confirmed', trackingProps());
     transitionMutation.mutate({
       instanceId,
       fromPhaseId: currentStateId,
@@ -123,6 +141,7 @@ export function DecisionProcessStepper({
 
   const handleDismiss = (open: boolean) => {
     if (!open && !transitionMutation.isPending) {
+      posthog.capture('manual_transition_dismissed', trackingProps());
       setShowConfirmModal(false);
     }
   };
@@ -140,7 +159,17 @@ export function DecisionProcessStepper({
         currentPhaseId={currentStateId}
         className={className}
         locale={locale}
-        onTransition={isAdmin ? () => setShowConfirmModal(true) : undefined}
+        onTransition={
+          isAdmin
+            ? () => {
+                posthog.capture(
+                  'manual_transition_initiated',
+                  trackingProps(),
+                );
+                setShowConfirmModal(true);
+              }
+            : undefined
+        }
       />
 
       {isMobile ? (

--- a/apps/app/src/components/decisions/DecisionProcessStepper.tsx
+++ b/apps/app/src/components/decisions/DecisionProcessStepper.tsx
@@ -131,7 +131,6 @@ export function DecisionProcessStepper({
     if (!instanceId || transitionMutation.isPending) {
       return;
     }
-    posthog.capture('manual_transition_confirmed', getTrackingProps());
     transitionMutation.mutate({
       instanceId,
       fromPhaseId: currentStateId,

--- a/apps/app/src/components/decisions/DecisionProcessStepper.tsx
+++ b/apps/app/src/components/decisions/DecisionProcessStepper.tsx
@@ -11,7 +11,7 @@ import { Sheet, SheetBody } from '@op/ui/Sheet';
 import { toast } from '@op/ui/Toast';
 import { useLocale } from 'next-intl';
 import { usePostHog } from 'posthog-js/react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useRouter, useTranslations } from '@/lib/i18n';
 
@@ -44,6 +44,7 @@ export function DecisionProcessStepper({
 
   const posthog = usePostHog();
   const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const transitionInitiatedRef = useRef(false);
   const isMobile = useMediaQuery(`(max-width: ${screens.sm})`);
 
   const transitionMutation = trpc.decision.transitionFromPhase.useMutation({
@@ -67,20 +68,18 @@ export function DecisionProcessStepper({
     currentPhaseEndDate,
   } = useMemo(() => {
     const idx = phases.findIndex((p) => p.id === currentStateId);
-    const nextId =
-      idx >= 0 && idx < phases.length - 1 ? phases[idx + 1]!.id : undefined;
+    const currentPhase = idx >= 0 ? phases[idx] : undefined;
+    const nextPhase = idx >= 0 ? phases[idx + 1] : undefined;
     return {
-      nextPhaseId: nextId,
-      currentPhaseName:
-        idx >= 0
-          ? (translatedPhaseNames?.get(phases[idx]!.id) ?? phases[idx]!.name)
-          : '',
-      nextPhaseName: nextId
-        ? (translatedPhaseNames?.get(nextId) ?? phases[idx + 1]!.name)
+      nextPhaseId: nextPhase?.id,
+      currentPhaseName: currentPhase
+        ? (translatedPhaseNames?.get(currentPhase.id) ?? currentPhase.name)
         : '',
-      currentPhaseAdvancement:
-        idx >= 0 ? phases[idx]!.advancementMethod : undefined,
-      currentPhaseEndDate: idx >= 0 ? phases[idx]!.phase?.endDate : undefined,
+      nextPhaseName: nextPhase
+        ? (translatedPhaseNames?.get(nextPhase.id) ?? nextPhase.name)
+        : '',
+      currentPhaseAdvancement: currentPhase?.advancementMethod,
+      currentPhaseEndDate: currentPhase?.phase?.endDate,
     };
   }, [phases, currentStateId, translatedPhaseNames]);
 
@@ -121,7 +120,7 @@ export function DecisionProcessStepper({
       from_phase_id: currentStateId,
       to_phase_id: nextPhaseId,
       before_end_date: currentPhaseEndDate
-        ? new Date() < new Date(currentPhaseEndDate)
+        ? isBeforeEndOfDayLocal(new Date(), currentPhaseEndDate)
         : null,
     }),
     [instanceId, currentStateId, nextPhaseId, currentPhaseEndDate],
@@ -131,6 +130,7 @@ export function DecisionProcessStepper({
     if (!instanceId || transitionMutation.isPending) {
       return;
     }
+    transitionInitiatedRef.current = true;
     transitionMutation.mutate({
       instanceId,
       fromPhaseId: currentStateId,
@@ -139,7 +139,9 @@ export function DecisionProcessStepper({
 
   const handleDismiss = (open: boolean) => {
     if (!open && !transitionMutation.isPending) {
-      posthog.capture('manual_transition_dismissed', getTrackingProps());
+      if (!transitionInitiatedRef.current) {
+        posthog.capture('manual_transition_dismissed', getTrackingProps());
+      }
       setShowConfirmModal(false);
     }
   };
@@ -160,6 +162,7 @@ export function DecisionProcessStepper({
         onTransition={
           isAdmin
             ? () => {
+                transitionInitiatedRef.current = false;
                 posthog.capture(
                   'manual_transition_initiated',
                   getTrackingProps(),
@@ -231,4 +234,25 @@ export function DecisionProcessStepper({
       )}
     </>
   );
+}
+
+// Phase end dates are persisted as ISO datetimes representing local midnight on
+// the deadline day (see PhaseDetailPage formatDateValue). The deadline conceptually
+// covers the entire day, so "before end date" must compare against the end of the
+// stored day in local time, not its midnight start.
+function isBeforeEndOfDayLocal(now: Date, endDate: string): boolean {
+  const parsed = new Date(endDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return false;
+  }
+  const endOfDayLocal = new Date(
+    parsed.getFullYear(),
+    parsed.getMonth(),
+    parsed.getDate() + 1,
+    0,
+    0,
+    0,
+    0,
+  );
+  return now < endOfDayLocal;
 }

--- a/apps/app/src/components/decisions/DecisionProcessStepper.tsx
+++ b/apps/app/src/components/decisions/DecisionProcessStepper.tsx
@@ -80,8 +80,7 @@ export function DecisionProcessStepper({
         : '',
       currentPhaseAdvancement:
         idx >= 0 ? phases[idx]!.advancementMethod : undefined,
-      currentPhaseEndDate:
-        idx >= 0 ? phases[idx]!.phase?.endDate : undefined,
+      currentPhaseEndDate: idx >= 0 ? phases[idx]!.phase?.endDate : undefined,
     };
   }, [phases, currentStateId, translatedPhaseNames]);
 
@@ -116,7 +115,7 @@ export function DecisionProcessStepper({
     ],
   );
 
-  const trackingProps = useCallback(
+  const getTrackingProps = useCallback(
     () => ({
       process_instance_id: instanceId,
       from_phase_id: currentStateId,
@@ -132,7 +131,7 @@ export function DecisionProcessStepper({
     if (!instanceId || transitionMutation.isPending) {
       return;
     }
-    posthog.capture('manual_transition_confirmed', trackingProps());
+    posthog.capture('manual_transition_confirmed', getTrackingProps());
     transitionMutation.mutate({
       instanceId,
       fromPhaseId: currentStateId,
@@ -141,7 +140,7 @@ export function DecisionProcessStepper({
 
   const handleDismiss = (open: boolean) => {
     if (!open && !transitionMutation.isPending) {
-      posthog.capture('manual_transition_dismissed', trackingProps());
+      posthog.capture('manual_transition_dismissed', getTrackingProps());
       setShowConfirmModal(false);
     }
   };
@@ -164,7 +163,7 @@ export function DecisionProcessStepper({
             ? () => {
                 posthog.capture(
                   'manual_transition_initiated',
-                  trackingProps(),
+                  getTrackingProps(),
                 );
                 setShowConfirmModal(true);
               }

--- a/apps/app/src/components/decisions/ManualSelectionList.tsx
+++ b/apps/app/src/components/decisions/ManualSelectionList.tsx
@@ -109,6 +109,35 @@ export const ManualSelectionList = ({
     },
   });
 
+  const handleConfirmDialogOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        posthog.capture('manual_selection_dialog_opened', {
+          process_instance_id: instanceId,
+          proposal_count: selectedIds.length,
+        });
+      } else if (!submitMutation.isPending) {
+        posthog.capture('manual_selection_dialog_dismissed', {
+          process_instance_id: instanceId,
+          proposal_count: selectedIds.length,
+        });
+      }
+      setIsConfirmOpen(open);
+    },
+    [instanceId, selectedIds.length, submitMutation.isPending, posthog],
+  );
+
+  const handleConfirmSelection = useCallback(() => {
+    posthog.capture('manual_selection_dialog_confirmed', {
+      process_instance_id: instanceId,
+      proposal_count: selectedIds.length,
+    });
+    submitMutation.mutate({
+      processInstanceId: instanceId,
+      proposalIds: selectedIds,
+    });
+  }, [instanceId, selectedIds, submitMutation, posthog]);
+
   if (candidatesQuery.isError) {
     return (
       <EmptyState icon={<LuTriangleAlert className="size-6" />}>
@@ -145,35 +174,6 @@ export const ManualSelectionList = ({
       </EmptyState>
     );
   }
-
-  const handleConfirmDialogOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        posthog.capture('manual_selection_dialog_opened', {
-          process_instance_id: instanceId,
-          proposal_count: selectedIds.length,
-        });
-      } else if (!submitMutation.isPending) {
-        posthog.capture('manual_selection_dialog_dismissed', {
-          process_instance_id: instanceId,
-          proposal_count: selectedIds.length,
-        });
-      }
-      setIsConfirmOpen(open);
-    },
-    [instanceId, selectedIds.length, submitMutation.isPending, posthog],
-  );
-
-  const handleConfirmSelection = useCallback(() => {
-    posthog.capture('manual_selection_dialog_confirmed', {
-      process_instance_id: instanceId,
-      proposal_count: selectedIds.length,
-    });
-    submitMutation.mutate({
-      processInstanceId: instanceId,
-      proposalIds: selectedIds,
-    });
-  }, [instanceId, selectedIds, submitMutation, posthog]);
 
   const toggleProposal = (proposalId: string) => {
     setSelectedIds(

--- a/apps/app/src/components/decisions/ManualSelectionList.tsx
+++ b/apps/app/src/components/decisions/ManualSelectionList.tsx
@@ -9,7 +9,8 @@ import { EmptyState } from '@op/ui/EmptyState';
 import { FooterBar } from '@op/ui/FooterBar';
 import { Header3 } from '@op/ui/Header';
 import { toast } from '@op/ui/Toast';
-import { useEffect, useMemo, useState } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { LuLeaf, LuTriangleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
@@ -34,6 +35,7 @@ export const ManualSelectionList = ({
 }: ManualSelectionListProps) => {
   const t = useTranslations();
   const { user } = useUser();
+  const posthog = usePostHog();
 
   const [selectedCategory, setSelectedCategory] = useState('all-categories');
   const [sortOrder, setSortOrder] = useState<'newest' | 'oldest'>('newest');
@@ -144,6 +146,35 @@ export const ManualSelectionList = ({
     );
   }
 
+  const handleConfirmDialogOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        posthog.capture('manual_selection_dialog_opened', {
+          process_instance_id: instanceId,
+          proposal_count: selectedIds.length,
+        });
+      } else if (!submitMutation.isPending) {
+        posthog.capture('manual_selection_dialog_dismissed', {
+          process_instance_id: instanceId,
+          proposal_count: selectedIds.length,
+        });
+      }
+      setIsConfirmOpen(open);
+    },
+    [instanceId, selectedIds.length, submitMutation.isPending, posthog],
+  );
+
+  const handleConfirmSelection = useCallback(() => {
+    posthog.capture('manual_selection_dialog_confirmed', {
+      process_instance_id: instanceId,
+      proposal_count: selectedIds.length,
+    });
+    submitMutation.mutate({
+      processInstanceId: instanceId,
+      proposalIds: selectedIds,
+    });
+  }, [instanceId, selectedIds, submitMutation, posthog]);
+
   const toggleProposal = (proposalId: string) => {
     setSelectedIds(
       selectedIds.includes(proposalId)
@@ -199,18 +230,13 @@ export const ManualSelectionList = ({
         <FooterBar.End>
           <SelectionConfirmDialog
             isOpen={isConfirmOpen}
-            onOpenChange={setIsConfirmOpen}
+            onOpenChange={handleConfirmDialogOpenChange}
             proposals={selectedProposals}
             count={numSelected}
             phaseName={currentPhaseName}
             triggerDisabled={numSelected === 0}
             isSubmitting={submitMutation.isPending}
-            onConfirm={() =>
-              submitMutation.mutate({
-                processInstanceId: instanceId,
-                proposalIds: selectedIds,
-              })
-            }
+            onConfirm={handleConfirmSelection}
           />
         </FooterBar.End>
       </FooterBar>

--- a/apps/app/src/components/decisions/ManualSelectionList.tsx
+++ b/apps/app/src/components/decisions/ManualSelectionList.tsx
@@ -10,7 +10,7 @@ import { FooterBar } from '@op/ui/FooterBar';
 import { Header3 } from '@op/ui/Header';
 import { toast } from '@op/ui/Toast';
 import { usePostHog } from 'posthog-js/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LuLeaf, LuTriangleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
@@ -62,6 +62,7 @@ export const ManualSelectionList = ({
     instance.currentStateId ?? '',
   );
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const submissionInitiatedRef = useRef(false);
 
   // Resolve selected ids → proposals via a cache that accumulates across
   // refetches, so picks survive filter/sort changes that exclude them.
@@ -112,11 +113,12 @@ export const ManualSelectionList = ({
   const handleConfirmDialogOpenChange = useCallback(
     (open: boolean) => {
       if (open) {
+        submissionInitiatedRef.current = false;
         posthog.capture('manual_selection_dialog_opened', {
           process_instance_id: instanceId,
           proposal_count: selectedIds.length,
         });
-      } else if (!submitMutation.isPending) {
+      } else if (!submitMutation.isPending && !submissionInitiatedRef.current) {
         posthog.capture('manual_selection_dialog_dismissed', {
           process_instance_id: instanceId,
           proposal_count: selectedIds.length,
@@ -128,6 +130,7 @@ export const ManualSelectionList = ({
   );
 
   const handleConfirmSelection = useCallback(() => {
+    submissionInitiatedRef.current = true;
     posthog.capture('manual_selection_dialog_confirmed', {
       process_instance_id: instanceId,
       proposal_count: selectedIds.length,

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -10,6 +10,7 @@ import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
 import { useQueryState } from 'nuqs';
+import { usePostHog } from 'posthog-js/react';
 import { useRef, useState } from 'react';
 import { LuTrash2 } from 'react-icons/lu';
 
@@ -75,6 +76,7 @@ function PhaseDetailForm({
   onDelete: () => void;
 }) {
   const t = useTranslations();
+  const posthog = usePostHog();
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   const instancePhases = instance.instanceData?.phases;
   const templatePhases = instance.process?.processSchema?.phases;
@@ -318,8 +320,14 @@ function PhaseDetailForm({
               value={safeParseLocal(phase.endDate)}
               minValue={safeParseLocal(phase.startDate)}
               onChange={(date) => {
-                updatePhase({ endDate: formatDateValue(date) });
+                const newEndDate = formatDateValue(date);
+                updatePhase({ endDate: newEndDate });
                 markTouched('endDate');
+                posthog.capture('phase_end_date_changed', {
+                  process_instance_id: instanceId,
+                  phase_id: phaseId,
+                  new_end_date: newEndDate,
+                });
               }}
               errorMessage={getErrorMessage('endDate')}
             />

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -10,7 +10,6 @@ import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
 import { useQueryState } from 'nuqs';
-import { usePostHog } from 'posthog-js/react';
 import { useRef, useState } from 'react';
 import { LuTrash2 } from 'react-icons/lu';
 
@@ -76,7 +75,6 @@ function PhaseDetailForm({
   onDelete: () => void;
 }) {
   const t = useTranslations();
-  const posthog = usePostHog();
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   const instancePhases = instance.instanceData?.phases;
   const templatePhases = instance.process?.processSchema?.phases;
@@ -320,14 +318,8 @@ function PhaseDetailForm({
               value={safeParseLocal(phase.endDate)}
               minValue={safeParseLocal(phase.startDate)}
               onChange={(date) => {
-                const newEndDate = formatDateValue(date);
-                updatePhase({ endDate: newEndDate });
+                updatePhase({ endDate: formatDateValue(date) });
                 markTouched('endDate');
-                posthog.capture('phase_end_date_changed', {
-                  process_instance_id: instanceId,
-                  phase_id: phaseId,
-                  new_end_date: newEndDate,
-                });
               }}
               errorMessage={getErrorMessage('endDate')}
             />

--- a/packages/analytics/src/testing.ts
+++ b/packages/analytics/src/testing.ts
@@ -111,31 +111,13 @@ export async function trackUserVoted(
   _additionalProps?: Record<string, any>,
 ): Promise<void> {}
 
-export async function trackManualTransitionInitiated(
-  _userId: string,
-  _processId: string,
-  _additionalProps?: Record<string, any>,
-): Promise<void> {}
-
 export async function trackManualTransitionConfirmed(
   _userId: string,
   _processId: string,
   _additionalProps?: Record<string, any>,
 ): Promise<void> {}
 
-export async function trackManualTransitionDismissed(
-  _userId: string,
-  _processId: string,
-  _additionalProps?: Record<string, any>,
-): Promise<void> {}
-
 export async function trackManualSelectionSubmitted(
-  _userId: string,
-  _processId: string,
-  _additionalProps?: Record<string, any>,
-): Promise<void> {}
-
-export async function trackPhaseEndDateChanged(
   _userId: string,
   _processId: string,
   _additionalProps?: Record<string, any>,

--- a/packages/analytics/src/testing.ts
+++ b/packages/analytics/src/testing.ts
@@ -111,6 +111,36 @@ export async function trackUserVoted(
   _additionalProps?: Record<string, any>,
 ): Promise<void> {}
 
+export async function trackManualTransitionInitiated(
+  _userId: string,
+  _processId: string,
+  _additionalProps?: Record<string, any>,
+): Promise<void> {}
+
+export async function trackManualTransitionConfirmed(
+  _userId: string,
+  _processId: string,
+  _additionalProps?: Record<string, any>,
+): Promise<void> {}
+
+export async function trackManualTransitionDismissed(
+  _userId: string,
+  _processId: string,
+  _additionalProps?: Record<string, any>,
+): Promise<void> {}
+
+export async function trackManualSelectionSubmitted(
+  _userId: string,
+  _processId: string,
+  _additionalProps?: Record<string, any>,
+): Promise<void> {}
+
+export async function trackPhaseEndDateChanged(
+  _userId: string,
+  _processId: string,
+  _additionalProps?: Record<string, any>,
+): Promise<void> {}
+
 export type {
   AnalyticsEvent,
   AnalyticsIdentify,

--- a/packages/analytics/src/testing.ts
+++ b/packages/analytics/src/testing.ts
@@ -123,6 +123,12 @@ export async function trackManualSelectionSubmitted(
   _additionalProps?: Record<string, any>,
 ): Promise<void> {}
 
+export async function trackPhaseEndDateChanged(
+  _userId: string,
+  _processId: string,
+  _additionalProps?: Record<string, any>,
+): Promise<void> {}
+
 export type {
   AnalyticsEvent,
   AnalyticsIdentify,

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -405,18 +405,6 @@ export async function trackUserVoted(
  * Manual transition analytics
  */
 
-export async function trackManualTransitionInitiated(
-  userId: string,
-  processId: string,
-  additionalProps?: Record<string, any>,
-): Promise<void> {
-  await trackEventWithContext(
-    userId,
-    'manual_transition_initiated',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
-  );
-}
-
 export async function trackManualTransitionConfirmed(
   userId: string,
   processId: string,
@@ -429,18 +417,6 @@ export async function trackManualTransitionConfirmed(
   );
 }
 
-export async function trackManualTransitionDismissed(
-  userId: string,
-  processId: string,
-  additionalProps?: Record<string, any>,
-): Promise<void> {
-  await trackEventWithContext(
-    userId,
-    'manual_transition_dismissed',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
-  );
-}
-
 export async function trackManualSelectionSubmitted(
   userId: string,
   processId: string,
@@ -449,18 +425,6 @@ export async function trackManualSelectionSubmitted(
   await trackEventWithContext(
     userId,
     'manual_selection_submitted',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
-  );
-}
-
-export async function trackPhaseEndDateChanged(
-  userId: string,
-  processId: string,
-  additionalProps?: Record<string, any>,
-): Promise<void> {
-  await trackEventWithContext(
-    userId,
-    'phase_end_date_changed',
     getDecisionCommonProperties(processId, undefined, additionalProps),
   );
 }

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -400,3 +400,67 @@ export async function trackUserVoted(
     }),
   });
 }
+
+/**
+ * Manual transition analytics
+ */
+
+export async function trackManualTransitionInitiated(
+  userId: string,
+  processId: string,
+  additionalProps?: Record<string, any>,
+): Promise<void> {
+  await trackEventWithContext(
+    userId,
+    'manual_transition_initiated',
+    getDecisionCommonProperties(processId, undefined, additionalProps),
+  );
+}
+
+export async function trackManualTransitionConfirmed(
+  userId: string,
+  processId: string,
+  additionalProps?: Record<string, any>,
+): Promise<void> {
+  await trackEventWithContext(
+    userId,
+    'manual_transition_confirmed',
+    getDecisionCommonProperties(processId, undefined, additionalProps),
+  );
+}
+
+export async function trackManualTransitionDismissed(
+  userId: string,
+  processId: string,
+  additionalProps?: Record<string, any>,
+): Promise<void> {
+  await trackEventWithContext(
+    userId,
+    'manual_transition_dismissed',
+    getDecisionCommonProperties(processId, undefined, additionalProps),
+  );
+}
+
+export async function trackManualSelectionSubmitted(
+  userId: string,
+  processId: string,
+  additionalProps?: Record<string, any>,
+): Promise<void> {
+  await trackEventWithContext(
+    userId,
+    'manual_selection_submitted',
+    getDecisionCommonProperties(processId, undefined, additionalProps),
+  );
+}
+
+export async function trackPhaseEndDateChanged(
+  userId: string,
+  processId: string,
+  additionalProps?: Record<string, any>,
+): Promise<void> {
+  await trackEventWithContext(
+    userId,
+    'phase_end_date_changed',
+    getDecisionCommonProperties(processId, undefined, additionalProps),
+  );
+}

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -428,3 +428,15 @@ export async function trackManualSelectionSubmitted(
     getDecisionCommonProperties(processId, undefined, additionalProps),
   );
 }
+
+export async function trackPhaseEndDateChanged(
+  userId: string,
+  processId: string,
+  additionalProps?: Record<string, any>,
+): Promise<void> {
+  await trackEventWithContext(
+    userId,
+    'phase_end_date_changed',
+    getDecisionCommonProperties(processId, undefined, additionalProps),
+  );
+}

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -84,6 +84,14 @@ export const updateDecisionInstance = async ({
     schemaValidator.validateJsonSchema(proposalTemplate);
   }
 
+  // Phases whose endDate actually changed — emitted to the caller so it can
+  // fire `phase_end_date_changed` analytics events for committed changes only.
+  const phaseEndDateChanges: Array<{
+    phaseId: string;
+    previousEndDate: string | undefined;
+    newEndDate: string;
+  }> = [];
+
   // Validate rubricTemplate is a structurally valid JSON Schema before persisting
   if (rubricTemplate !== undefined) {
     schemaValidator.validateJsonSchema(rubricTemplate);
@@ -165,6 +173,20 @@ export const updateDecisionInstance = async ({
         existingInstanceData.phases.map((p) => [p.phaseId, p]),
       );
 
+      for (const phase of phases) {
+        if (phase.endDate === undefined) {
+          continue;
+        }
+        const existing = existingPhaseMap.get(phase.phaseId);
+        if (existing && existing.endDate !== phase.endDate) {
+          phaseEndDateChanges.push({
+            phaseId: phase.phaseId,
+            previousEndDate: existing.endDate,
+            newEndDate: phase.endDate,
+          });
+        }
+      }
+
       updatedInstanceData.phases = phases.map((phase) => {
         const existing = existingPhaseMap.get(phase.phaseId);
         return {
@@ -219,7 +241,7 @@ export const updateDecisionInstance = async ({
       throw new CommonError('Failed to fetch decision profile');
     }
 
-    return profile;
+    return { profile, phaseEndDateChanges };
   }
 
   const isBeingPublished =
@@ -329,7 +351,7 @@ export const updateDecisionInstance = async ({
       // Use the first invite's inviter as the sender
       const firstInvite = queuedInvites[0];
       if (!firstInvite) {
-        return;
+        return { profile, phaseEndDateChanges };
       }
       const senderProfileId = firstInvite.invitedBy;
 
@@ -345,5 +367,5 @@ export const updateDecisionInstance = async ({
     }
   }
 
-  return profile;
+  return { profile, phaseEndDateChanges };
 };

--- a/services/api/src/routers/decision/instances/submitManualSelection.ts
+++ b/services/api/src/routers/decision/instances/submitManualSelection.ts
@@ -1,7 +1,9 @@
 import { Channels, submitManualSelection } from '@op/common';
+import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
 import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { trackManualSelectionSubmitted } from '../../../utils/analytics';
 
 const submitManualSelectionInputSchema = z.object({
   processInstanceId: z.uuid(),
@@ -21,5 +23,11 @@ export const submitManualSelectionRouter = router({
       ctx.registerMutationChannels([
         Channels.decisionInstance(input.processInstanceId),
       ]);
+
+      waitUntil(
+        trackManualSelectionSubmitted(ctx, input.processInstanceId, {
+          proposal_count: input.proposalIds.length,
+        }),
+      );
     }),
 });

--- a/services/api/src/routers/decision/instances/transitionFromPhase.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.ts
@@ -1,7 +1,9 @@
 import { Channels, triggerPhaseAdvancement } from '@op/common';
+import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
 import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { trackManualTransitionConfirmed } from '../../../utils/analytics';
 
 export const transitionFromPhaseRouter = router({
   transitionFromPhase: commonAuthedProcedure()
@@ -27,6 +29,13 @@ export const transitionFromPhaseRouter = router({
       ctx.registerMutationChannels([
         Channels.decisionInstance(input.instanceId),
       ]);
+
+      waitUntil(
+        trackManualTransitionConfirmed(ctx, input.instanceId, {
+          from_phase_id: result.previousPhaseId,
+          to_phase_id: result.currentPhaseId,
+        }),
+      );
 
       return result;
     }),

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.ts
@@ -1,4 +1,6 @@
+import { trackPhaseEndDateChanged } from '@op/analytics';
 import { Channels, updateDecisionInstance } from '@op/common';
+import { waitUntil } from '@vercel/functions';
 
 import {
   decisionProfileWithSchemaEncoder,
@@ -13,7 +15,7 @@ export const updateDecisionInstanceRouter = router({
     .mutation(async ({ ctx, input }) => {
       const { user } = ctx;
 
-      const profile = await updateDecisionInstance({
+      const { profile, phaseEndDateChanges } = await updateDecisionInstance({
         ...input,
         user,
       });
@@ -21,6 +23,16 @@ export const updateDecisionInstanceRouter = router({
       ctx.registerMutationChannels([
         Channels.decisionInstance(input.instanceId),
       ]);
+
+      for (const change of phaseEndDateChanges) {
+        waitUntil(
+          trackPhaseEndDateChanged(ctx.user.id, input.instanceId, {
+            phase_id: change.phaseId,
+            previous_end_date: change.previousEndDate,
+            new_end_date: change.newEndDate,
+          }),
+        );
+      }
 
       return decisionProfileWithSchemaEncoder.parse(profile);
     }),

--- a/services/api/src/utils/analytics.ts
+++ b/services/api/src/utils/analytics.ts
@@ -2,6 +2,8 @@ import {
   trackEventWithContext,
   trackFundingToggle as trackFundingToggleOriginal,
   trackImageUpload as trackImageUploadOriginal,
+  trackManualSelectionSubmitted as trackManualSelectionSubmittedOriginal,
+  trackManualTransitionConfirmed as trackManualTransitionConfirmedOriginal,
   trackProcessViewed as trackProcessViewedOriginal,
   trackProposalCommented as trackProposalCommentedOriginal,
   trackProposalFollowed as trackProposalFollowedOriginal,
@@ -168,6 +170,36 @@ export const trackFundingToggle = (
   },
 ) => {
   return trackFundingToggleOriginal(organizationContext, fundingStatus);
+};
+
+/**
+ * Track manual selection submission with automatic context injection
+ */
+export const trackManualSelectionSubmitted = (
+  ctx: AnalyticsContext,
+  processId: string,
+  additionalProps?: Record<string, any>,
+) => {
+  return trackManualSelectionSubmittedOriginal(
+    ctx.user.id,
+    processId,
+    additionalProps,
+  );
+};
+
+/**
+ * Track manual transition confirmed with automatic context injection
+ */
+export const trackManualTransitionConfirmed = (
+  ctx: AnalyticsContext,
+  processId: string,
+  additionalProps?: Record<string, any>,
+) => {
+  return trackManualTransitionConfirmedOriginal(
+    ctx.user.id,
+    processId,
+    additionalProps,
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add client-side tracking events for manual phase transitions and manual selection submissions
- Add server-side analytics utilities for tracking decision transition and manual selection events
- Add analytics testing helpers for validating tracking calls

Closes Asana task 1214044834439694