### PR TITLE
feat(auth): typed error UX for SSO sign-in

### DIFF
--- a/apps/app/src/app/api/auth/callback/route.ts
+++ b/apps/app/src/app/api/auth/callback/route.ts
@@ -2,22 +2,55 @@
  * This route is used to handle the callback from OAuth providers.
  */
 import { createClient } from '@op/api/serverClient';
+import { UnauthorizedError, ValidationError } from '@op/common';
 import { isSafeRedirectPath } from '@op/common/client';
 import { OPURLConfig } from '@op/core';
+import { logger } from '@op/logging';
 import { createSBServerClient } from '@op/supabase/server';
+import { TRPCError } from '@trpc/server';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+
+import type { LoginErrorCode } from '@/lib/auth/loginError';
+
+const buildErrorRedirect = (
+  request: NextRequest,
+  code: LoginErrorCode,
+  redirectPath: string | null,
+) => {
+  const url = new URL('/login', request.nextUrl.origin);
+  url.searchParams.set('error', code);
+  if (isSafeRedirectPath(redirectPath)) {
+    url.searchParams.set('redirect', redirectPath);
+  }
+  return NextResponse.redirect(url);
+};
+
+const unwrapCause = (error: unknown): unknown =>
+  error instanceof TRPCError ? error.cause : error;
+
+const classifyLoginError = (error: unknown): LoginErrorCode => {
+  const cause = unwrapCause(error);
+  if (cause instanceof UnauthorizedError) {
+    return 'not_invited';
+  }
+  if (cause instanceof ValidationError) {
+    return 'invalid_email';
+  }
+  return 'unknown';
+};
+
+const errorFields = (error: unknown) => ({
+  name: error instanceof Error ? error.name : undefined,
+  message: error instanceof Error ? error.message : String(error),
+});
 
 export const GET = async (request: NextRequest) => {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get('code');
+  const redirectPath = searchParams.get('redirect');
 
-  // On successful verification, always redirect the user to the app
   const useUrl = OPURLConfig('APP');
-
-  // Errors are surfaced by LoginPanel via the `?error=` query param. Sending
-  // them to the bare origin landed unauthed users on a page with no error UI.
-  const errorRedirect = new URL('/login', request.nextUrl.origin).toString();
 
   if (code) {
     const supabase = await createSBServerClient();
@@ -26,48 +59,41 @@ export const GET = async (request: NextRequest) => {
       await supabase.auth.exchangeCodeForSession(code);
 
     if (error) {
-      console.error(error);
-
-      // return the user to an error page with some instructions
-      return NextResponse.redirect(
-        `${errorRedirect}?error=${error.message || 'There was an error signing you in.'}`,
-      );
+      logger.error('[auth/callback] oauth exchange failed', {
+        ...errorFields(error),
+        code: error.code,
+        status: error.status,
+      });
+      return buildErrorRedirect(request, 'oauth_failed', redirectPath);
     }
 
-    if (authData.user?.email) {
-      // Check if the user is allowed to login
-      // Note: User and profile are automatically created by database trigger
-      // when Supabase creates the auth.users record
-      try {
-        const client = await createClient();
-        await client.account.login({
-          email: authData.user.email,
-          usingOAuth: true,
-        });
-      } catch (error) {
-        // If the user is not invited or not registered, sign them out
-        await supabase.auth.signOut();
-
-        if (error instanceof Error) {
-          return NextResponse.redirect(
-            `${errorRedirect}?error=${error.message}`,
-          );
-        }
-
-        return NextResponse.redirect(
-          `${errorRedirect}?error=${'Unable to verify your email address. Please try again.'}`,
-        );
-      }
-    } else {
+    if (!authData.user?.email) {
       await supabase.auth.signOut();
+      return buildErrorRedirect(request, 'no_email', redirectPath);
+    }
 
-      return NextResponse.redirect(
-        `${errorRedirect}?error=${'Unable to verify your email address. Please try again.'}`,
-      );
+    try {
+      const client = await createClient();
+      await client.account.login({
+        email: authData.user.email,
+        usingOAuth: true,
+      });
+    } catch (loginError) {
+      const errorCode = classifyLoginError(loginError);
+      if (errorCode === 'unknown') {
+        const cause = unwrapCause(loginError);
+        logger.error('[auth/callback] login query failed', {
+          ...errorFields(loginError),
+          causeName: cause instanceof Error ? cause.name : undefined,
+          causeMessage: cause instanceof Error ? cause.message : undefined,
+        });
+      }
+      // Clear the partial Supabase session so the user isn't left
+      // half-authenticated after an allow-list rejection.
+      await supabase.auth.signOut();
+      return buildErrorRedirect(request, errorCode, redirectPath);
     }
   }
-
-  const redirectPath = searchParams.get('redirect');
 
   if (isSafeRedirectPath(redirectPath)) {
     return NextResponse.redirect(new URL(redirectPath, useUrl.ENV_URL));

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -4,6 +4,7 @@ import { trpc } from '@op/api/client';
 import { useAuthUser } from '@op/hooks';
 import { useRouter } from 'next/navigation';
 
+import { OAuthHashErrorHandler } from '@/components/OAuthHashErrorHandler';
 import { ComingSoonScreen } from '@/components/screens/ComingSoon/ComingSoonScreen';
 
 const MainPage = () => {
@@ -23,7 +24,11 @@ const MainPage = () => {
     }
   }
 
-  return null;
+  // Only mounted at `/` because Supabase's Site URL config points here, so
+  // OAuth provider-side errors (e.g. user cancels Google consent) land on
+  // this route with the error in the URL fragment. If Site URL ever moves,
+  // mount this handler at the new location too.
+  return <OAuthHashErrorHandler />;
 };
 
 export default MainPage;

--- a/apps/app/src/components/LoginPanel.tsx
+++ b/apps/app/src/components/LoginPanel.tsx
@@ -19,6 +19,7 @@ import { FcGoogle as GoogleIcon } from 'react-icons/fc';
 import { z } from 'zod';
 import { create } from 'zustand';
 
+import { isLoginErrorCode, loginErrorMessages } from '@/lib/auth/loginError';
 import { useTranslations } from '@/lib/i18n';
 
 import { CommonLogo } from './CommonLogo';
@@ -64,9 +65,17 @@ export const LoginPanel = () => {
 
   const { mounted } = useMount();
   const searchParams = useSearchParams();
-  const error = searchParams.get('error');
+  const rawErrorCode = searchParams.get('error');
+  const errorCode = isLoginErrorCode(rawErrorCode)
+    ? rawErrorCode
+    : rawErrorCode
+      ? 'unknown'
+      : null;
+  const errorDescription = searchParams.get('error_description');
   const isSignup = searchParams.get('signup');
   const redirectParam = searchParams.get('redirect');
+
+  const urlErrorMessage = errorCode ? loginErrorMessages[errorCode] : undefined;
 
   const {
     email,
@@ -117,7 +126,11 @@ export const LoginPanel = () => {
     },
   );
 
-  const combinedError = (login.error?.message || error) ?? undefined;
+  const combinedError = login.error?.message || urlErrorMessage;
+  const isInviteRelatedError =
+    errorCode === 'not_invited' ||
+    combinedError?.includes('invite') ||
+    combinedError?.includes('waitlist');
 
   const emailParser = z.email();
 
@@ -145,91 +158,83 @@ export const LoginPanel = () => {
 
   if (!mounted) return null;
 
+  const isOffline = user?.error?.name === 'AuthRetryableFetchError';
+  const hasError = login.isError || combinedError || tokenError;
+  const errorMessage =
+    combinedError || tokenError || t('There was an error signing you in.');
+  const showDescription = !!errorDescription && !tokenError;
+
+  const headerContent = isOffline ? (
+    t('Connection issue')
+  ) : hasError ? (
+    isInviteRelatedError ? (
+      t('Stay tuned!')
+    ) : (
+      t('Oops!')
+    )
+  ) : !loginSuccess ? (
+    isSignup ? (
+      t('Sign up to {appName}', { appName: APP_NAME })
+    ) : (
+      <div className="flex flex-col gap-2">
+        <span className="sm:text-base">{t('Welcome to')}</span>
+        <span>
+          <CommonLogo className="h-8 w-auto" />
+        </span>
+      </div>
+    )
+  ) : (
+    <div className="flex flex-col items-center justify-center gap-4">
+      <CheckIcon />
+      <span className="text-title-base sm:text-title-lg">
+        {t('Email sent!')}
+      </span>
+    </div>
+  );
+
+  const bodyContent = isOffline ? (
+    t(
+      "{appName} can't connect to the internet. Please check your internet connection and try again.",
+      { appName: APP_NAME },
+    )
+  ) : hasError ? (
+    showDescription ? (
+      <div
+        className={cn(
+          'flex flex-col gap-2',
+          tokenError && 'text-functional-red',
+        )}
+      >
+        <span>{errorMessage}</span>
+        <span className="text-sm text-neutral-gray4">{errorDescription}</span>
+      </div>
+    ) : (
+      <span className={cn(tokenError && 'text-functional-red')}>
+        {errorMessage}
+      </span>
+    )
+  ) : !loginSuccess ? (
+    t(
+      'Connect with aligned organizations and funders building a new economy together',
+    )
+  ) : (
+    <span>
+      {t('A code was sent to {email}. Type the code below to sign in.', {
+        email,
+      })}
+    </span>
+  );
+
   // TODO: using a tailwind v4 class here "min-w-xs"
   return (
     <div className="flex items-center justify-center sm:block">
       <div className="z-[999999] max-h-full w-auto min-w-xs rounded-lg border-offWhite bg-white bg-clip-padding px-4 py-8 font-sans text-neutral-gray4 xs:w-96 sm:border-0">
         <div className="flex flex-col gap-12 sm:gap-8">
           <section className="flex flex-col items-center justify-center gap-2 sm:gap-4">
-            <Header1 className="text-center">
-              {user?.error?.name === 'AuthRetryableFetchError'
-                ? t('Connection issue')
-                : (() => {
-                    if (login.isError || error || tokenError) {
-                      if (
-                        combinedError?.includes('invite') ||
-                        combinedError?.includes('waitlist')
-                      ) {
-                        return t('Stay tuned!');
-                      }
-
-                      return t('Oops!');
-                    }
-
-                    if (!loginSuccess) {
-                      if (isSignup) {
-                        return t('Sign up to {appName}', {
-                          appName: APP_NAME,
-                        });
-                      }
-
-                      return (
-                        <div className="flex flex-col gap-2">
-                          <span className="sm:text-base">
-                            {t('Welcome to')}
-                          </span>
-                          <span>
-                            <CommonLogo className="h-8 w-auto" />
-                          </span>
-                        </div>
-                      );
-                    }
-
-                    return (
-                      <div className="flex flex-col items-center justify-center gap-4">
-                        <CheckIcon />
-                        <span className="text-title-base sm:text-title-lg">
-                          {t('Email sent!')}
-                        </span>
-                      </div>
-                    );
-                  })()}
-            </Header1>
+            <Header1 className="text-center">{headerContent}</Header1>
 
             <div className="px-4 text-center text-sm leading-[130%] text-neutral-gray4 sm:text-base">
-              {user?.error?.name === 'AuthRetryableFetchError'
-                ? t(
-                    "{appName} can't connect to the internet. Please check your internet connection and try again.",
-                    { appName: APP_NAME },
-                  )
-                : (() => {
-                    if (combinedError || tokenError) {
-                      return (
-                        <span
-                          className={cn(tokenError && 'text-functional-red')}
-                        >
-                          {combinedError ||
-                            tokenError ||
-                            t('There was an error signing you in.')}
-                        </span>
-                      );
-                    }
-
-                    if (!loginSuccess) {
-                      return t(
-                        'Connect with aligned organizations and funders building a new economy together',
-                      );
-                    }
-
-                    return (
-                      <span>
-                        {t(
-                          'A code was sent to {email}. Type the code below to sign in.',
-                          { email },
-                        )}
-                      </span>
-                    );
-                  })()}
+              {bodyContent}
             </div>
           </section>
 

--- a/apps/app/src/components/OAuthHashErrorHandler.tsx
+++ b/apps/app/src/components/OAuthHashErrorHandler.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { logger } from '@op/logging';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import type { LoginErrorCode } from '@/lib/auth/loginError';
+
+/**
+ * Supabase OAuth surfaces provider-side errors (e.g. user cancelled the
+ * Google consent screen) by redirecting to the configured Site URL with the
+ * error in the URL fragment, not the query string. The browser never sends
+ * the fragment to the server, so the callback route can't see it.
+ * This client effect parses the fragment and routes the user to /login with
+ * a typed error code and the provider's description so the LoginPanel can
+ * render a real error UI.
+ */
+export const OAuthHashErrorHandler = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const hash = window.location.hash;
+    if (!hash) {
+      return;
+    }
+    const params = new URLSearchParams(
+      hash.startsWith('#') ? hash.slice(1) : hash,
+    );
+    // `sb` is Supabase's marker on OAuth-error redirects. Gating on it avoids
+    // colliding with regular in-page anchor links that happen to contain
+    // "error".
+    if (!params.has('sb')) {
+      return;
+    }
+    const providerError = params.get('error');
+    if (!providerError) {
+      return;
+    }
+    const providerErrorCode = params.get('error_code');
+    const providerErrorDescription = params.get('error_description');
+
+    logger.error('[oauth] provider returned error', {
+      error: providerError,
+      error_code: providerErrorCode,
+      error_description: providerErrorDescription,
+    });
+
+    const code: LoginErrorCode =
+      providerError === 'access_denied' ? 'oauth_cancelled' : 'oauth_failed';
+    const target = new URL('/login', window.location.origin);
+    target.searchParams.set('error', code);
+    if (providerErrorDescription) {
+      target.searchParams.set('error_description', providerErrorDescription);
+    }
+    router.replace(`${target.pathname}${target.search}`);
+  }, [router]);
+
+  return null;
+};

--- a/apps/app/src/lib/auth/loginError.ts
+++ b/apps/app/src/lib/auth/loginError.ts
@@ -1,0 +1,28 @@
+import { APP_NAME } from '@op/core';
+
+export const LOGIN_ERROR_CODES = [
+  'not_invited',
+  'invalid_email',
+  'oauth_cancelled',
+  'oauth_failed',
+  'no_email',
+  'unknown',
+] as const;
+
+export type LoginErrorCode = (typeof LOGIN_ERROR_CODES)[number];
+
+export const isLoginErrorCode = (value: unknown): value is LoginErrorCode =>
+  typeof value === 'string' &&
+  (LOGIN_ERROR_CODES as readonly string[]).includes(value);
+
+export const loginErrorMessages: Record<LoginErrorCode, string> = {
+  not_invited: `${APP_NAME} is invite-only. You’re now on the waitlist — keep an eye on your inbox for updates.`,
+  invalid_email:
+    'We couldn’t read the email on your account. Please try a different sign-in method.',
+  oauth_cancelled: 'Sign-in was cancelled. Please try again.',
+  oauth_failed:
+    'We couldn’t complete sign-in with your provider. Please try again.',
+  no_email:
+    'Your account didn’t share an email address. Please try a different sign-in method.',
+  unknown: 'There was an error signing you in.',
+};

--- a/tests/e2e/tests/login-error-ux.spec.ts
+++ b/tests/e2e/tests/login-error-ux.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '../fixtures/index.js';
+
+// LoginPanel only renders for unauthed users; the worker-scoped fixture in
+// auth.ts auto-authenticates the default `page`, so opt out for this describe.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('Login error UX', () => {
+  test('renders waitlist UI for not_invited code', async ({ page }) => {
+    await page.goto('/login?error=not_invited');
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Stay tuned/ }),
+    ).toBeVisible();
+    await expect(page.getByText(/invite-only/i)).toBeVisible();
+    await expect(page.getByText(/waitlist/i)).toBeVisible();
+  });
+
+  test('renders Oops UI with cancelled copy for oauth_cancelled', async ({
+    page,
+  }) => {
+    await page.goto('/login?error=oauth_cancelled');
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Oops/ }),
+    ).toBeVisible();
+    await expect(page.getByText(/cancelled/i)).toBeVisible();
+  });
+
+  test('renders Oops UI with provider copy for oauth_failed', async ({
+    page,
+  }) => {
+    await page.goto('/login?error=oauth_failed');
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Oops/ }),
+    ).toBeVisible();
+    await expect(page.getByText(/sign-in with your provider/i)).toBeVisible();
+  });
+
+  test('falls back to generic copy for unrecognized error codes', async ({
+    page,
+  }) => {
+    await page.goto('/login?error=totally_made_up_code');
+
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Oops/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/There was an error signing you in/i),
+    ).toBeVisible();
+  });
+
+  test('surfaces error_description as a sub-message when present', async ({
+    page,
+  }) => {
+    const description = 'The provider returned a custom failure detail.';
+    await page.goto(
+      `/login?error=oauth_failed&error_description=${encodeURIComponent(description)}`,
+    );
+
+    await expect(page.getByText(/sign-in with your provider/i)).toBeVisible();
+    await expect(page.getByText(description)).toBeVisible();
+  });
+
+  test('hash handler routes Supabase OAuth-error fragment to /login', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/#error=access_denied&error_description=User+denied+the+request&sb=',
+    );
+
+    await expect(page).toHaveURL(/\/login\?error=oauth_cancelled/, {
+      timeout: 10000,
+    });
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Oops/ }),
+    ).toBeVisible();
+    await expect(page.getByText(/cancelled/i)).toBeVisible();
+  });
+
+  test('hash handler ignores fragments without the Supabase sb marker', async ({
+    page,
+  }) => {
+    await page.goto('/#error=something&error_description=anchor+collision');
+
+    // No redirect — we should stay on / (homepage / landing)
+    await page.waitForTimeout(1500);
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+
+  test('hash handler ignores plain in-page anchor links', async ({ page }) => {
+    await page.goto('/#section-2');
+
+    await page.waitForTimeout(1500);
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+});


### PR DESCRIPTION
- Stable error codes (`not_invited`, `oauth_cancelled`, `oauth_failed`, `no_email`, `invalid_email`, `unknown`) shared across the callback route, hash handler, and `LoginPanel`
- New `OAuthHashErrorHandler` on `/` to catch provider-side errors that Supabase puts in the URL fragment (e.g. user cancels Google consent)
- `LoginPanel` maps codes to copy and surfaces `error_description` as a sub-message when present
- Structured `logger.error` (`@op/logging`) with code, status, name, message
- Playwright e2e covers each error code's UI, the `error_description` sub-message, and the hash handler's bounce + anchor-collision guard