### PR TITLE
fix(api): unwrap channel envelope on SSR

### DIFF
--- a/services/api/src/links.test.ts
+++ b/services/api/src/links.test.ts
@@ -1,0 +1,168 @@
+import { queryChannelRegistry } from '@op/common/realtime';
+import { observable } from '@trpc/server/observable';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { wrapResponseWithChannels } from './channelTransformer';
+import { createChannelRegistrationLink } from './links';
+
+/**
+ * Drives a single operation through the channel-registration link and returns
+ * the values seen by the downstream observer (i.e. what reaches the
+ * application). The link is supposed to unwrap any `{ _data, _meta }` envelope
+ * regardless of runtime.
+ */
+function runLink({
+  isServer,
+  op,
+  emitted,
+}: {
+  isServer: boolean;
+  op: { type: 'query' | 'mutation'; path: string; input?: unknown };
+  emitted: unknown;
+}): unknown[] {
+  const link = createChannelRegistrationLink({ isServer })({} as never);
+
+  const next = () =>
+    observable<{ result: { data: unknown } }, unknown>((emit) => {
+      emit.next({ result: { data: emitted } });
+      emit.complete();
+    });
+
+  const observed: unknown[] = [];
+  link({
+    op: { ...op, id: 1, context: {} } as never,
+    next: next as never,
+  }).subscribe({
+    next(v) {
+      observed.push(v);
+    },
+  });
+
+  return observed;
+}
+
+describe('createChannelRegistrationLink', () => {
+  let registerQuery: ReturnType<typeof vi.spyOn>;
+  let registerMutation: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    registerQuery = vi
+      .spyOn(queryChannelRegistry, 'registerQuery')
+      .mockImplementation(() => {});
+    registerMutation = vi
+      .spyOn(queryChannelRegistry, 'registerMutation')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('unwrap symmetry — wrap on the wire MUST be unwrapped before the app sees it', () => {
+    // This is the regression test for the SSR `_data/_meta` leak:
+    // before the fix, the link skipped unwrap when isServer=true, so the
+    // server-rendered tree saw `{ _data, _meta }` and crashed accessing
+    // fields like `decisionProfile.processInstance`.
+    it.each([
+      ['client', false],
+      ['server (SSR)', true],
+    ] as const)('unwraps a wrapped envelope on %s', (_label, isServer) => {
+      const wrapped = wrapResponseWithChannels(
+        { processInstance: { id: 'abc', instanceData: { phases: [] } } },
+        ['decisionInstance:abc'],
+      );
+
+      const observed = runLink({
+        isServer,
+        op: { type: 'query', path: 'decision.getDecisionBySlug' },
+        emitted: wrapped,
+      });
+
+      expect(observed).toHaveLength(1);
+      expect((observed[0] as { result: { data: unknown } }).result.data).toEqual({
+        processInstance: { id: 'abc', instanceData: { phases: [] } },
+      });
+    });
+
+    it.each([
+      ['client', false],
+      ['server (SSR)', true],
+    ] as const)(
+      'passes non-wrapped data through unchanged on %s',
+      (_label, isServer) => {
+        const flat = { id: 'abc', name: 'Foo' };
+
+        const observed = runLink({
+          isServer,
+          op: { type: 'query', path: 'profile.get' },
+          emitted: flat,
+        });
+
+        expect(observed).toHaveLength(1);
+        expect((observed[0] as { result: { data: unknown } }).result.data).toBe(
+          flat,
+        );
+      },
+    );
+  });
+
+  describe('channel registry is browser-only (would leak across requests on the server)', () => {
+    it('registers query channels on the client', () => {
+      const wrapped = wrapResponseWithChannels({ id: 'x' }, ['ch:x']);
+
+      runLink({
+        isServer: false,
+        op: { type: 'query', path: 'thing.get', input: { id: 'x' } },
+        emitted: wrapped,
+      });
+
+      expect(registerQuery).toHaveBeenCalledTimes(1);
+      expect(registerQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ channels: ['ch:x'] }),
+      );
+    });
+
+    it('does NOT touch the registry on the server', () => {
+      const wrapped = wrapResponseWithChannels({ id: 'x' }, ['ch:x']);
+
+      runLink({
+        isServer: true,
+        op: { type: 'query', path: 'thing.get', input: { id: 'x' } },
+        emitted: wrapped,
+      });
+
+      expect(registerQuery).not.toHaveBeenCalled();
+      expect(registerMutation).not.toHaveBeenCalled();
+    });
+
+    it('registers mutation channels on the client', () => {
+      const wrapped = wrapResponseWithChannels(
+        { ok: true },
+        ['ch:invalidate'],
+      );
+
+      runLink({
+        isServer: false,
+        op: { type: 'mutation', path: 'thing.update' },
+        emitted: wrapped,
+      });
+
+      expect(registerMutation).toHaveBeenCalledTimes(1);
+      expect(registerMutation).toHaveBeenCalledWith(
+        expect.objectContaining({ channels: ['ch:invalidate'] }),
+      );
+    });
+  });
+
+  it('does not call the registry when the wrapped envelope has no channels', () => {
+    const wrappedWithoutChannels = wrapResponseWithChannels({ id: 'x' }, []);
+
+    runLink({
+      isServer: false,
+      op: { type: 'query', path: 'thing.get' },
+      emitted: wrappedWithoutChannels,
+    });
+
+    expect(registerQuery).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/src/links.test.ts
+++ b/services/api/src/links.test.ts
@@ -90,7 +90,9 @@ describe('createChannelRegistrationLink', () => {
       });
 
       expect(observed).toHaveLength(1);
-      expect((observed[0] as { result: { data: unknown } }).result.data).toEqual({
+      expect(
+        (observed[0] as { result: { data: unknown } }).result.data,
+      ).toEqual({
         processInstance: { id: 'abc', instanceData: { phases: [] } },
       });
     });
@@ -147,10 +149,9 @@ describe('createChannelRegistrationLink', () => {
     });
 
     it('registers mutation channels on the client', () => {
-      const wrapped = wrapResponseWithChannels(
-        { ok: true },
-        ['org:invalidate'],
-      );
+      const wrapped = wrapResponseWithChannels({ ok: true }, [
+        'org:invalidate',
+      ]);
 
       runLink({
         isServer: false,

--- a/services/api/src/links.test.ts
+++ b/services/api/src/links.test.ts
@@ -10,6 +10,10 @@ import { createChannelRegistrationLink } from './links';
  * the values seen by the downstream observer (i.e. what reaches the
  * application). The link is supposed to unwrap any `{ _data, _meta }` envelope
  * regardless of runtime.
+ *
+ * `isServer` is simulated by toggling `globalThis.window`: vitest's node env
+ * starts with no `window`, so the server case is the default; the client case
+ * stubs an empty object. `vi.unstubAllGlobals()` in `afterEach` resets it.
  */
 function runLink({
   isServer,
@@ -20,7 +24,13 @@ function runLink({
   op: { type: 'query' | 'mutation'; path: string; input?: unknown };
   emitted: unknown;
 }): unknown[] {
-  const link = createChannelRegistrationLink({ isServer })({} as never);
+  if (isServer) {
+    vi.stubGlobal('window', undefined);
+  } else {
+    vi.stubGlobal('window', {});
+  }
+
+  const link = createChannelRegistrationLink()({} as never);
 
   const next = () =>
     observable<{ result: { data: unknown } }, unknown>((emit) => {
@@ -56,6 +66,7 @@ describe('createChannelRegistrationLink', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('unwrap symmetry — wrap on the wire MUST be unwrapped before the app sees it', () => {
@@ -108,7 +119,7 @@ describe('createChannelRegistrationLink', () => {
 
   describe('channel registry is browser-only (would leak across requests on the server)', () => {
     it('registers query channels on the client', () => {
-      const wrapped = wrapResponseWithChannels({ id: 'x' }, ['ch:x']);
+      const wrapped = wrapResponseWithChannels({ id: 'x' }, ['org:x']);
 
       runLink({
         isServer: false,
@@ -118,12 +129,12 @@ describe('createChannelRegistrationLink', () => {
 
       expect(registerQuery).toHaveBeenCalledTimes(1);
       expect(registerQuery).toHaveBeenCalledWith(
-        expect.objectContaining({ channels: ['ch:x'] }),
+        expect.objectContaining({ channels: ['org:x'] }),
       );
     });
 
     it('does NOT touch the registry on the server', () => {
-      const wrapped = wrapResponseWithChannels({ id: 'x' }, ['ch:x']);
+      const wrapped = wrapResponseWithChannels({ id: 'x' }, ['org:x']);
 
       runLink({
         isServer: true,
@@ -138,7 +149,7 @@ describe('createChannelRegistrationLink', () => {
     it('registers mutation channels on the client', () => {
       const wrapped = wrapResponseWithChannels(
         { ok: true },
-        ['ch:invalidate'],
+        ['org:invalidate'],
       );
 
       runLink({
@@ -149,7 +160,7 @@ describe('createChannelRegistrationLink', () => {
 
       expect(registerMutation).toHaveBeenCalledTimes(1);
       expect(registerMutation).toHaveBeenCalledWith(
-        expect.objectContaining({ channels: ['ch:invalidate'] }),
+        expect.objectContaining({ channels: ['org:invalidate'] }),
       );
     });
   });

--- a/services/api/src/links.ts
+++ b/services/api/src/links.ts
@@ -97,12 +97,20 @@ function createFetchWithSSRCookies(encryptedCookies?: string) {
  * Custom link that registers queries and mutations with the channel registry.
  *
  * Extracts channels from wrapped response body (_meta.channels) and unwraps
- * data before passing to application.
+ * data before passing to application. Unwrapping happens on both server (SSR)
+ * and client; channel registration only happens on the client because the
+ * registry is a module singleton that would leak across requests on the server.
  *
  * For queries: Registers channels for future invalidation lookup
  * For mutations: Triggers invalidation of queries registered on matching channels
+ *
+ * @param opts.isServer - Override the runtime check (used by tests). Defaults
+ * to `typeof window === 'undefined'`.
  */
-function createChannelRegistrationLink(): TRPCLink<AppRouter> {
+export function createChannelRegistrationLink(opts?: {
+  isServer?: boolean;
+}): TRPCLink<AppRouter> {
+  const isServerForLink = opts?.isServer ?? isServer;
   return () => {
     return ({ next, op }) => {
       return observable((observer) => {
@@ -115,17 +123,14 @@ function createChannelRegistrationLink(): TRPCLink<AppRouter> {
 
         const unsubscribe = next(op).subscribe({
           next(value) {
-            // Handle channel registration from response body (both queries and mutations)
-            if (!isServer && value.result?.data !== undefined) {
+            if (value.result?.data !== undefined) {
               const unwrapped = unwrapResponseWithChannels(value.result.data);
               if (unwrapped) {
                 const { data, channels } = unwrapped;
-                if (channels.length > 0) {
+                if (!isServerForLink && channels.length > 0) {
                   if (op.type === 'query') {
-                    // Register query's channels for future invalidation
                     queryChannelRegistry.registerQuery({ queryKey, channels });
                   } else if (op.type === 'mutation') {
-                    // Get request ID from response headers, fallback to random UUID
                     const response = value.context?.response as
                       | Response
                       | undefined;
@@ -133,7 +138,6 @@ function createChannelRegistrationLink(): TRPCLink<AppRouter> {
                       response?.headers.get('x-request-id') ??
                       crypto.randomUUID();
 
-                    // Register mutation to trigger invalidation of matching queries
                     queryChannelRegistry.registerMutation({
                       channels,
                       mutationId: requestId,
@@ -141,7 +145,6 @@ function createChannelRegistrationLink(): TRPCLink<AppRouter> {
                   }
                 }
 
-                // Unwrap data before passing to application
                 observer.next({
                   ...value,
                   result: {
@@ -211,5 +214,3 @@ export function createLinks(encryptedCookies?: string): TRPCLink<AppRouter>[] {
   ];
 }
 
-// Backwards compatibility - creates links without SSR cookies
-export const links = createLinks();

--- a/services/api/src/links.ts
+++ b/services/api/src/links.ts
@@ -103,14 +103,8 @@ function createFetchWithSSRCookies(encryptedCookies?: string) {
  *
  * For queries: Registers channels for future invalidation lookup
  * For mutations: Triggers invalidation of queries registered on matching channels
- *
- * @param opts.isServer - Override the runtime check (used by tests). Defaults
- * to `typeof window === 'undefined'`.
  */
-export function createChannelRegistrationLink(opts?: {
-  isServer?: boolean;
-}): TRPCLink<AppRouter> {
-  const isServerForLink = opts?.isServer ?? isServer;
+export function createChannelRegistrationLink(): TRPCLink<AppRouter> {
   return () => {
     return ({ next, op }) => {
       return observable((observer) => {
@@ -127,7 +121,9 @@ export function createChannelRegistrationLink(opts?: {
               const unwrapped = unwrapResponseWithChannels(value.result.data);
               if (unwrapped) {
                 const { data, channels } = unwrapped;
-                if (!isServerForLink && channels.length > 0) {
+                // Read lazily so tests can flip the runtime via stubGlobal('window', ...)
+                const isServerRuntime = typeof window === 'undefined';
+                if (!isServerRuntime && channels.length > 0) {
                   if (op.type === 'query') {
                     queryChannelRegistry.registerQuery({ queryKey, channels });
                   } else if (op.type === 'mutation') {

--- a/services/api/src/links.ts
+++ b/services/api/src/links.ts
@@ -212,4 +212,3 @@ export function createLinks(encryptedCookies?: string): TRPCLink<AppRouter>[] {
     }),
   ];
 }
-

--- a/services/api/src/links.ts
+++ b/services/api/src/links.ts
@@ -143,6 +143,7 @@ export function createChannelRegistrationLink(): TRPCLink<AppRouter> {
                   }
                 }
 
+                // Unwrap data before passing to application
                 observer.next({
                   ...value,
                   result: {

--- a/services/api/src/links.ts
+++ b/services/api/src/links.ts
@@ -121,12 +121,13 @@ export function createChannelRegistrationLink(): TRPCLink<AppRouter> {
               const unwrapped = unwrapResponseWithChannels(value.result.data);
               if (unwrapped) {
                 const { data, channels } = unwrapped;
-                // Read lazily so tests can flip the runtime via stubGlobal('window', ...)
                 const isServerRuntime = typeof window === 'undefined';
                 if (!isServerRuntime && channels.length > 0) {
                   if (op.type === 'query') {
+                    // Register query's channels for future invalidation
                     queryChannelRegistry.registerQuery({ queryKey, channels });
                   } else if (op.type === 'mutation') {
+                    // Get request ID from response headers, fallback to random UUID
                     const response = value.context?.response as
                       | Response
                       | undefined;
@@ -134,6 +135,7 @@ export function createChannelRegistrationLink(): TRPCLink<AppRouter> {
                       response?.headers.get('x-request-id') ??
                       crypto.randomUUID();
 
+                    // Register mutation to trigger invalidation of matching queries
                     queryChannelRegistry.registerMutation({
                       channels,
                       mutationId: requestId,


### PR DESCRIPTION
SSR-rendered queries were leaking the `{ _data, _meta }` envelope into the application because the channel-registration link skipped unwrap on the server. Unwrap now runs on both runtimes; only the registry registration stays browser-only to avoid cross-request leaks.