### PR TITLE
fix: Update process creator to use profileId of individual

### DIFF
--- a/packages/common/src/services/decision/createInstanceFromTemplate.ts
+++ b/packages/common/src/services/decision/createInstanceFromTemplate.ts
@@ -147,11 +147,14 @@ export const createInstanceFromTemplate = async ({
     new UnauthorizedError('User must be authenticated'),
   );
 
-  const ownerProfileId = dbUser.currentProfileId ?? dbUser.profileId;
+  // Owner is always the individual creator. Steward is the profile the user is
+  // acting as (an org when in org context, otherwise the individual themselves).
+  const ownerProfileId = dbUser.profileId;
   if (!ownerProfileId) {
     // TODO: profileId should not be nullable in the schema
-    throw new UnauthorizedError('User must have an active profile');
+    throw new UnauthorizedError('User must have a profile');
   }
+  const stewardProfileId = dbUser.currentProfileId ?? ownerProfileId;
 
   // TODO: This shouldn't be a requirement in the future and we need to resolve that (SMS accounts for instance)
   if (!user.email) {
@@ -168,7 +171,7 @@ export const createInstanceFromTemplate = async ({
     instanceData,
     name,
     ownerProfileId,
-    stewardProfileId: ownerProfileId,
+    stewardProfileId,
     creatorAuthUserId: user.id,
     creatorEmail: user.email,
   });

--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -48,10 +48,14 @@ export const duplicateInstance = async ({
     new UnauthorizedError('User must be authenticated'),
   );
 
-  const ownerProfileId = dbUser.currentProfileId ?? dbUser.profileId;
+  // Owner is always the individual creator. Steward defaults to the profile the
+  // user is acting as (an org when in org context, otherwise the individual).
+  const ownerProfileId = dbUser.profileId;
   if (!ownerProfileId) {
-    throw new UnauthorizedError('User must have an active profile');
+    throw new UnauthorizedError('User must have a profile');
   }
+  const resolvedStewardProfileId =
+    stewardProfileId ?? dbUser.currentProfileId ?? ownerProfileId;
 
   if (!user.email) {
     throw new CommonError(
@@ -98,7 +102,7 @@ export const duplicateInstance = async ({
     name,
     description: sourceInstance.description ?? undefined,
     ownerProfileId,
-    stewardProfileId,
+    stewardProfileId: resolvedStewardProfileId,
     creatorAuthUserId: user.id,
     creatorEmail: user.email,
     instanceData: newInstanceData,


### PR DESCRIPTION
Updates the process creation to use the profile of the individual instead of the currentProfileId which could be an  organization. The organization relation is now based on the steward instead of the owner in this case.