### PR TITLE
fix(reviews): require phaseId on review-aggregate endpoints

### DIFF
--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -24,10 +24,12 @@ const SORT_DIRS = ['asc', 'desc'] as const;
 
 export function ReviewAssignmentsList({
   processInstanceId,
+  phaseId,
   decisionSlug,
   canViewReviewers = false,
 }: {
   processInstanceId: string;
+  phaseId: string;
   decisionSlug: string;
   canViewReviewers?: boolean;
 }) {
@@ -58,6 +60,7 @@ export function ReviewAssignmentsList({
       {
         processInstanceId,
         proposalIds,
+        phaseId,
       },
       {
         enabled: canViewReviewers && proposalIds.length > 0,

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
@@ -71,6 +71,9 @@ export async function ReviewSummaryLayout({
 
   const proposalId = proposal.id;
   const phaseId = resolveReviewPhaseId(instance);
+  if (!phaseId) {
+    notFound();
+  }
 
   await utils.decision.getProposalWithReviewAggregates.prefetch({
     processInstanceId: instanceId,

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
@@ -18,7 +18,7 @@ interface ReviewSummaryViewProps {
   instanceId: string;
   proposalId: string;
   proposalProfileId: string;
-  phaseId: string | undefined;
+  phaseId: string;
 }
 
 export function ReviewSummaryView({

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -84,6 +84,7 @@ export function ReviewPage({
               {canReview ? (
                 <ReviewAssignmentsList
                   processInstanceId={instance.id}
+                  phaseId={currentPhase.phaseId}
                   decisionSlug={decisionSlug}
                   canViewReviewers={Boolean(instance.access?.admin)}
                 />

--- a/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
@@ -1,6 +1,5 @@
 import { db } from '@op/db/client';
 import type { User } from '@op/supabase/lib';
-import { z } from 'zod';
 
 import { NotFoundError, UnauthorizedError } from '../../utils';
 import { getInstance } from './getInstance';
@@ -11,29 +10,21 @@ import {
   getSubmittedReviewScore,
   proposalRelations,
 } from './listProposalsWithReviewAggregates';
+import type { ProposalPhaseRef } from './schemas/instance';
 import {
   type ProposalWithSubmittedReviews,
   proposalWithSubmittedReviewsSchema,
 } from './schemas/reviews';
-
-export const getProposalWithReviewAggregatesInputSchema = z.object({
-  processInstanceId: z.uuid(),
-  proposalId: z.uuid(),
-  phaseId: z.string().optional(),
-});
-
-export type GetProposalWithReviewAggregatesInput = z.infer<
-  typeof getProposalWithReviewAggregatesInputSchema
->;
+import { assertInstancePhase } from './utils/instance';
 
 /**
  * Submitted-only by design: drafts and unstarted assignments contribute to
  * `aggregates.assignmentsCount` but are not surfaced in `reviews[]`.
  */
 export async function getProposalWithReviewAggregates(
-  input: GetProposalWithReviewAggregatesInput & { user: User },
+  input: ProposalPhaseRef & { user: User },
 ): Promise<ProposalWithSubmittedReviews> {
-  const { user, processInstanceId, proposalId } = input;
+  const { user, processInstanceId, proposalId, phaseId } = input;
 
   const instance = await getInstance({ instanceId: processInstanceId, user });
 
@@ -43,14 +34,14 @@ export async function getProposalWithReviewAggregates(
     );
   }
 
+  assertInstancePhase({ instance, phaseId });
+
   const rubricTemplate = instance.instanceData.rubricTemplate;
   const scoredCriterionKeys = rubricTemplate
     ? getRubricScoringInfo(rubricTemplate)
         .criteria.filter((c) => c.scored)
         .map((c) => c.key)
     : [];
-
-  const phaseId = input.phaseId ?? instance.currentStateId ?? undefined;
 
   const [proposal, categoriesByProposalId] = await Promise.all([
     db.query.proposals.findFirst({

--- a/packages/common/src/services/decision/listProposalsWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/listProposalsWithReviewAggregates.ts
@@ -21,11 +21,13 @@ import {
   OVERALL_RECOMMENDATION_KEY,
   getRubricScoringInfo,
 } from './getRubricScoringInfo';
+import { instancePhaseRefSchema } from './schemas/instance';
 import {
   type ProposalCategoryItem,
   type ProposalsWithReviewAggregatesList,
   proposalsWithReviewAggregatesListSchema,
 } from './schemas/reviews';
+import { assertInstancePhase } from './utils/instance';
 
 // ── Input schema ───────────────────────────────────────────────────────
 
@@ -35,14 +37,10 @@ import {
  *   - paginated: phase-scoped, cursor-paginated.
  */
 export const listProposalsWithReviewAggregatesInputSchema = z.union([
-  z.object({
-    processInstanceId: z.uuid(),
-    phaseId: z.string().optional(),
+  instancePhaseRefSchema.extend({
     proposalIds: z.array(z.uuid()).min(1),
   }),
-  z.object({
-    processInstanceId: z.uuid(),
-    phaseId: z.string().optional(),
+  instancePhaseRefSchema.extend({
     limit: z.number().int().min(1).max(100).default(50),
     cursor: z.string().optional(),
   }),
@@ -67,7 +65,7 @@ export type ListProposalsWithReviewAggregatesInput = z.infer<
 export async function listProposalsWithReviewAggregates(
   input: ListProposalsWithReviewAggregatesInput & { user: User },
 ): Promise<ProposalsWithReviewAggregatesList> {
-  const { user, processInstanceId } = input;
+  const { user, processInstanceId, phaseId } = input;
 
   const instance = await getInstance({ instanceId: processInstanceId, user });
 
@@ -77,6 +75,8 @@ export async function listProposalsWithReviewAggregates(
     );
   }
 
+  assertInstancePhase({ instance, phaseId });
+
   const rubricTemplate = instance.instanceData.rubricTemplate;
   const scoredCriterionKeys = rubricTemplate
     ? getRubricScoringInfo(rubricTemplate)
@@ -84,7 +84,6 @@ export async function listProposalsWithReviewAggregates(
         .map((c) => c.key)
     : [];
 
-  const phaseId = input.phaseId ?? instance.currentStateId ?? undefined;
   const phaseProposalIds = await getProposalIdsForPhase({
     instance,
     phaseId,

--- a/packages/common/src/services/decision/schemas/instance.ts
+++ b/packages/common/src/services/decision/schemas/instance.ts
@@ -9,3 +9,12 @@ export const instancePhaseRefSchema = z.object({
 });
 
 export type InstancePhaseRef = z.infer<typeof instancePhaseRefSchema>;
+
+/**
+ * Reference to a specific proposal scoped to an instance phase.
+ */
+export const proposalPhaseRefSchema = instancePhaseRefSchema.extend({
+  proposalId: z.uuid(),
+});
+
+export type ProposalPhaseRef = z.infer<typeof proposalPhaseRefSchema>;

--- a/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
+++ b/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
@@ -78,6 +78,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
       reviewerCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: created.context.instance.instance.id,
         proposalId: created.proposal.id,
+        phaseId: 'review',
       }),
     ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
@@ -101,6 +102,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
       adminCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: primary.context.instance.instance.id,
         proposalId: foreign.proposal.id,
+        phaseId: 'review',
       }),
     ).rejects.toMatchObject({ cause: { name: 'NotFoundError' } });
   });
@@ -119,6 +121,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
       adminCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: context.instance.instance.id,
         proposalId: '00000000-0000-0000-0000-000000000000',
+        phaseId: 'review',
       }),
     ).rejects.toMatchObject({ cause: { name: 'NotFoundError' } });
   });
@@ -184,6 +187,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
     const result = await adminCaller.decision.getProposalWithReviewAggregates({
       processInstanceId: context.instance.instance.id,
       proposalId: submittedScenario.proposal.id,
+      phaseId: 'review',
     });
 
     expect(result.proposal.id).toBe(submittedScenario.proposal.id);
@@ -270,6 +274,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
     const result = await adminCaller.decision.getProposalWithReviewAggregates({
       processInstanceId: context.instance.instance.id,
       proposalId: firstScenario.proposal.id,
+      phaseId: 'review',
     });
 
     expect(result.aggregates).toMatchObject({

--- a/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.ts
+++ b/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.ts
@@ -1,6 +1,6 @@
 import {
   getProposalWithReviewAggregates,
-  getProposalWithReviewAggregatesInputSchema,
+  proposalPhaseRefSchema,
   proposalWithSubmittedReviewsSchema,
 } from '@op/common';
 
@@ -8,7 +8,7 @@ import { commonAuthedProcedure, router } from '../../../trpcFactory';
 
 export const getProposalWithReviewAggregatesRouter = router({
   getProposalWithReviewAggregates: commonAuthedProcedure()
-    .input(getProposalWithReviewAggregatesInputSchema)
+    .input(proposalPhaseRefSchema)
     .output(proposalWithSubmittedReviewsSchema)
     .query(async ({ ctx, input }) => {
       return await getProposalWithReviewAggregates({

--- a/services/api/src/routers/decision/proposals/listWithReviewAggregates.test.ts
+++ b/services/api/src/routers/decision/proposals/listWithReviewAggregates.test.ts
@@ -100,6 +100,7 @@ describe.concurrent('listWithReviewAggregates', () => {
     await expect(
       reviewerCaller.decision.listWithReviewAggregates({
         processInstanceId: context.instance.instance.id,
+        phaseId: 'review',
       }),
     ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
@@ -120,6 +121,7 @@ describe.concurrent('listWithReviewAggregates', () => {
       reviewerCaller.decision.listWithReviewAggregates({
         processInstanceId: created.context.instance.instance.id,
         proposalIds: [created.proposal.id],
+        phaseId: 'review',
       }),
     ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
@@ -166,6 +168,7 @@ describe.concurrent('listWithReviewAggregates', () => {
     const result = await adminCaller.decision.listWithReviewAggregates({
       processInstanceId: context.instance.instance.id,
       proposalIds: [withReview.proposal.id, withoutReview.proposal.id],
+      phaseId: 'review',
     });
 
     expect(result.items).toHaveLength(2);
@@ -217,6 +220,7 @@ describe.concurrent('listWithReviewAggregates', () => {
     const result = await adminCaller.decision.listWithReviewAggregates({
       processInstanceId: primary.context.instance.instance.id,
       proposalIds: [primary.proposal.id, foreign.proposal.id],
+      phaseId: 'review',
     });
 
     expect(result.items.map((i) => i.proposal.id)).toEqual([
@@ -249,6 +253,7 @@ describe.concurrent('listWithReviewAggregates', () => {
     const result = await adminCaller.decision.listWithReviewAggregates({
       processInstanceId: created.context.instance.instance.id,
       proposalIds: [created.proposal.id],
+      phaseId: 'review',
     });
 
     expect(result.items).toEqual([]);
@@ -274,6 +279,7 @@ describe.concurrent('listWithReviewAggregates', () => {
     const page1 = await adminCaller.decision.listWithReviewAggregates({
       processInstanceId: context.instance.instance.id,
       limit: 2,
+      phaseId: 'review',
     });
 
     expect(page1.total).toBe(3);
@@ -284,6 +290,7 @@ describe.concurrent('listWithReviewAggregates', () => {
       processInstanceId: context.instance.instance.id,
       limit: 2,
       cursor: page1.next!,
+      phaseId: 'review',
     });
 
     expect(page2.items).toHaveLength(1);
@@ -325,6 +332,7 @@ describe.concurrent('listWithReviewAggregates', () => {
 
     const result = await adminCaller.decision.listWithReviewAggregates({
       processInstanceId: context.instance.instance.id,
+      phaseId: 'review',
     });
 
     const tagged = result.items.find(
@@ -356,6 +364,7 @@ describe.concurrent('listWithReviewAggregates', () => {
     const result = await adminCaller.decision.listWithReviewAggregates({
       processInstanceId: context.instance.instance.id,
       proposalIds: [created.proposal.id],
+      phaseId: 'review',
     });
 
     expect(result.items).toHaveLength(1);


### PR DESCRIPTION
Unknown phases used to silently resolve to currentStateId and return empty results; now they fail loudly via assertInstancePhase.