### PR TITLE
fix: Fix comment box retaining expanded height after posting

### DIFF
--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -580,18 +580,24 @@ const PostUpdateWithUser = ({
     const textarea = textareaRef.current;
     if (textarea) {
       const handleInput = () => {
-        textarea.style.height = '1.5rem'; // Reset to min height
-        textarea.style.height = `${textarea.scrollHeight}px`; // Set to scrollHeight
+        textarea.style.height = '1.5rem';
+        textarea.style.height = `${textarea.scrollHeight}px`;
       };
 
       textarea.addEventListener('input', handleInput);
 
-      // Cleanup function to remove event listener
       return () => {
         textarea.removeEventListener('input', handleInput);
       };
     }
   }, []);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea && !content) {
+      textarea.style.height = '1.5rem';
+    }
+  }, [content]);
 
   if (!user.currentProfile) {
     return null;


### PR DESCRIPTION
## Summary
- Fixes Asana task 1214510786062310: Comment box retains last post height after posting
- The textarea auto-resize only triggered on `input` events. When `setContent('')` cleared state after posting, no `input` event fired, leaving the inline `style.height` at the expanded value
- Added a `useEffect` watching `content` state that resets textarea height to `1.5rem` when content becomes empty

## Test plan
- [ ] Post a long multi-line comment in a discussion thread
- [ ] Verify the textarea contracts back to its original single-line height after posting
- [ ] Post a short comment and verify textarea still resets correctly
- [ ] Verify textarea still auto-expands when typing long content