### PR TITLE
feat(decisions): mirror phase short name in page header

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -239,7 +239,7 @@ function PhaseDetailForm({
             })}
           </p>
           <Header2 className="font-serif text-title-base">
-            {t('Add phase')}
+            {phase.name?.trim() ? phase.name : t('Add phase')}
           </Header2>
         </div>
         <SaveStatusIndicator


### PR DESCRIPTION
## Summary
- The phase configuration page header (previously a static "Add phase") now mirrors the **Short name** input value in real time, falling back to "Add phase" when the field is empty or whitespace.
- One-line change in [PhaseDetailPage.tsx:242](apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx#L242). The header reactively updates because `phase.name` is already written to the Zustand store on every keystroke.

## Test plan
- [ ] Open the New Committee-Based Process flow and add a phase
- [ ] Confirm the header reads "Add phase" while the Short name field is empty
- [ ] Type into Short name and confirm the header updates live to match
- [ ] Clear the Short name and confirm the header reverts to "Add phase"