### PR TITLE
Fix newline rendering in comments

### DIFF
--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -57,7 +57,7 @@ const PostContent = ({ content }: { content?: string }) => {
     return null;
   }
 
-  return linkifyText(content);
+  return <p className="whitespace-pre-wrap">{linkifyText(content)}</p>;
 };
 
 const PostAttachments = ({


### PR DESCRIPTION
## Summary
- Fixes [Asana #1214389909113731](https://app.asana.com/1/1108348036672214/project/1213315744811204/task/1214389909113731): newlines entered in comments were being collapsed into spaces when rendered
- Root cause: `PostContent` component rendered `linkifyText()` output as bare React elements without CSS whitespace preservation
- Added `whitespace-pre-wrap` to the content wrapper, matching the existing pattern used in `RevisionFeedbackCard` and `AuthorRevisionNote`

## Changes
- `apps/app/src/components/PostFeed/index.tsx` — wrapped `linkifyText()` output in `<p className="whitespace-pre-wrap">`

## Test plan
- [ ] Open a post (or create one) and add a comment with line breaks (e.g. bullet points on separate lines)
- [ ] Verify the posted comment retains and displays the line breaks
- [ ] Verify comments in the Discussion Modal also preserve line breaks
- [ ] Verify existing comments without line breaks still render correctly
- [ ] Verify links within comments still render as clickable teal links
- [ ] Verify the post detail page (`PostItemOnDetailPage`) also preserves newlines