### PR TITLE
feat(reviews): show comments on proposal review page

### DIFF
--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -12,7 +12,13 @@ import { useTranslations } from '@/lib/i18n';
 import { PostFeed, PostItem, usePostFeedActions } from '../PostFeed';
 import { PostUpdate } from '../PostUpdate';
 
-export function ProposalComments({ proposal }: { proposal: Proposal }) {
+export function ProposalComments({
+  proposal,
+  readOnly = false,
+}: {
+  proposal: Proposal;
+  readOnly?: boolean;
+}) {
   const t = useTranslations();
   const { user } = useUser();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -46,18 +52,20 @@ export function ProposalComments({ proposal }: { proposal: Proposal }) {
           {t('Comments')} ({comments.length})
         </Header3>
 
-        <div className="mb-8">
-          <Surface className="border-0 p-0 sm:border sm:p-4">
-            <PostUpdate
-              profileId={proposal.profileId || undefined}
-              placeholder={`${t('Comment')}${user.currentProfile?.name ? ` as ${user.currentProfile?.name}` : ''}...`}
-              label={t('Comment')}
-              onSuccess={scrollToComments}
-              proposalId={proposal.id}
-              processInstanceId={proposal.processInstanceId}
-            />
-          </Surface>
-        </div>
+        {!readOnly && (
+          <div className="mb-8">
+            <Surface className="border-0 p-0 sm:border sm:p-4">
+              <PostUpdate
+                profileId={proposal.profileId || undefined}
+                placeholder={`${t('Comment')}${user.currentProfile?.name ? ` as ${user.currentProfile?.name}` : ''}...`}
+                label={t('Comment')}
+                onSuccess={scrollToComments}
+                proposalId={proposal.id}
+                processInstanceId={proposal.processInstanceId}
+              />
+            </Surface>
+          </div>
+        )}
 
         {commentsLoading ? (
           <div
@@ -91,7 +99,9 @@ export function ProposalComments({ proposal }: { proposal: Proposal }) {
             role="status"
             aria-label={t('No comments')}
           >
-            {t('No comments yet. Be the first to comment!')}
+            {readOnly
+              ? t('No comments yet.')
+              : t('No comments yet. Be the first to comment!')}
           </div>
         )}
       </div>

--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useUser } from '@/utils/UserProvider';
+import { trpc } from '@op/api/client';
+import type { Proposal } from '@op/common/client';
+import { Header3 } from '@op/ui/Header';
+import { Surface } from '@op/ui/Surface';
+import { useCallback, useRef } from 'react';
+
+import { useTranslations } from '@/lib/i18n';
+
+import { PostFeed, PostItem, usePostFeedActions } from '../PostFeed';
+import { PostUpdate } from '../PostUpdate';
+
+export function ProposalComments({ proposal }: { proposal: Proposal }) {
+  const t = useTranslations();
+  const { user } = useUser();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { data: commentsData, isLoading: commentsLoading } =
+    trpc.posts.getPosts.useQuery({
+      profileId: proposal.profileId || undefined,
+      parentPostId: null,
+      limit: 50,
+      offset: 0,
+      includeChildren: false,
+    });
+
+  const comments = commentsData || [];
+  const { handleReactionClick } = usePostFeedActions();
+
+  const scrollToComments = useCallback(() => {
+    setTimeout(() => {
+      containerRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+        inline: 'nearest',
+      });
+    }, 100);
+  }, []);
+
+  return (
+    <div ref={containerRef}>
+      <div className="border-t pt-8">
+        <Header3 className="mb-6">
+          {t('Comments')} ({comments.length})
+        </Header3>
+
+        <div className="mb-8">
+          <Surface className="border-0 p-0 sm:border sm:p-4">
+            <PostUpdate
+              profileId={proposal.profileId || undefined}
+              placeholder={`${t('Comment')}${user.currentProfile?.name ? ` as ${user.currentProfile?.name}` : ''}...`}
+              label={t('Comment')}
+              onSuccess={scrollToComments}
+              proposalId={proposal.id}
+              processInstanceId={proposal.processInstanceId}
+            />
+          </Surface>
+        </div>
+
+        {commentsLoading ? (
+          <div
+            className="py-8 text-center text-gray-500"
+            role="status"
+            aria-label={t('Loading comments')}
+          >
+            {t('Loading comments...')}
+          </div>
+        ) : comments.length > 0 ? (
+          <div role="feed" aria-label={`${comments.length} comments`}>
+            <PostFeed>
+              {comments.map((comment, i) => (
+                <div key={comment.id}>
+                  <PostItem
+                    post={comment}
+                    organization={null}
+                    user={user}
+                    withLinks={false}
+                    onReactionClick={handleReactionClick}
+                    className="sm:px-0"
+                  />
+                  {comments.length !== i + 1 && <hr className="my-4" />}
+                </div>
+              ))}
+            </PostFeed>
+          </div>
+        ) : (
+          <div
+            className="py-8 text-center text-gray-500"
+            role="status"
+            aria-label={t('No comments')}
+          >
+            {t('No comments yet. Be the first to comment!')}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRelationshipMutations } from '@/hooks/useRelationshipMutations';
-import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import {
   type Proposal,
@@ -9,17 +8,14 @@ import {
   type ProposalTranslation,
   type SupportedLocale,
 } from '@op/common/client';
-import { Header3 } from '@op/ui/Header';
 import { SplitPane } from '@op/ui/SplitPane';
-import { Surface } from '@op/ui/Surface';
 import { useLocale } from 'next-intl';
 import { useQueryStates } from 'nuqs';
-import { type ReactNode, useCallback, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
-import { PostFeed, PostItem, usePostFeedActions } from '../PostFeed';
-import { PostUpdate } from '../PostUpdate';
+import { ProposalComments } from './ProposalComments';
 import { ProposalPreview } from './ProposalPreview';
 import { ProposalRevisionSubmittedPanel } from './ProposalRevisionSubmittedPanel';
 import { ProposalViewLayout } from './ProposalViewLayout';
@@ -38,7 +34,6 @@ export function ProposalView({
 }) {
   const t = useTranslations();
   const locale = useLocale();
-  const commentsContainerRef = useRef<HTMLDivElement>(null);
 
   const { data: proposal } = trpc.decision.getProposal.useQuery({
     profileId: initialProposal.profileId,
@@ -46,9 +41,6 @@ export function ProposalView({
 
   // Safety check - fallback to initial data if query returns undefined
   const currentProposal = proposal || initialProposal;
-
-  // Get current user to check edit permissions
-  const { user } = useUser();
 
   // Use relationship mutations hook for like/follow functionality
   const {
@@ -113,36 +105,6 @@ export function ProposalView({
       { history: 'push', scroll: false },
     );
   }, [firstRevisionRequestId, reviewRevision, setQueryState]);
-
-  // Get comments for the proposal using the posts API
-  const { data: commentsData, isLoading: commentsLoading } =
-    trpc.posts.getPosts.useQuery({
-      profileId: currentProposal.profileId || undefined,
-      parentPostId: null, // Get top-level comments only
-      limit: 50,
-      offset: 0,
-      includeChildren: false,
-    });
-
-  const comments = commentsData || [];
-
-  const { handleReactionClick } = usePostFeedActions();
-
-  // Function to scroll to show comments after adding a new one
-  const scrollToComments = useCallback(() => {
-    if (commentsContainerRef.current) {
-      setTimeout(() => {
-        const container = commentsContainerRef.current;
-        if (container) {
-          container.scrollIntoView({
-            behavior: 'smooth',
-            block: 'start',
-            inline: 'nearest',
-          });
-        }
-      }, 100);
-    }
-  }, []);
 
   const [bannerDismissed, setBannerDismissed] = useState(false);
 
@@ -211,65 +173,7 @@ export function ProposalView({
         }
       />
 
-      {/* Comments Section */}
-      <div ref={commentsContainerRef}>
-        <div className="border-t pt-8">
-          <Header3 className="mb-6">
-            {t('Comments')} ({comments.length})
-          </Header3>
-
-          {/* Comment Input */}
-          <div className="mb-8">
-            <Surface className="border-0 p-0 sm:border sm:p-4">
-              <PostUpdate
-                profileId={currentProposal.profileId || undefined}
-                placeholder={`${t('Comment')}${user.currentProfile?.name ? ` as ${user.currentProfile?.name}` : ''}...`}
-                label={t('Comment')}
-                onSuccess={scrollToComments}
-                proposalId={currentProposal.id}
-                processInstanceId={currentProposal.processInstanceId}
-              />
-            </Surface>
-          </div>
-
-          {/* Comments Display */}
-          {commentsLoading ? (
-            <div
-              className="py-8 text-center text-gray-500"
-              role="status"
-              aria-label={t('Loading comments')}
-            >
-              {t('Loading comments...')}
-            </div>
-          ) : comments.length > 0 ? (
-            <div role="feed" aria-label={`${comments.length} comments`}>
-              <PostFeed>
-                {comments.map((comment, i) => (
-                  <div key={comment.id}>
-                    <PostItem
-                      post={comment}
-                      organization={null}
-                      user={user}
-                      withLinks={false}
-                      onReactionClick={handleReactionClick}
-                      className="sm:px-0"
-                    />
-                    {comments.length !== i + 1 && <hr className="my-4" />}
-                  </div>
-                ))}
-              </PostFeed>
-            </div>
-          ) : (
-            <div
-              className="py-8 text-center text-gray-500"
-              role="status"
-              aria-label={t('No comments')}
-            >
-              {t('No comments yet. Be the first to comment!')}
-            </div>
-          )}
-        </div>
-      </div>
+      <ProposalComments proposal={currentProposal} />
     </>
   );
 

--- a/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
@@ -30,7 +30,7 @@ export function ReviewProposalPane() {
         }
       />
 
-      <ProposalComments proposal={assignment.proposal} />
+      <ProposalComments proposal={assignment.proposal} readOnly />
     </>
   );
 }

--- a/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
@@ -2,6 +2,7 @@
 
 import { ProposalReviewRequestState } from '@op/common/client';
 
+import { ProposalComments } from '../ProposalComments';
 import { ProposalPreview } from '../ProposalPreview';
 import { AuthorRevisionNote, RevisedOnBadge } from './AuthorRevisionNote';
 import { useReviewForm } from './ReviewFormContext';
@@ -16,16 +17,20 @@ export function ReviewProposalPane() {
   const responseComment = respondedAt ? revisionRequest?.responseComment : null;
 
   return (
-    <ProposalPreview
-      proposal={assignment.proposal}
-      submissionMetaSuffix={
-        respondedAt ? <RevisedOnBadge respondedAt={respondedAt} /> : undefined
-      }
-      headerBanner={
-        responseComment ? (
-          <AuthorRevisionNote comment={responseComment} />
-        ) : undefined
-      }
-    />
+    <>
+      <ProposalPreview
+        proposal={assignment.proposal}
+        submissionMetaSuffix={
+          respondedAt ? <RevisedOnBadge respondedAt={respondedAt} /> : undefined
+        }
+        headerBanner={
+          responseComment ? (
+            <AuthorRevisionNote comment={responseComment} />
+          ) : undefined
+        }
+      />
+
+      <ProposalComments proposal={assignment.proposal} />
+    </>
   );
 }

--- a/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
@@ -17,7 +17,7 @@ export function ReviewProposalPane() {
   const responseComment = respondedAt ? revisionRequest?.responseComment : null;
 
   return (
-    <>
+    <div className="flex flex-col gap-8">
       <ProposalPreview
         proposal={assignment.proposal}
         submissionMetaSuffix={
@@ -31,6 +31,6 @@ export function ReviewProposalPane() {
       />
 
       <ProposalComments proposal={assignment.proposal} readOnly />
-    </>
+    </div>
   );
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -193,6 +193,7 @@
   "This proposal is currently in draft mode, only you and collaborators can access it.": "এই প্রস্তাবটি বর্তমানে খসড়া মোডে আছে, শুধুমাত্র আপনি এবং সহযোগীরা এটি অ্যাক্সেস করতে পারেন।",
   "Edit proposal": "প্রস্তাব সম্পাদনা করুন",
   "Loading comments...": "মন্তব্য লোড হচ্ছে...",
+  "No comments yet.": "এখনও কোনো মন্তব্য নেই।",
   "No comments yet. Be the first to comment!": "এখনও কোনো মন্তব্য নেই। প্রথম মন্তব্য করুন!",
   "SHARE YOUR IDEAS.": "আপনার ধারণা শেয়ার করুন।",
   "CONFIRM THE WINNING PROPOSALS": "বিজয়ী প্রস্তাবগুলি নিশ্চিত করুন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -190,6 +190,7 @@
   "This proposal is currently in draft mode, only you and collaborators can access it.": "This proposal is currently in draft mode, only you and collaborators can access it.",
   "Edit proposal": "Edit proposal",
   "Loading comments...": "Loading comments...",
+  "No comments yet.": "No comments yet.",
   "No comments yet. Be the first to comment!": "No comments yet. Be the first to comment!",
   "SHARE YOUR IDEAS.": "SHARE YOUR IDEAS.",
   "CONFIRM THE WINNING PROPOSALS": "CONFIRM THE WINNING PROPOSALS",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -192,6 +192,7 @@
   "This proposal is currently in draft mode, only you and collaborators can access it.": "Esta propuesta está actualmente en modo borrador, solo tú y los colaboradores pueden acceder a ella.",
   "Edit proposal": "Editar propuesta",
   "Loading comments...": "Cargando comentarios...",
+  "No comments yet.": "Aún no hay comentarios.",
   "No comments yet. Be the first to comment!": "Aún no hay comentarios. ¡Sé el primero en comentar!",
   "SHARE YOUR IDEAS.": "COMPARTE TUS IDEAS.",
   "CONFIRM THE WINNING PROPOSALS": "CONFIRMA LAS PROPUESTAS GANADORAS",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -193,6 +193,7 @@
   "This proposal is currently in draft mode, only you and collaborators can access it.": "Cette proposition est actuellement en mode brouillon, seuls vous et les collaborateurs pouvez y accéder.",
   "Edit proposal": "Modifier la proposition",
   "Loading comments...": "En train de charger les commentaires...",
+  "No comments yet.": "Aucun commentaire pour le moment.",
   "No comments yet. Be the first to comment!": "Aucun commentaire pour le moment. Soyez le premier à commenter !",
   "SHARE YOUR IDEAS.": "PARTAGEZ VOS IDÉES.",
   "CONFIRM THE WINNING PROPOSALS": "CONFIRMEZ LES PROPOSITIONS GAGNANTES",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -193,6 +193,7 @@
   "This proposal is currently in draft mode, only you and collaborators can access it.": "Esta proposta está atualmente em modo rascunho, apenas você e os colaboradores podem acessá-la.",
   "Edit proposal": "Editar proposta",
   "Loading comments...": "Carregando comentários...",
+  "No comments yet.": "Nenhum comentário ainda.",
   "No comments yet. Be the first to comment!": "Nenhum comentário ainda. Seja o primeiro a comentar!",
   "SHARE YOUR IDEAS.": "COMPARTILHE SUAS IDEIAS.",
   "CONFIRM THE WINNING PROPOSALS": "CONFIRME AS PROPOSTAS VENCEDORAS",

--- a/tests/e2e/tests/proposal-view.spec.ts
+++ b/tests/e2e/tests/proposal-view.spec.ts
@@ -582,7 +582,6 @@ test.describe('Proposal View', () => {
       email: org.adminUser.email,
       proposalData: {
         title: 'Commentable Proposal',
-        collaborationDocId: MOCK_DOC_ID,
       },
     });
 

--- a/tests/e2e/tests/proposal-view.spec.ts
+++ b/tests/e2e/tests/proposal-view.spec.ts
@@ -561,6 +561,65 @@ test.describe('Proposal View', () => {
     ).toBeVisible();
   });
 
+  test('allows posting a comment on the proposal view', async ({
+    authenticatedPage,
+    org,
+  }) => {
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: template.processSchema,
+    });
+
+    const proposal = await createProposal({
+      processInstanceId: instance.instance.id,
+      submittedByProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      proposalData: {
+        title: 'Commentable Proposal',
+        collaborationDocId: MOCK_DOC_ID,
+      },
+    });
+
+    await authenticatedPage.goto(
+      `/en/decisions/${instance.slug}/proposal/${proposal.profileId}`,
+    );
+
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Commentable Proposal' }),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Comments section starts empty with the write-mode empty state.
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Comments (0)' }),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByText('Be the first to comment').first(),
+    ).toBeVisible();
+
+    const commentText = 'This is a great proposal — looking forward to it!';
+    const commentBox = authenticatedPage.getByPlaceholder(/^Comment/);
+    await expect(commentBox).toBeVisible();
+    await commentBox.fill(commentText);
+
+    await authenticatedPage
+      .getByRole('button', { name: 'Comment', exact: true })
+      .click();
+
+    // After post the comment appears in the feed and the counter increments.
+    await expect(authenticatedPage.getByText(commentText)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Comments (1)' }),
+    ).toBeVisible();
+  });
+
   test('handles missing document gracefully', async ({
     authenticatedPage,
     org,

--- a/tests/e2e/tests/review-submit.spec.ts
+++ b/tests/e2e/tests/review-submit.spec.ts
@@ -442,6 +442,70 @@ test.describe('Review Submit', () => {
     });
   });
 
+  test('shows comments section on the review page in read-only mode', async ({
+    authenticatedPage: page,
+    org,
+  }) => {
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: REVIEW_SCHEMA,
+    });
+
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...(instance.instance.instanceData as Record<string, unknown>),
+          rubricTemplate: RUBRIC_TEMPLATE,
+        },
+        currentStateId: 'review',
+      })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    await createReviewScenario({
+      instance: { id: instance.instance.id },
+      author: {
+        profileId: org.organizationProfile.id,
+        authUserId: org.adminUser.authUserId,
+        email: org.adminUser.email,
+      },
+      reviewer: { profileId: org.adminUser.profileId },
+      proposalData: {
+        title: PROPOSAL_TITLE,
+        collaborationDocId: 'test-proposal-view-doc',
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    await page.goto(`/en/decisions/${instance.slug}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await expect(page.getByText('Proposals to review')).toBeVisible({
+      timeout: 36_000,
+    });
+    await page.getByText(PROPOSAL_TITLE).first().click();
+    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
+    await expect(
+      page.getByText('Review Proposal', { exact: true }).first(),
+    ).toBeVisible({ timeout: 36_000 });
+
+    // The comments section header renders alongside the proposal — reviewers
+    // can read but not post, so the empty-state copy omits the call to action
+    // and no comment textbox is present.
+    await expect(
+      page.getByRole('heading', { name: /^Comments \(\d+\)$/ }),
+    ).toBeVisible();
+    await expect(page.getByText('No comments yet.')).toBeVisible();
+    await expect(page.getByText('Be the first to comment')).toHaveCount(0);
+    await expect(page.getByPlaceholder(/^Comment( as |\.\.\.)/)).toHaveCount(0);
+  });
+
   test('hides Request revision button when reviewsAllowRevisions is false', async ({
     authenticatedPage: page,
     org,


### PR DESCRIPTION
Reviewers couldn't comment on a proposal while reviewing it. The comments section now appears in the review pane alongside the standalone proposal view, sharing the same UI.

## Demo
<img width="2508" height="1442" alt="CleanShot 2026-05-11 at 22 35 28@2x" src="https://github.com/user-attachments/assets/6d52f187-7b82-4a78-9d51-6f51df538f24" />

