### PR TITLE
fix(legal): add mailto and URL hyperlinks to legal content modals

### DIFF
--- a/apps/app/src/components/CoCContent/index.tsx
+++ b/apps/app/src/components/CoCContent/index.tsx
@@ -96,16 +96,27 @@ export const CoCContent = () => {
         <p>
           Violations of the code of conduct may result in temporary suspension
           or permanent account termination. If you witness or experience any
-          behavior that violates this Code of Conduct please contact
-          support@oneproject.org. This Code of Conduct will be updated and
-          evolved in collaboration with partners.
+          behavior that violates this Code of Conduct please contact{' '}
+          <a
+            href="mailto:support@oneproject.org"
+            className="text-primary-teal hover:underline"
+          >
+            support@oneproject.org
+          </a>
+          . This Code of Conduct will be updated and evolved in collaboration
+          with partners.
         </p>
       </FormalSection>
 
       <FormalSection>
         <p>
-          Last updated: June 18, 2025. Questions? Contact us at:
-          support@oneproject.org
+          Last updated: June 18, 2025. Questions? Contact us at:{' '}
+          <a
+            href="mailto:support@oneproject.org"
+            className="text-primary-teal hover:underline"
+          >
+            support@oneproject.org
+          </a>
         </p>
       </FormalSection>
     </div>

--- a/apps/app/src/components/PrivacyPolicyContent/index.tsx
+++ b/apps/app/src/components/PrivacyPolicyContent/index.tsx
@@ -482,10 +482,17 @@ export const PrivacyPolicyContent = () => {
           of cookies, there is a simple procedure in most browsers that allows
           you to automatically decline cookies or be given the choice of
           declining or accepting the transfer to your computer of a particular
-          cookie (or cookies) from a particular site. Visit
-          http://www.allaboutcookies.org/manage-cookies/index.html for more
-          information. If, however, you do not accept these cookies, you may
-          experience some inconvenience in your use of the Services. For
+          cookie (or cookies) from a particular site. Visit{' '}
+          <a
+            href="http://www.allaboutcookies.org/manage-cookies/index.html"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-teal hover:underline"
+          >
+            http://www.allaboutcookies.org/manage-cookies/index.html
+          </a>{' '}
+          for more information. If, however, you do not accept these cookies,
+          you may experience some inconvenience in your use of the Services. For
           example, we may not be able to recognize your computer, and you may
           need to log in every time you visit.
         </p>
@@ -713,7 +720,15 @@ export const PrivacyPolicyContent = () => {
           Personal Data is processed, or to exercise your privacy rights, please
           contact us by one of the methods below:
         </p>
-        <p className="mb-2">Email: privacy@oneproject.org</p>
+        <p className="mb-2">
+          Email:{' '}
+          <a
+            href="mailto:privacy@oneproject.org"
+            className="text-primary-teal hover:underline"
+          >
+            privacy@oneproject.org
+          </a>
+        </p>
         <p className="mb-2">
           Mail: 548 Market Street, Suite 85871, San Francisco, California 94104
         </p>

--- a/apps/app/src/components/ToSContent/ToSContentShort.tsx
+++ b/apps/app/src/components/ToSContent/ToSContentShort.tsx
@@ -196,7 +196,15 @@ export const ToSContentShort = () => {
 
       <FormalSection>
         <Header3 className="font-serif">Contact Us</Header3>
-        <p className="mb-4">Questions? Email us at support@oneproject.org</p>
+        <p className="mb-4">
+          Questions? Email us at{' '}
+          <a
+            href="mailto:support@oneproject.org"
+            className="text-primary-teal hover:underline"
+          >
+            support@oneproject.org
+          </a>
+        </p>
       </FormalSection>
     </div>
   );

--- a/apps/app/src/components/ToSContent/index.tsx
+++ b/apps/app/src/components/ToSContent/index.tsx
@@ -437,11 +437,17 @@ export const ToSContent = () => {
           Millennium Copyright Act ("DMCA") and other applicable intellectual
           property laws with respect to any alleged or actual infringement. A
           notification of claimed copyright infringement should be emailed to
-          One Project's Copyright Agent at privacy@oneproject.org (Subject line:
-          "DMCA Takedown Request"). You may also contact us by mail at: 548
-          Market Street, Suite 85871, San Francisco, California 94104. To be
-          effective, the notification must be in writing and contain the
-          following information:
+          One Project's Copyright Agent at{' '}
+          <a
+            href="mailto:privacy@oneproject.org"
+            className="text-primary-teal hover:underline"
+          >
+            privacy@oneproject.org
+          </a>{' '}
+          (Subject line: "DMCA Takedown Request"). You may also contact us by
+          mail at: 548 Market Street, Suite 85871, San Francisco, California
+          94104. To be effective, the notification must be in writing and
+          contain the following information:
         </p>
         <ul className="mb-4 list-disc pl-6">
           <li className="mb-2">
@@ -825,22 +831,37 @@ export const ToSContent = () => {
           dispute) shall be conducted by a single, neutral arbitrator
           administered by JAMS or its successor ("JAMS") and conducted pursuant
           to the then-current Streamlined Arbitration Rules and Procedures
-          (available at https://www.jamsadr.com/rules-streamlined-arbitration/)
-          and, if you are an individual, in accordance with JAMS' Consumer
-          Arbitration Minimum Standards (available at
-          https://www.jamsadr.com/consumer-minimum-standards/) (as applicable,
-          the "JAMS Rules"). If the JAMS Rules conflict with any portion of
-          these Terms of Service, these Terms of Service shall control. You and
-          One Project shall mutually agree on a neutral arbitrator, provided
-          that if the parties cannot agree on an arbitrator within ten (10)
-          days, then JAMS will choose the arbitrator. The arbitration of any
-          claims or disputes hereunder shall be conducted in San Francisco,
-          California, except that if you are an individual the arbitration may
-          be conducted in the county or parish of your primary residence. You or
-          we also may choose to have the arbitration conducted by telephone,
-          based on written submissions, or in person at another mutually agreed
-          location. Payment of all filing, administration, and arbitrator fees
-          will be governed by the JAMS Rules.
+          (available at{' '}
+          <a
+            href="https://www.jamsadr.com/rules-streamlined-arbitration/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-teal hover:underline"
+          >
+            https://www.jamsadr.com/rules-streamlined-arbitration/
+          </a>
+          ) and, if you are an individual, in accordance with JAMS' Consumer
+          Arbitration Minimum Standards (available at{' '}
+          <a
+            href="https://www.jamsadr.com/consumer-minimum-standards/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-teal hover:underline"
+          >
+            https://www.jamsadr.com/consumer-minimum-standards/
+          </a>
+          ) (as applicable, the "JAMS Rules"). If the JAMS Rules conflict with
+          any portion of these Terms of Service, these Terms of Service shall
+          control. You and One Project shall mutually agree on a neutral
+          arbitrator, provided that if the parties cannot agree on an arbitrator
+          within ten (10) days, then JAMS will choose the arbitrator. The
+          arbitration of any claims or disputes hereunder shall be conducted in
+          San Francisco, California, except that if you are an individual the
+          arbitration may be conducted in the county or parish of your primary
+          residence. You or we also may choose to have the arbitration conducted
+          by telephone, based on written submissions, or in person at another
+          mutually agreed location. Payment of all filing, administration, and
+          arbitrator fees will be governed by the JAMS Rules.
         </p>
         <p className="mb-4">
           The arbitrator shall apply the law of the State of California as
@@ -907,10 +928,23 @@ export const ToSContent = () => {
           Terms of Service. The address for One Project for notice purposes
           under these Terms of Service is 548 Market Street, Suite 85871, San
           Francisco, California 94104, although you may also send a copy of any
-          notice sent to that address to support@oneproject.org. All other
-          feedback, comments, requests for technical support, and other
-          communications from you relating to the Services or these Terms of
-          Service should be directed to: support@oneproject.org.
+          notice sent to that address to{' '}
+          <a
+            href="mailto:support@oneproject.org"
+            className="text-primary-teal hover:underline"
+          >
+            support@oneproject.org
+          </a>
+          . All other feedback, comments, requests for technical support, and
+          other communications from you relating to the Services or these Terms
+          of Service should be directed to:{' '}
+          <a
+            href="mailto:support@oneproject.org"
+            className="text-primary-teal hover:underline"
+          >
+            support@oneproject.org
+          </a>
+          .
         </p>
       </FormalSection>
     </div>


### PR DESCRIPTION
## Summary
- Add clickable `mailto:` links for email addresses in Privacy Policy, Terms of Use, and Code of Conduct modals
- Add clickable URL hyperlinks for external references in legal content
- Ensure links open in new tabs with proper security attributes

<img width="531" height="131" alt="Screenshot 2026-05-05 at 18 35 25" src="https://github.com/user-attachments/assets/e4393902-0980-4958-acbc-e038917d690c" />
<img width="436" height="110" alt="Screenshot 2026-05-05 at 18 35 08" src="https://github.com/user-attachments/assets/d2fd9e92-1590-446c-89bc-9a8a8695ee9a" />
