### PR TITLE
fix: Update settings button icon color to match text

### DIFF
--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -53,7 +53,7 @@ export const DecisionInstanceHeader = ({
             color="secondary"
             size="small"
           >
-            <LuSettings className="size-4 text-neutral-black md:text-teal" />
+            <LuSettings className="size-4" />
             <span className="hidden md:inline">{t('Settings')}</span>
           </ButtonLink>
         )}


### PR DESCRIPTION
## Summary
- Removed explicit color overrides (`text-neutral-black md:text-teal`) from the settings gear icon in `DecisionInstanceHeader`
- The icon now inherits `text-neutral-black` from the secondary `ButtonLink`, matching the adjacent "Settings" text label

<img width="281" height="70" alt="Screenshot 2026-05-05 at 20 59 28" src="https://github.com/user-attachments/assets/f7ccb67c-59d7-439b-97f6-014d8ecee3f3" />
