### PR TITLE
feat(decisions): add defaultProposalsHidden config

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSectionForm.tsx
@@ -28,6 +28,7 @@ const createOverviewValidator = (t: TranslateFn) =>
     organizeByCategories: z.boolean(),
     requireCollaborativeProposals: z.boolean(),
     isPrivate: z.boolean(),
+    defaultProposalsHidden: z.boolean(),
   });
 
 // Form data type
@@ -113,6 +114,7 @@ export function OverviewSectionForm({
         organizeByCategories: values.organizeByCategories,
         requireCollaborativeProposals: values.requireCollaborativeProposals,
         isPrivate: values.isPrivate,
+        defaultProposalsHidden: values.defaultProposalsHidden,
       },
     });
   };
@@ -134,6 +136,8 @@ export function OverviewSectionForm({
       requireCollaborativeProposals:
         instanceData?.config?.requireCollaborativeProposals ?? false,
       isPrivate: instanceData?.config?.isPrivate ?? false,
+      defaultProposalsHidden:
+        instanceData?.config?.defaultProposalsHidden ?? false,
     },
     validators: {
       onBlur: createOverviewValidator(t),
@@ -313,6 +317,24 @@ export function OverviewSectionForm({
                   <field.ToggleButton
                     isSelected={!field.state.value}
                     onChange={(value) => field.handleChange(!value)}
+                    size="small"
+                  />
+                </ToggleRow>
+              )}
+            />
+
+            <form.AppField
+              name="defaultProposalsHidden"
+              children={(field) => (
+                <ToggleRow
+                  label={t('Hide proposals by default')}
+                  description={t(
+                    'New proposals are hidden from other participants until an admin makes them visible.',
+                  )}
+                >
+                  <field.ToggleButton
+                    isSelected={field.state.value}
+                    onChange={field.handleChange}
                     size="small"
                   />
                 </ToggleRow>

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -639,6 +639,8 @@
   "Only invited members can view and participate in this process": "শুধুমাত্র আমন্ত্রিত সদস্যরা এই প্রক্রিয়া দেখতে এবং অংশগ্রহণ করতে পারেন",
   "Open for learning": "শেখার জন্য খোলা",
   "Anyone on Common can view this process. Only invited participants can submit.": "Common-এ যে কেউ এই প্রক্রিয়াটি দেখতে পারে। শুধুমাত্র আমন্ত্রিত অংশগ্রহণকারীরা জমা দিতে পারে।",
+  "Hide proposals by default": "ডিফল্টভাবে প্রস্তাব লুকান",
+  "New proposals are hidden from other participants until an admin makes them visible.": "নতুন প্রস্তাবগুলি অন্য অংশগ্রহণকারীদের কাছ থেকে লুকানো থাকে যতক্ষণ না একজন প্রশাসক সেগুলি দৃশ্যমান করেন।",
   "Process Overview": "প্রক্রিয়া সংক্ষেপ",
   "Organize proposals into categories": "প্রস্তাবগুলি বিভাগে সংগঠিত করুন",
   "Group proposals into categories for better organization and evaluation.": "ভালো সংগঠন এবং মূল্যায়নের জন্য প্রস্তাবগুলি বিভাগে গোষ্ঠীবদ্ধ করুন।",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -639,6 +639,8 @@
   "Only invited members can view and participate in this process": "Only invited members can view and participate in this process",
   "Open for learning": "Open for learning",
   "Anyone on Common can view this process. Only invited participants can submit.": "Anyone on Common can view this process. Only invited participants can submit.",
+  "Hide proposals by default": "Hide proposals by default",
+  "New proposals are hidden from other participants until an admin makes them visible.": "New proposals are hidden from other participants until an admin makes them visible.",
   "Process Overview": "Process Overview",
   "Organize proposals into categories": "Organize proposals into categories",
   "Group proposals into categories for better organization and evaluation.": "Group proposals into categories for better organization and evaluation.",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -637,6 +637,8 @@
   "Only invited members can view and participate in this process": "Solo los miembros invitados pueden ver y participar en este proceso",
   "Open for learning": "Abierto para aprender",
   "Anyone on Common can view this process. Only invited participants can submit.": "Cualquiera en Common puede ver este proceso. Solo los participantes invitados pueden enviar.",
+  "Hide proposals by default": "Ocultar propuestas por defecto",
+  "New proposals are hidden from other participants until an admin makes them visible.": "Las nuevas propuestas están ocultas para otros participantes hasta que un administrador las haga visibles.",
   "Process Overview": "Resumen del proceso",
   "Organize proposals into categories": "Organizar propuestas en categorías",
   "Group proposals into categories for better organization and evaluation.": "Agrupar propuestas en categorías para una mejor organización y evaluación.",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -638,6 +638,8 @@
   "Only invited members can view and participate in this process": "Seuls les membres invités peuvent voir et participer à ce processus",
   "Open for learning": "Ouvert pour l'apprentissage",
   "Anyone on Common can view this process. Only invited participants can submit.": "N'importe qui sur Common peut voir ce processus. Seuls les participants invités peuvent soumettre.",
+  "Hide proposals by default": "Masquer les propositions par défaut",
+  "New proposals are hidden from other participants until an admin makes them visible.": "Les nouvelles propositions sont masquées aux autres participants jusqu'à ce qu'un administrateur les rende visibles.",
   "Process Overview": "Aperçu du processus",
   "Organize proposals into categories": "Organiser les propositions en catégories",
   "Group proposals into categories for better organization and evaluation.": "Regrouper les propositions en catégories pour une meilleure organisation et évaluation.",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -638,6 +638,8 @@
   "Only invited members can view and participate in this process": "Apenas membros convidados podem ver e participar deste processo",
   "Open for learning": "Aberto para aprendizado",
   "Anyone on Common can view this process. Only invited participants can submit.": "Qualquer pessoa no Common pode ver este processo. Apenas participantes convidados podem enviar.",
+  "Hide proposals by default": "Ocultar propostas por padrão",
+  "New proposals are hidden from other participants until an admin makes them visible.": "Novas propostas ficam ocultas para outros participantes até que um administrador as torne visíveis.",
   "Process Overview": "Visão geral do processo",
   "Organize proposals into categories": "Organizar propostas em categorias",
   "Group proposals into categories for better organization and evaluation.": "Agrupar propostas em categorias para melhor organização e avaliação.",

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -73,6 +73,7 @@ export interface ProcessConfig {
   organizeByCategories?: boolean;
   requireCollaborativeProposals?: boolean;
   isPrivate?: boolean;
+  defaultProposalsHidden?: boolean;
   reviewsPolicy?: ReviewsPolicy;
   reviewsAllowRevisions?: boolean;
   reviewsAnonymousFeedback?: boolean;

--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -1,6 +1,11 @@
 import { getTipTapClient } from '@op/collab';
 import { db, eq } from '@op/db/client';
-import { type ProcessInstance, ProposalStatus, proposals } from '@op/db/schema';
+import {
+  type ProcessInstance,
+  ProposalStatus,
+  Visibility,
+  proposals,
+} from '@op/db/schema';
 import { assertAccess, permission } from 'access-zones';
 
 import { CommonError, NotFoundError, ValidationError } from '../../utils';
@@ -119,6 +124,8 @@ export const submitProposal = async ({
       return null;
     });
 
+  const defaultHidden = instanceData.config?.defaultProposalsHidden === true;
+
   // Update proposal status to submitted and re-query with profile
   const updatedProposal = await db.transaction(async (tx) => {
     const proposalDataUpdate =
@@ -133,6 +140,7 @@ export const submitProposal = async ({
       .update(proposals)
       .set({
         status: ProposalStatus.SUBMITTED,
+        ...(defaultHidden ? { visibility: Visibility.HIDDEN } : {}),
         ...(proposalDataUpdate ? { proposalData: proposalDataUpdate } : {}),
       })
       .where(eq(proposals.id, data.proposalId))

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -171,6 +171,7 @@ const processConfigEncoder = z.object({
   organizeByCategories: z.boolean().optional(),
   requireCollaborativeProposals: z.boolean().optional(),
   isPrivate: z.boolean().optional(),
+  defaultProposalsHidden: z.boolean().optional(),
   reviewsPolicy: reviewsPolicyEncoder.optional(),
   reviewsAllowRevisions: z.boolean().optional(),
   reviewsAnonymousFeedback: z.boolean().optional(),

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -796,6 +796,33 @@ describe.concurrent('submitProposal', () => {
   });
 });
 
+const hiddenDefaultSchema = {
+  id: 'hidden-default-schema',
+  version: '1.0.0',
+  name: 'Hidden Default Schema',
+  config: { defaultProposalsHidden: true },
+  phases: [
+    {
+      id: 'initial',
+      name: 'Initial Phase',
+      rules: {
+        proposals: { submit: true },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'final',
+      name: 'Final Phase',
+      rules: {
+        proposals: { submit: false },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+  ],
+};
+
 describe.concurrent('submitProposal defaultProposalsHidden', () => {
   it('should set visibility to HIDDEN when defaultProposalsHidden config is enabled', async ({
     task,
@@ -806,32 +833,7 @@ describe.concurrent('submitProposal defaultProposalsHidden', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 1,
       grantAccess: true,
-      processSchema: {
-        id: 'hidden-default-schema',
-        version: '1.0.0',
-        name: 'Hidden Default Schema',
-        config: { defaultProposalsHidden: true },
-        phases: [
-          {
-            id: 'initial',
-            name: 'Initial Phase',
-            rules: {
-              proposals: { submit: true },
-              voting: { submit: false },
-              advancement: { method: 'manual' as const },
-            },
-          },
-          {
-            id: 'final',
-            name: 'Final Phase',
-            rules: {
-              proposals: { submit: false },
-              voting: { submit: false },
-              advancement: { method: 'manual' as const },
-            },
-          },
-        ],
-      },
+      processSchema: hiddenDefaultSchema,
     });
 
     const instance = setup.instances[0];
@@ -896,32 +898,7 @@ describe.concurrent('submitProposal defaultProposalsHidden', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 1,
       grantAccess: true,
-      processSchema: {
-        id: 'hidden-default-schema',
-        version: '1.0.0',
-        name: 'Hidden Default Schema',
-        config: { defaultProposalsHidden: true },
-        phases: [
-          {
-            id: 'initial',
-            name: 'Initial Phase',
-            rules: {
-              proposals: { submit: true },
-              voting: { submit: false },
-              advancement: { method: 'manual' as const },
-            },
-          },
-          {
-            id: 'final',
-            name: 'Final Phase',
-            rules: {
-              proposals: { submit: false },
-              voting: { submit: false },
-              advancement: { method: 'manual' as const },
-            },
-          },
-        ],
-      },
+      processSchema: hiddenDefaultSchema,
     });
 
     const instance = setup.instances[0];
@@ -971,32 +948,7 @@ describe.concurrent('submitProposal defaultProposalsHidden', () => {
     const setup = await testData.createDecisionSetup({
       instanceCount: 1,
       grantAccess: true,
-      processSchema: {
-        id: 'hidden-default-schema',
-        version: '1.0.0',
-        name: 'Hidden Default Schema',
-        config: { defaultProposalsHidden: true },
-        phases: [
-          {
-            id: 'initial',
-            name: 'Initial Phase',
-            rules: {
-              proposals: { submit: true },
-              voting: { submit: false },
-              advancement: { method: 'manual' as const },
-            },
-          },
-          {
-            id: 'final',
-            name: 'Final Phase',
-            rules: {
-              proposals: { submit: false },
-              voting: { submit: false },
-              advancement: { method: 'manual' as const },
-            },
-          },
-        ],
-      },
+      processSchema: hiddenDefaultSchema,
     });
 
     const instance = setup.instances[0];

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -1,5 +1,10 @@
 import { mockCollab } from '@op/collab/testing';
-import { ProposalStatus, processInstances, proposals } from '@op/db/schema';
+import {
+  ProposalStatus,
+  Visibility,
+  processInstances,
+  proposals,
+} from '@op/db/schema';
 import { db, eq } from '@op/db/test';
 import { describe, expect, it } from 'vitest';
 
@@ -788,5 +793,240 @@ describe.concurrent('submitProposal', () => {
     });
 
     expect(result.status).toBe(ProposalStatus.SUBMITTED);
+  });
+});
+
+describe.concurrent('submitProposal defaultProposalsHidden', () => {
+  it('should set visibility to HIDDEN when defaultProposalsHidden config is enabled', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+      processSchema: {
+        id: 'hidden-default-schema',
+        version: '1.0.0',
+        name: 'Hidden Default Schema',
+        config: { defaultProposalsHidden: true },
+        phases: [
+          {
+            id: 'initial',
+            name: 'Initial Phase',
+            rules: {
+              proposals: { submit: true },
+              voting: { submit: false },
+              advancement: { method: 'manual' as const },
+            },
+          },
+          {
+            id: 'final',
+            name: 'Final Phase',
+            rules: {
+              proposals: { submit: false },
+              voting: { submit: false },
+              advancement: { method: 'manual' as const },
+            },
+          },
+        ],
+      },
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Auto-Hidden Proposal' },
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.submitProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result.status).toBe(ProposalStatus.SUBMITTED);
+    expect(result.visibility).toBe(Visibility.HIDDEN);
+  });
+
+  it('should keep visibility as VISIBLE when defaultProposalsHidden is not set', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Normal Proposal' },
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.submitProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result.status).toBe(ProposalStatus.SUBMITTED);
+    expect(result.visibility).toBe(Visibility.VISIBLE);
+  });
+
+  it('should allow admin to see hidden-by-default proposals and non-admin to not see them', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+      processSchema: {
+        id: 'hidden-default-schema',
+        version: '1.0.0',
+        name: 'Hidden Default Schema',
+        config: { defaultProposalsHidden: true },
+        phases: [
+          {
+            id: 'initial',
+            name: 'Initial Phase',
+            rules: {
+              proposals: { submit: true },
+              voting: { submit: false },
+              advancement: { method: 'manual' as const },
+            },
+          },
+          {
+            id: 'final',
+            name: 'Final Phase',
+            rules: {
+              proposals: { submit: false },
+              voting: { submit: false },
+              advancement: { method: 'manual' as const },
+            },
+          },
+        ],
+      },
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Hidden By Default' },
+    });
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+
+    await adminCaller.decision.submitProposal({
+      proposalId: proposal.id,
+    });
+
+    // Admin should see the proposal
+    const adminResult = await adminCaller.decision.listProposals({
+      processInstanceId: instance.instance.id,
+    });
+    expect(adminResult.proposals).toHaveLength(1);
+    expect(adminResult.proposals[0]?.visibility).toBe(Visibility.HIDDEN);
+
+    // Non-admin should NOT see the hidden-by-default proposal
+    const memberUser = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+
+    const memberCaller = await createAuthenticatedCaller(memberUser.email);
+
+    const memberResult = await memberCaller.decision.listProposals({
+      processInstanceId: instance.instance.id,
+    });
+    expect(memberResult.proposals).toHaveLength(0);
+  });
+
+  it('should allow proposal owner to see their own hidden-by-default proposal', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+      processSchema: {
+        id: 'hidden-default-schema',
+        version: '1.0.0',
+        name: 'Hidden Default Schema',
+        config: { defaultProposalsHidden: true },
+        phases: [
+          {
+            id: 'initial',
+            name: 'Initial Phase',
+            rules: {
+              proposals: { submit: true },
+              voting: { submit: false },
+              advancement: { method: 'manual' as const },
+            },
+          },
+          {
+            id: 'final',
+            name: 'Final Phase',
+            rules: {
+              proposals: { submit: false },
+              voting: { submit: false },
+              advancement: { method: 'manual' as const },
+            },
+          },
+        ],
+      },
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Create a member who submits a proposal
+    const submitter = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+
+    const proposal = await testData.createProposal({
+      userEmail: submitter.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'My Hidden Proposal' },
+    });
+
+    const submitterCaller = await createAuthenticatedCaller(submitter.email);
+
+    await submitterCaller.decision.submitProposal({
+      proposalId: proposal.id,
+    });
+
+    // Submitter should still see their own hidden proposal
+    const result = await submitterCaller.decision.listProposals({
+      processInstanceId: instance.instance.id,
+    });
+    expect(result.proposals).toHaveLength(1);
+    expect(result.proposals[0]?.visibility).toBe(Visibility.HIDDEN);
   });
 });


### PR DESCRIPTION
## Summary
- Add `defaultProposalsHidden` config option to decision schema so admins can hide proposals on submission by default
- Apply hidden status during proposal submission when the config is enabled
- Add admin toggle in the Overview section of decision setup with i18n support

Closes Asana task 1213994771108172

## Test plan
- [x] Unit tests for submit proposal with `defaultProposalsHidden` enabled/disabled