### PR TITLE
fix: Update process creator to use profileId of individual

### DIFF
--- a/packages/common/src/services/decision/createInstanceFromTemplate.ts
+++ b/packages/common/src/services/decision/createInstanceFromTemplate.ts
@@ -147,11 +147,14 @@ export const createInstanceFromTemplate = async ({
     new UnauthorizedError('User must be authenticated'),
   );
 
-  const ownerProfileId = dbUser.currentProfileId ?? dbUser.profileId;
+  // Owner is always the individual creator. Steward is the profile the user is
+  // acting as (an org when in org context, otherwise the individual themselves).
+  const ownerProfileId = dbUser.profileId;
   if (!ownerProfileId) {
     // TODO: profileId should not be nullable in the schema
-    throw new UnauthorizedError('User must have an active profile');
+    throw new UnauthorizedError('User must have a profile');
   }
+  const stewardProfileId = dbUser.currentProfileId ?? ownerProfileId;
 
   // TODO: This shouldn't be a requirement in the future and we need to resolve that (SMS accounts for instance)
   if (!user.email) {
@@ -168,7 +171,7 @@ export const createInstanceFromTemplate = async ({
     instanceData,
     name,
     ownerProfileId,
-    stewardProfileId: ownerProfileId,
+    stewardProfileId,
     creatorAuthUserId: user.id,
     creatorEmail: user.email,
   });

--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -48,10 +48,14 @@ export const duplicateInstance = async ({
     new UnauthorizedError('User must be authenticated'),
   );
 
-  const ownerProfileId = dbUser.currentProfileId ?? dbUser.profileId;
+  // Owner is always the individual creator. Steward defaults to the profile the
+  // user is acting as (an org when in org context, otherwise the individual).
+  const ownerProfileId = dbUser.profileId;
   if (!ownerProfileId) {
-    throw new UnauthorizedError('User must have an active profile');
+    throw new UnauthorizedError('User must have a profile');
   }
+  const resolvedStewardProfileId =
+    stewardProfileId ?? dbUser.currentProfileId ?? ownerProfileId;
 
   if (!user.email) {
     throw new CommonError(
@@ -98,7 +102,7 @@ export const duplicateInstance = async ({
     name,
     description: sourceInstance.description ?? undefined,
     ownerProfileId,
-    stewardProfileId,
+    stewardProfileId: resolvedStewardProfileId,
     creatorAuthUserId: user.id,
     creatorEmail: user.email,
     instanceData: newInstanceData,

--- a/services/api/src/routers/decision/instances/createInstanceFromTemplate.test.ts
+++ b/services/api/src/routers/decision/instances/createInstanceFromTemplate.test.ts
@@ -259,4 +259,86 @@ describe.concurrent('createInstanceFromTemplate', () => {
     const instanceData = instance!.instanceData as DecisionInstanceData;
     expect(instanceData.proposalTemplate).toEqual(proposalTemplate);
   });
+
+  it('should set ownerProfileId to individual profile and stewardProfileId to currentProfileId', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const [userRecord] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, setup.userEmail));
+
+    expect(userRecord!.profileId).toBeDefined();
+    expect(userRecord!.currentProfileId).toBe(setup.organization.profileId);
+
+    const [template] = await db
+      .insert(decisionProcesses)
+      .values({
+        name: `Owner/Steward Template ${task.id}`,
+        processSchema: simpleVoting,
+        createdByProfileId: userRecord!.profileId!,
+      })
+      .returning();
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+    const result = await caller.decision.createInstanceFromTemplate({
+      templateId: template!.id,
+      name: `Owner Steward Test ${task.id}`,
+    });
+
+    testData.trackProfileForCleanup(result.id);
+
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: result.processInstance.id },
+    });
+
+    expect(instance!.ownerProfileId).toBe(userRecord!.profileId);
+    expect(instance!.stewardProfileId).toBe(setup.organization.profileId);
+  });
+
+  it('should fall back stewardProfileId to individual profile when currentProfileId is null', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const [userRecord] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, setup.userEmail));
+
+    await db
+      .update(users)
+      .set({ currentProfileId: null })
+      .where(eq(users.id, userRecord!.id));
+
+    const [template] = await db
+      .insert(decisionProcesses)
+      .values({
+        name: `No Org Context Template ${task.id}`,
+        processSchema: simpleVoting,
+        createdByProfileId: userRecord!.profileId!,
+      })
+      .returning();
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+    const result = await caller.decision.createInstanceFromTemplate({
+      templateId: template!.id,
+      name: `No Org Context Test ${task.id}`,
+    });
+
+    testData.trackProfileForCleanup(result.id);
+
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: result.processInstance.id },
+    });
+
+    expect(instance!.ownerProfileId).toBe(userRecord!.profileId);
+    expect(instance!.stewardProfileId).toBe(userRecord!.profileId);
+  });
 });

--- a/services/api/src/routers/decision/instances/duplicateInstance.test.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.test.ts
@@ -502,4 +502,40 @@ describe.concurrent('duplicateInstance', () => {
     expect(instanceData.proposalTemplate).toBeUndefined();
     expect(instanceData.rubricTemplate).toBeUndefined();
   });
+
+  it('should default ownerProfileId to individual and stewardProfileId to currentProfileId when steward not provided', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const {
+      result: source,
+      caller,
+      userEmail,
+    } = await createSourceInstance(testData, task.id);
+
+    const [userRecord] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, userEmail));
+
+    expect(userRecord!.profileId).toBeDefined();
+    expect(userRecord!.currentProfileId).toBeDefined();
+    expect(userRecord!.currentProfileId).not.toBe(userRecord!.profileId);
+
+    const duplicate = await caller.decision.duplicateInstance({
+      instanceId: source.processInstance.id,
+      name: `Default Steward Test ${task.id}`,
+      include: ALL_INCLUDED,
+    });
+
+    testData.trackProfileForCleanup(duplicate.id);
+
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
+    });
+
+    expect(instance!.ownerProfileId).toBe(userRecord!.profileId);
+    expect(instance!.stewardProfileId).toBe(userRecord!.currentProfileId);
+  });
 });


### PR DESCRIPTION
Updates the process creation to use the profile of the individual instead of the currentProfileId which could be an organization. The organization relation is now based on the steward instead of the owner in this case.
