### PR TITLE
fix(a11y): bump core color tokens for WCAG contrast

### DIFF
--- a/apps/app/src/components/LinkPreview/index.tsx
+++ b/apps/app/src/components/LinkPreview/index.tsx
@@ -95,7 +95,7 @@ export const LinkPreview = memo(
     return (
       <Surface
         className={cn(
-          'group bg-neutral-white relative rounded-lg border-neutral-gray1',
+          'group bg-white relative rounded-lg border-neutral-gray1',
           className,
         )}
       >

--- a/apps/app/src/components/LinkPreview/index.tsx
+++ b/apps/app/src/components/LinkPreview/index.tsx
@@ -95,7 +95,7 @@ export const LinkPreview = memo(
     return (
       <Surface
         className={cn(
-          'group bg-white relative rounded-lg border-neutral-gray1',
+          'group relative rounded-lg border-neutral-gray1 bg-white',
           className,
         )}
       >

--- a/apps/app/src/components/LoginPanel.tsx
+++ b/apps/app/src/components/LoginPanel.tsx
@@ -252,9 +252,9 @@ export const LoginPanel = () => {
                       </Button>
 
                       <div className="flex w-full items-center justify-center gap-4 text-darkGray">
-                        <div className="h-px grow bg-current" />
+                        <div className="h-px grow bg-current opacity-50" />
                         <span>{t('or')}</span>
-                        <div className="h-px grow bg-current" />
+                        <div className="h-px grow bg-current opacity-50" />
                       </div>
                     </>
                   )}

--- a/apps/app/src/components/LoginPanel.tsx
+++ b/apps/app/src/components/LoginPanel.tsx
@@ -251,7 +251,7 @@ export const LoginPanel = () => {
                         {t('Continue with Google')}
                       </Button>
 
-                      <div className="flex w-full items-center justify-center gap-4 text-midGray">
+                      <div className="flex w-full items-center justify-center gap-4 text-darkGray">
                         <div className="h-px grow bg-current" />
                         <span>{t('or')}</span>
                         <div className="h-px grow bg-current" />
@@ -404,7 +404,7 @@ export const LoginPanel = () => {
               {user?.error?.name === 'AuthRetryableFetchError' ||
               login.isError ||
               !!combinedError ? null : (
-                <div className="flex flex-col items-center justify-center text-center text-xs text-midGray sm:text-sm">
+                <div className="flex flex-col items-center justify-center text-center text-xs text-darkGray sm:text-sm">
                   {isSignup ? (
                     <span>
                       {t(

--- a/apps/app/src/components/decisions/MyBallot.tsx
+++ b/apps/app/src/components/decisions/MyBallot.tsx
@@ -107,7 +107,7 @@ const MyBallotProposals = ({
 
               <ProposalCardPreview proposal={proposal} />
 
-              <div className="border-neutral-gray-2 h-0 w-full border-b" />
+              <div className="h-0 w-full border-b border-neutral-gray-2" />
 
               <ProposalCardFooter>
                 <div className="flex items-start gap-1 text-base text-neutral-charcoal">

--- a/apps/app/src/components/decisions/MyBallot.tsx
+++ b/apps/app/src/components/decisions/MyBallot.tsx
@@ -107,7 +107,7 @@ const MyBallotProposals = ({
 
               <ProposalCardPreview proposal={proposal} />
 
-              <div className="border-neutral-silver h-0 w-full border-b" />
+              <div className="border-neutral-gray-2 h-0 w-full border-b" />
 
               <ProposalCardFooter>
                 <div className="flex items-start gap-1 text-base text-neutral-charcoal">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
@@ -186,7 +186,7 @@ function FieldConfigDropdownOptions({
         color="ghost"
         size="small"
         onPress={handleAddOption}
-        className="hover:text-primary-tealDark gap-1 p-0 text-primary-teal"
+        className="hover:text-primary-tealBlack gap-1 p-0 text-primary-teal"
       >
         <LuPlus className="size-4" />
         <span>{t('Add option')}</span>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
@@ -186,7 +186,7 @@ function FieldConfigDropdownOptions({
         color="ghost"
         size="small"
         onPress={handleAddOption}
-        className="hover:text-primary-tealBlack gap-1 p-0 text-primary-teal"
+        className="gap-1 p-0 text-primary-teal hover:text-primary-tealBlack"
       >
         <LuPlus className="size-4" />
         <span>{t('Add option')}</span>

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -500,7 +500,7 @@ function ProfileInviteModalContent({
                     <ListBoxItem
                       id="add-email"
                       textValue={debouncedQuery}
-                      className="hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1 cursor-pointer px-4 py-3 outline-none"
+                      className="cursor-pointer px-4 py-3 outline-none hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1"
                     >
                       <div className="text-sm">
                         {t('Invite {email}', { email: debouncedQuery })}
@@ -512,7 +512,7 @@ function ProfileInviteModalContent({
                       key={result.id}
                       id={result.id}
                       textValue={result.name}
-                      className="hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1 cursor-pointer px-4 py-3 outline-none"
+                      className="cursor-pointer px-4 py-3 outline-none hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1"
                     >
                       <ProfileItem
                         size="small"

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -500,7 +500,7 @@ function ProfileInviteModalContent({
                     <ListBoxItem
                       id="add-email"
                       textValue={debouncedQuery}
-                      className="hover:bg-neutral-gray0 focus-visible:bg-neutral-gray0 cursor-pointer px-4 py-3 outline-none"
+                      className="hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1 cursor-pointer px-4 py-3 outline-none"
                     >
                       <div className="text-sm">
                         {t('Invite {email}', { email: debouncedQuery })}
@@ -512,7 +512,7 @@ function ProfileInviteModalContent({
                       key={result.id}
                       id={result.id}
                       textValue={result.name}
-                      className="hover:bg-neutral-gray0 focus-visible:bg-neutral-gray0 cursor-pointer px-4 py-3 outline-none"
+                      className="hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1 cursor-pointer px-4 py-3 outline-none"
                     >
                       <ProfileItem
                         size="small"

--- a/apps/app/src/components/decisions/ResultsList.tsx
+++ b/apps/app/src/components/decisions/ResultsList.tsx
@@ -81,7 +81,7 @@ export const ResultsList = ({
             <ProposalCardContent>
               {slug !== 'cowop' && resultStats?.membersVoted ? (
                 <div className="flex flex-col gap-3">
-                  <div className="border-neutral-silver h-0 w-full border-b" />
+                  <div className="border-neutral-gray-2 h-0 w-full border-b" />
 
                   {/* Footer - Total Votes */}
                   <ProposalCardFooter>

--- a/apps/app/src/components/decisions/ResultsList.tsx
+++ b/apps/app/src/components/decisions/ResultsList.tsx
@@ -81,7 +81,7 @@ export const ResultsList = ({
             <ProposalCardContent>
               {slug !== 'cowop' && resultStats?.membersVoted ? (
                 <div className="flex flex-col gap-3">
-                  <div className="border-neutral-gray-2 h-0 w-full border-b" />
+                  <div className="h-0 w-full border-b border-neutral-gray-2" />
 
                   {/* Footer - Total Votes */}
                   <ProposalCardFooter>

--- a/apps/app/src/components/decisions/ShareProposalModal.tsx
+++ b/apps/app/src/components/decisions/ShareProposalModal.tsx
@@ -403,7 +403,7 @@ function ShareProposalModalContent({
                     <ListBoxItem
                       id="add-email"
                       textValue={debouncedQuery}
-                      className="hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1 cursor-pointer px-4 py-3 outline-none"
+                      className="cursor-pointer px-4 py-3 outline-none hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1"
                     >
                       <div className="text-sm">
                         {t('Invite {email}', { email: debouncedQuery })}
@@ -415,7 +415,7 @@ function ShareProposalModalContent({
                       key={result.id}
                       id={result.id}
                       textValue={result.name}
-                      className="hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1 cursor-pointer px-4 py-3 outline-none"
+                      className="cursor-pointer px-4 py-3 outline-none hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1"
                     >
                       <ProfileItem
                         size="small"

--- a/apps/app/src/components/decisions/ShareProposalModal.tsx
+++ b/apps/app/src/components/decisions/ShareProposalModal.tsx
@@ -403,7 +403,7 @@ function ShareProposalModalContent({
                     <ListBoxItem
                       id="add-email"
                       textValue={debouncedQuery}
-                      className="hover:bg-neutral-gray0 focus-visible:bg-neutral-gray0 cursor-pointer px-4 py-3 outline-none"
+                      className="hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1 cursor-pointer px-4 py-3 outline-none"
                     >
                       <div className="text-sm">
                         {t('Invite {email}', { email: debouncedQuery })}
@@ -415,7 +415,7 @@ function ShareProposalModalContent({
                       key={result.id}
                       id={result.id}
                       textValue={result.name}
-                      className="hover:bg-neutral-gray0 focus-visible:bg-neutral-gray0 cursor-pointer px-4 py-3 outline-none"
+                      className="hover:bg-neutral-gray-1 focus-visible:bg-neutral-gray-1 cursor-pointer px-4 py-3 outline-none"
                     >
                       <ProfileItem
                         size="small"

--- a/apps/app/src/components/screens/PlatformAdmin/AddUserToOrgModal.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/AddUserToOrgModal.tsx
@@ -128,7 +128,7 @@ const AddUserToOrgModalContent = ({
       {/* Body */}
       <ModalBody className="space-y-4">
         {/* User Info */}
-        <div className="bg-neutral-gray0 rounded-lg p-4">
+        <div className="bg-neutral-gray-1 rounded-lg p-4">
           <ProfileItem
             avatar={
               <Avatar

--- a/apps/app/src/components/screens/PlatformAdmin/AddUserToOrgModal.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/AddUserToOrgModal.tsx
@@ -128,7 +128,7 @@ const AddUserToOrgModalContent = ({
       {/* Body */}
       <ModalBody className="space-y-4">
         {/* User Info */}
-        <div className="bg-neutral-gray-1 rounded-lg p-4">
+        <div className="rounded-lg bg-neutral-gray-1 p-4">
           <ProfileItem
             avatar={
               <Avatar

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
@@ -146,7 +146,7 @@ const InstanceDataModal = ({
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable>
       <ModalHeader>{t('Instance data for {name}', { name })}</ModalHeader>
       <ModalBody className="pb-6">
-        <pre className="bg-neutral-gray0 max-h-[60vh] overflow-auto rounded-lg p-4 text-xs">
+        <pre className="bg-neutral-gray-1 max-h-[60vh] overflow-auto rounded-lg p-4 text-xs">
           {JSON.stringify(instanceData, null, 2)}
         </pre>
       </ModalBody>

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
@@ -146,7 +146,7 @@ const InstanceDataModal = ({
     <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable>
       <ModalHeader>{t('Instance data for {name}', { name })}</ModalHeader>
       <ModalBody className="pb-6">
-        <pre className="bg-neutral-gray-1 max-h-[60vh] overflow-auto rounded-lg p-4 text-xs">
+        <pre className="max-h-[60vh] overflow-auto rounded-lg bg-neutral-gray-1 p-4 text-xs">
           {JSON.stringify(instanceData, null, 2)}
         </pre>
       </ModalBody>

--- a/apps/app/src/components/screens/PlatformAdmin/OrgMembersModal.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/OrgMembersModal.tsx
@@ -30,7 +30,7 @@ export const OrgMembersModal = ({
       <ModalHeader>{t('Members of {orgName}', { orgName })}</ModalHeader>
       <ModalBody className="space-y-4 pb-6">
         {/* Organization Info */}
-        <div className="bg-neutral-gray-1 rounded-lg p-4">
+        <div className="rounded-lg bg-neutral-gray-1 p-4">
           <ProfileItem
             avatar={
               <Avatar placeholder={orgName} className="size-10 shrink-0" />

--- a/apps/app/src/components/screens/PlatformAdmin/OrgMembersModal.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/OrgMembersModal.tsx
@@ -30,7 +30,7 @@ export const OrgMembersModal = ({
       <ModalHeader>{t('Members of {orgName}', { orgName })}</ModalHeader>
       <ModalBody className="space-y-4 pb-6">
         {/* Organization Info */}
-        <div className="bg-neutral-gray0 rounded-lg p-4">
+        <div className="bg-neutral-gray-1 rounded-lg p-4">
           <ProfileItem
             avatar={
               <Avatar placeholder={orgName} className="size-10 shrink-0" />

--- a/packages/styles/intent-ui-theme.css
+++ b/packages/styles/intent-ui-theme.css
@@ -3,6 +3,8 @@
  * Maps Intent UI CSS variables to @op/styles tokens
  *
  * Note: Border color defaults and radius values are defined in shared-styles.css
+ * Note: Alpha tints use color-mix() against the semantic --color-* tokens since
+ * the raw --op-* layer now stores full hsla() values rather than HSL triplets.
  */
 
 /* Tailwind theme colors that map to Intent UI variables */
@@ -14,6 +16,19 @@
   --color-fg: var(--fg);
   --color-bg: var(--bg);
   --color-ring: var(--ring);
+
+  /* Foreground on primary surfaces */
+  --color-primary-fg: var(--primary-fg);
+
+  /* Semantic subtle pairs (bg + fg) used by AlertBanner et al. */
+  --color-info-subtle: var(--info-subtle);
+  --color-info-subtle-fg: var(--info-subtle-fg);
+  --color-success-subtle: var(--success-subtle);
+  --color-success-subtle-fg: var(--success-subtle-fg);
+  --color-warning-subtle: var(--warning-subtle);
+  --color-warning-subtle-fg: var(--warning-subtle-fg);
+  --color-danger-subtle: var(--danger-subtle);
+  --color-danger-subtle-fg: var(--danger-subtle-fg);
 }
 
 :root {
@@ -24,62 +39,86 @@
   --fg: var(--color-neutral-charcoal);
 
   /* Primary - teal */
-  --primary: var(--color-primary-teal);
+  --primary: var(--color-primary);
   --primary-fg: var(--color-white);
-  --primary-subtle: hsl(var(--op-teal-500) / 0.15);
-  --primary-subtle-fg: var(--color-primary-tealBlack);
+  --primary-subtle: color-mix(
+    in srgb,
+    var(--color-primary-500) 15%,
+    transparent
+  );
+  --primary-subtle-fg: var(--color-primary-700);
 
   /* Secondary - neutral */
-  --secondary: var(--color-neutral-gray1);
+  --secondary: var(--color-neutral-gray-1);
   --secondary-fg: var(--color-neutral-charcoal);
 
   /* Overlay */
-  --overlay: hsl(var(--op-neutral-950) / 0.6);
+  --overlay: color-mix(in srgb, var(--color-neutral-black) 60%, transparent);
   --overlay-fg: var(--color-white);
 
   /* Accent - neutral */
-  --accent: var(--color-neutral-gray1);
+  --accent: var(--color-neutral-gray-1);
   --accent-fg: var(--color-neutral-charcoal);
-  --accent-subtle: hsl(var(--op-neutral-500) / 0.1);
-  --accent-subtle-fg: var(--color-neutral-gray4);
+  --accent-subtle: color-mix(
+    in srgb,
+    var(--color-neutral-gray-3) 10%,
+    transparent
+  );
+  --accent-subtle-fg: var(--color-neutral-gray-4);
 
   /* Muted */
-  --muted: var(--color-neutral-offWhite);
-  --muted-fg: var(--color-neutral-gray4);
+  --muted: var(--color-neutral-off-white);
+  --muted-fg: var(--color-neutral-gray-4);
 
   /* ============================================
    * Semantic Colors
    * ============================================ */
   /* Success - green */
-  --success: var(--color-functional-green);
+  --success: var(--color-functional-green-600);
   --success-fg: var(--color-white);
-  --success-subtle: hsl(var(--op-green-500) / 0.15);
-  --success-subtle-fg: var(--color-green-700);
+  --success-subtle: color-mix(
+    in srgb,
+    var(--color-functional-green-600) 15%,
+    transparent
+  );
+  --success-subtle-fg: var(--color-functional-green-600);
 
   /* Info - teal */
-  --info: hsl(var(--op-teal-400));
+  --info: var(--color-primary-500);
   --info-fg: var(--color-white);
-  --info-subtle: hsl(var(--op-teal-400) / 0.15);
-  --info-subtle-fg: hsl(var(--op-teal-700));
+  --info-subtle: color-mix(
+    in srgb,
+    var(--color-primary-500) 15%,
+    transparent
+  );
+  --info-subtle-fg: var(--color-primary-700);
 
   /* Warning - yellow */
-  --warning: var(--color-primary-yellow);
+  --warning: var(--color-primary-yellow-500);
   --warning-fg: var(--color-neutral-charcoal);
-  --warning-subtle: hsl(var(--op-yellow-500) / 0.2);
-  --warning-subtle-fg: hsl(var(--op-yellow-700));
+  --warning-subtle: color-mix(
+    in srgb,
+    var(--color-primary-yellow-500) 20%,
+    transparent
+  );
+  --warning-subtle-fg: var(--color-neutral-charcoal);
 
   /* Danger - red */
-  --danger: var(--color-functional-red);
+  --danger: var(--color-functional-red-600);
   --danger-fg: var(--color-white);
-  --danger-subtle: hsl(var(--op-red-500) / 0.15);
-  --danger-subtle-fg: var(--color-red-700);
+  --danger-subtle: color-mix(
+    in srgb,
+    var(--color-functional-red-600) 15%,
+    transparent
+  );
+  --danger-subtle-fg: var(--color-functional-red-800);
 
   /* ============================================
    * UI Elements
    * ============================================ */
-  --border: var(--color-neutral-gray1);
-  --input: var(--color-neutral-gray1);
-  --ring: var(--color-primary-teal);
+  --border: var(--color-neutral-gray-1);
+  --input: var(--color-neutral-gray-1);
+  --ring: var(--color-primary-500);
 
   /* ============================================
    * Layout
@@ -87,21 +126,25 @@
   --navbar: var(--color-white);
   --navbar-fg: var(--color-neutral-charcoal);
 
-  --sidebar: var(--color-neutral-offWhite);
+  --sidebar: var(--color-neutral-off-white);
   --sidebar-fg: var(--color-neutral-charcoal);
-  --sidebar-primary: hsl(var(--op-teal-500) / 0.15);
-  --sidebar-primary-fg: var(--color-primary-tealBlack);
-  --sidebar-accent: var(--color-neutral-gray1);
+  --sidebar-primary: color-mix(
+    in srgb,
+    var(--color-primary-500) 15%,
+    transparent
+  );
+  --sidebar-primary-fg: var(--color-primary-700);
+  --sidebar-accent: var(--color-neutral-gray-1);
   --sidebar-accent-fg: var(--color-neutral-charcoal);
-  --sidebar-border: var(--color-neutral-gray1);
-  --sidebar-ring: var(--color-primary-teal);
+  --sidebar-border: var(--color-neutral-gray-1);
+  --sidebar-ring: var(--color-primary-500);
 
   /* ============================================
    * Charts
    * ============================================ */
-  --chart-1: var(--color-primary-teal);
-  --chart-2: var(--color-functional-green);
-  --chart-3: var(--color-primary-yellow);
+  --chart-1: var(--color-primary-500);
+  --chart-2: var(--color-functional-green-600);
+  --chart-3: var(--color-primary-yellow-500);
   --chart-4: var(--color-data-purple);
   --chart-5: var(--color-data-blue);
 }
@@ -110,50 +153,78 @@
 .dark,
 [data-theme='dark'] {
   --bg: var(--color-neutral-black);
-  --fg: var(--color-neutral-offWhite);
+  --fg: var(--color-neutral-off-white);
 
-  --primary: hsl(var(--op-teal-400));
+  --primary: var(--color-primary-500);
   --primary-fg: var(--color-neutral-black);
-  --primary-subtle: hsl(var(--op-teal-400) / 0.1);
-  --primary-subtle-fg: var(--color-teal-200);
+  --primary-subtle: color-mix(
+    in srgb,
+    var(--color-primary-500) 10%,
+    transparent
+  );
+  --primary-subtle-fg: var(--color-primary-100);
 
-  --secondary: var(--color-neutral-gray4);
-  --secondary-fg: var(--color-neutral-offWhite);
+  --secondary: var(--color-neutral-gray-4);
+  --secondary-fg: var(--color-neutral-off-white);
 
   --overlay: var(--color-neutral-charcoal);
-  --overlay-fg: var(--color-neutral-offWhite);
+  --overlay-fg: var(--color-neutral-off-white);
 
-  --accent: var(--color-neutral-gray4);
-  --accent-fg: var(--color-neutral-offWhite);
-  --accent-subtle: hsl(var(--op-neutral-500) / 0.1);
-  --accent-subtle-fg: var(--color-neutral-gray2);
+  --accent: var(--color-neutral-gray-4);
+  --accent-fg: var(--color-neutral-off-white);
+  --accent-subtle: color-mix(
+    in srgb,
+    var(--color-neutral-gray-3) 10%,
+    transparent
+  );
+  --accent-subtle-fg: var(--color-neutral-gray-2);
 
   --muted: var(--color-neutral-charcoal);
-  --muted-fg: var(--color-neutral-gray2);
+  --muted-fg: var(--color-neutral-gray-2);
 
-  --success-subtle: hsl(var(--op-green-500) / 0.1);
-  --success-subtle-fg: hsl(var(--op-green-300));
+  --success-subtle: color-mix(
+    in srgb,
+    var(--color-functional-green-600) 10%,
+    transparent
+  );
+  --success-subtle-fg: var(--color-functional-green-100);
 
-  --info-subtle: hsl(var(--op-teal-400) / 0.1);
-  --info-subtle-fg: var(--color-teal-200);
+  --info-subtle: color-mix(
+    in srgb,
+    var(--color-primary-500) 10%,
+    transparent
+  );
+  --info-subtle-fg: var(--color-primary-100);
 
-  --warning-subtle: hsl(var(--op-yellow-500) / 0.1);
-  --warning-subtle-fg: hsl(var(--op-yellow-400));
+  --warning-subtle: color-mix(
+    in srgb,
+    var(--color-primary-yellow-500) 10%,
+    transparent
+  );
+  --warning-subtle-fg: var(--color-primary-yellow-500);
 
-  --danger-subtle: hsl(var(--op-red-500) / 0.1);
-  --danger-subtle-fg: var(--color-red-300);
+  --danger-subtle: color-mix(
+    in srgb,
+    var(--color-functional-red-600) 10%,
+    transparent
+  );
+  --danger-subtle-fg: var(--color-functional-red-100);
 
-  --border: var(--color-neutral-gray4);
-  --input: var(--color-neutral-gray4);
+  --border: var(--color-neutral-gray-4);
+  --input: var(--color-neutral-gray-4);
 
   --navbar: var(--color-neutral-charcoal);
-  --navbar-fg: var(--color-neutral-offWhite);
+  --navbar-fg: var(--color-neutral-off-white);
 
   --sidebar: var(--color-neutral-charcoal);
-  --sidebar-fg: var(--color-neutral-offWhite);
-  --sidebar-primary: hsl(var(--op-teal-400) / 0.1);
-  --sidebar-primary-fg: var(--color-teal-200);
-  --sidebar-accent: var(--color-neutral-gray4);
-  --sidebar-accent-fg: var(--color-neutral-offWhite);
-  --sidebar-border: var(--color-neutral-gray4);
+  --sidebar-fg: var(--color-neutral-off-white);
+  --sidebar-primary: color-mix(
+    in srgb,
+    var(--color-primary-500) 10%,
+    transparent
+  );
+  --sidebar-primary-fg: var(--color-primary-100);
+  --sidebar-accent: var(--color-neutral-gray-4);
+  --sidebar-accent-fg: var(--color-neutral-off-white);
+  --sidebar-border: var(--color-neutral-gray-4);
 }

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -170,7 +170,7 @@
   --color-teal-100: hsl(var(--op-teal-100));
   --color-teal-200: hsl(var(--op-teal-200));
   --color-teal-300: hsl(var(--op-teal-300));
-  --color-teal: hsl(var(--op-teal-500));
+  --color-teal: hsl(var(--op-teal-600));
 
   /* ============================================
    * Colors - Red
@@ -208,10 +208,10 @@
   /* ============================================
    * Colors - Primary
    * ============================================ */
-  --color-primary: hsl(var(--op-teal-500));
-  --color-primary-teal: hsl(var(--op-teal-500));
+  --color-primary: hsl(var(--op-teal-600));
+  --color-primary-teal: hsl(var(--op-teal-600));
   --color-primary-tealWhite: hsl(var(--op-teal-white));
-  --color-primary-tealBlack: hsl(var(--op-teal-600));
+  --color-primary-tealBlack: hsl(var(--op-teal-700));
   --color-primary-yellow: hsl(var(--op-yellow-500));
   --color-primary-orange1: hsl(var(--op-orange1-500));
   --color-primary-orange2: hsl(var(--op-orange2-500));
@@ -230,10 +230,10 @@
   /* ============================================
    * Colors - Functional
    * ============================================ */
-  --color-functional-red: hsl(var(--op-red-500));
-  --color-functional-redBlack: hsl(var(--op-red-600));
+  --color-functional-red: hsl(var(--op-red-600));
+  --color-functional-redBlack: hsl(var(--op-red-700));
   --color-functional-redWhite: hsl(var(--op-red-50));
-  --color-functional-green: hsl(var(--op-green-500));
+  --color-functional-green: hsl(var(--op-green-700));
   --color-functional-greenWhite: hsl(var(--op-green-50));
   --color-functional-yellowWhite: hsl(var(--op-yellow-50));
   --color-status-green: hsl(var(--op-status-green));

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -37,7 +37,7 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--color-neutral-gray1, currentColor);
+    border-color: var(--color-neutral-gray-1, currentColor);
   }
 }
 
@@ -164,90 +164,52 @@
   --spacing-18: 4.5rem;
 
   /* ============================================
-   * Colors - Teal
+   * Colors - Primary (Figma source-of-truth names)
    * ============================================ */
-  --color-teal-50: hsl(var(--op-teal-50));
-  --color-teal-100: hsl(var(--op-teal-100));
-  --color-teal-200: hsl(var(--op-teal-200));
-  --color-teal-300: hsl(var(--op-teal-300));
-  --color-teal: hsl(var(--op-teal-600));
+  --color-primary-50: var(--op-primary-50);
+  --color-primary-100: var(--op-primary-100);
+  --color-primary-500: var(--op-primary-500);
+  --color-primary-700: var(--op-primary-700);
+
+  --color-primary-yellow-500: var(--op-primary-yellow-500);
+  --color-primary-orange-50: var(--op-primary-orange-50);
+  --color-primary-orange-500: var(--op-primary-orange-500);
 
   /* ============================================
-   * Colors - Red
+   * Colors - Neutrals
    * ============================================ */
-  --color-red-100: hsl(var(--op-red-100));
-  --color-red-300: hsl(var(--op-red-300));
-  --color-red-600: hsl(var(--op-red-600));
-  --color-red-700: hsl(var(--op-red-700));
-  --color-red: hsl(var(--op-red-500));
-
-  /* ============================================
-   * Colors - Green
-   * ============================================ */
-  --color-green-500: hsl(var(--op-green-500));
-  --color-green-700: hsl(var(--op-green-700));
-  --color-green: hsl(var(--op-green-500));
-
-  /* ============================================
-   * Colors - Semantic Neutrals
-   * ============================================ */
-  --color-black: hsl(var(--op-neutral-950));
-  --color-charcoal: hsl(var(--op-neutral-900));
-  --color-darkGray: hsl(var(--op-neutral-700));
-  --color-midGray: hsl(var(--op-neutral-500));
-  --color-lightGray: hsl(var(--op-neutral-400));
-  --color-offWhite: hsl(var(--op-neutral-200));
-  --color-whiteish: hsl(var(--op-neutral-50));
-  --color-white: hsl(var(--op-white));
-
-  /* ============================================
-   * Colors - Border
-   * ============================================ */
-  --color-border: hsl(var(--op-offWhite));
-
-  /* ============================================
-   * Colors - Primary
-   * ============================================ */
-  --color-primary: hsl(var(--op-teal-600));
-  --color-primary-teal: hsl(var(--op-teal-600));
-  --color-primary-tealWhite: hsl(var(--op-teal-white));
-  --color-primary-tealBlack: hsl(var(--op-teal-700));
-  --color-primary-yellow: hsl(var(--op-yellow-500));
-  --color-primary-orange1: hsl(var(--op-orange1-500));
-  --color-primary-orange2: hsl(var(--op-orange2-500));
-
-  /* ============================================
-   * Colors - Neutral (semantic aliases)
-   * ============================================ */
-  --color-neutral-offWhite: hsl(var(--op-neutral-50));
-  --color-neutral-gray1: hsl(var(--op-neutral-200));
-  --color-neutral-gray2: hsl(var(--op-neutral-400));
-  --color-neutral-gray3: hsl(var(--op-neutral-500));
-  --color-neutral-gray4: hsl(var(--op-neutral-700));
-  --color-neutral-charcoal: hsl(var(--op-neutral-900));
-  --color-neutral-black: hsl(var(--op-neutral-950));
+  --color-white: var(--op-white);
+  --color-neutral-off-white: var(--op-neutral-off-white);
+  --color-neutral-gray-1: var(--op-neutral-gray-1);
+  --color-neutral-gray-2: var(--op-neutral-gray-2);
+  --color-neutral-gray-3: var(--op-neutral-gray-3);
+  --color-neutral-gray-4: var(--op-neutral-gray-4);
+  --color-neutral-charcoal: var(--op-neutral-charcoal);
+  --color-neutral-black: var(--op-neutral-black);
 
   /* ============================================
    * Colors - Functional
    * ============================================ */
-  --color-functional-red: hsl(var(--op-red-600));
-  --color-functional-redBlack: hsl(var(--op-red-700));
-  --color-functional-redWhite: hsl(var(--op-red-50));
-  --color-functional-green: hsl(var(--op-green-700));
-  --color-functional-greenWhite: hsl(var(--op-green-50));
-  --color-functional-yellowWhite: hsl(var(--op-yellow-50));
-  --color-status-green: hsl(var(--op-status-green));
-  --color-status-greenBg: hsl(var(--op-status-green-bg));
+  --color-functional-red-50: var(--op-functional-red-50);
+  --color-functional-red-100: var(--op-functional-red-100);
+  --color-functional-red-600: var(--op-functional-red-600);
+  --color-functional-red-800: var(--op-functional-red-800);
+  --color-functional-green-100: var(--op-functional-green-100);
+  --color-functional-green-600: var(--op-functional-green-600);
 
   /* ============================================
    * Colors - Data Visualization
    * ============================================ */
-  --color-data-purple: hsl(var(--op-purple-500));
-  --color-data-blue: hsl(var(--op-blue-500));
+  --color-data-purple: var(--op-data-purple);
+  --color-data-blue: var(--op-data-blue);
 
   /* ============================================
-   * Colors - Accent (from tailwindcss/colors.neutral)
-   * These are the default Tailwind neutral palette
+   * Colors - Border
+   * ============================================ */
+  --color-border: var(--color-neutral-gray-2);
+
+  /* ============================================
+   * Colors - Accent (default Tailwind neutral palette)
    * ============================================ */
   --color-accent-50: #fafafa;
   --color-accent-100: #f5f5f5;
@@ -262,13 +224,72 @@
   --color-accent-950: #0a0a0a;
 
   /* ============================================
+   * Legacy color aliases — pre-rename naming.
+   * Kept so existing components (text-primary-teal, bg-neutral-gray1, etc.)
+   * keep rendering during the gradual codemod. Remove once all consumers
+   * use the Figma-aligned names above.
+   *
+   * Notes on Figma↔code gaps:
+   *   - primary-orange1 and primary-orange2 collapse to one orange (hue distinction lost)
+   *   - functional-greenWhite maps to green-100 (Figma has no green-50)
+   *   - functional-yellowWhite borrows the orange-50 tint
+   *   - status-green / status-greenBg share the functional green scale
+   * ============================================ */
+  --color-primary: var(--op-primary-500);
+  --color-primary-teal: var(--color-primary-500);
+  --color-primary-tealBlack: var(--color-primary-700);
+  --color-primary-tealWhite: var(--color-primary-50);
+  --color-teal: var(--color-primary-500);
+  --color-teal-50: var(--color-primary-50);
+  --color-teal-100: var(--color-primary-100);
+  --color-teal-200: var(--color-primary-100);
+  --color-teal-300: var(--color-primary-100);
+
+  --color-primary-yellow: var(--color-primary-yellow-500);
+  --color-primary-orange1: var(--color-primary-orange-500);
+  --color-primary-orange2: var(--color-primary-orange-500);
+
+  --color-neutral-offWhite: var(--color-neutral-off-white);
+  --color-neutral-gray1: var(--color-neutral-gray-1);
+  --color-neutral-gray2: var(--color-neutral-gray-2);
+  --color-neutral-gray3: var(--color-neutral-gray-3);
+  --color-neutral-gray4: var(--color-neutral-gray-4);
+
+  /* Bare neutral aliases (e.g. text-charcoal, bg-offWhite) */
+  --color-black: var(--color-neutral-black);
+  --color-charcoal: var(--color-neutral-charcoal);
+  --color-darkGray: var(--color-neutral-gray-4);
+  --color-midGray: var(--color-neutral-gray-3);
+  --color-lightGray: var(--color-neutral-gray-2);
+  --color-offWhite: var(--color-neutral-gray-1);
+  --color-whiteish: var(--color-neutral-off-white);
+
+  --color-functional-red: var(--color-functional-red-600);
+  --color-functional-redBlack: var(--color-functional-red-800);
+  --color-functional-redWhite: var(--color-functional-red-50);
+  --color-red: var(--color-functional-red-600);
+  --color-red-100: var(--color-functional-red-100);
+  --color-red-300: var(--color-functional-red-100);
+  --color-red-600: var(--color-functional-red-600);
+  --color-red-700: var(--color-functional-red-800);
+
+  --color-functional-green: var(--color-functional-green-600);
+  --color-functional-greenWhite: var(--color-functional-green-100);
+  --color-functional-yellowWhite: var(--color-primary-orange-50);
+  --color-status-green: var(--color-functional-green-600);
+  --color-status-greenBg: var(--color-functional-green-100);
+  --color-green: var(--color-functional-green-600);
+  --color-green-500: var(--color-functional-green-600);
+  --color-green-700: var(--color-functional-green-600);
+
+  /* ============================================
    * Box Shadows
    * ============================================ */
-  --shadow: 0px 0px 48px 0px rgba(20, 35, 38, 0.08);
+  --shadow: 0px 0px 16px 0px rgba(20, 35, 38, 0.08);
   --shadow-light: 0px 0px 16px 0px rgba(20, 35, 38, 0.04);
-  --shadow-md: 0px 0px 48px 0px rgba(20, 35, 38, 0.08);
-  --shadow-green: 0px 0px 48px 0px rgba(193, 255, 173, 0.88);
-  --shadow-orange: 0px 0px 48px 0px rgba(242, 183, 5, 0.64);
+  --shadow-md: var(--shadow);
+  --shadow-green: 0px 0px 16px 0px rgba(193, 255, 173, 0.88);
+  --shadow-orange: 0px 0px 16px 0px rgba(242, 183, 5, 0.64);
 
   /* ============================================
    * Backdrop Blur
@@ -415,11 +436,11 @@
 
   /* Placeholder styles */
   input::placeholder {
-    color: var(--color-neutral-gray3);
+    color: var(--color-neutral-gray-3);
   }
 
   textarea::placeholder {
-    color: var(--color-neutral-gray3);
+    color: var(--color-neutral-gray-3);
   }
 
   /* Hide Google extension bubble */
@@ -435,7 +456,7 @@
   /* Default hr styling - Tailwind v4 reset removes borders */
   hr {
     border-top-width: 1px;
-    border-color: var(--color-neutral-gray1);
+    border-color: var(--color-neutral-gray-1);
   }
 
   /* Only show focus outlines for keyboard navigation, not mouse clicks */
@@ -452,7 +473,7 @@
 @utility better-scrollbar {
   overflow-y: scroll;
   scrollbar-width: thin;
-  scrollbar-color: var(--color-neutral-gray4) transparent;
+  scrollbar-color: var(--color-neutral-gray-4) transparent;
 }
 
 @utility scrollable-hidden-scrollbar {
@@ -500,7 +521,7 @@
 /* Border glow utility */
 @utility border-glow {
   border: 1px solid
-    color-mix(in srgb, var(--color-neutral-gray3) 50%, transparent);
+    color-mix(in srgb, var(--color-neutral-gray-3) 50%, transparent);
   background-clip: padding-box;
   backdrop-filter: blur(40px) contrast(1.5) saturate(3);
   box-shadow:
@@ -562,11 +583,11 @@
 @keyframes border-highlight {
   0%,
   40% {
-    border-color: var(--color-primary-teal);
+    border-color: var(--color-primary-500);
   }
 
   100% {
-    border-color: var(--color-neutral-gray1);
+    border-color: var(--color-neutral-gray-1);
   }
 }
 

--- a/packages/styles/tokens.css
+++ b/packages/styles/tokens.css
@@ -1,131 +1,63 @@
 /*
- * OP Brand Design Tokens
- * These CSS custom properties define the core color palette
- * and are referenced by shared-styles.css
+ * OP Brand Design Tokens — Figma source of truth
+ *
+ * Raw palette values from the design-system Figma file. Consumed by
+ * shared-styles.css, which maps these into the Tailwind `@theme` layer
+ * as `--color-*` tokens (plus legacy aliases for the pre-rename naming).
+ *
+ * Naming: --op-<category>[-<role>]-<scale>
+ *
+ * Figma↔code gaps (handled by semantic aliases in shared-styles.css):
+ *   - no green-50  → functional-greenWhite alias uses green-100
+ *   - one orange   → orange1 + orange2 collapse to a single hue
+ *   - no separate status-green → uses functional-green-600 / -100
  */
 
 :root {
   /* ============================================
-   * Base Colors
+   * Primary (teal)
    * ============================================ */
-  --op-white: 0 0% 100%;
+  --op-primary-50: hsla(187, 47.4%, 96.3%, 1); /* #F1F9FA */
+  --op-primary-100: hsla(186, 42.9%, 90.4%, 1); /* #DCEFF1 */
+  --op-primary-500: hsla(191, 39.8%, 36.5%, 1); /* #387582 */
+  --op-primary-700: hsla(192, 36.7%, 31%, 1); /* #32606C */
 
   /* ============================================
-   * Neutral Scale
+   * Primary - Yellow
    * ============================================ */
-  --op-neutral-950: 191 32% 11%; /* black */
-  --op-neutral-900: 191 11% 26%; /* charcoal / gray-5 */
-  --op-neutral-700: 190 6% 40%; /* darkGray / gray-4 */
-  --op-neutral-500: 189 4% 68%; /* midGray / gray-3 */
-  --op-neutral-400: 195 4% 82%; /* lightGray / gray-2 */
-  --op-neutral-200: 180 3% 93%; /* offWhite / gray-1 */
-  --op-neutral-50: 180 11% 98%; /* whiteish */
+  --op-primary-yellow-500: hsla(45, 96%, 48.4%, 1); /* #F2B705 */
 
   /* ============================================
-   * Teal Scale (Primary)
+   * Primary - Orange
    * ============================================ */
-  --op-teal-white: 180 43% 97%;
-  --op-teal-50: 185 48% 86%;
-  --op-teal-100: 185 48% 76%;
-  --op-teal-200: 185 48% 65%;
-  --op-teal-300: 186 48% 55%;
-  --op-teal-400: 186 61% 48%;
-  --op-teal-500: 186 96% 33%;
-  --op-teal-600: 186 93% 28%;
-  --op-teal-700: 186 95% 23%;
-  --op-teal-800: 186 100% 17%;
-  --op-teal-900: 186 94% 12%;
-  --op-teal-950: 186 83% 5%;
+  --op-primary-orange-50: hsla(41, 80%, 96.1%, 1); /* #FDF8ED */
+  --op-primary-orange-500: hsla(31, 71.1%, 51.2%, 1); /* #DB862A */
 
   /* ============================================
-   * Yellow Scale
+   * Neutrals
    * ============================================ */
-  --op-yellow-50: 44 92% 96%;
-  --op-yellow-100: 45 90% 73%;
-  --op-yellow-200: 45 90% 73%;
-  --op-yellow-300: 45 90% 65%;
-  --op-yellow-400: 45 91% 57%;
-  --op-yellow-500: 39 96% 48%;
-  --op-yellow-600: 39 95% 41%;
-  --op-yellow-700: 39 98% 33%;
-  --op-yellow-800: 39 94% 25%;
-  --op-yellow-900: 39 96% 18%;
-  --op-yellow-950: 40 96% 10%;
+  --op-white: #ffffff;
+  --op-neutral-off-white: hsla(180, 11.1%, 98.2%, 1); /* #FAFBFB */
+  --op-neutral-gray-1: hsla(180, 2.9%, 93.1%, 1); /* #EDEEEE */
+  --op-neutral-gray-2: hsla(195, 4.4%, 82.4%, 1); /* #D0D3D4 */
+  --op-neutral-gray-3: hsla(189, 4.3%, 68%, 1); /* #AAB0B1 */
+  --op-neutral-gray-4: hsla(190, 5.9%, 40%, 1); /* #606A6C */
+  --op-neutral-charcoal: hsla(188, 11.5%, 25.7%, 1); /* #3A4749 */
+  --op-neutral-black: hsla(187, 31%, 11.4%, 1); /* #142426 */
 
   /* ============================================
-   * Orange1 Scale
+   * Functional
    * ============================================ */
-  --op-orange1-50: 39 89% 90%;
-  --op-orange1-100: 39 90% 73%;
-  --op-orange1-200: 39 90% 73%;
-  --op-orange1-300: 39 90% 65%;
-  --op-orange1-400: 39 91% 57%;
-  --op-orange1-500: 39 96% 48%;
-  --op-orange1-600: 39 95% 41%;
-  --op-orange1-700: 39 98% 33%;
-  --op-orange1-800: 39 94% 25%;
-  --op-orange1-900: 39 96% 18%;
-  --op-orange1-950: 40 96% 10%;
+  --op-functional-red-50: hsla(6, 71.4%, 97.3%, 1); /* #FDF4F3 */
+  --op-functional-red-100: hsla(5, 80%, 94.1%, 1); /* #FCE6E4 */
+  --op-functional-red-600: hsla(5, 61.3%, 49.6%, 1); /* #CC3D31 */
+  --op-functional-red-800: hsla(5, 58.9%, 35.3%, 1); /* #8F2D25 */
+  --op-functional-green-100: hsla(96, 63.6%, 89.2%, 1); /* #E0F5D2 */
+  --op-functional-green-600: hsla(100, 59.7%, 31.2%, 1); /* #3F7F20 */
 
   /* ============================================
-   * Orange2 Scale
+   * Data Visualization
    * ============================================ */
-  --op-orange2-50: 28 89% 90%;
-  --op-orange2-100: 28 90% 73%;
-  --op-orange2-200: 28 90% 73%;
-  --op-orange2-300: 28 90% 65%;
-  --op-orange2-400: 28 91% 57%;
-  --op-orange2-500: 28 96% 48%;
-  --op-orange2-600: 28 95% 41%;
-  --op-orange2-700: 28 98% 33%;
-  --op-orange2-800: 28 94% 25%;
-  --op-orange2-900: 28 96% 18%;
-  --op-orange2-950: 28 96% 10%;
-
-  /* ============================================
-   * Red Scale
-   * ============================================ */
-  --op-red-50: 16 89% 90%;
-  --op-red-100: 16 90% 73%;
-  --op-red-200: 16 90% 73%;
-  --op-red-300: 16 90% 65%;
-  --op-red-400: 16 91% 57%;
-  --op-red-500: 16 96% 48%;
-  --op-red-600: 16 95% 41%;
-  --op-red-700: 16 98% 33%;
-  --op-red-800: 16 94% 25%;
-  --op-red-900: 16 96% 18%;
-  --op-red-950: 16 96% 10%;
-
-  /* ============================================
-   * Green Scale
-   * ============================================ */
-  --op-green-50: 102 62% 88%;
-  --op-green-100: 101 94% 63%;
-  --op-green-200: 101 94% 63%;
-  --op-green-300: 101 94% 55%;
-  --op-green-400: 101 95% 47%;
-  --op-green-500: 101 100% 38%;
-  --op-green-600: 101 99% 31%;
-  --op-green-700: 101 100% 27%;
-  --op-green-800: 101 98% 15%;
-  --op-green-900: 101 100% 8%;
-  --op-green-950: 101 100% 0%;
-
-  /* ============================================
-   * Status Badge Colors
-   * ============================================ */
-  --op-status-green: 101 100% 33%; /* #35A700 */
-  --op-status-green-bg: 104 100% 97%; /* #F4FFF0 */
-
-  /* ============================================
-   * Data Visualization Colors
-   * ============================================ */
-  --op-purple-500: 270 100% 38%;
-  --op-blue-500: 218 100% 38%;
-
-  /* ============================================
-   * Legacy Aliases (for backwards compatibility)
-   * ============================================ */
-  --op-offWhite: var(--op-neutral-200);
+  --op-data-purple: hsla(302, 24.5%, 51.2%, 1); /* #A1649F */
+  --op-data-blue: hsla(240, 57.1%, 53.3%, 1); /* #4444CC */
 }

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -33,7 +33,7 @@ const buttonStyle = tv({
       destructive:
         'border-functional-red bg-functional-red text-neutral-offWhite hover:bg-functional-redBlack',
       ghost:
-        'border-0 bg-transparent text-midGray shadow-none hover:text-darkGray pressed:text-darkGray pressed:shadow-none',
+        'border-0 bg-transparent text-darkGray shadow-none hover:text-charcoal pressed:text-charcoal pressed:shadow-none',
       pill: '',
     },
     size: {

--- a/packages/ui/src/components/RadioGroup.tsx
+++ b/packages/ui/src/components/RadioGroup.tsx
@@ -48,7 +48,7 @@ export const RadioGroup = (props: RadioGroupProps) => {
 
 const styles = tv({
   // extend: focusRing,
-  base: 'bg-neutral-white aspect-square size-4 shrink-0 rounded-full border border-neutral-gray3 transition-all',
+  base: 'bg-white aspect-square size-4 shrink-0 rounded-full border border-neutral-gray3 transition-all',
   variants: {
     isSelected: {
       false:

--- a/packages/ui/src/components/RadioGroup.tsx
+++ b/packages/ui/src/components/RadioGroup.tsx
@@ -48,7 +48,7 @@ export const RadioGroup = (props: RadioGroupProps) => {
 
 const styles = tv({
   // extend: focusRing,
-  base: 'bg-white aspect-square size-4 shrink-0 rounded-full border border-neutral-gray3 transition-all',
+  base: 'aspect-square size-4 shrink-0 rounded-full border border-neutral-gray3 bg-white transition-all',
   variants: {
     isSelected: {
       false:

--- a/packages/ui/src/components/Surface.tsx
+++ b/packages/ui/src/components/Surface.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes, ReactNode } from 'react';
 import { VariantProps, cn, tv } from '../lib/utils';
 
 const variantStyles = tv({
-  base: 'bg-neutral-white overflow-hidden rounded border',
+  base: 'bg-white overflow-hidden rounded border',
   variants: {
     variant: {
       empty: '',

--- a/packages/ui/src/components/Surface.tsx
+++ b/packages/ui/src/components/Surface.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes, ReactNode } from 'react';
 import { VariantProps, cn, tv } from '../lib/utils';
 
 const variantStyles = tv({
-  base: 'bg-white overflow-hidden rounded border',
+  base: 'overflow-hidden rounded border bg-white',
   variants: {
     variant: {
       empty: '',

--- a/packages/ui/src/components/Toast.tsx
+++ b/packages/ui/src/components/Toast.tsx
@@ -30,9 +30,9 @@ export const Toast = () => {
             'group relative text-5 toast w-full bg-neutral-offWhite rounded-lg backdrop-blur-md border text-neutral-black p-3 flex gap-3',
           description: 'text-neutral-charcoal',
           actionButton:
-            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+            'group-[.toast]:bg-primary group-[.toast]:text-primary-fg',
           cancelButton:
-            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+            'group-[.toast]:bg-muted group-[.toast]:text-muted-fg',
           closeButton: '!absolute !right-0 top-0 !cursor-pointer',
         },
       }}

--- a/packages/ui/src/components/Toast.tsx
+++ b/packages/ui/src/components/Toast.tsx
@@ -31,8 +31,7 @@ export const Toast = () => {
           description: 'text-neutral-charcoal',
           actionButton:
             'group-[.toast]:bg-primary group-[.toast]:text-primary-fg',
-          cancelButton:
-            'group-[.toast]:bg-muted group-[.toast]:text-muted-fg',
+          cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-fg',
           closeButton: '!absolute !right-0 top-0 !cursor-pointer',
         },
       }}

--- a/packages/ui/stories/Accordion.stories.tsx
+++ b/packages/ui/stories/Accordion.stories.tsx
@@ -320,7 +320,7 @@ export const Controlled: Story = {
       <div className="w-[400px]">
         <div className="mb-4 flex gap-2">
           <button
-            className="text-primary-fg rounded-lg bg-primary px-3 py-1 text-sm"
+            className="rounded-lg bg-primary px-3 py-1 text-sm text-primary-fg"
             onClick={() => setExpandedKeys(new Set(['1', '2', '3']))}
           >
             Expand All

--- a/tests/e2e/a11y-baseline/summary.json
+++ b/tests/e2e/a11y-baseline/summary.json
@@ -7,28 +7,28 @@
     "wcag21aa"
   ],
   "totals": {
-    "critical": 0,
-    "serious": 6,
-    "moderate": 3,
+    "critical": 3,
+    "serious": 12,
+    "moderate": 16,
     "minor": 0
   },
-  "totalViolations": 9,
+  "totalViolations": 31,
   "routesScanned": 16,
   "ruleTotals": [
     {
-      "id": "color-contrast",
-      "impact": "serious",
+      "id": "button-name",
+      "impact": "critical",
       "occurrences": 3,
       "routes": 1,
       "wcagCriteria": [
-        "1.4.3"
+        "4.1.2"
       ]
     },
     {
       "id": "link-name",
       "impact": "serious",
-      "occurrences": 2,
-      "routes": 2,
+      "occurrences": 11,
+      "routes": 11,
       "wcagCriteria": [
         "2.4.4",
         "4.1.2"
@@ -47,8 +47,8 @@
     {
       "id": "meta-viewport",
       "impact": "moderate",
-      "occurrences": 3,
-      "routes": 3,
+      "occurrences": 16,
+      "routes": 16,
       "wcagCriteria": [
         "1.4.4"
       ]
@@ -62,7 +62,7 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 3,
+        "serious": 0,
         "moderate": 1,
         "minor": 0
       }
@@ -95,172 +95,159 @@
       "url": "/en/",
       "label": "Home",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 0,
-        "moderate": 0,
+        "serious": 1,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/decisions",
       "label": "Decisions index",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 0,
-        "moderate": 0,
+        "serious": 1,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/decisions\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/profile",
       "label": "Profile index",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 0,
-        "moderate": 0,
+        "serious": 1,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/profile\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/search",
       "label": "Search",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 0,
-        "moderate": 0,
+        "serious": 1,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/search\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/org",
       "label": "Org index",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 0,
-        "moderate": 0,
+        "serious": 1,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/org\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/does-not-exist",
       "label": "Not found (404)",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 0,
-        "moderate": 0,
+        "serious": 1,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/does-not-exist\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/org/{slug}",
       "label": "Organization page",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 0,
-        "moderate": 0,
+        "serious": 1,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/org/test-org-w54-45fa4301-698d-4df3-b075-3d15faf54647\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/org/{slug}/relationships",
       "label": "Org relationships",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 0,
-        "moderate": 0,
+        "serious": 1,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/org/test-org-w54-45fa4301-698d-4df3-b075-3d15faf54647/relationships\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/profile/{slug}",
       "label": "User profile",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 0,
-        "moderate": 0,
+        "serious": 1,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/profile/w54-admin-8fb428\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/decisions/{slug}",
       "label": "Decision detail",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
         "serious": 0,
-        "moderate": 0,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/decisions/test-instance-17ad467e-532c-4eee-a15d-fbd20333977f\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/decisions/{slug}/edit",
       "label": "Decision editor",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
-        "critical": 0,
+        "critical": 3,
         "serious": 0,
-        "moderate": 0,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/decisions/test-instance-17ad467e-532c-4eee-a15d-fbd20333977f/edit\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/decisions/{slug}/proposal/{profileId}",
       "label": "Proposal view",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
         "serious": 0,
-        "moderate": 0,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/decisions/test-instance-17ad467e-532c-4eee-a15d-fbd20333977f/proposal/a7572b96-4b0c-4b09-8aa4-5117aac508fb\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     },
     {
       "url": "/en/decisions/{slug}/proposal/{profileId}/edit",
       "label": "Proposal editor",
       "auth": "authenticated",
-      "status": "error",
+      "status": "ok",
       "counts": {
         "critical": 0,
         "serious": 0,
-        "moderate": 0,
+        "moderate": 1,
         "minor": 0
-      },
-      "error": "page.goto: Timeout 30000ms exceeded.\nCall log:\n\u001b[2m  - navigating to \"http://localhost:4100/en/decisions/test-instance-17ad467e-532c-4eee-a15d-fbd20333977f/proposal/a7572b96-4b0c-4b09-8aa4-5117aac508fb/edit\", waiting until \"domcontentloaded\"\u001b[22m\n"
+      }
     }
   ],
-  "screenshotsAttempted": 9,
-  "screenshotsCaptured": 6
+  "screenshotsAttempted": 31,
+  "screenshotsCaptured": 15
 }


### PR DESCRIPTION
## Summary

- Darkens teal, red, and green semantic tokens (and their *Black variants) in `packages/styles/shared-styles.css` to meet AA contrast on white
- Leaves `--color-data-purple` / `--color-data-blue` at `-500` since deeper shades aren't defined in `tokens.css` and -500 is already AAA