### PR TITLE
fix(auth): redirect SSO callback errors to /login

### DIFF
--- a/apps/app/src/app/api/auth/callback/route.ts
+++ b/apps/app/src/app/api/auth/callback/route.ts
@@ -15,7 +15,9 @@ export const GET = async (request: NextRequest) => {
   // On successful verification, always redirect the user to the app
   const useUrl = OPURLConfig('APP');
 
-  const errorRedirect = request.nextUrl.clone().origin;
+  // Errors are surfaced by LoginPanel via the `?error=` query param. Sending
+  // them to the bare origin landed unauthed users on a page with no error UI.
+  const errorRedirect = new URL('/login', request.nextUrl.origin).toString();
 
   if (code) {
     const supabase = await createSBServerClient();


### PR DESCRIPTION
- Bare-origin error redirects landed unauthed users on a route with no error UI
- LoginPanel already reads `?error=` from the query string — point at `/login` so the message renders
- 3-line change; minimal diff for the P0 hotfix

Splits PR #1093 — see `chore/auth-callback-trpc-client` and `feat/login-error-ux` for the rest of that work, both stacked on this branch.