### PR TITLE
fix(decisions): add pointer cursor to View feedback button

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -74,7 +74,7 @@ export function ReviewRubricForm() {
               {t('Reviewing is paused until author submits a revision.')}{' '}
               <button
                 type="button"
-                className="underline"
+                className="cursor-pointer underline"
                 onClick={() => setIsViewModalOpen(true)}
               >
                 {t('View feedback')}


### PR DESCRIPTION
Bare button in the revision-requested AlertBanner didn't inherit the banner's anchor-only hover styles, so it kept the default arrow.