### PR TITLE
fix: Fix proposal viewer 'Content could not be loaded' flash

### DIFF
--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -22,6 +22,7 @@ import { Link } from '@/lib/i18n/routing';
 
 import { Bullet } from '../../Bullet';
 import { BudgetDisplay, formatBudget } from '../BudgetDisplay';
+import { DocumentNotAvailable } from '../DocumentNotAvailable';
 import { useCardTranslation } from '../ProposalTranslationContext';
 import { RevisionRequestChip } from '../RevisionRequestChip';
 import {
@@ -410,6 +411,10 @@ export function ProposalCardPreview({
       : undefined;
 
   const displayText = translatedPreview ?? previewText;
+
+  if (proposal.documentContent?.type === 'unavailable') {
+    return <DocumentNotAvailable className="py-4" />;
+  }
 
   if (displayText === null) {
     return null;

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -22,7 +22,6 @@ import { Link } from '@/lib/i18n/routing';
 
 import { Bullet } from '../../Bullet';
 import { BudgetDisplay, formatBudget } from '../BudgetDisplay';
-import { DocumentNotAvailable } from '../DocumentNotAvailable';
 import { useCardTranslation } from '../ProposalTranslationContext';
 import { RevisionRequestChip } from '../RevisionRequestChip';
 import {
@@ -411,10 +410,6 @@ export function ProposalCardPreview({
       : undefined;
 
   const displayText = translatedPreview ?? previewText;
-
-  if (proposal.documentContent?.type === 'unavailable') {
-    return <DocumentNotAvailable className="py-4" />;
-  }
 
   if (displayText === null) {
     return null;

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -22,7 +22,6 @@ import { Link } from '@/lib/i18n/routing';
 
 import { Bullet } from '../../Bullet';
 import { BudgetDisplay, formatBudget } from '../BudgetDisplay';
-import { DocumentNotAvailable } from '../DocumentNotAvailable';
 import { useCardTranslation } from '../ProposalTranslationContext';
 import { RevisionRequestChip } from '../RevisionRequestChip';
 import {
@@ -413,7 +412,7 @@ export function ProposalCardPreview({
   const displayText = translatedPreview ?? previewText;
 
   if (displayText === null) {
-    return <DocumentNotAvailable className="py-4" />;
+    return null;
   }
 
   if (!displayText) {

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -27,7 +27,6 @@ import { Link as NavLink } from '@/lib/i18n/routing';
 
 import { ProfileAvatar } from '../ProfileAvatar';
 import { BudgetDisplay, formatBudget } from './BudgetDisplay';
-import { DocumentNotAvailable } from './DocumentNotAvailable';
 import { ProposalAttachmentViewList } from './ProposalAttachmentViewList';
 import { ProposalContentRenderer } from './ProposalContentRenderer';
 import { ProposalHtmlContent } from './ProposalHtmlContent';
@@ -253,9 +252,7 @@ export function ProposalPreview({
           location={proposal.proposalData?.location}
           translatedMeta={translatedMeta}
         />
-      ) : (
-        <DocumentNotAvailable />
-      )}
+      ) : null}
 
       {/* Attachments Section */}
       {proposal.attachments && proposal.attachments.length > 0 && (

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -12,6 +12,7 @@ import {
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Header1, Header3 } from '@op/ui/Header';
 import { Link } from '@op/ui/Link';
+import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Tag, TagGroup } from '@op/ui/TagGroup';
 import type { ReactNode } from 'react';
 import {
@@ -27,6 +28,7 @@ import { Link as NavLink } from '@/lib/i18n/routing';
 
 import { ProfileAvatar } from '../ProfileAvatar';
 import { BudgetDisplay, formatBudget } from './BudgetDisplay';
+import { DocumentNotAvailable } from './DocumentNotAvailable';
 import { ProposalAttachmentViewList } from './ProposalAttachmentViewList';
 import { ProposalContentRenderer } from './ProposalContentRenderer';
 import { ProposalHtmlContent } from './ProposalHtmlContent';
@@ -48,6 +50,14 @@ export type ProposalPreviewProps = {
   submissionMetaSuffix?: ReactNode;
   /** Rendered between the header section and the proposal body. */
   headerBanner?: ReactNode;
+  /**
+   * Drives the body region when the collaboration document can't be rendered
+   * yet. `'pending'` shows a loading state (still fetching/propagating),
+   * `'error'` shows the "content not found" fallback, `'ready'` (default)
+   * renders whatever content is present. Defaults to `'ready'` so callers that
+   * don't track document loading (e.g. the review pane) are unaffected.
+   */
+  documentState?: 'ready' | 'pending' | 'error';
 };
 
 export function ProposalPreview({
@@ -56,6 +66,7 @@ export function ProposalPreview({
   translation,
   submissionMetaSuffix,
   headerBanner,
+  documentState = 'ready',
 }: ProposalPreviewProps) {
   const t = useTranslations();
 
@@ -243,7 +254,13 @@ export function ProposalPreview({
       {headerBanner}
 
       {/* Proposal Content */}
-      {legacyHtml ? (
+      {documentState === 'pending' ? (
+        <div className="flex justify-center py-8">
+          <LoadingSpinner />
+        </div>
+      ) : documentState === 'error' ? (
+        <DocumentNotAvailable className="py-4" />
+      ) : legacyHtml ? (
         <ProposalHtmlContent html={legacyHtml} />
       ) : htmlContent && proposalTemplate ? (
         <ProposalContentRenderer

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -27,6 +27,7 @@ import { Link as NavLink } from '@/lib/i18n/routing';
 
 import { ProfileAvatar } from '../ProfileAvatar';
 import { BudgetDisplay, formatBudget } from './BudgetDisplay';
+import { DocumentNotAvailable } from './DocumentNotAvailable';
 import { ProposalAttachmentViewList } from './ProposalAttachmentViewList';
 import { ProposalContentRenderer } from './ProposalContentRenderer';
 import { ProposalHtmlContent } from './ProposalHtmlContent';
@@ -252,6 +253,8 @@ export function ProposalPreview({
           location={proposal.proposalData?.location}
           translatedMeta={translatedMeta}
         />
+      ) : proposal.documentContent?.type === 'unavailable' ? (
+        <DocumentNotAvailable />
       ) : null}
 
       {/* Attachments Section */}

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -27,7 +27,6 @@ import { Link as NavLink } from '@/lib/i18n/routing';
 
 import { ProfileAvatar } from '../ProfileAvatar';
 import { BudgetDisplay, formatBudget } from './BudgetDisplay';
-import { DocumentNotAvailable } from './DocumentNotAvailable';
 import { ProposalAttachmentViewList } from './ProposalAttachmentViewList';
 import { ProposalContentRenderer } from './ProposalContentRenderer';
 import { ProposalHtmlContent } from './ProposalHtmlContent';
@@ -253,8 +252,6 @@ export function ProposalPreview({
           location={proposal.proposalData?.location}
           translatedMeta={translatedMeta}
         />
-      ) : proposal.documentContent?.type === 'unavailable' ? (
-        <DocumentNotAvailable />
       ) : null}
 
       {/* Attachments Section */}

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -14,7 +14,7 @@ import {
 import { SplitPane } from '@op/ui/SplitPane';
 import { useLocale } from 'next-intl';
 import { useQueryStates } from 'nuqs';
-import { type ReactNode, useCallback, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -25,6 +25,17 @@ import { ProposalViewLayout } from './ProposalViewLayout';
 import { RevisedOnBadge } from './Review/AuthorRevisionNote';
 import { TranslateBanner } from './TranslateBanner';
 import { proposalEditorReviewRevisionParser } from './proposalEditor/proposalEditorAsideParams';
+
+/** How often to re-fetch while the document is still propagating from TipTap. */
+const DOCUMENT_POLL_INTERVAL_MS = 2500;
+/**
+ * How long to keep polling for a missing document before treating it as
+ * truly not found. Bounds the "still loading" window so a genuinely absent
+ * document eventually surfaces an error instead of spinning forever.
+ */
+const DOCUMENT_POLL_TIMEOUT_MS = 20000;
+
+export type ProposalDocumentState = 'ready' | 'pending' | 'error';
 
 export function ProposalView({
   proposal: initialProposal,
@@ -40,12 +51,49 @@ export function ProposalView({
   const t = useTranslations();
   const locale = useLocale();
 
-  const { data: proposal } = trpc.decision.getProposal.useQuery({
-    profileId: initialProposal.profileId,
-  });
+  // When the document fetch failed server-side it comes back as
+  // `{ type: 'unavailable' }`. That can be transient (still syncing from the
+  // collaboration server), so poll until it resolves, and only after a bounded
+  // wait treat it as truly missing.
+  const [documentLoadTimedOut, setDocumentLoadTimedOut] = useState(false);
+
+  const { data: proposal } = trpc.decision.getProposal.useQuery(
+    {
+      profileId: initialProposal.profileId,
+    },
+    {
+      refetchInterval: (query) =>
+        query.state.data?.documentContent?.type === 'unavailable' &&
+        !documentLoadTimedOut
+          ? DOCUMENT_POLL_INTERVAL_MS
+          : false,
+    },
+  );
 
   // Safety check - fallback to initial data if query returns undefined
   const currentProposal = proposal || initialProposal;
+
+  const isDocumentUnavailable =
+    currentProposal.documentContent?.type === 'unavailable';
+
+  useEffect(() => {
+    if (!isDocumentUnavailable) {
+      setDocumentLoadTimedOut(false);
+      return;
+    }
+
+    const timer = setTimeout(
+      () => setDocumentLoadTimedOut(true),
+      DOCUMENT_POLL_TIMEOUT_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [isDocumentUnavailable]);
+
+  const documentState: ProposalDocumentState = isDocumentUnavailable
+    ? documentLoadTimedOut
+      ? 'error'
+      : 'pending'
+    : 'ready';
 
   const { processInstanceId, id: proposalId } = currentProposal;
   useTrackPageView(
@@ -173,6 +221,7 @@ export function ProposalView({
       <ProposalPreview
         proposal={currentProposal}
         selection={selection}
+        documentState={documentState}
         translation={
           translatedHtmlContent
             ? {

--- a/apps/app/src/components/decisions/proposalContentUtils.ts
+++ b/apps/app/src/components/decisions/proposalContentUtils.ts
@@ -30,7 +30,7 @@ export function getProposalContentPreview(
   documentContent: DocumentContent | undefined,
   proposalTemplate: ProposalTemplateSchema | undefined,
 ): string | null {
-  if (!documentContent) {
+  if (!documentContent || documentContent.type === 'unavailable') {
     return null;
   }
 

--- a/apps/app/src/components/decisions/proposalContentUtils.ts
+++ b/apps/app/src/components/decisions/proposalContentUtils.ts
@@ -30,7 +30,7 @@ export function getProposalContentPreview(
   documentContent: DocumentContent | undefined,
   proposalTemplate: ProposalTemplateSchema | undefined,
 ): string | null {
-  if (!documentContent || documentContent.type === 'unavailable') {
+  if (!documentContent) {
     return null;
   }
 

--- a/apps/app/src/components/decisions/proposalContentUtils.ts
+++ b/apps/app/src/components/decisions/proposalContentUtils.ts
@@ -76,9 +76,14 @@ export function getProposalContentPreview(
     }
   }
 
-  return (
-    getTextPreview({ content: documentContent.content, maxLines: 3 }) ?? ''
-  );
+  if (documentContent.type === 'html') {
+    return (
+      getTextPreview({ content: documentContent.content, maxLines: 3 }) ?? ''
+    );
+  }
+
+  // type === 'unavailable' — no text to preview.
+  return null;
 }
 
 /**

--- a/packages/common/src/services/decision/getProposal.ts
+++ b/packages/common/src/services/decision/getProposal.ts
@@ -207,15 +207,22 @@ export const getProposal = async ({
         }))
       : Promise.resolve({ commentsCount: 0, likesCount: 0, followersCount: 0 }),
 
-    // Fetch document content
-    getProposalDocumentsContent([
-      {
-        id: proposal.id,
-        proposalData: proposal.proposalData,
-        proposalTemplate,
-        collaborationDocVersionId,
-      },
-    ]),
+    // Fetch document content. Mark a failed fetch as 'unavailable' rather
+    // than throwing: the proposal (title, budget, attachments) still renders
+    // while the client polls for the document and only shows a "content not
+    // found" state after a bounded wait — a still-syncing doc shouldn't flash
+    // an error.
+    getProposalDocumentsContent(
+      [
+        {
+          id: proposal.id,
+          proposalData: proposal.proposalData,
+          proposalTemplate,
+          collaborationDocVersionId,
+        },
+      ],
+      { onFetchError: 'unavailable' },
+    ),
   ]);
 
   // Generate signed URLs for attachments

--- a/packages/common/src/services/decision/getProposalDocumentsContent.ts
+++ b/packages/common/src/services/decision/getProposalDocumentsContent.ts
@@ -6,11 +6,16 @@ import { parseProposalData } from './proposalDataSchema';
 import type { ProposalTemplateSchema } from './types';
 
 /**
- * Proposal document content can be either TipTap JSON or legacy HTML
+ * Proposal document content can be either TipTap JSON, legacy HTML, or
+ * `unavailable` when a collaborationDocId was set but the fetch failed.
+ * The `unavailable` variant lets callers distinguish a real load failure
+ * (worth surfacing to the user) from a proposal that genuinely has no body
+ * (e.g. an unedited draft).
  */
 export type ProposalDocumentContent =
   | { type: 'json'; fragments: TipTapFragmentResponse }
-  | { type: 'html'; content: string };
+  | { type: 'html'; content: string }
+  | { type: 'unavailable' };
 
 /**
  * Fetch document contents for proposals, handling both TipTap collaboration docs
@@ -97,6 +102,8 @@ export async function getProposalDocumentsContent(
     for (const { id, fragments } of results) {
       if (fragments) {
         documentContentMap.set(id, { type: 'json', fragments });
+      } else {
+        documentContentMap.set(id, { type: 'unavailable' });
       }
     }
   }

--- a/packages/common/src/services/decision/getProposalDocumentsContent.ts
+++ b/packages/common/src/services/decision/getProposalDocumentsContent.ts
@@ -6,16 +6,14 @@ import { parseProposalData } from './proposalDataSchema';
 import type { ProposalTemplateSchema } from './types';
 
 /**
- * Proposal document content can be either TipTap JSON, legacy HTML, or
- * `unavailable` when a collaborationDocId was set but the fetch failed.
- * The `unavailable` variant lets callers distinguish a real load failure
- * (worth surfacing to the user) from a proposal that genuinely has no body
- * (e.g. an unedited draft).
+ * Proposal document content can be either TipTap JSON or legacy HTML.
+ * Failed TipTap fetches throw — callers rely on Suspense to retry while
+ * loading and ErrorBoundary to render a fallback when the fetch ultimately
+ * fails.
  */
 export type ProposalDocumentContent =
   | { type: 'json'; fragments: TipTapFragmentResponse }
-  | { type: 'html'; content: string }
-  | { type: 'unavailable' };
+  | { type: 'html'; content: string };
 
 /**
  * Fetch document contents for proposals, handling both TipTap collaboration docs
@@ -74,37 +72,25 @@ export async function getProposalDocumentsContent(
         proposalTemplate,
         collaborationDocVersionId,
       }) => {
-        try {
-          const fragmentNames = proposalTemplate
-            ? getProposalFragmentNames(proposalTemplate)
-            : ['default'];
+        const fragmentNames = proposalTemplate
+          ? getProposalFragmentNames(proposalTemplate)
+          : ['default'];
 
-          const fragments = await client.getDocumentFragments(
-            collaborationDocId,
-            fragmentNames,
-            collaborationDocVersionId != null
-              ? { version: collaborationDocVersionId }
-              : undefined,
-          );
+        const fragments = await client.getDocumentFragments(
+          collaborationDocId,
+          fragmentNames,
+          collaborationDocVersionId != null
+            ? { version: collaborationDocVersionId }
+            : undefined,
+        );
 
-          return { id, fragments };
-        } catch (error) {
-          console.warn('Failed to fetch TipTap document', {
-            collaborationDocId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return { id, fragments: undefined };
-        }
+        return { id, fragments };
       },
       { concurrency: 10 },
     );
 
     for (const { id, fragments } of results) {
-      if (fragments) {
-        documentContentMap.set(id, { type: 'json', fragments });
-      } else {
-        documentContentMap.set(id, { type: 'unavailable' });
-      }
+      documentContentMap.set(id, { type: 'json', fragments });
     }
   }
 

--- a/packages/common/src/services/decision/getProposalDocumentsContent.ts
+++ b/packages/common/src/services/decision/getProposalDocumentsContent.ts
@@ -14,9 +14,8 @@ import type { ProposalTemplateSchema } from './types';
  * propagating from the collaboration server (transient — it will appear), or
  * it is genuinely gone (permanent). The caller picks how to handle that via
  * `onFetchError`:
- * - `'throw'` (default): the error propagates.
- * - `'omit'`: the failing proposal is left out of the returned map (its
- *   `documentContent` is undefined). Used by list reads so a single
+ * - `'omit'` (default): the failing proposal is left out of the returned map
+ *   (its `documentContent` is undefined). Used by list reads so a single
  *   unavailable document can't break the entire list.
  * - `'unavailable'`: the proposal is mapped to `{ type: 'unavailable' }`.
  *   Used by the single-proposal viewer so the rest of the proposal still
@@ -32,9 +31,9 @@ export type ProposalDocumentContent =
 export interface GetProposalDocumentsContentOptions {
   /**
    * What to do when a TipTap document fetch fails.
-   * Defaults to `'throw'`.
+   * Defaults to `'omit'`.
    */
-  onFetchError?: 'throw' | 'omit' | 'unavailable';
+  onFetchError?: 'omit' | 'unavailable';
 }
 
 /**
@@ -56,7 +55,7 @@ export async function getProposalDocumentsContent(
   }>,
   options: GetProposalDocumentsContentOptions = {},
 ): Promise<Map<string, ProposalDocumentContent>> {
-  const { onFetchError = 'throw' } = options;
+  const { onFetchError = 'omit' } = options;
   const documentContentMap = new Map<string, ProposalDocumentContent>();
 
   const proposalsWithCollabDoc: Array<{
@@ -111,10 +110,6 @@ export async function getProposalDocumentsContent(
 
           return { id, fragments, failed: false as const };
         } catch (error) {
-          if (onFetchError === 'throw') {
-            throw error;
-          }
-
           console.warn('Failed to fetch TipTap document', {
             collaborationDocId,
             error: error instanceof Error ? error.message : String(error),

--- a/packages/common/src/services/decision/getProposalDocumentsContent.ts
+++ b/packages/common/src/services/decision/getProposalDocumentsContent.ts
@@ -6,27 +6,35 @@ import { parseProposalData } from './proposalDataSchema';
 import type { ProposalTemplateSchema } from './types';
 
 /**
- * Proposal document content can be either TipTap JSON or legacy HTML.
+ * Proposal document content can be either TipTap JSON or legacy HTML, or a
+ * sentinel marking the document as temporarily unavailable.
  *
- * How a failed TipTap fetch is handled depends on `onFetchError`:
- * - `'throw'` (default): the error propagates. Used by single-proposal reads
- *   (e.g. the proposal viewer) so the client can rely on Suspense to retry
- *   while loading and an ErrorBoundary to render a fallback when the fetch
- *   ultimately fails — instead of flashing an inline error.
+ * A failed TipTap fetch can mean two different things that look identical at
+ * the moment of the request (both surface as a 404): the document is still
+ * propagating from the collaboration server (transient — it will appear), or
+ * it is genuinely gone (permanent). The caller picks how to handle that via
+ * `onFetchError`:
+ * - `'throw'` (default): the error propagates.
  * - `'omit'`: the failing proposal is left out of the returned map (its
  *   `documentContent` is undefined). Used by list reads so a single
  *   unavailable document can't break the entire list.
+ * - `'unavailable'`: the proposal is mapped to `{ type: 'unavailable' }`.
+ *   Used by the single-proposal viewer so the rest of the proposal still
+ *   renders while the client polls for the document, and only shows a
+ *   "content not found" state once a bounded wait elapses — instead of
+ *   flashing an error the instant a still-syncing document 404s.
  */
 export type ProposalDocumentContent =
   | { type: 'json'; fragments: TipTapFragmentResponse }
-  | { type: 'html'; content: string };
+  | { type: 'html'; content: string }
+  | { type: 'unavailable' };
 
 export interface GetProposalDocumentsContentOptions {
   /**
    * What to do when a TipTap document fetch fails.
    * Defaults to `'throw'`.
    */
-  onFetchError?: 'throw' | 'omit';
+  onFetchError?: 'throw' | 'omit' | 'unavailable';
 }
 
 /**
@@ -101,7 +109,7 @@ export async function getProposalDocumentsContent(
               : undefined,
           );
 
-          return { id, fragments };
+          return { id, fragments, failed: false as const };
         } catch (error) {
           if (onFetchError === 'throw') {
             throw error;
@@ -111,15 +119,20 @@ export async function getProposalDocumentsContent(
             collaborationDocId,
             error: error instanceof Error ? error.message : String(error),
           });
-          return { id, fragments: undefined };
+          return { id, fragments: undefined, failed: true as const };
         }
       },
       { concurrency: 10 },
     );
 
-    for (const { id, fragments } of results) {
+    for (const { id, fragments, failed } of results) {
       if (fragments) {
         documentContentMap.set(id, { type: 'json', fragments });
+      } else if (failed && onFetchError === 'unavailable') {
+        // Distinguish "couldn't fetch" from "no document": list reads omit
+        // the entry, but the viewer needs the sentinel to drive its poll +
+        // bounded "content not found" fallback.
+        documentContentMap.set(id, { type: 'unavailable' });
       }
     }
   }

--- a/packages/common/src/services/decision/getProposalDocumentsContent.ts
+++ b/packages/common/src/services/decision/getProposalDocumentsContent.ts
@@ -7,13 +7,27 @@ import type { ProposalTemplateSchema } from './types';
 
 /**
  * Proposal document content can be either TipTap JSON or legacy HTML.
- * Failed TipTap fetches throw — callers rely on Suspense to retry while
- * loading and ErrorBoundary to render a fallback when the fetch ultimately
- * fails.
+ *
+ * How a failed TipTap fetch is handled depends on `onFetchError`:
+ * - `'throw'` (default): the error propagates. Used by single-proposal reads
+ *   (e.g. the proposal viewer) so the client can rely on Suspense to retry
+ *   while loading and an ErrorBoundary to render a fallback when the fetch
+ *   ultimately fails — instead of flashing an inline error.
+ * - `'omit'`: the failing proposal is left out of the returned map (its
+ *   `documentContent` is undefined). Used by list reads so a single
+ *   unavailable document can't break the entire list.
  */
 export type ProposalDocumentContent =
   | { type: 'json'; fragments: TipTapFragmentResponse }
   | { type: 'html'; content: string };
+
+export interface GetProposalDocumentsContentOptions {
+  /**
+   * What to do when a TipTap document fetch fails.
+   * Defaults to `'throw'`.
+   */
+  onFetchError?: 'throw' | 'omit';
+}
 
 /**
  * Fetch document contents for proposals, handling both TipTap collaboration docs
@@ -32,7 +46,9 @@ export async function getProposalDocumentsContent(
     proposalTemplate?: ProposalTemplateSchema | null;
     collaborationDocVersionId?: number;
   }>,
+  options: GetProposalDocumentsContentOptions = {},
 ): Promise<Map<string, ProposalDocumentContent>> {
+  const { onFetchError = 'throw' } = options;
   const documentContentMap = new Map<string, ProposalDocumentContent>();
 
   const proposalsWithCollabDoc: Array<{
@@ -76,21 +92,35 @@ export async function getProposalDocumentsContent(
           ? getProposalFragmentNames(proposalTemplate)
           : ['default'];
 
-        const fragments = await client.getDocumentFragments(
-          collaborationDocId,
-          fragmentNames,
-          collaborationDocVersionId != null
-            ? { version: collaborationDocVersionId }
-            : undefined,
-        );
+        try {
+          const fragments = await client.getDocumentFragments(
+            collaborationDocId,
+            fragmentNames,
+            collaborationDocVersionId != null
+              ? { version: collaborationDocVersionId }
+              : undefined,
+          );
 
-        return { id, fragments };
+          return { id, fragments };
+        } catch (error) {
+          if (onFetchError === 'throw') {
+            throw error;
+          }
+
+          console.warn('Failed to fetch TipTap document', {
+            collaborationDocId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return { id, fragments: undefined };
+        }
       },
       { concurrency: 10 },
     );
 
     for (const { id, fragments } of results) {
-      documentContentMap.set(id, { type: 'json', fragments });
+      if (fragments) {
+        documentContentMap.set(id, { type: 'json', fragments });
+      }
     }
   }
 

--- a/packages/common/src/services/decision/getReviewAssignment.ts
+++ b/packages/common/src/services/decision/getReviewAssignment.ts
@@ -63,7 +63,7 @@ export async function getReviewAssignment({
 
   const documentContent = documentContentMap.get(proposalSnapshot.id);
 
-  if (!documentContent) {
+  if (!documentContent || documentContent.type === 'unavailable') {
     throw new ValidationError(
       `Could not resolve document content for proposal ${proposalSnapshot.id}`,
     );

--- a/packages/common/src/services/decision/getReviewAssignment.ts
+++ b/packages/common/src/services/decision/getReviewAssignment.ts
@@ -63,7 +63,7 @@ export async function getReviewAssignment({
 
   const documentContent = documentContentMap.get(proposalSnapshot.id);
 
-  if (!documentContent || documentContent.type === 'unavailable') {
+  if (!documentContent) {
     throw new ValidationError(
       `Could not resolve document content for proposal ${proposalSnapshot.id}`,
     );

--- a/packages/common/src/services/decision/getReviewAssignment.ts
+++ b/packages/common/src/services/decision/getReviewAssignment.ts
@@ -49,15 +49,19 @@ export async function getReviewAssignment({
         profileId: assignment.proposal.profileId,
         viewerProfileId: assignment.reviewerProfileId,
       }),
-      getProposalDocumentsContent([
-        {
-          id: proposalSnapshot.id,
-          proposalData: proposalSnapshot.proposalData,
-          proposalTemplate,
-          collaborationDocVersionId:
-            proposalSnapshot.proposalData.collaborationDocVersionId,
-        },
-      ]),
+      getProposalDocumentsContent(
+        [
+          {
+            id: proposalSnapshot.id,
+            proposalData: proposalSnapshot.proposalData,
+            proposalTemplate,
+            collaborationDocVersionId:
+              proposalSnapshot.proposalData.collaborationDocVersionId,
+          },
+        ],
+        // Tolerate an unavailable document rather than failing the review view.
+        { onFetchError: 'omit' },
+      ),
       getProposalAttachmentsWithSignedUrls(proposalSnapshot.id),
     ]);
 

--- a/packages/common/src/services/decision/getReviewAssignment.ts
+++ b/packages/common/src/services/decision/getReviewAssignment.ts
@@ -67,7 +67,9 @@ export async function getReviewAssignment({
 
   const documentContent = documentContentMap.get(proposalSnapshot.id);
 
-  if (!documentContent) {
+  // 'omit' keeps a failed fetch out of the map entirely, so a present entry is
+  // always real content here; guard 'unavailable' too for type-safety.
+  if (!documentContent || documentContent.type === 'unavailable') {
     throw new ValidationError(
       `Could not resolve document content for proposal ${proposalSnapshot.id}`,
     );

--- a/packages/common/src/services/decision/listAllProposals.ts
+++ b/packages/common/src/services/decision/listAllProposals.ts
@@ -239,6 +239,8 @@ export const listAllProposals = async ({
           proposalData: proposal.proposalData,
           proposalTemplate,
         })),
+        // A single unavailable document must not break the whole list.
+        { onFetchError: 'omit' },
       ),
       getSelectedProposalIds(processInstanceId),
       // Flagged items reach this point only for their creator or an admin —

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -545,6 +545,8 @@ export const listProposals = async ({
                 : parsed.collaborationDocVersionId,
           };
         }),
+        // A single unavailable document must not break the whole list.
+        { onFetchError: 'omit' },
       ),
       getSelectedProposalIds(processInstanceId),
       // Flagged items reach this point only for their creator or an admin —

--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -79,8 +79,11 @@ export async function listReviewAssignments({
     });
   }
 
-  const documentContentMap =
-    await getProposalDocumentsContent(docContentInputs);
+  const documentContentMap = await getProposalDocumentsContent(
+    docContentInputs,
+    // A single unavailable document must not break the whole list.
+    { onFetchError: 'omit' },
+  );
 
   const assignmentList = assignments.map((assignment) => {
     const proposalSnapshot = resolveAssignmentProposal(assignment);

--- a/packages/common/src/services/decision/schemas/proposal.ts
+++ b/packages/common/src/services/decision/schemas/proposal.ts
@@ -79,6 +79,11 @@ export const documentContentSchema = z.discriminatedUnion('type', [
     type: z.literal('html'),
     content: z.string(),
   }),
+  // The document fetch failed; the client polls and shows a bounded
+  // "content not found" fallback rather than flashing an error immediately.
+  z.object({
+    type: z.literal('unavailable'),
+  }),
 ]);
 
 export const proposalAccessSchema = z.object({

--- a/packages/common/src/services/decision/schemas/proposal.ts
+++ b/packages/common/src/services/decision/schemas/proposal.ts
@@ -79,9 +79,6 @@ export const documentContentSchema = z.discriminatedUnion('type', [
     type: z.literal('html'),
     content: z.string(),
   }),
-  z.object({
-    type: z.literal('unavailable'),
-  }),
 ]);
 
 export const proposalAccessSchema = z.object({

--- a/packages/common/src/services/decision/schemas/proposal.ts
+++ b/packages/common/src/services/decision/schemas/proposal.ts
@@ -79,6 +79,9 @@ export const documentContentSchema = z.discriminatedUnion('type', [
     type: z.literal('html'),
     content: z.string(),
   }),
+  z.object({
+    type: z.literal('unavailable'),
+  }),
 ]);
 
 export const proposalAccessSchema = z.object({

--- a/packages/common/src/services/translation/translateProposals.ts
+++ b/packages/common/src/services/translation/translateProposals.ts
@@ -120,6 +120,8 @@ export async function translateProposals({
       proposalTemplate:
         templateByProcessId.get(p.processInstance.processId) ?? null,
     })),
+    // A single unavailable document must not break the whole batch.
+    { onFetchError: 'omit' },
   );
 
   // 4. Build translatable entries for all proposals

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -491,7 +491,7 @@ describe.concurrent('getProposal', () => {
     });
   });
 
-  it('should throw when TipTap returns 404 so the client can suspend/retry', async ({
+  it('should mark documentContent unavailable when TipTap returns 404 so the client can poll', async ({
     task,
     onTestFinished,
   }) => {
@@ -518,11 +518,19 @@ describe.concurrent('getProposal', () => {
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
-    // TipTap fetch failures propagate so callers can suspend (retry) and
-    // fall back to ErrorBoundary instead of rendering a flashed error inline.
-    await expect(
-      caller.decision.getProposal({ profileId: proposal.profileId }),
-    ).rejects.toThrow();
+    // A failed TipTap fetch must not fail the whole read: the proposal still
+    // resolves and documentContent is marked unavailable so the client can
+    // poll (still syncing) and only show "content not found" after a bounded
+    // wait — instead of flashing an error inline.
+    const result = await caller.decision.getProposal({
+      profileId: proposal.profileId,
+    });
+
+    expect(result.proposalData).toMatchObject({
+      title: 'Missing Doc Proposal',
+    });
+    expect(result.documentContent).toEqual({ type: 'unavailable' });
+    expect(result.htmlContent).toBeUndefined();
   });
 
   it('should fetch the saved collaboration version for non-draft proposals', async ({

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -525,8 +525,9 @@ describe.concurrent('getProposal', () => {
       title: 'Missing Doc Proposal',
       collaborationDocId: expect.any(String),
     });
-    // When TipTap fetch fails, documentContent is undefined (UI handles error state)
-    expect(result.documentContent).toBeUndefined();
+    // When TipTap fetch fails, documentContent is marked unavailable so the UI
+    // can distinguish a load failure from a proposal with no body.
+    expect(result.documentContent).toEqual({ type: 'unavailable' });
   });
 
   it('should fetch the saved collaboration version for non-draft proposals', async ({

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -490,7 +490,7 @@ describe.concurrent('getProposal', () => {
     });
   });
 
-  it('should return undefined documentContent when TipTap returns 404', async ({
+  it('should throw when TipTap returns 404 so the client can suspend/retry', async ({
     task,
     onTestFinished,
   }) => {
@@ -517,17 +517,11 @@ describe.concurrent('getProposal', () => {
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
-    const result = await caller.decision.getProposal({
-      profileId: proposal.profileId,
-    });
-
-    expect(result.proposalData).toMatchObject({
-      title: 'Missing Doc Proposal',
-      collaborationDocId: expect.any(String),
-    });
-    // When TipTap fetch fails, documentContent is marked unavailable so the UI
-    // can distinguish a load failure from a proposal with no body.
-    expect(result.documentContent).toEqual({ type: 'unavailable' });
+    // TipTap fetch failures propagate so callers can suspend (retry) and
+    // fall back to ErrorBoundary instead of rendering a flashed error inline.
+    await expect(
+      caller.decision.getProposal({ profileId: proposal.profileId }),
+    ).rejects.toThrow();
   });
 
   it('should fetch the saved collaboration version for non-draft proposals', async ({

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -393,6 +393,7 @@ describe.concurrent('getProposal', () => {
       userEmail: submitter.email,
       processInstanceId: instance.instance.id,
       proposalData: { title: 'Co-authored Hidden Proposal' },
+      seedCollabDoc: true,
     });
 
     // Add the collaborator as a profileUser on the proposal's profile —
@@ -1231,6 +1232,7 @@ describe.concurrent('getProposal', () => {
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
       proposalData: { title: 'Org Admin Fallback Proposal' },
+      seedCollabDoc: true,
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -1262,6 +1264,7 @@ describe.concurrent('getProposal', () => {
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
       proposalData: { title: 'Org Member Fallback Proposal' },
+      seedCollabDoc: true,
     });
 
     await db
@@ -1305,6 +1308,7 @@ describe.concurrent('getProposal', () => {
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
       proposalData: { title: 'Cross-Org Profile Access Proposal' },
+      seedCollabDoc: true,
     });
 
     await db
@@ -1397,6 +1401,7 @@ describe.concurrent('getProposal', () => {
       proposalData: {
         title: 'Proposal With Attachments',
       },
+      seedCollabDoc: true,
     });
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -1464,6 +1469,7 @@ describe.concurrent('getProposal', () => {
       userEmail: submitter.email,
       processInstanceId: instance.instance.id,
       proposalData: { title: 'My Draft Proposal' },
+      seedCollabDoc: true,
     });
 
     // Verify it's actually a draft
@@ -1560,6 +1566,7 @@ describe.concurrent('getProposal', () => {
       userEmail: submitter.email,
       processInstanceId: instance.instance.id,
       proposalData: { title: 'Public Submitted Proposal' },
+      seedCollabDoc: true,
     });
 
     const submitterCaller = await createAuthenticatedCaller(submitter.email);

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -762,7 +762,7 @@ describe.concurrent('listProposals', () => {
     });
   });
 
-  it('should return undefined documentContent when TipTap fetch fails', async ({
+  it('should throw when TipTap fetch fails so the client can suspend/retry', async ({
     task,
     onTestFinished,
   }) => {
@@ -780,7 +780,7 @@ describe.concurrent('listProposals', () => {
 
     // Mock returns 404 by default for unknown docIds (no explicit setup needed)
 
-    const [proposal, caller] = await Promise.all([
+    const [, caller] = await Promise.all([
       testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -791,14 +791,13 @@ describe.concurrent('listProposals', () => {
       createAuthenticatedCaller(setup.userEmail),
     ]);
 
-    const result = await caller.decision.listProposals({
-      processInstanceId: instance.instance.id,
-    });
-
-    const foundProposal = result.proposals.find((p) => p.id === proposal.id);
-    // When TipTap fetch fails, documentContent is marked unavailable so the UI
-    // can distinguish a load failure from a proposal with no body.
-    expect(foundProposal?.documentContent).toEqual({ type: 'unavailable' });
+    // TipTap fetch failures propagate so callers can suspend (retry) and
+    // fall back to ErrorBoundary instead of rendering a flashed error inline.
+    await expect(
+      caller.decision.listProposals({
+        processInstanceId: instance.instance.id,
+      }),
+    ).rejects.toThrow();
   });
 
   it('should fetch multiple TipTap documents in parallel', async ({

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -796,8 +796,9 @@ describe.concurrent('listProposals', () => {
     });
 
     const foundProposal = result.proposals.find((p) => p.id === proposal.id);
-    // When TipTap fetch fails, documentContent should be undefined
-    expect(foundProposal?.documentContent).toBeUndefined();
+    // When TipTap fetch fails, documentContent is marked unavailable so the UI
+    // can distinguish a load failure from a proposal with no body.
+    expect(foundProposal?.documentContent).toEqual({ type: 'unavailable' });
   });
 
   it('should fetch multiple TipTap documents in parallel', async ({

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -762,7 +762,7 @@ describe.concurrent('listProposals', () => {
     });
   });
 
-  it('should throw when TipTap fetch fails so the client can suspend/retry', async ({
+  it('should omit documentContent when a TipTap fetch fails so one bad doc does not break the list', async ({
     task,
     onTestFinished,
   }) => {
@@ -780,7 +780,7 @@ describe.concurrent('listProposals', () => {
 
     // Mock returns 404 by default for unknown docIds (no explicit setup needed)
 
-    const [, caller] = await Promise.all([
+    const [proposal, caller] = await Promise.all([
       testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -791,13 +791,14 @@ describe.concurrent('listProposals', () => {
       createAuthenticatedCaller(setup.userEmail),
     ]);
 
-    // TipTap fetch failures propagate so callers can suspend (retry) and
-    // fall back to ErrorBoundary instead of rendering a flashed error inline.
-    await expect(
-      caller.decision.listProposals({
-        processInstanceId: instance.instance.id,
-      }),
-    ).rejects.toThrow();
+    // A single unavailable document must not break the whole list: the list
+    // still resolves and the affected proposal's documentContent is undefined.
+    const result = await caller.decision.listProposals({
+      processInstanceId: instance.instance.id,
+    });
+
+    const foundProposal = result.proposals.find((p) => p.id === proposal.id);
+    expect(foundProposal?.documentContent).toBeUndefined();
   });
 
   it('should fetch multiple TipTap documents in parallel', async ({

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -1,3 +1,4 @@
+import { mockCollab } from '@op/collab/testing';
 import {
   type DecisionInstanceData,
   advancePhase,
@@ -573,12 +574,19 @@ export class TestDecisionsDataManager {
   /**
    * Creates a proposal via the decision service and tracks its profile for cleanup.
    * If `description` is provided, removes `collaborationDocId` to simulate legacy proposals.
+   *
+   * Set `seedCollabDoc` to register an empty TipTap document for the proposal's
+   * generated `collaborationDocId`. Single-proposal reads (e.g. getProposal)
+   * propagate TipTap fetch failures, so tests that aren't exercising the
+   * doc-unavailable path should seed a fetchable doc — mirroring production,
+   * where a proposal's collaboration document always exists.
    */
   async createProposal({
     userEmail,
     processInstanceId,
     proposalData,
     status,
+    seedCollabDoc = false,
   }: {
     userEmail: string;
     processInstanceId: string;
@@ -588,6 +596,7 @@ export class TestDecisionsDataManager {
       collaborationDocId?: string;
     };
     status?: ProposalStatus;
+    seedCollabDoc?: boolean;
   }) {
     this.ensureCleanupRegistered();
 
@@ -616,6 +625,20 @@ export class TestDecisionsDataManager {
           return { ...rest, ...proposalData };
         })()
       : undefined;
+
+    // Register a fetchable (empty) doc so reads that propagate TipTap failures
+    // resolve. Legacy proposals have no collaborationDocId, so nothing to seed.
+    if (seedCollabDoc && !legacyProposalData) {
+      const { collaborationDocId } = proposal.proposalData as {
+        collaborationDocId?: string;
+      };
+      if (collaborationDocId) {
+        mockCollab.setDocResponse(collaborationDocId, {
+          type: 'doc',
+          content: [],
+        });
+      }
+    }
 
     if (nonDefaultStatus || legacyProposalData) {
       await db

--- a/tests/e2e/tests/proposal-view.spec.ts
+++ b/tests/e2e/tests/proposal-view.spec.ts
@@ -654,16 +654,22 @@ test.describe('Proposal View', () => {
       `/en/decisions/${instance.slug}/proposal/${proposal.profileId}`,
     );
 
-    // Title still renders (wait for client-side hydration)
+    // Title still renders (wait for client-side hydration). The document fetch
+    // failing no longer takes down the whole page — title/budget/metadata show
+    // regardless.
     await expect(
       authenticatedPage.getByRole('heading', {
         name: 'Missing Document Proposal',
       }),
     ).toBeVisible({ timeout: 30_000 });
 
-    // Fallback message shown instead of document content
+    // A failed fetch is treated as "unavailable" first: the viewer polls in
+    // case the document is still propagating, and only renders the fallback
+    // once the bounded wait elapses (so a still-syncing doc doesn't flash an
+    // error). The doc here is permanently missing, so the fallback appears
+    // after the poll window — wait past it.
     await expect(
       authenticatedPage.getByText('Content could not be loaded').first(),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30_000 });
   });
 });


### PR DESCRIPTION
## Summary
- Removed `DocumentNotAvailable` synchronous fallback from `ProposalPreview` and `ProposalCardPreview` — empty/draft proposals now render nothing instead of flashing an error state
- Added `key={profileId}` to edit-page `ErrorBoundary` so it resets on navigation instead of staying tripped

## Test plan
- [ ] Create a draft proposal, go back to the proposal listing page — no flash of "Content could not be loaded"
- [ ] Submit a draft proposal, click "Back to proposals" — card renders without error flash
- [ ] View an individual proposal — no content flash on page load
- [ ] Verify proposals with actual content still render correctly

Fixes Asana task 1214539304463546

(Replaces #1111 — branch renamed to shorten name)
