### PR TITLE
fix(invites): redirect decision invite emails to process page

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/invite/route.ts
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/invite/route.ts
@@ -1,0 +1,24 @@
+import { createClient } from '@op/api/serverClient';
+import { OPURLConfig } from '@op/core';
+import { NextResponse } from 'next/server';
+
+export const GET = async (
+  _request: Request,
+  {
+    params,
+  }: {
+    params: Promise<{ locale: string; slug: string }>;
+  },
+) => {
+  const { slug } = await params;
+  const decisionUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${slug}`;
+
+  try {
+    const client = await createClient();
+    await client.decision.acceptDecisionInvite({ slug });
+  } catch {
+    // Redirect to the decision page and let the natural access error occur
+  }
+
+  return NextResponse.redirect(decisionUrl);
+};

--- a/packages/common/src/services/decision/acceptDecisionInvite.ts
+++ b/packages/common/src/services/decision/acceptDecisionInvite.ts
@@ -1,0 +1,93 @@
+import { db, eq } from '@op/db/client';
+import {
+  profileInvites,
+  profileUserToAccessRoles,
+  profileUsers,
+} from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+
+import {
+  CommonError,
+  ConflictError,
+  NotFoundError,
+  UnauthorizedError,
+} from '../../utils/error';
+import { assertProfileBySlug } from '../assert';
+
+export const acceptDecisionInvite = async ({
+  profileId,
+  slug,
+  user,
+}: {
+  profileId?: string;
+  slug?: string;
+  user: User;
+}) => {
+  const email = user.email;
+  if (!email) {
+    throw new UnauthorizedError('User must have an email address');
+  }
+
+  let resolvedProfileId = profileId;
+  if (!resolvedProfileId) {
+    if (!slug) {
+      throw new CommonError('Either profileId or slug must be provided');
+    }
+    const profile = await assertProfileBySlug(slug);
+    resolvedProfileId = profile.id;
+  }
+
+  const invite = await db.query.profileInvites.findFirst({
+    where: {
+      profileId: resolvedProfileId,
+      email: email.toLowerCase(),
+      acceptedOn: { isNull: true },
+    },
+  });
+
+  if (!invite) {
+    throw new NotFoundError('No pending invite found for this decision');
+  }
+
+  if (invite.acceptedOn) {
+    throw new ConflictError('This invite has already been accepted');
+  }
+
+  const existingMembership = await db.query.profileUsers.findFirst({
+    where: { profileId: invite.profileId, authUserId: user.id },
+  });
+
+  if (existingMembership) {
+    throw new CommonError('You are already a member of this profile');
+  }
+
+  const profileUser = await db.transaction(async (tx) => {
+    const [newProfileUser] = await tx
+      .insert(profileUsers)
+      .values({
+        authUserId: user.id,
+        profileId: invite.profileId,
+        email,
+      })
+      .returning();
+
+    if (!newProfileUser) {
+      throw new CommonError('Failed to create profile user');
+    }
+
+    await Promise.all([
+      tx.insert(profileUserToAccessRoles).values({
+        profileUserId: newProfileUser.id,
+        accessRoleId: invite.accessRoleId,
+      }),
+      tx
+        .update(profileInvites)
+        .set({ acceptedOn: new Date().toISOString() })
+        .where(eq(profileInvites.id, invite.id)),
+    ]);
+
+    return newProfileUser;
+  });
+
+  return { profileUser };
+};

--- a/packages/common/src/services/decision/acceptDecisionInvite.ts
+++ b/packages/common/src/services/decision/acceptDecisionInvite.ts
@@ -8,7 +8,6 @@ import type { User } from '@op/supabase/lib';
 
 import {
   CommonError,
-  ConflictError,
   NotFoundError,
   UnauthorizedError,
 } from '../../utils/error';
@@ -47,10 +46,6 @@ export const acceptDecisionInvite = async ({
 
   if (!invite) {
     throw new NotFoundError('No pending invite found for this decision');
-  }
-
-  if (invite.acceptedOn) {
-    throw new ConflictError('This invite has already been accepted');
   }
 
   const existingMembership = await db.query.profileUsers.findFirst({

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -38,7 +38,8 @@ export * from './getResultsStats';
 // Selection pipeline
 export * from './selectionPipeline';
 
-// Proposal invites
+// Invites
+export * from './acceptDecisionInvite';
 export * from './acceptProposalInvite';
 
 // Proposal management

--- a/packages/common/src/services/profile/inviteUsersToProfile.ts
+++ b/packages/common/src/services/profile/inviteUsersToProfile.ts
@@ -237,11 +237,13 @@ export const inviteUsersToProfile = async ({
   const profileName = profile.name;
   const baseUrl = OPURLConfig('APP').ENV_URL;
 
-  // Build the full invite URL for proposal profiles
+  // Build the full invite URL based on profile type
   let inviteUrl = baseUrl;
   const decisionSlug = proposalWithDecision?.processInstance?.profile?.slug;
   if (profile.type === 'proposal' && decisionSlug) {
     inviteUrl = `${baseUrl}/decisions/${decisionSlug}/proposal/${profileId}/invite`;
+  } else if (profile.type === 'decision' && profile.slug) {
+    inviteUrl = `${baseUrl}/decisions/${profile.slug}/invite`;
   }
 
   const usersByEmail = new Map(

--- a/services/api/src/routers/decision/instances/acceptDecisionInvite.test.ts
+++ b/services/api/src/routers/decision/instances/acceptDecisionInvite.test.ts
@@ -1,0 +1,204 @@
+import { db } from '@op/db/client';
+import { EntityType, profileInvites } from '@op/db/schema';
+import { ROLES } from '@op/db/seedData/accessControl';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import { TestProfileUserDataManager } from '../../../test/helpers/TestProfileUserDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+describe.concurrent('decision.acceptDecisionInvite', () => {
+  it('should add user as member of the decision process when accepting a decision invite', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const profileData = new TestProfileUserDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const invitee = await profileData.createStandaloneUser();
+
+    const [invite] = await db
+      .insert(profileInvites)
+      .values({
+        email: invitee.email,
+        profileId: instance.profileId,
+        profileEntityType: EntityType.DECISION,
+        accessRoleId: ROLES.MEMBER.id,
+        invitedBy: setup.organization.profileId,
+      })
+      .returning();
+
+    if (!invite) {
+      throw new Error('Failed to create invite');
+    }
+
+    profileData.trackProfileInvite(invitee.email, instance.profileId);
+
+    const caller = await createAuthenticatedCaller(invitee.email);
+    await caller.decision.acceptDecisionInvite({
+      profileId: instance.profileId,
+    });
+
+    const decisionProfileUser = await db.query.profileUsers.findFirst({
+      where: {
+        profileId: instance.profileId,
+        authUserId: invitee.authUserId,
+      },
+      with: {
+        roles: {
+          with: { accessRole: true },
+        },
+      },
+    });
+
+    expect(decisionProfileUser).toBeDefined();
+    expect(decisionProfileUser?.roles).toHaveLength(1);
+    expect(decisionProfileUser?.roles[0]?.accessRole.id).toBe(ROLES.MEMBER.id);
+
+    const updatedInvite = await db.query.profileInvites.findFirst({
+      where: { id: invite.id },
+    });
+    expect(updatedInvite?.acceptedOn).not.toBeNull();
+  });
+
+  it('should fail when invite does not exist', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const profileData = new TestProfileUserDataManager(task.id, onTestFinished);
+    const invitee = await profileData.createStandaloneUser();
+
+    const caller = await createAuthenticatedCaller(invitee.email);
+
+    await expect(
+      caller.decision.acceptDecisionInvite({
+        profileId: '00000000-0000-0000-0000-000000000000',
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'NotFoundError' },
+    });
+  });
+
+  it('should fail when invite is already accepted', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const profileData = new TestProfileUserDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const invitee = await profileData.createStandaloneUser();
+
+    const [invite] = await db
+      .insert(profileInvites)
+      .values({
+        email: invitee.email,
+        profileId: instance.profileId,
+        profileEntityType: EntityType.DECISION,
+        accessRoleId: ROLES.MEMBER.id,
+        invitedBy: setup.organization.profileId,
+        acceptedOn: new Date().toISOString(),
+      })
+      .returning();
+
+    if (!invite) {
+      throw new Error('Failed to create invite');
+    }
+
+    profileData.trackProfileInvite(invitee.email, instance.profileId);
+
+    const caller = await createAuthenticatedCaller(invitee.email);
+
+    await expect(
+      caller.decision.acceptDecisionInvite({
+        profileId: instance.profileId,
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'NotFoundError' },
+    });
+  });
+
+  it('should fail when user is already a member of the decision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const profileData = new TestProfileUserDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const invitee = await profileData.createStandaloneUser();
+    await testData.grantProfileAccess(
+      instance.profileId,
+      invitee.authUserId,
+      invitee.email,
+      false,
+    );
+
+    const [invite] = await db
+      .insert(profileInvites)
+      .values({
+        email: invitee.email,
+        profileId: instance.profileId,
+        profileEntityType: EntityType.DECISION,
+        accessRoleId: ROLES.MEMBER.id,
+        invitedBy: setup.organization.profileId,
+      })
+      .returning();
+
+    if (!invite) {
+      throw new Error('Failed to create invite');
+    }
+
+    profileData.trackProfileInvite(invitee.email, instance.profileId);
+
+    const caller = await createAuthenticatedCaller(invitee.email);
+
+    await expect(
+      caller.decision.acceptDecisionInvite({
+        profileId: instance.profileId,
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'CommonError' },
+    });
+  });
+});

--- a/services/api/src/routers/decision/instances/acceptDecisionInvite.ts
+++ b/services/api/src/routers/decision/instances/acceptDecisionInvite.ts
@@ -1,0 +1,24 @@
+import { invalidate } from '@op/cache';
+import { acceptDecisionInvite } from '@op/common';
+import { waitUntil } from '@vercel/functions';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const acceptDecisionInviteRouter = router({
+  acceptDecisionInvite: commonAuthedProcedure()
+    .input(
+      z.union([
+        z.object({ profileId: z.string().uuid() }),
+        z.object({ slug: z.string() }),
+      ]),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await acceptDecisionInvite({
+        ...input,
+        user: ctx.user,
+      });
+
+      waitUntil(invalidate({ type: 'user', params: [ctx.user.id] }));
+    }),
+});

--- a/services/api/src/routers/decision/instances/index.ts
+++ b/services/api/src/routers/decision/instances/index.ts
@@ -1,4 +1,5 @@
 import { mergeRouters } from '../../../trpcFactory';
+import { acceptDecisionInviteRouter } from './acceptDecisionInvite';
 import { createInstanceFromTemplateRouter } from './createInstanceFromTemplate';
 import { deleteDecisionRouter } from './deleteDecision';
 import { duplicateInstanceRouter } from './duplicateInstance';
@@ -14,6 +15,7 @@ import { transitionFromPhaseRouter } from './transitionFromPhase';
 import { updateDecisionInstanceRouter } from './updateDecisionInstance';
 
 export const instancesRouter = mergeRouters(
+  acceptDecisionInviteRouter,
   createInstanceFromTemplateRouter,
   deleteDecisionRouter,
   duplicateInstanceRouter,


### PR DESCRIPTION
## Summary
- Add `acceptDecisionInvite` service that accepts a decision invite and returns the decision slug
- Add `/decisions/[slug]/invite` API route that accepts the invite and redirects to the process page
- Wire up tRPC `acceptDecisionInvite` mutation for client-side invite acceptance
- Remove unreachable `acceptedOn` guard in `acceptDecisionInvite` service

Closes Asana task 1213980970950662

## Test plan
- Accept a decision invite from an email link and verify redirect lands on the process page, not the homepage
- Verify already-accepted invites still redirect correctly
- Run `acceptDecisionInvite` integration tests