### PR TITLE
feat: Default hidden proposals for admin control

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
@@ -161,14 +161,17 @@ export function ProcessBuilderAutosaveProvider({
       }
 
       // Accumulate dirty fields for the next debounced save.
-      // Deep-merge config so rapid cross-section edits don't overwrite
-      // each other's config sub-fields within the debounce window.
+      // Deep-merge config and defaultRules so rapid cross-section edits
+      // don't overwrite each other's sub-fields within the debounce window.
       dirtyFieldsRef.current = {
         ...dirtyFieldsRef.current,
         ...data,
         config: data.config
           ? { ...dirtyFieldsRef.current.config, ...data.config }
           : dirtyFieldsRef.current.config,
+        defaultRules: data.defaultRules
+          ? { ...dirtyFieldsRef.current.defaultRules, ...data.defaultRules }
+          : dirtyFieldsRef.current.defaultRules,
       };
 
       debouncedSave();

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -346,6 +346,45 @@ function PhaseDetailForm({
           />
         </ToggleRow>
         <ToggleRow
+          label={t('Hide proposals by default')}
+          description={t(
+            'New proposals are hidden from other participants until an admin makes them visible.',
+          )}
+        >
+          <ToggleButton
+            isSelected={
+              instance.instanceData?.defaultRules?.proposals?.defaultHidden ??
+              false
+            }
+            onChange={(val) => {
+              saveChanges({
+                defaultRules: {
+                  proposals: { defaultHidden: val },
+                },
+              });
+              utils.decision.getInstance.setData({ instanceId }, (old) => {
+                if (!old?.instanceData) {
+                  return old;
+                }
+                return {
+                  ...old,
+                  instanceData: {
+                    ...old.instanceData,
+                    defaultRules: {
+                      ...old.instanceData.defaultRules,
+                      proposals: {
+                        ...old.instanceData.defaultRules?.proposals,
+                        defaultHidden: val,
+                      },
+                    },
+                  },
+                };
+              });
+            }}
+            size="small"
+          />
+        </ToggleRow>
+        <ToggleRow
           label={t('Proposal editing')}
           description={t('Authors can edit their proposals after submitting')}
         >

--- a/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.ts
@@ -142,6 +142,9 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
                 ...existing,
                 ...data,
                 config: { ...existing?.config, ...data.config },
+                defaultRules: data.defaultRules
+                  ? { ...existing?.defaultRules, ...data.defaultRules }
+                  : existing?.defaultRules,
               },
             },
           };

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -565,6 +565,8 @@
   "Phases": "পর্যায়সমূহ",
   "Define the phases of your decision-making process": "আপনার সিদ্ধান্ত গ্রহণ প্রক্রিয়ার পর্যায়গুলি নির্ধারণ করুন",
   "Proposal submission": "প্রস্তাব জমা",
+  "Hide proposals by default": "Hide proposals by default",
+  "New proposals are hidden from other participants until an admin makes them visible.": "New proposals are hidden from other participants until an admin makes them visible.",
   "Participants can submit new proposals during this phase.": "অংশগ্রহণকারীরা এই পর্যায়ে নতুন প্রস্তাব জমা দিতে পারেন।",
   "Proposal editing": "প্রস্তাব সম্পাদনা",
   "Authors can edit their proposals after submitting": "লেখকরা জমা দেওয়ার পরে তাদের প্রস্তাব সম্পাদনা করতে পারেন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -565,6 +565,8 @@
   "Phases": "Phases",
   "Define the phases of your decision-making process": "Define the phases of your decision-making process",
   "Proposal submission": "Proposal submission",
+  "Hide proposals by default": "Hide proposals by default",
+  "New proposals are hidden from other participants until an admin makes them visible.": "New proposals are hidden from other participants until an admin makes them visible.",
   "Participants can submit new proposals during this phase.": "Participants can submit new proposals during this phase.",
   "Proposal editing": "Proposal editing",
   "Authors can edit their proposals after submitting": "Authors can edit their proposals after submitting",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -563,6 +563,8 @@
   "Phases": "Fases",
   "Define the phases of your decision-making process": "Define las fases de tu proceso de toma de decisiones",
   "Proposal submission": "Envío de propuestas",
+  "Hide proposals by default": "Hide proposals by default",
+  "New proposals are hidden from other participants until an admin makes them visible.": "New proposals are hidden from other participants until an admin makes them visible.",
   "Participants can submit new proposals during this phase.": "Los participantes pueden enviar nuevas propuestas durante esta fase.",
   "Proposal editing": "Edición de propuestas",
   "Authors can edit their proposals after submitting": "Los autores pueden editar sus propuestas después de enviarlas",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -564,6 +564,8 @@
   "Phases": "Phases",
   "Define the phases of your decision-making process": "Définissez les phases de votre processus de prise de décision",
   "Proposal submission": "Soumission de propositions",
+  "Hide proposals by default": "Hide proposals by default",
+  "New proposals are hidden from other participants until an admin makes them visible.": "New proposals are hidden from other participants until an admin makes them visible.",
   "Participants can submit new proposals during this phase.": "Les participants peuvent soumettre de nouvelles propositions pendant cette phase.",
   "Proposal editing": "Modification des propositions",
   "Authors can edit their proposals after submitting": "Les auteurs peuvent modifier leurs propositions après soumission",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -564,6 +564,8 @@
   "Phases": "Fases",
   "Define the phases of your decision-making process": "Defina as fases do seu processo de tomada de decisão",
   "Proposal submission": "Envio de propostas",
+  "Hide proposals by default": "Hide proposals by default",
+  "New proposals are hidden from other participants until an admin makes them visible.": "New proposals are hidden from other participants until an admin makes them visible.",
   "Participants can submit new proposals during this phase.": "Os participantes podem enviar novas propostas durante esta fase.",
   "Proposal editing": "Edição de propostas",
   "Authors can edit their proposals after submitting": "Os autores podem editar suas propostas após o envio",

--- a/packages/common/src/services/decision/schemas/instanceData.ts
+++ b/packages/common/src/services/decision/schemas/instanceData.ts
@@ -49,6 +49,8 @@ export interface PhaseInstanceData {
  */
 export interface DecisionInstanceData {
   config?: ProcessConfig;
+  /** Instance-level default rules deep-merged into every phase's rules (phase overrides). */
+  defaultRules?: PhaseRules;
   fieldValues?: Record<string, unknown>;
   templateId?: string;
   templateVersion?: string;

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -16,6 +16,7 @@ export interface PhaseRules {
     submit?: boolean;
     edit?: boolean;
     review?: boolean;
+    defaultHidden?: boolean;
   };
   voting?: {
     submit?: boolean;

--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -1,6 +1,11 @@
 import { getTipTapClient } from '@op/collab';
 import { db, eq } from '@op/db/client';
-import { type ProcessInstance, ProposalStatus, proposals } from '@op/db/schema';
+import {
+  type ProcessInstance,
+  ProposalStatus,
+  Visibility,
+  proposals,
+} from '@op/db/schema';
 import { assertAccess, permission } from 'access-zones';
 
 import { CommonError, NotFoundError, ValidationError } from '../../utils';
@@ -9,7 +14,10 @@ import { decisionPermission } from './permissions';
 import { parseProposalData } from './proposalDataSchema';
 import { resolveProposalTemplate } from './resolveProposalTemplate';
 import type { DecisionInstanceData } from './schemas/instanceData';
-import { checkProposalsAllowed } from './utils/proposal';
+import {
+  checkProposalsAllowed,
+  shouldDefaultHideProposals,
+} from './utils/proposal';
 import { validateProposalAgainstTemplate } from './validateProposalAgainstTemplate';
 
 export interface SubmitProposalInput {
@@ -119,6 +127,11 @@ export const submitProposal = async ({
       return null;
     });
 
+  const hideByDefault = shouldDefaultHideProposals(
+    instanceData,
+    currentPhaseId,
+  );
+
   // Update proposal status to submitted and re-query with profile
   const updatedProposal = await db.transaction(async (tx) => {
     const proposalDataUpdate =
@@ -133,6 +146,7 @@ export const submitProposal = async ({
       .update(proposals)
       .set({
         status: ProposalStatus.SUBMITTED,
+        ...(hideByDefault ? { visibility: Visibility.HIDDEN } : {}),
         ...(proposalDataUpdate ? { proposalData: proposalDataUpdate } : {}),
       })
       .where(eq(proposals.id, data.proposalId))

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -21,7 +21,7 @@ import type {
   DecisionInstanceData,
   PhaseOverride,
 } from './schemas/instanceData';
-import type { ProcessConfig } from './schemas/types';
+import type { PhaseRules, ProcessConfig } from './schemas/types';
 import { updateTransitionsForProcess } from './updateTransitionsForProcess';
 
 /**
@@ -34,6 +34,7 @@ export const updateDecisionInstance = async ({
   status,
   stewardProfileId,
   config,
+  defaultRules,
   phases,
   proposalTemplate,
   rubricTemplate,
@@ -46,6 +47,8 @@ export const updateDecisionInstance = async ({
   stewardProfileId?: string;
   /** Process-level configuration (e.g., hideBudget) */
   config?: ProcessConfig;
+  /** Instance-level default rules deep-merged into every phase's rules */
+  defaultRules?: PhaseRules;
   /** Optional phase overrides (dates and settings) */
   phases?: PhaseOverride[];
   /** Proposal template (JSON Schema) */
@@ -120,12 +123,14 @@ export const updateDecisionInstance = async ({
 
   // Apply config, phase overrides, and/or template updates to existing instanceData
   const hasConfigUpdate = config !== undefined;
+  const hasDefaultRulesUpdate = defaultRules !== undefined;
   const hasPhaseUpdates = phases && phases.length > 0;
   const hasProposalTemplateUpdate = proposalTemplate !== undefined;
   const hasRubricTemplateUpdate = rubricTemplate !== undefined;
 
   if (
     hasConfigUpdate ||
+    hasDefaultRulesUpdate ||
     hasPhaseUpdates ||
     hasProposalTemplateUpdate ||
     hasRubricTemplateUpdate
@@ -152,6 +157,22 @@ export const updateDecisionInstance = async ({
         ...existingInstanceData.config,
         ...config,
         ...(config?.categories ? { categories: normalizedCategories } : {}),
+      };
+    }
+
+    // Apply defaultRules update (merge with existing defaultRules)
+    if (hasDefaultRulesUpdate) {
+      updatedInstanceData.defaultRules = {
+        ...existingInstanceData.defaultRules,
+        ...defaultRules,
+        proposals: {
+          ...existingInstanceData.defaultRules?.proposals,
+          ...defaultRules?.proposals,
+        },
+        voting: {
+          ...existingInstanceData.defaultRules?.voting,
+          ...defaultRules?.voting,
+        },
       };
     }
 

--- a/packages/common/src/services/decision/utils/proposal.test.ts
+++ b/packages/common/src/services/decision/utils/proposal.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DecisionInstanceData } from '../schemas/instanceData';
+import type { PhaseRules } from '../schemas/types';
+import { mergePhaseRules, shouldDefaultHideProposals } from './proposal';
+
+describe('mergePhaseRules', () => {
+  it('should return phase rules when no defaults', () => {
+    const phaseRules: PhaseRules = {
+      proposals: { submit: true, defaultHidden: true },
+    };
+    expect(mergePhaseRules(undefined, phaseRules)).toEqual(phaseRules);
+  });
+
+  it('should return defaults when no phase rules', () => {
+    const defaults: PhaseRules = {
+      proposals: { defaultHidden: true },
+    };
+    expect(mergePhaseRules(defaults, undefined)).toEqual(defaults);
+  });
+
+  it('should return empty object when both are undefined', () => {
+    expect(mergePhaseRules(undefined, undefined)).toEqual({});
+  });
+
+  it('should deep-merge proposals with phase overriding defaults', () => {
+    const defaults: PhaseRules = {
+      proposals: { submit: true, defaultHidden: true },
+    };
+    const phaseRules: PhaseRules = {
+      proposals: { defaultHidden: false },
+    };
+    const merged = mergePhaseRules(defaults, phaseRules);
+    expect(merged.proposals?.submit).toBe(true);
+    expect(merged.proposals?.defaultHidden).toBe(false);
+  });
+
+  it('should deep-merge voting with phase overriding defaults', () => {
+    const defaults: PhaseRules = {
+      voting: { submit: true, edit: true },
+    };
+    const phaseRules: PhaseRules = {
+      voting: { edit: false },
+    };
+    const merged = mergePhaseRules(defaults, phaseRules);
+    expect(merged.voting?.submit).toBe(true);
+    expect(merged.voting?.edit).toBe(false);
+  });
+
+  it('should prefer phase advancement over default', () => {
+    const defaults: PhaseRules = {
+      advancement: { method: 'date', endDate: '2026-01-01' },
+    };
+    const phaseRules: PhaseRules = {
+      advancement: { method: 'manual' },
+    };
+    const merged = mergePhaseRules(defaults, phaseRules);
+    expect(merged.advancement?.method).toBe('manual');
+  });
+});
+
+describe('shouldDefaultHideProposals', () => {
+  const baseInstanceData: DecisionInstanceData = {
+    phases: [
+      { phaseId: 'phase-1', rules: { proposals: { submit: true } } },
+      { phaseId: 'phase-2', rules: { proposals: { submit: true } } },
+    ],
+  };
+
+  it('should return false when no defaultRules set', () => {
+    expect(shouldDefaultHideProposals(baseInstanceData, 'phase-1')).toBe(false);
+  });
+
+  it('should return true when defaultRules has defaultHidden', () => {
+    const data: DecisionInstanceData = {
+      ...baseInstanceData,
+      defaultRules: { proposals: { defaultHidden: true } },
+    };
+    expect(shouldDefaultHideProposals(data, 'phase-1')).toBe(true);
+  });
+
+  it('should return false when phase overrides defaultHidden to false', () => {
+    const data: DecisionInstanceData = {
+      defaultRules: { proposals: { defaultHidden: true } },
+      phases: [
+        {
+          phaseId: 'phase-1',
+          rules: { proposals: { submit: true, defaultHidden: false } },
+        },
+      ],
+    };
+    expect(shouldDefaultHideProposals(data, 'phase-1')).toBe(false);
+  });
+
+  it('should return false for unknown phase', () => {
+    const data: DecisionInstanceData = {
+      ...baseInstanceData,
+      defaultRules: { proposals: { defaultHidden: true } },
+    };
+    expect(shouldDefaultHideProposals(data, 'nonexistent')).toBe(false);
+  });
+});

--- a/packages/common/src/services/decision/utils/proposal.ts
+++ b/packages/common/src/services/decision/utils/proposal.ts
@@ -1,4 +1,32 @@
-import type { PhaseInstanceData } from '../schemas/instanceData';
+import type { DecisionInstanceData, PhaseInstanceData } from '../schemas/instanceData';
+import type { PhaseRules } from '../schemas/types';
+
+/**
+ * Deep-merges instance-level defaultRules with a phase's own rules.
+ * Phase values take precedence over defaults.
+ */
+export function mergePhaseRules(
+  defaultRules: PhaseRules | undefined,
+  phaseRules: PhaseRules | undefined,
+): PhaseRules {
+  if (!defaultRules) {
+    return phaseRules ?? {};
+  }
+  if (!phaseRules) {
+    return defaultRules;
+  }
+  return {
+    proposals: {
+      ...defaultRules.proposals,
+      ...phaseRules.proposals,
+    },
+    voting: {
+      ...defaultRules.voting,
+      ...phaseRules.voting,
+    },
+    advancement: phaseRules.advancement ?? defaultRules.advancement,
+  };
+}
 
 /**
  * Helper to check if proposals are allowed in the current phase.
@@ -14,4 +42,20 @@ export function checkProposalsAllowed(
   }
   const allowed = phase.rules?.proposals?.submit !== false;
   return { allowed, phaseName: phase.name ?? 'Unknown' };
+}
+
+/**
+ * Returns true when proposals should be hidden by default in the given phase,
+ * accounting for instance-level defaultRules merged with phase-specific rules.
+ */
+export function shouldDefaultHideProposals(
+  instanceData: DecisionInstanceData,
+  phaseId: string,
+): boolean {
+  const phase = instanceData.phases.find((p) => p.phaseId === phaseId);
+  if (!phase) {
+    return false;
+  }
+  const merged = mergePhaseRules(instanceData.defaultRules, phase.rules);
+  return merged.proposals?.defaultHidden === true;
 }

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -98,6 +98,7 @@ const phaseRulesEncoder = z.object({
       submit: z.boolean().optional(),
       edit: z.boolean().optional(),
       review: z.boolean().optional(),
+      defaultHidden: z.boolean().optional(),
     })
     .optional(),
   voting: z
@@ -230,6 +231,7 @@ export const instancePhaseDataEncoder = z.object({
 /** Instance data encoder for new schema format */
 const instanceDataWithSchemaEncoder = z.object({
   config: processConfigEncoder.optional(),
+  defaultRules: phaseRulesEncoder.optional(),
   fieldValues: z.record(z.string(), z.unknown()).optional(),
   templateId: z.string().optional(),
   templateVersion: z.string().optional(),
@@ -505,6 +507,8 @@ export const updateDecisionInstanceInputSchema = z.object({
   stewardProfileId: z.string().uuid().optional(),
   /** Process-level configuration (e.g., hideBudget, categories) */
   config: processConfigEncoder.optional(),
+  /** Instance-level default rules deep-merged into every phase's rules */
+  defaultRules: phaseRulesEncoder.optional(),
   /** Phase overrides for dates, rules, and settings */
   phases: z.array(instancePhaseDataInputEncoder).optional(),
   /** Proposal template (JSON Schema) */

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -1,5 +1,10 @@
 import { mockCollab } from '@op/collab/testing';
-import { ProposalStatus, processInstances, proposals } from '@op/db/schema';
+import {
+  ProposalStatus,
+  Visibility,
+  processInstances,
+  proposals,
+} from '@op/db/schema';
 import { db, eq } from '@op/db/test';
 import { describe, expect, it } from 'vitest';
 
@@ -788,5 +793,161 @@ describe.concurrent('submitProposal', () => {
     });
 
     expect(result.status).toBe(ProposalStatus.SUBMITTED);
+  });
+
+  it('should set visibility to HIDDEN when defaultRules.proposals.defaultHidden is true', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Set defaultRules on the instance to hide proposals by default
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: eq(processInstances.id, instance.instance.id),
+    });
+
+    if (!instanceRecord) {
+      throw new Error('Instance record not found');
+    }
+
+    const existingData = instanceRecord.instanceData as Record<string, unknown>;
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...existingData,
+          defaultRules: {
+            proposals: { defaultHidden: true },
+          },
+        },
+      })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Should Be Hidden' },
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.submitProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result.status).toBe(ProposalStatus.SUBMITTED);
+    expect(result.visibility).toBe(Visibility.HIDDEN);
+  });
+
+  it('should keep visibility VISIBLE when defaultRules.proposals.defaultHidden is not set', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Should Stay Visible' },
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.submitProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result.status).toBe(ProposalStatus.SUBMITTED);
+    expect(result.visibility).toBe(Visibility.VISIBLE);
+  });
+
+  it('should allow phase rules to override defaultRules.proposals.defaultHidden', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Set defaultRules to hide proposals, but override at the phase level to show them
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: eq(processInstances.id, instance.instance.id),
+    });
+
+    if (!instanceRecord) {
+      throw new Error('Instance record not found');
+    }
+
+    const existingData = instanceRecord.instanceData as Record<string, unknown>;
+    const phases = existingData.phases as Array<Record<string, unknown>>;
+
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...existingData,
+          defaultRules: {
+            proposals: { defaultHidden: true },
+          },
+          phases: phases.map((p) =>
+            p.phaseId === instanceRecord.currentStateId
+              ? {
+                  ...p,
+                  rules: {
+                    ...(p.rules as Record<string, unknown>),
+                    proposals: {
+                      ...((p.rules as Record<string, unknown>)?.proposals as Record<string, unknown>),
+                      defaultHidden: false,
+                    },
+                  },
+                }
+              : p,
+          ),
+        },
+      })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Phase Override Visible' },
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.submitProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result.status).toBe(ProposalStatus.SUBMITTED);
+    expect(result.visibility).toBe(Visibility.VISIBLE);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a "Hide proposals by default" toggle to the process builder phase settings
- When enabled, proposals are automatically set to HIDDEN visibility upon submission
- Admins and proposal owners can still see hidden proposals; other participants cannot
- Uses a `defaultRules` mechanism at the instance level that deep-merges with per-phase rules

## Implementation
- **Type layer**: Added `defaultHidden?: boolean` to `PhaseRules.proposals` and `defaultRules?: PhaseRules` to `DecisionInstanceData`
- **Server**: `submitProposal` checks merged rules and sets `visibility: HIDDEN` when `defaultHidden` is true
- **UI**: Toggle in PhaseDetailPage writes to instance-level `defaultRules` with optimistic cache update
- **Merge utility**: `mergePhaseRules()` deep-merges instance defaults with phase-specific overrides

## Test plan
- [ ] Unit tests for `mergePhaseRules` and `shouldDefaultHideProposals` utilities
- [ ] Integration test: proposal submitted with `defaultHidden=true` gets HIDDEN visibility
- [ ] Integration test: proposal submitted without `defaultHidden` stays VISIBLE
- [ ] Integration test: phase-level override of `defaultHidden=false` keeps proposal VISIBLE
- [ ] Verify toggle appears in process builder phase settings below "Proposal submission"
- [ ] Verify toggle state persists across page refreshes via autosave
- [ ] Verify hidden proposals visible to admins and owners, not to other participants

Asana task: https://app.asana.com/1/1108348036672214/project/1209934992627645/task/1213994771108172