### PR TITLE
fix: use NotFoundError resource/id interface across services

### DIFF
--- a/packages/common/src/services/assert/assertProfileUser.ts
+++ b/packages/common/src/services/assert/assertProfileUser.ts
@@ -8,7 +8,7 @@ import { NotFoundError } from '../../utils';
  */
 export async function assertProfileUser(
   id: string,
-  error: Error = new NotFoundError('User not found', id),
+  error: Error = new NotFoundError('Profile user', id),
   db: DbClient = defaultDb,
 ): Promise<ProfileUser> {
   const profileUser = await db.query.profileUsers.findFirst({

--- a/packages/common/src/services/decision/acceptProposalInvite.ts
+++ b/packages/common/src/services/decision/acceptProposalInvite.ts
@@ -40,7 +40,7 @@ export const acceptProposalInvite = async ({
   });
 
   if (!invite) {
-    throw new NotFoundError('No pending invite found for this proposal');
+    throw new NotFoundError('Proposal invite');
   }
 
   if (invite.acceptedOn) {

--- a/packages/common/src/services/decision/cancelRevisionRequest.ts
+++ b/packages/common/src/services/decision/cancelRevisionRequest.ts
@@ -30,7 +30,7 @@ export async function cancelRevisionRequest({
   const existingRequest = context.revisionRequest;
 
   if (!existingRequest || existingRequest.id !== revisionRequestId) {
-    throw new NotFoundError('Revision request');
+    throw new NotFoundError('Revision request', revisionRequestId);
   }
 
   if (existingRequest.state !== ProposalReviewRequestState.REQUESTED) {

--- a/packages/common/src/services/decision/createProposal.ts
+++ b/packages/common/src/services/decision/createProposal.ts
@@ -53,7 +53,7 @@ export const createProposal = async ({
     });
 
     if (!instance) {
-      throw new NotFoundError('Process instance not found');
+      throw new NotFoundError('Process instance', data.processInstanceId);
     }
 
     if (!instance.profileId) {

--- a/packages/common/src/services/decision/deleteDecision.ts
+++ b/packages/common/src/services/decision/deleteDecision.ts
@@ -18,7 +18,7 @@ export const deleteDecision = async ({
   });
 
   if (!instance) {
-    throw new NotFoundError('Decision not found');
+    throw new NotFoundError('Decision', instanceId);
   }
 
   if (!instance.profileId) {

--- a/packages/common/src/services/decision/deleteProposal.ts
+++ b/packages/common/src/services/decision/deleteProposal.ts
@@ -36,12 +36,12 @@ export const deleteProposal = async ({
     }
 
     if (!existingProposal) {
-      throw new NotFoundError('Proposal');
+      throw new NotFoundError('Proposal', proposalId);
     }
 
     const processInstance = existingProposal.processInstance as ProcessInstance;
     if (!processInstance) {
-      throw new NotFoundError('Process instance not found');
+      throw new NotFoundError('Process instance');
     }
 
     // Check permissions on proposal's profile and instance's profile in parallel

--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -69,7 +69,7 @@ export const duplicateInstance = async ({
   });
 
   if (!sourceInstance) {
-    throw new NotFoundError('Process instance not found');
+    throw new NotFoundError('Process instance', instanceId);
   }
 
   if (!sourceInstance.profileId) {

--- a/packages/common/src/services/decision/exportProposals.ts
+++ b/packages/common/src/services/decision/exportProposals.ts
@@ -44,11 +44,11 @@ export const exportProposals = async ({
     .limit(1);
 
   if (!result[0]) {
-    throw new NotFoundError('Process instance not found');
+    throw new NotFoundError('Process instance', processInstanceId);
   }
 
   if (!result[0].profileId) {
-    throw new NotFoundError('Decision profile not found');
+    throw new NotFoundError('Decision profile', processInstanceId);
   }
 
   // Check user permissions via profile

--- a/packages/common/src/services/decision/getDecisionBySlug.ts
+++ b/packages/common/src/services/decision/getDecisionBySlug.ts
@@ -104,7 +104,7 @@ export const getDecisionBySlug = async ({
   ]);
 
   if (!authAndStatsResult || !profile?.processInstance) {
-    throw new NotFoundError('Decision profile not found');
+    throw new NotFoundError('Decision profile', slug);
   }
 
   return {

--- a/packages/common/src/services/decision/getExportStatus.ts
+++ b/packages/common/src/services/decision/getExportStatus.ts
@@ -55,11 +55,11 @@ export const getExportStatus = async ({
     .limit(1);
 
   if (!instance[0]) {
-    throw new NotFoundError('Process instance not found');
+    throw new NotFoundError('Process instance', exportStatus.processInstanceId);
   }
 
   if (!instance[0].profileId) {
-    throw new NotFoundError('Decision profile not found');
+    throw new NotFoundError('Decision profile', exportStatus.processInstanceId);
   }
 
   // Get user's profile membership and roles

--- a/packages/common/src/services/decision/getInstance.ts
+++ b/packages/common/src/services/decision/getInstance.ts
@@ -92,7 +92,7 @@ export const getInstance = async ({ instanceId, user }: GetInstanceInput) => {
     });
 
     if (!instance) {
-      throw new NotFoundError('Process instance not found');
+      throw new NotFoundError('Process instance', instanceId);
     }
 
     // Fetch profileUser and assert access in parallel — both need the instance
@@ -112,7 +112,7 @@ export const getInstance = async ({ instanceId, user }: GetInstanceInput) => {
     // Resolve access capabilities for the current user.
     // profileId is guaranteed non-null here: assertInstanceProfileAccess throws above if null.
     if (!instance.profileId) {
-      throw new NotFoundError('Process instance not found');
+      throw new NotFoundError('Process instance', instanceId);
     }
     const access = await resolveInstanceAccess(
       user,
@@ -170,6 +170,6 @@ export const getInstance = async ({ instanceId, user }: GetInstanceInput) => {
       throw error;
     }
     console.error('Error fetching process instance:', error);
-    throw new NotFoundError('Process instance not found');
+    throw new NotFoundError('Process instance', instanceId);
   }
 };

--- a/packages/common/src/services/decision/getProcess.ts
+++ b/packages/common/src/services/decision/getProcess.ts
@@ -13,7 +13,7 @@ export const getProcess = async (processId: string) => {
     });
 
     if (!process) {
-      throw new NotFoundError('Decision process not found');
+      throw new NotFoundError('Decision process', processId);
     }
 
     return process;
@@ -22,6 +22,6 @@ export const getProcess = async (processId: string) => {
       throw error;
     }
     console.error('Error fetching decision process:', error);
-    throw new NotFoundError('Decision process not found');
+    throw new NotFoundError('Decision process', processId);
   }
 };

--- a/packages/common/src/services/decision/getProposal.ts
+++ b/packages/common/src/services/decision/getProposal.ts
@@ -103,7 +103,7 @@ export const getProposal = async ({
   });
 
   if (!proposal) {
-    throw new NotFoundError('Proposal');
+    throw new NotFoundError('Proposal', profileId);
   }
 
   // Draft proposals are only visible to users with proposal-level access
@@ -118,7 +118,7 @@ export const getProposal = async ({
     });
 
     if (!hasProposalAccess) {
-      throw new NotFoundError('Proposal');
+      throw new NotFoundError('Proposal', profileId);
     }
   }
 

--- a/packages/common/src/services/decision/getResults.ts
+++ b/packages/common/src/services/decision/getResults.ts
@@ -52,7 +52,7 @@ export const getLatestResultWithProposals = async ({
     .limit(1);
 
   if (!instance[0]) {
-    throw new NotFoundError('Process instance');
+    throw new NotFoundError('Process instance', processInstanceId);
   }
 
   await assertInstanceProfileAccess({

--- a/packages/common/src/services/decision/getResultsStats.ts
+++ b/packages/common/src/services/decision/getResultsStats.ts
@@ -34,11 +34,11 @@ export const getResultsStats = async ({
     .limit(1);
 
   if (!instance[0]) {
-    throw new NotFoundError('Process instance not found');
+    throw new NotFoundError('Process instance', instanceId);
   }
 
   if (!instance[0].profileId) {
-    throw new NotFoundError('Decision profile not found');
+    throw new NotFoundError('Decision profile', instanceId);
   }
 
   await assertInstanceProfileAccess({

--- a/packages/common/src/services/decision/getTemplate.ts
+++ b/packages/common/src/services/decision/getTemplate.ts
@@ -16,7 +16,7 @@ export const getTemplate = async (
   });
 
   if (!templateRecord) {
-    throw new NotFoundError(`Template '${templateId}' not found`);
+    throw new NotFoundError('Template', templateId);
   }
 
   return templateRecord.processSchema as DecisionSchemaDefinition;

--- a/packages/common/src/services/decision/listProposalRevisionRequests.ts
+++ b/packages/common/src/services/decision/listProposalRevisionRequests.ts
@@ -36,7 +36,7 @@ export async function listProposalRevisionRequests({
   });
 
   if (!proposal) {
-    throw new NotFoundError('Proposal not found');
+    throw new NotFoundError('Proposal', proposalId);
   }
 
   const instance = await getInstance({

--- a/packages/common/src/services/decision/listSelectionCandidates.ts
+++ b/packages/common/src/services/decision/listSelectionCandidates.ts
@@ -41,7 +41,7 @@ export async function listSelectionCandidates({
   });
 
   if (!instance) {
-    throw new NotFoundError('Process instance not found');
+    throw new NotFoundError('Process instance', processInstanceId);
   }
 
   if (!instance.profileId) {

--- a/packages/common/src/services/decision/proposalVersionUtils.ts
+++ b/packages/common/src/services/decision/proposalVersionUtils.ts
@@ -22,7 +22,7 @@ export async function assertProposalVersionPermissions({
   });
 
   if (!proposal) {
-    throw new NotFoundError('Proposal');
+    throw new NotFoundError('Proposal', proposalId);
   }
 
   const proposalProfileUser = await getProfileAccessUser({

--- a/packages/common/src/services/decision/reviewHelpers.ts
+++ b/packages/common/src/services/decision/reviewHelpers.ts
@@ -110,7 +110,7 @@ export async function assertReviewAssignmentContext({
   ]);
 
   if (!assignment) {
-    throw new NotFoundError('Review assignment');
+    throw new NotFoundError('Review assignment', assignmentId);
   }
 
   if (!dbUser.profileId) {

--- a/packages/common/src/services/decision/submitManualSelection.ts
+++ b/packages/common/src/services/decision/submitManualSelection.ts
@@ -55,7 +55,7 @@ export async function submitManualSelection({
   ]);
 
   if (!instance) {
-    throw new NotFoundError('Process instance not found');
+    throw new NotFoundError('Process instance', processInstanceId);
   }
 
   if (!instance.profileId) {
@@ -110,7 +110,7 @@ export async function submitManualSelection({
       .for('update');
 
     if (!lockedInstance) {
-      throw new NotFoundError('Process instance not found');
+      throw new NotFoundError('Process instance', processInstanceId);
     }
 
     if (lockedInstance.status !== ProcessStatus.PUBLISHED) {

--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -36,7 +36,7 @@ export const submitProposal = async ({
   });
 
   if (!existingProposal) {
-    throw new NotFoundError('Proposal');
+    throw new NotFoundError('Proposal', data.proposalId);
   }
 
   // Only allow submitting drafts
@@ -49,7 +49,7 @@ export const submitProposal = async ({
   const instance = existingProposal.processInstance as ProcessInstance;
 
   if (!instance.profileId) {
-    throw new NotFoundError('Decision profile not found');
+    throw new NotFoundError('Decision profile');
   }
 
   // Authorization check - verify user has access to the decision profile

--- a/packages/common/src/services/decision/submitRevisionResponse.ts
+++ b/packages/common/src/services/decision/submitRevisionResponse.ts
@@ -46,7 +46,7 @@ export async function submitRevisionResponse({
   ]);
 
   if (!request) {
-    throw new NotFoundError('Revision request');
+    throw new NotFoundError('Revision request', revisionRequestId);
   }
 
   if (!dbUser.profileId) {

--- a/packages/common/src/services/decision/triggerPhaseAdvancement.ts
+++ b/packages/common/src/services/decision/triggerPhaseAdvancement.ts
@@ -55,7 +55,7 @@ export async function triggerPhaseAdvancement({
   }
 
   if (!instance) {
-    throw new NotFoundError('Process instance not found');
+    throw new NotFoundError('Process instance', instanceId);
   }
 
   if (!instance.profileId) {

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -61,7 +61,7 @@ export const updateDecisionInstance = async ({
   });
 
   if (!existingInstance) {
-    throw new NotFoundError('Process instance not found');
+    throw new NotFoundError('Process instance', instanceId);
   }
 
   const { profileId } = existingInstance;

--- a/packages/common/src/services/decision/updateProcess.ts
+++ b/packages/common/src/services/decision/updateProcess.ts
@@ -36,7 +36,7 @@ export const updateProcess = async ({
     });
 
     if (!existingProcess) {
-      throw new NotFoundError('Decision process not found');
+      throw new NotFoundError('Decision process', processId);
     }
 
     // Only allow editing from the context of the process owner (usually an org)

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -116,7 +116,7 @@ export const updateProposal = async ({
   });
 
   if (!existingProposal) {
-    throw new NotFoundError('Proposal');
+    throw new NotFoundError('Proposal', proposalId);
   }
 
   const processInstance = existingProposal.processInstance;

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -161,11 +161,11 @@ export const submitVote = async ({
     });
 
     if (!processInstance) {
-      throw new NotFoundError('Process instance not found');
+      throw new NotFoundError('Process instance', data.processInstanceId);
     }
 
     if (!processInstance.profileId) {
-      throw new NotFoundError('Decision profile not found');
+      throw new NotFoundError('Decision profile', data.processInstanceId);
     }
 
     const instanceData = processInstance.instanceData as DecisionInstanceData;
@@ -358,7 +358,7 @@ export const getVotingStatus = async ({
     });
 
     if (!processInstance) {
-      throw new NotFoundError('Process instance not found');
+      throw new NotFoundError('Process instance', data.processInstanceId);
     }
 
     const instanceData = processInstance.instanceData as DecisionInstanceData;

--- a/packages/common/src/services/individual/getIndividualTerms.ts
+++ b/packages/common/src/services/individual/getIndividualTerms.ts
@@ -26,7 +26,7 @@ export const getIndividualTerms = async ({
     .execute();
 
   if (!indTerms) {
-    throw new NotFoundError('Could not get individual terms');
+    throw new NotFoundError('Individual terms', individualId);
   }
 
   const termUris = indTerms.reduce(

--- a/packages/common/src/services/organization/createOrganization.ts
+++ b/packages/common/src/services/organization/createOrganization.ts
@@ -157,7 +157,7 @@ export const createOrganization = async ({
       .returning();
 
     if (!newOrg) {
-      throw new NotFoundError('Failed to create organization');
+      throw new NotFoundError('Organization');
     }
 
     // Insert organizationUser linking the user to organization, with a default role of owner

--- a/packages/common/src/services/organization/deleteOrganization.ts
+++ b/packages/common/src/services/organization/deleteOrganization.ts
@@ -20,7 +20,7 @@ export async function deleteOrganization({
   });
 
   if (!organization) {
-    throw new NotFoundError('Organization not found');
+    throw new NotFoundError('Organization', organizationProfileId);
   }
 
   // Get the org access user and assert admin DELETE permissions
@@ -43,7 +43,7 @@ export async function deleteOrganization({
     .returning();
 
   if (!deletedOrganization) {
-    throw new NotFoundError('Failed to delete organization');
+    throw new NotFoundError('Organization', organizationProfileId);
   }
 
   // Invalidate caches for the deleted organization

--- a/packages/common/src/services/organization/deleteOrganizationUser.ts
+++ b/packages/common/src/services/organization/deleteOrganizationUser.ts
@@ -36,7 +36,7 @@ export async function deleteOrganizationUser({
   });
 
   if (!targetOrgUser) {
-    throw new NotFoundError('Organization user not found');
+    throw new NotFoundError('Organization user', organizationUserId);
   }
 
   // Prevent users from deleting themselves
@@ -65,7 +65,7 @@ export async function deleteOrganizationUser({
   });
 
   if (!deletedUser) {
-    throw new NotFoundError('Failed to delete organization user');
+    throw new NotFoundError('Organization user', organizationUserId);
   }
 
   return deletedUser;

--- a/packages/common/src/services/organization/getOrganization.ts
+++ b/packages/common/src/services/organization/getOrganization.ts
@@ -5,7 +5,7 @@ import { NotFoundError } from '../../utils';
 
 export const getOrganization = async ({ slug }: { slug: string }) => {
   if (!slug) {
-    throw new NotFoundError('Organization not found');
+    throw new NotFoundError('Organization');
   }
 
   const profile = await db
@@ -17,7 +17,7 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
   const profileId = profile?.[0]?.id;
 
   if (!profileId) {
-    throw new NotFoundError('Could not find organization');
+    throw new NotFoundError('Organization', slug);
   }
 
   const org = await db.query.organizations.findFirst({
@@ -60,7 +60,7 @@ export const getOrganization = async ({ slug }: { slug: string }) => {
   });
 
   if (!org) {
-    throw new NotFoundError('Could not find organization');
+    throw new NotFoundError('Organization', slug);
   }
 
   return {

--- a/packages/common/src/services/organization/getOrganizationTerms.ts
+++ b/packages/common/src/services/organization/getOrganizationTerms.ts
@@ -27,7 +27,7 @@ export const getOrganizationTerms = async ({
     .execute();
 
   if (!orgTerms) {
-    throw new NotFoundError('Organization terms not found');
+    throw new NotFoundError('Organization terms', organizationId);
   }
 
   const termUris = orgTerms.reduce(

--- a/packages/common/src/services/organization/listOrganizations.ts
+++ b/packages/common/src/services/organization/listOrganizations.ts
@@ -70,7 +70,7 @@ export const listOrganizations = async ({
     });
 
     if (!result) {
-      throw new NotFoundError('Organizations not found');
+      throw new NotFoundError('Organizations');
     }
 
     const flattened = result.map((org) => ({

--- a/packages/common/src/services/organization/relationships.ts
+++ b/packages/common/src/services/organization/relationships.ts
@@ -97,7 +97,7 @@ export const sendRelationshipNotification = async ({
   ]);
 
   if (!sourceOrg || !targetOrg) {
-    throw new NotFoundError('Organization not found');
+    throw new NotFoundError('Organization');
   }
 
   // Send email notifications to target organization admin users only

--- a/packages/common/src/services/organization/updateOrganization.ts
+++ b/packages/common/src/services/organization/updateOrganization.ts
@@ -62,7 +62,7 @@ export const updateOrganization = async ({
     .returning();
 
   if (!orgToUpdate) {
-    throw new NotFoundError('Failed to update organization');
+    throw new NotFoundError('Organization', organizationId);
   }
 
   // Loop through changes concurrently
@@ -304,7 +304,7 @@ export const updateOrganization = async ({
   ]);
 
   if (!updatedOrg || !updatedProfile) {
-    throw new NotFoundError('Organization not found after update');
+    throw new NotFoundError('Organization', organizationId);
   }
 
   // @ts-ignore

--- a/packages/common/src/services/organization/updateOrganizationUser.ts
+++ b/packages/common/src/services/organization/updateOrganizationUser.ts
@@ -49,7 +49,7 @@ export async function updateOrganizationUser({
   });
 
   if (!targetOrgUser) {
-    throw new NotFoundError('Organization user not found');
+    throw new NotFoundError('Organization user', organizationUserId);
   }
 
   // Update the organization user basic info
@@ -86,7 +86,7 @@ export async function updateOrganizationUser({
         .where(inArray(accessRoles.id, data.roleIds));
 
       if (existingRoles.length !== data.roleIds.length) {
-        throw new NotFoundError('One or more role IDs are invalid');
+        throw new NotFoundError('Role');
       }
     }
 
@@ -124,7 +124,7 @@ export async function updateOrganizationUser({
   });
 
   if (!updatedUserWithRoles) {
-    throw new NotFoundError('Failed to retrieve updated user');
+    throw new NotFoundError('Organization user', organizationUserId);
   }
 
   await invalidate({

--- a/packages/common/src/services/posts/createPostOnProfile.ts
+++ b/packages/common/src/services/posts/createPostOnProfile.ts
@@ -28,7 +28,7 @@ export const createPostOnProfile = async (input: CreatePostOnProfileInput) => {
       .returning();
 
     if (!post) {
-      throw new NotFoundError('Failed to create post');
+      throw new NotFoundError('Post');
     }
 
     // Link the post to the target profile so it appears there

--- a/packages/common/src/services/posts/listPosts.ts
+++ b/packages/common/src/services/posts/listPosts.ts
@@ -48,7 +48,7 @@ export const listPosts = async ({
     const profileId = profile?.[0]?.id;
 
     if (!profileId) {
-      throw new NotFoundError('Could not find organization');
+      throw new NotFoundError('Organization', slug);
     }
 
     const org = await db._query.organizations.findFirst({
@@ -60,7 +60,7 @@ export const listPosts = async ({
         profileId,
         slug,
       });
-      throw new NotFoundError('Organization not found');
+      throw new NotFoundError('Organization', profileId);
     }
 
     const result = await db._query.postsToOrganizations.findMany({

--- a/packages/common/src/services/profile/acceptProfileInvite.ts
+++ b/packages/common/src/services/profile/acceptProfileInvite.ts
@@ -31,7 +31,7 @@ export const acceptProfileInvite = async ({
   });
 
   if (!invite) {
-    throw new NotFoundError('Invite not found', inviteId);
+    throw new NotFoundError('Profile invite', inviteId);
   }
 
   if (invite.acceptedOn) {

--- a/packages/common/src/services/profile/declineProfileInvite.ts
+++ b/packages/common/src/services/profile/declineProfileInvite.ts
@@ -28,7 +28,7 @@ export const declineProfileInvite = async ({
   });
 
   if (!invite) {
-    throw new NotFoundError('Invite not found or already processed');
+    throw new NotFoundError('Profile invite', inviteId);
   }
 
   // Verify user email matches invite email (case-insensitive)

--- a/packages/common/src/services/profile/deleteProfileInvite.ts
+++ b/packages/common/src/services/profile/deleteProfileInvite.ts
@@ -26,7 +26,7 @@ export const deleteProfileInvite = async ({
   });
 
   if (!invite) {
-    throw new NotFoundError('Invite not found');
+    throw new NotFoundError('Profile invite', inviteId);
   }
 
   // Check if user has ADMIN access on the profile
@@ -47,7 +47,7 @@ export const deleteProfileInvite = async ({
     .returning();
 
   if (!deleted) {
-    throw new NotFoundError('Failed to delete invite');
+    throw new NotFoundError('Profile invite', inviteId);
   }
 
   return deleted;

--- a/packages/common/src/services/profile/getProfile.ts
+++ b/packages/common/src/services/profile/getProfile.ts
@@ -59,7 +59,7 @@ export const getProfile = async ({
   });
 
   if (!profile) {
-    throw new NotFoundError('Profile not found');
+    throw new NotFoundError('Profile', slug);
   }
 
   return profileResultSchema.parse(profile);

--- a/packages/common/src/services/profile/listProfiles.ts
+++ b/packages/common/src/services/profile/listProfiles.ts
@@ -96,7 +96,7 @@ export const listProfiles = async ({
     });
 
     if (!result) {
-      throw new NotFoundError('Profiles not found');
+      throw new NotFoundError('Profiles');
     }
 
     const hasMore = result.length > limit;

--- a/packages/common/src/services/profile/removeProfileUser.ts
+++ b/packages/common/src/services/profile/removeProfileUser.ts
@@ -47,7 +47,7 @@ export const removeProfileUser = async ({
     .returning();
 
   if (!deletedUser) {
-    throw new NotFoundError('Failed to delete profile user');
+    throw new NotFoundError('Profile user', profileUserId);
   }
 
   await Promise.all([

--- a/packages/common/src/services/profile/updateProfileInvite.ts
+++ b/packages/common/src/services/profile/updateProfileInvite.ts
@@ -45,7 +45,7 @@ export const updateProfileInvite = async ({
   ]);
 
   if (!invite) {
-    throw new NotFoundError('Invite not found');
+    throw new NotFoundError('Profile invite', inviteId);
   }
 
   if (!role) {

--- a/packages/common/src/services/profile/updateProfileUserRole.ts
+++ b/packages/common/src/services/profile/updateProfileUserRole.ts
@@ -44,7 +44,7 @@ export const updateProfileUserRoles = async ({
   ]);
 
   if (!targetProfileUser) {
-    throw new NotFoundError('User not found');
+    throw new NotFoundError('Profile user', profileUserId);
   }
 
   if (validRoles.length !== roleIdsDeduped.length) {

--- a/packages/common/src/services/translation/translateDecision.ts
+++ b/packages/common/src/services/translation/translateDecision.ts
@@ -56,7 +56,7 @@ export async function translateDecision({
     .limit(1);
 
   if (instances.length === 0) {
-    throw new NotFoundError('Decision profile not found');
+    throw new NotFoundError('Decision profile', decisionProfileId);
   }
 
   const processInstance = instances[0]!;

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -405,7 +405,7 @@ export const switchUserOrganization = async (
     .returning();
 
   if (!result.length || !result[0]) {
-    throw new NotFoundError('User');
+    throw new NotFoundError('User', authUserId);
   }
 
   return result[0];

--- a/services/api/src/routers/account/getMyAccount.ts
+++ b/services/api/src/routers/account/getMyAccount.ts
@@ -33,7 +33,7 @@ export const getMyAccount = router({
 
       if (!user) {
         if (!email) {
-          throw new NotFoundError('Could not find user');
+          throw new NotFoundError('User', id);
         }
 
         // if there is no user but the user is authenticated, create one

--- a/services/api/src/routers/account/switchProfile.ts
+++ b/services/api/src/routers/account/switchProfile.ts
@@ -24,7 +24,7 @@ export const switchProfile = router({
       const user = await getUserForProfileSwitch({ authUserId: id });
 
       if (!user) {
-        throw new NotFoundError('User');
+        throw new NotFoundError('User', id);
       }
 
       // Check if switching to user's own individual profile
@@ -57,7 +57,7 @@ export const switchProfile = router({
       });
 
       if (!result.length || !result[0]) {
-        throw new NotFoundError('User');
+        throw new NotFoundError('User', id);
       }
 
       // Invalidate user cache since current profile/organization context has changed

--- a/services/api/src/routers/account/uploadBannerImage.ts
+++ b/services/api/src/routers/account/uploadBannerImage.ts
@@ -129,11 +129,7 @@ export const uploadBannerImage = router({
           // Track analytics (non-blocking)
           waitUntil(trackImageUpload(ctx, 'banner', !!hadPreviousImage));
         } else {
-          throw new NotFoundError(
-            'User profile',
-            undefined,
-            'User profile not found. Please create a profile first.',
-          );
+          throw new NotFoundError('User profile');
         }
       }
 

--- a/services/api/src/routers/decision/results/getInstanceResults.ts
+++ b/services/api/src/routers/decision/results/getInstanceResults.ts
@@ -22,11 +22,7 @@ export const getInstanceResultsRouter = router({
       });
 
       if (!result) {
-        throw new NotFoundError(
-          'Results',
-          input?.instanceId,
-          'Results have not been processed yet for this instance',
-        );
+        throw new NotFoundError('Results', input?.instanceId);
       }
 
       return result;

--- a/services/api/src/routers/organization/deletePost.ts
+++ b/services/api/src/routers/organization/deletePost.ts
@@ -33,11 +33,7 @@ export const deletePost = router({
         .limit(1);
 
       if (!organization.length) {
-        throw new NotFoundError(
-          'Organization',
-          profileId,
-          'Organization not found for the specified profileId',
-        );
+        throw new NotFoundError('Organization', profileId);
       }
 
       const organizationId = organization[0]!.id;

--- a/services/api/src/routers/platform/admin/addUsersToOrganization.ts
+++ b/services/api/src/routers/platform/admin/addUsersToOrganization.ts
@@ -71,7 +71,7 @@ export const addUsersToOrganizationRouter = router({
         (authUserId) => !existingAuthUserIds.has(authUserId),
       );
       if (invalidAuthUserIds.length > 0) {
-        throw new NotFoundError('User');
+        throw new NotFoundError('User', invalidAuthUserIds[0]);
       }
 
       // Check all role IDs exist
@@ -80,7 +80,7 @@ export const addUsersToOrganizationRouter = router({
         (roleId) => !existingRoleIds.has(roleId),
       );
       if (invalidRoleIds.length > 0) {
-        throw new NotFoundError('Role');
+        throw new NotFoundError('Role', invalidRoleIds[0]);
       }
 
       // Join each user to the organization

--- a/services/api/src/routers/posts/getPost.ts
+++ b/services/api/src/routers/posts/getPost.ts
@@ -19,7 +19,7 @@ export const getPost = router({
       });
 
       if (!post) {
-        throw new NotFoundError('Post');
+        throw new NotFoundError('Post', input.postId);
       }
 
       return outputSchema.parse(post);


### PR DESCRIPTION
Pass resourceType (and resourceId when in scope) to NotFoundError instead of pre-built message strings, so errors carry structured metadata and produce consistent default messages.