### PR TITLE
fix(a11y): stabilize baseline scan against render timing flake

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -461,6 +461,7 @@ jobs:
             || echo '{}' > /tmp/base-summary.json
 
       - name: Render a11y diff
+        id: render-diff
         if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         run: |
           pnpm tsx scripts/a11y-baseline-diff.ts \
@@ -470,10 +471,24 @@ jobs:
             "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             > /tmp/a11y-comment.md
           cat /tmp/a11y-comment.md
+          # The diff script emits these section headers only when there's
+          # something to show; their absence means "clean run, no deviation."
+          if grep -qE "^### (New rules|Resolved rules|Changed rules|Changed routes)" /tmp/a11y-comment.md; then
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Post sticky PR comment
-        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+        if: ${{ github.event_name == 'pull_request' && !cancelled() && steps.render-diff.outputs.has-changes == 'true' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: a11y-baseline
           path: /tmp/a11y-comment.md
+
+      - name: Remove sticky PR comment when no deviation
+        if: ${{ github.event_name == 'pull_request' && !cancelled() && steps.render-diff.outputs.has-changes == 'false' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: a11y-baseline
+          delete: true

--- a/tests/e2e/tests/a11y-baseline.spec.ts
+++ b/tests/e2e/tests/a11y-baseline.spec.ts
@@ -7,7 +7,7 @@ import {
   createProposal,
   getSeededTemplate,
 } from '@op/test';
-import type { Page } from '@playwright/test';
+import type { ConsoleMessage, Page } from '@playwright/test';
 import type { AxeResults, ImpactValue, Result } from 'axe-core';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
@@ -110,6 +110,18 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPORT_DIR = path.resolve(__dirname, '../a11y-baseline');
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
 const SEVERITIES: Severity[] = ['critical', 'serious', 'moderate', 'minor'];
+
+// React 18/19 hydration warnings are emitted via console. If any fire during a
+// route render, the DOM is unstable across runs and axe will produce drifting
+// counts; treat the route as errored rather than baselining a half-hydrated page.
+const HYDRATION_ERROR_PATTERNS = [
+  /hydration failed because the server rendered html didn't match the client/i,
+  /hydration completed but contains mismatches/i,
+  /hydration (text content|node|attribute) mismatch/i,
+];
+
+const DOM_SETTLE_QUIET_MS = 500;
+const DOM_SETTLE_TIMEOUT_MS = 5_000;
 
 const PUBLIC_ROUTES: RouteScan[] = [
   { url: '/login', label: 'Login', auth: 'public' },
@@ -325,18 +337,37 @@ async function scanRouteWithTimeout(
 
 async function scanRoute(page: Page, route: RouteScan): Promise<RouteResult> {
   const reportUrl = route.displayUrl ?? route.url;
+  const hydrationErrors: string[] = [];
+  const onConsole = (msg: ConsoleMessage) => {
+    const text = msg.text();
+    if (HYDRATION_ERROR_PATTERNS.some((p) => p.test(text))) {
+      hydrationErrors.push(text);
+    }
+  };
+  page.on('console', onConsole);
+
   try {
     await page.goto(route.url, {
       waitUntil: 'domcontentloaded',
       timeout: 30_000,
     });
-    // Wait for window.load (recommended over networkidle, which the Playwright docs
-    // discourage because apps with persistent connections never reach idle).
-    await page.waitForLoadState('load', { timeout: 15_000 }).catch(() => {
-      console.warn(
-        `[a11y-baseline] load event timeout on ${route.label}; scanning anyway`,
-      );
+    // Don't swallow the load timeout — a partial render produces a partial axe
+    // scan and silently shifts the baseline. Let it throw into the catch below.
+    await page.waitForLoadState('load', { timeout: 15_000 });
+    // axe `color-contrast` reads computed font metrics; without this wait it
+    // measures fallback-font widths and counts drift run-to-run.
+    await page.evaluate(async () => {
+      await document.fonts.ready;
     });
+    // Suspense queries and React Aria autogen IDs keep swapping DOM after the
+    // load event. Wait for mutations to quiet so axe sees a stable tree.
+    await waitForDomSettle(page, DOM_SETTLE_QUIET_MS, DOM_SETTLE_TIMEOUT_MS);
+
+    if (hydrationErrors.length > 0) {
+      throw new Error(
+        `hydration error: ${hydrationErrors[0]?.slice(0, 200) ?? ''}`,
+      );
+    }
 
     const axe = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
     const violations = summarize(axe);
@@ -364,7 +395,47 @@ async function scanRoute(page: Page, route: RouteScan): Promise<RouteResult> {
       finalUrl: page.url(),
       error: err instanceof Error ? err.message : String(err),
     };
+  } finally {
+    page.off('console', onConsole);
   }
+}
+
+async function waitForDomSettle(
+  page: Page,
+  quietMs: number,
+  timeoutMs: number,
+): Promise<void> {
+  await page.evaluate(
+    ({ quietMs, timeoutMs }) =>
+      new Promise<void>((resolve, reject) => {
+        let lastMutation = Date.now();
+        const observer = new MutationObserver(() => {
+          lastMutation = Date.now();
+        });
+        observer.observe(document.body, {
+          childList: true,
+          subtree: true,
+          attributes: true,
+          characterData: true,
+        });
+        const start = Date.now();
+        const tick = () => {
+          if (Date.now() - lastMutation >= quietMs) {
+            observer.disconnect();
+            resolve();
+            return;
+          }
+          if (Date.now() - start >= timeoutMs) {
+            observer.disconnect();
+            reject(new Error(`DOM did not settle within ${timeoutMs}ms`));
+            return;
+          }
+          setTimeout(tick, 100);
+        };
+        tick();
+      }),
+    { quietMs, timeoutMs },
+  );
 }
 
 async function captureScreenshots(


### PR DESCRIPTION
## Summary

- axe scan was racing render: fonts not yet loaded → `color-contrast` drift; Suspense not yet settled → `button-name`/`link-name` drift. Recent CI runs swung between 53–61 violations against a committed baseline of 70 with no related code changes.
- Fixes in `tests/e2e/tests/a11y-baseline.spec.ts`: wait for `document.fonts.ready`, wait for DOM mutations to quiet for 500ms, stop swallowing the `load`-event timeout
- Plus a hydration-warning console listener: if React emits a hydration mismatch during a route render, the route is marked errored rather than baselined
- Only posts a comment when there is deviation from the baseline.

Two consecutive local runs both produce 70/13/41/16, matching the committed baseline.

## Next: moving to a "known violations" model

This stabilizes the current count baseline, but the count approach is fragile by design — a fixed violation plus a new violation cancel out to zero net change, so swaps go undetected.

Follow-up on branch `a11y-known-violations` (already created off `dev`) will replace `summary.json` with `known-violations.json` — an identity-keyed list of `(rule, route, fingerprint)` tuples. CI fails on any violation not in the list and on any list entry that no longer fires. Each entry is debt to drive to zero as part of the WCAG 2.1 AA sprint, and the existing `summary.json` becomes the seed for the initial list.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214453886143072