### PR TITLE
feat(platform-admin): distinguish draft and non-draft proposal counts

### DIFF
--- a/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
@@ -59,7 +59,24 @@ export const DecisionsRowCells = ({
         {decision.stewardName ?? '—'}
       </TableCell>
       <TableCell className="text-neutral-charcoal">
-        {decision.proposalCount}
+        {decision.totalProposalCount > decision.proposalCount ? (
+          <TooltipTrigger>
+            <Button className="underline decoration-dotted underline-offset-2 outline-hidden">
+              {decision.proposalCount} ({decision.totalProposalCount})
+            </Button>
+            <Tooltip>
+              {t(
+                '{nonDraft} non-draft proposals, {total} total including drafts',
+                {
+                  nonDraft: decision.proposalCount,
+                  total: decision.totalProposalCount,
+                },
+              )}
+            </Tooltip>
+          </TooltipTrigger>
+        ) : (
+          decision.proposalCount
+        )}
       </TableCell>
       <TableCell className="text-neutral-charcoal">
         {decision.participantCount}

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -515,6 +515,7 @@
   "Instance data for {name}": "{name}-এর ইনস্ট্যান্স ডেটা",
   "decisions": "সিদ্ধান্ত",
   "Ends {date}": "{date} তারিখে শেষ হবে",
+  "{nonDraft} non-draft proposals, {total} total including drafts": "{nonDraft}টি অ-খসড়া প্রস্তাব, খসড়াসহ মোট {total}টি",
   "Join requests": "অনুরোধ",
   "{name} wants to join your organization": "{name} আপনার সংস্থায় যোগ দিতে চায়",
   "Request accepted": "অনুরোধ গৃহীত",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1183,6 +1183,7 @@
   "Instance data for {name}": "Instance data for {name}",
   "decisions": "decisions",
   "Ends {date}": "Ends {date}",
+  "{nonDraft} non-draft proposals, {total} total including drafts": "{nonDraft} non-draft proposals, {total} total including drafts",
   "No proposals available to select": "No proposals available to select",
   "No proposals match the current filter": "No proposals match the current filter",
   "The previous phase did not leave any eligible proposals.": "The previous phase did not leave any eligible proposals.",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -512,6 +512,7 @@
   "Instance data for {name}": "Datos de la instancia para {name}",
   "decisions": "decisiones",
   "Ends {date}": "Finaliza el {date}",
+  "{nonDraft} non-draft proposals, {total} total including drafts": "{nonDraft} propuestas no borrador, {total} en total incluyendo borradores",
   "No more updates.": "No hay más actualizaciones.",
   "Join requests": "Solicitudes",
   "{name} wants to join your organization": "{name} quiere unirse a tu organización",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -513,6 +513,7 @@
   "Instance data for {name}": "Données de l'instance pour {name}",
   "decisions": "décisions",
   "Ends {date}": "Se termine le {date}",
+  "{nonDraft} non-draft proposals, {total} total including drafts": "{nonDraft} propositions hors brouillon, {total} au total incluant les brouillons",
   "No more updates.": "Plus de mises à jour.",
   "Join requests": "Demandes",
   "{name} wants to join your organization": "{name} souhaite rejoindre votre organisation",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -513,6 +513,7 @@
   "Instance data for {name}": "Dados da instância para {name}",
   "decisions": "decisões",
   "Ends {date}": "Termina em {date}",
+  "{nonDraft} non-draft proposals, {total} total including drafts": "{nonDraft} propostas não rascunho, {total} no total incluindo rascunhos",
   "No more updates.": "Não há mais atualizações.",
   "Join requests": "Solicitações",
   "{name} wants to join your organization": "{name} quer entrar na sua organização",

--- a/packages/common/src/services/decision/schemas/adminDecisionInstance.ts
+++ b/packages/common/src/services/decision/schemas/adminDecisionInstance.ts
@@ -15,6 +15,7 @@ export const adminDecisionInstanceSchema = z.object({
   currentPhase: adminDecisionCurrentPhaseSchema.nullable(),
   stewardName: z.string().nullable(),
   proposalCount: z.number(),
+  totalProposalCount: z.number(),
   participantCount: z.number(),
   instanceData: z.unknown(),
 });

--- a/services/api/src/routers/platform/admin/listAllDecisionInstances.test.ts
+++ b/services/api/src/routers/platform/admin/listAllDecisionInstances.test.ts
@@ -1,6 +1,8 @@
+import { ProcessStatus, ProposalStatus } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { platformAdminRouter } from '.';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
 import { TestOrganizationDataManager } from '../../../test/helpers/TestOrganizationDataManager';
 import {
   createIsolatedSession,
@@ -25,5 +27,77 @@ describe.concurrent('platform.admin.listAllDecisionInstances', () => {
     const caller = createCaller(await createTestContextWithSession(session));
 
     await expect(() => caller.listAllDecisionInstances()).rejects.toThrow();
+  });
+
+  it('proposalCount excludes drafts; totalProposalCount includes them', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      status: ProcessStatus.PUBLISHED,
+    });
+    const instanceId = setup.instances[0]!.instance.id;
+
+    await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Draft 1 ${task.id}` },
+        status: ProposalStatus.DRAFT,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Draft 2 ${task.id}` },
+        status: ProposalStatus.DRAFT,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Submitted ${task.id}` },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Approved ${task.id}` },
+        status: ProposalStatus.APPROVED,
+      }),
+    ]);
+
+    const { session } = await createIsolatedSession(setup.userEmail);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    // Filter to just our instance (other concurrent tests may create others).
+    const result = await caller.listAllDecisionInstances({ query: task.id });
+    const ours = result.items.find((i) => i.id === instanceId);
+
+    expect(ours).toBeDefined();
+    expect(ours?.proposalCount).toBe(2);
+    expect(ours?.totalProposalCount).toBe(4);
+  });
+
+  it('counts are zero when an instance has no proposals', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      status: ProcessStatus.PUBLISHED,
+    });
+    const instanceId = setup.instances[0]!.instance.id;
+
+    const { session } = await createIsolatedSession(setup.userEmail);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    const result = await caller.listAllDecisionInstances({ query: task.id });
+    const ours = result.items.find((i) => i.id === instanceId);
+
+    expect(ours).toBeDefined();
+    expect(ours?.proposalCount).toBe(0);
+    expect(ours?.totalProposalCount).toBe(0);
   });
 });

--- a/services/api/src/routers/platform/admin/listAllDecisionInstances.ts
+++ b/services/api/src/routers/platform/admin/listAllDecisionInstances.ts
@@ -4,8 +4,16 @@ import {
   getGenericCursorCondition,
 } from '@op/common';
 import { adminDecisionInstanceSchema } from '@op/common/client';
-import { and, count, countDistinct, db, ilike, inArray } from '@op/db/client';
-import { processInstances, proposals } from '@op/db/schema';
+import {
+  and,
+  count,
+  countDistinct,
+  db,
+  ilike,
+  inArray,
+  sql,
+} from '@op/db/client';
+import { ProposalStatus, processInstances, proposals } from '@op/db/schema';
 import type { SQL } from 'drizzle-orm';
 import { z } from 'zod';
 
@@ -158,7 +166,11 @@ export const listAllDecisionInstancesRouter = router({
           ? await db
               .select({
                 processInstanceId: proposals.processInstanceId,
-                proposalCount: count(proposals.id),
+                proposalCount:
+                  sql<number>`count(*) filter (where ${proposals.status} <> ${ProposalStatus.DRAFT})`.mapWith(
+                    Number,
+                  ),
+                totalProposalCount: count(proposals.id),
                 participantCount: countDistinct(proposals.submittedByProfileId),
               })
               .from(proposals)
@@ -184,6 +196,7 @@ export const listAllDecisionInstancesRouter = router({
             stewardName: instance.steward?.name ?? null,
             status: instance.status,
             proposalCount: stats?.proposalCount ?? 0,
+            totalProposalCount: stats?.totalProposalCount ?? 0,
             participantCount: stats?.participantCount ?? 0,
             createdAt: instance.createdAt,
             instanceData: instance.instanceData,


### PR DESCRIPTION
Show non-draft proposal count with total in parentheses when drafts exist, so admins can tell at a glance which instances have proposals actually in play vs. still being authored.

## Demo
<img width="2294" height="926" alt="CleanShot 2026-05-04 at 18 20 26@2x" src="https://github.com/user-attachments/assets/e56f5803-3474-47ab-9447-d46692a9b49a" />


