### PR TITLE
feat(decisions): show revision-requested CTA on author's cards in review phase

### DIFF
--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
@@ -75,6 +75,32 @@ export function ProposalCardActions({
 }
 
 /**
+ * Primary CTA shown on the author's card when a reviewer has requested
+ * revisions. Replaces the standard like/follow or edit actions so the
+ * author can jump straight into the editor.
+ */
+export function ProposalCardReviseAction({
+  editHref,
+  className,
+}: {
+  editHref: string;
+  className?: string;
+}) {
+  const t = useTranslations();
+
+  return (
+    <ButtonLink
+      href={editHref}
+      color="primary"
+      size="small"
+      className={`w-full${className ? ` ${className}` : ''}`}
+    >
+      {t('Revise proposal')}
+    </ButtonLink>
+  );
+}
+
+/**
  * Edit/Delete actions for the proposal owner
  */
 export function ProposalCardOwnerActions({

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
@@ -82,6 +82,7 @@ export function ProposalCardReviseAction({
   className?: string;
 }) {
   const t = useTranslations();
+  const [navigating, setNavigating] = useState(false);
 
   return (
     <ButtonLink
@@ -89,6 +90,8 @@ export function ProposalCardReviseAction({
       color="primary"
       size="small"
       className={`w-full${className ? ` ${className}` : ''}`}
+      onPress={() => setNavigating(true)}
+      isLoading={navigating}
     >
       {t('Revise proposal')}
     </ButtonLink>

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
@@ -74,11 +74,6 @@ export function ProposalCardActions({
   );
 }
 
-/**
- * Primary CTA shown on the author's card when a reviewer has requested
- * revisions. Replaces the standard like/follow or edit actions so the
- * author can jump straight into the editor.
- */
 export function ProposalCardReviseAction({
   editHref,
   className,

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -16,7 +16,7 @@ import { Surface } from '@op/ui/Surface';
 import { cn } from '@op/ui/utils';
 import Image from 'next/image';
 import type { HTMLAttributes, ReactNode } from 'react';
-import { LuBookmark, LuHeart, LuMessageCircle } from 'react-icons/lu';
+import { LuBookmark, LuHeart, LuMail, LuMessageCircle } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 import { Link } from '@/lib/i18n/routing';
@@ -195,8 +195,10 @@ export function ProposalCardBudget({
 export function ProposalCardMeta({
   proposal,
   withLink = true,
+  revisionRequested = false,
   className,
 }: BaseProposalCardProps & {
+  revisionRequested?: boolean;
   className?: string;
 }) {
   return (
@@ -204,7 +206,34 @@ export function ProposalCardMeta({
       <ProposalCardAuthor proposal={proposal} withLink={withLink} />
       <ProposalCardCategory proposal={proposal} />
       <ProposalCardStatus proposal={proposal} />
+      {revisionRequested ? <ProposalCardRevisionRequestedChip /> : null}
     </div>
+  );
+}
+
+/**
+ * Chip shown to the proposal author when a reviewer has requested revisions
+ * on their proposal. Sits alongside category/status in the meta row.
+ */
+export function ProposalCardRevisionRequestedChip({
+  className,
+}: {
+  className?: string;
+}) {
+  const t = useTranslations();
+  return (
+    <>
+      <Bullet />
+      <span
+        className={cn(
+          'inline-flex items-center gap-1 rounded-md bg-primary-orange2/10 p-1 text-xs text-neutral-charcoal',
+          className,
+        )}
+      >
+        <LuMail className="size-3 text-primary-orange2" />
+        {t('Revision requested')}
+      </span>
+    </>
   );
 }
 

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -204,9 +204,14 @@ export function ProposalCardMeta({
   return (
     <div className={cn('flex flex-wrap items-center gap-2', className)}>
       <ProposalCardAuthor proposal={proposal} withLink={withLink} />
-      <ProposalCardCategory proposal={proposal} />
-      <ProposalCardStatus proposal={proposal} />
-      {revisionRequested ? <ProposalCardRevisionRequestedChip /> : null}
+      {revisionRequested ? (
+        <ProposalCardRevisionRequestedChip />
+      ) : (
+        <>
+          <ProposalCardCategory proposal={proposal} />
+          <ProposalCardStatus proposal={proposal} />
+        </>
+      )}
     </div>
   );
 }

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -224,15 +224,10 @@ export function ProposalCardRevisionRequestedChip({
   return (
     <>
       <Bullet />
-      <span
-        className={cn(
-          'inline-flex items-center gap-1 rounded-md bg-primary-orange2/10 p-1 text-xs text-neutral-charcoal',
-          className,
-        )}
-      >
+      <Chip className={cn('inline-flex gap-1 bg-primary-orange2/10', className)}>
         <LuMail className="size-3 text-primary-orange2" />
         {t('Revision requested')}
-      </span>
+      </Chip>
     </>
   );
 }

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -216,10 +216,6 @@ export function ProposalCardMeta({
   );
 }
 
-/**
- * Chip shown to the proposal author when a reviewer has requested revisions
- * on their proposal. Sits alongside category/status in the meta row.
- */
 export function ProposalCardRevisionRequestedChip({
   className,
 }: {

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -224,7 +224,9 @@ export function ProposalCardRevisionRequestedChip({
   return (
     <>
       <Bullet />
-      <Chip className={cn('inline-flex gap-1 bg-primary-orange2/10', className)}>
+      <Chip
+        className={cn('inline-flex gap-1 bg-primary-orange2/10', className)}
+      >
         <LuMail className="size-3 text-primary-orange2" />
         {t('Revision requested')}
       </Chip>

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -16,7 +16,7 @@ import { Surface } from '@op/ui/Surface';
 import { cn } from '@op/ui/utils';
 import Image from 'next/image';
 import type { HTMLAttributes, ReactNode } from 'react';
-import { LuBookmark, LuHeart, LuMail, LuMessageCircle } from 'react-icons/lu';
+import { LuBookmark, LuHeart, LuMessageCircle } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 import { Link } from '@/lib/i18n/routing';
@@ -24,6 +24,7 @@ import { Link } from '@/lib/i18n/routing';
 import { Bullet } from '../../Bullet';
 import { DocumentNotAvailable } from '../DocumentNotAvailable';
 import { useCardTranslation } from '../ProposalTranslationContext';
+import { RevisionRequestChip } from '../RevisionRequestChip';
 import {
   getProposalContentPreview,
   resolveProposalSystemFields,
@@ -205,7 +206,10 @@ export function ProposalCardMeta({
     <div className={cn('flex flex-wrap items-center gap-2', className)}>
       <ProposalCardAuthor proposal={proposal} withLink={withLink} />
       {revisionRequested ? (
-        <ProposalCardRevisionRequestedChip />
+        <>
+          <Bullet />
+          <RevisionRequestChip />
+        </>
       ) : (
         <>
           <ProposalCardCategory proposal={proposal} />
@@ -213,25 +217,6 @@ export function ProposalCardMeta({
         </>
       )}
     </div>
-  );
-}
-
-export function ProposalCardRevisionRequestedChip({
-  className,
-}: {
-  className?: string;
-}) {
-  const t = useTranslations();
-  return (
-    <>
-      <Bullet />
-      <Chip
-        className={cn('inline-flex gap-1 bg-primary-orange2/10', className)}
-      >
-        <LuMail className="size-3 text-primary-orange2" />
-        {t('Revision requested')}
-      </Chip>
-    </>
   );
 }
 

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -165,18 +165,10 @@ interface ProposalsProps {
   permissions?: DecisionAccess | null;
   votedProposalIds?: string[];
   hasFilter: boolean;
-  /**
-   * When true, the current phase has voting enabled — always show voting UI.
-   * Derived from `currentPhase.rules.voting.submit` upstream.
-   */
+  /** When true, the current phase has voting enabled — always show voting UI */
   isVotingPhase?: boolean;
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
-  /**
-   * Proposal IDs for which the current user has a pending revision request.
-   * Empty in non-review phases.
-   */
-  revisionRequestedProposalIds?: Set<string>;
 }
 
 const VotingProposalsList = ({
@@ -452,7 +444,13 @@ const ViewProposalsList = ({
   hasFilter,
   proposalsHidden,
   revisionRequestedProposalIds,
-}: ProposalsProps) => {
+}: ProposalsProps & {
+  /**
+   * Proposal IDs for which the current user has a pending revision request.
+   * Only computed in review phases; empty otherwise.
+   */
+  revisionRequestedProposalIds?: Set<string>;
+}) => {
   const canManageProposals = permissions?.admin ?? false;
   if (!proposals || proposals.length === 0) {
     if (proposalsHidden && !hasFilter) {
@@ -532,7 +530,12 @@ const ViewProposalsList = ({
   );
 };
 
-const Proposals = (props: ProposalsProps) => {
+const Proposals = ({
+  revisionRequestedProposalIds,
+  ...props
+}: ProposalsProps & {
+  revisionRequestedProposalIds?: Set<string>;
+}) => {
   const { instanceId, isVotingPhase } = props;
 
   // Get voting status for this user and process
@@ -546,10 +549,16 @@ const Proposals = (props: ProposalsProps) => {
     isVotingPhase || !!voteStatus?.votingConfiguration?.allowDecisions;
 
   if (isVotingEnabled) {
+    // Revisions are review-phase-only — never forward into the voting list.
     return <VotingProposalsList {...props} />;
   }
 
-  return <ViewProposalsList {...props} />;
+  return (
+    <ViewProposalsList
+      {...props}
+      revisionRequestedProposalIds={revisionRequestedProposalIds}
+    />
+  );
 };
 
 export const ProposalsList = ({

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -689,21 +689,11 @@ export const ProposalsList = ({
       { enabled: !!isReviewPhase },
     );
 
-  const revisionRequestIdByProposalId = useMemo(() => {
-    const map = new Map<string, string>();
-    if (!revisionRequestsData) {
-      return map;
-    }
-    for (const {
-      revisionRequest,
-      proposal,
-    } of revisionRequestsData.revisionRequests) {
-      if (proposal.processInstanceId === instanceId && !map.has(proposal.id)) {
-        map.set(proposal.id, revisionRequest.id);
-      }
-    }
-    return map;
-  }, [revisionRequestsData, instanceId]);
+  const revisionRequestIdByProposalId = new Map<string, string>(
+    revisionRequestsData?.revisionRequests.map(
+      ({ proposal, revisionRequest }) => [proposal.id, revisionRequest.id],
+    ),
+  );
 
   // --- Translation state ---
   const locale = useLocale();

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -502,7 +502,10 @@ const ViewProposalsList = ({
             <ProposalCardContent>
               <ProposalCardFooter>
                 {hasRevisionRequest ? (
-                  <ProposalCardReviseAction editHref={reviseHref} />
+                  <>
+                    <ProposalCardMetrics proposal={proposal} />
+                    <ProposalCardReviseAction editHref={reviseHref} />
+                  </>
                 ) : isDraft ? (
                   <ProposalCardOwnerActions
                     proposal={proposal}

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -4,6 +4,7 @@ import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import {
   type DecisionAccess,
+  type InstancePhaseData,
   ProposalFilter,
   ProposalStatus,
 } from '@op/api/encoders';
@@ -164,7 +165,10 @@ interface ProposalsProps {
   permissions?: DecisionAccess | null;
   votedProposalIds?: string[];
   hasFilter: boolean;
-  /** When true, the current phase has voting enabled — always show voting UI */
+  /**
+   * When true, the current phase has voting enabled — always show voting UI.
+   * Derived from `currentPhase.rules.voting.submit` upstream.
+   */
   isVotingPhase?: boolean;
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
@@ -556,8 +560,7 @@ export const ProposalsList = ({
   permissions,
   initialFilter,
   phase,
-  isVotingPhase,
-  isReviewPhase,
+  currentPhase,
   proposalsHidden,
 }: {
   slug: string;
@@ -572,17 +575,18 @@ export const ProposalsList = ({
   initialFilter?: ProposalFilter;
   /** When set to 'results', all proposals are returned as non-editable */
   phase?: 'results';
-  /** When true, the current phase has voting enabled — always show voting UI */
-  isVotingPhase?: boolean;
   /**
-   * When true, the current phase has review enabled. Gates a non-blocking
-   * fetch of the viewer's pending revision requests so the author sees a
-   * "Revision requested" chip and a "Revise proposal" CTA on their cards.
+   * The current phase of the decision instance. Used to derive
+   * capability-driven UI: voting cards in voting phases, the
+   * "Revision requested" chip + "Revise proposal" CTA in review
+   * phases. Omit in phases that have neither (e.g. results).
    */
-  isReviewPhase?: boolean;
+  currentPhase?: InstancePhaseData;
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
 }) => {
+  const isReviewPhase = currentPhase?.rules?.proposals?.review === true;
+  const isVotingPhase = currentPhase?.rules?.voting?.submit === true;
   const t = useTranslations();
   const { user } = useUser();
   const router = useRouter();

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -10,6 +10,7 @@ import {
 import {
   type Proposal,
   type ProposalTranslation,
+  ProposalReviewRequestState,
   SUPPORTED_LOCALES,
   type SupportedLocale,
   isVotingEligible,
@@ -44,6 +45,7 @@ import {
   ProposalCardMetrics,
   ProposalCardOwnerActions,
   ProposalCardPreview,
+  ProposalCardReviseAction,
 } from './ProposalCard';
 import { ProposalTranslationProvider } from './ProposalTranslationContext';
 import { ResponsiveSelect } from './ResponsiveSelect';
@@ -166,6 +168,11 @@ interface ProposalsProps {
   isVotingPhase?: boolean;
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
+  /**
+   * Proposal IDs for which the current user has a pending revision request.
+   * Empty in non-review phases.
+   */
+  revisionRequestedProposalIds?: Set<string>;
 }
 
 const VotingProposalsList = ({
@@ -440,6 +447,7 @@ const ViewProposalsList = ({
   permissions,
   hasFilter,
   proposalsHidden,
+  revisionRequestedProposalIds,
 }: ProposalsProps) => {
   const canManageProposals = permissions?.admin ?? false;
   if (!proposals || proposals.length === 0) {
@@ -455,6 +463,8 @@ const ViewProposalsList = ({
         const isDraft = proposal.status === ProposalStatus.DRAFT;
         const isEditable = Boolean(proposal.isEditable);
         const showMenu = canManageProposals;
+        const hasRevisionRequest =
+          revisionRequestedProposalIds?.has(proposal.id) ?? false;
         // Use new route structure if decisionSlug is provided, otherwise fallback to legacy route
         const editHref = decisionSlug
           ? `/decisions/${decisionSlug}/proposal/${proposal.profileId}/edit`
@@ -479,13 +489,18 @@ const ViewProposalsList = ({
                     )
                   }
                 />
-                <ProposalCardMeta proposal={proposal} />
+                <ProposalCardMeta
+                  proposal={proposal}
+                  revisionRequested={hasRevisionRequest}
+                />
                 <ProposalCardPreview proposal={proposal} />
               </ProposalCardContent>
             </div>
             <ProposalCardContent>
               <ProposalCardFooter>
-                {isDraft ? (
+                {hasRevisionRequest ? (
+                  <ProposalCardReviseAction editHref={editHref} />
+                ) : isDraft ? (
                   <ProposalCardOwnerActions
                     proposal={proposal}
                     editHref={editHref}
@@ -542,6 +557,7 @@ export const ProposalsList = ({
   initialFilter,
   phase,
   isVotingPhase,
+  isReviewPhase,
   proposalsHidden,
 }: {
   slug: string;
@@ -558,6 +574,12 @@ export const ProposalsList = ({
   phase?: 'results';
   /** When true, the current phase has voting enabled — always show voting UI */
   isVotingPhase?: boolean;
+  /**
+   * When true, the current phase has review enabled. Gates a non-blocking
+   * fetch of the viewer's pending revision requests so the author sees a
+   * "Revision requested" chip and a "Revise proposal" CTA on their cards.
+   */
+  isReviewPhase?: boolean;
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
 }) => {
@@ -652,6 +674,27 @@ export const ProposalsList = ({
 
   const { proposals: allProposals } = proposalsData ?? {};
   const canManageProposals = permissions?.admin ?? false;
+
+  // Non-blocking lookup of the viewer's pending revision requests. Only
+  // fires in review phase — voting/results/standard phases don't render
+  // the chip or "Revise proposal" CTA, so the fetch is wasted otherwise.
+  // The endpoint is scoped server-side to the caller's own proposals.
+  const { data: revisionRequestsData } =
+    trpc.decision.listProposalsRevisionRequests.useQuery(
+      { states: [ProposalReviewRequestState.REQUESTED] },
+      { enabled: !!isReviewPhase },
+    );
+
+  const revisionRequestedProposalIds = useMemo(() => {
+    if (!revisionRequestsData) {
+      return new Set<string>();
+    }
+    return new Set(
+      revisionRequestsData.revisionRequests
+        .filter(({ proposal }) => proposal.processInstanceId === instanceId)
+        .map(({ proposal }) => proposal.id),
+    );
+  }, [revisionRequestsData, instanceId]);
 
   // --- Translation state ---
   const locale = useLocale();
@@ -932,6 +975,7 @@ export const ProposalsList = ({
           hasFilter={selectedCategory !== 'all-categories'}
           isVotingPhase={isVotingPhase}
           proposalsHidden={proposalsHidden}
+          revisionRequestedProposalIds={revisionRequestedProposalIds}
         />
       </ProposalTranslationProvider>
 

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -443,9 +443,9 @@ const ViewProposalsList = ({
   permissions,
   hasFilter,
   proposalsHidden,
-  revisionRequestedProposalIds,
+  revisionRequestIdByProposalId,
 }: ProposalsProps & {
-  revisionRequestedProposalIds?: Set<string>;
+  revisionRequestIdByProposalId?: Map<string, string>;
 }) => {
   const canManageProposals = permissions?.admin ?? false;
   if (!proposals || proposals.length === 0) {
@@ -461,12 +461,17 @@ const ViewProposalsList = ({
         const isDraft = proposal.status === ProposalStatus.DRAFT;
         const isEditable = Boolean(proposal.isEditable);
         const showMenu = canManageProposals;
-        const hasRevisionRequest =
-          revisionRequestedProposalIds?.has(proposal.id) ?? false;
+        const revisionRequestId = revisionRequestIdByProposalId?.get(
+          proposal.id,
+        );
+        const hasRevisionRequest = revisionRequestId !== undefined;
         // Use new route structure if decisionSlug is provided, otherwise fallback to legacy route
         const editHref = decisionSlug
           ? `/decisions/${decisionSlug}/proposal/${proposal.profileId}/edit`
           : `/profile/${slug}/decisions/${instanceId}/proposal/${proposal.profileId}/edit`;
+        const reviseHref = revisionRequestId
+          ? `${editHref}?reviewRevision=${revisionRequestId}`
+          : editHref;
         const viewHref = decisionSlug
           ? `/decisions/${decisionSlug}/proposal/${proposal.profileId}`
           : `/profile/${slug}/decisions/${instanceId}/proposal/${proposal.profileId}`;
@@ -497,7 +502,7 @@ const ViewProposalsList = ({
             <ProposalCardContent>
               <ProposalCardFooter>
                 {hasRevisionRequest ? (
-                  <ProposalCardReviseAction editHref={editHref} />
+                  <ProposalCardReviseAction editHref={reviseHref} />
                 ) : isDraft ? (
                   <ProposalCardOwnerActions
                     proposal={proposal}
@@ -527,10 +532,10 @@ const ViewProposalsList = ({
 };
 
 const Proposals = ({
-  revisionRequestedProposalIds,
+  revisionRequestIdByProposalId,
   ...props
 }: ProposalsProps & {
-  revisionRequestedProposalIds?: Set<string>;
+  revisionRequestIdByProposalId?: Map<string, string>;
 }) => {
   const { instanceId, isVotingPhase } = props;
 
@@ -551,7 +556,7 @@ const Proposals = ({
   return (
     <ViewProposalsList
       {...props}
-      revisionRequestedProposalIds={revisionRequestedProposalIds}
+      revisionRequestIdByProposalId={revisionRequestIdByProposalId}
     />
   );
 };
@@ -684,15 +689,20 @@ export const ProposalsList = ({
       { enabled: !!isReviewPhase },
     );
 
-  const revisionRequestedProposalIds = useMemo(() => {
+  const revisionRequestIdByProposalId = useMemo(() => {
+    const map = new Map<string, string>();
     if (!revisionRequestsData) {
-      return new Set<string>();
+      return map;
     }
-    return new Set(
-      revisionRequestsData.revisionRequests
-        .filter(({ proposal }) => proposal.processInstanceId === instanceId)
-        .map(({ proposal }) => proposal.id),
-    );
+    for (const {
+      revisionRequest,
+      proposal,
+    } of revisionRequestsData.revisionRequests) {
+      if (proposal.processInstanceId === instanceId && !map.has(proposal.id)) {
+        map.set(proposal.id, revisionRequest.id);
+      }
+    }
+    return map;
   }, [revisionRequestsData, instanceId]);
 
   // --- Translation state ---
@@ -974,7 +984,7 @@ export const ProposalsList = ({
           hasFilter={selectedCategory !== 'all-categories'}
           isVotingPhase={isVotingPhase}
           proposalsHidden={proposalsHidden}
-          revisionRequestedProposalIds={revisionRequestedProposalIds}
+          revisionRequestIdByProposalId={revisionRequestIdByProposalId}
         />
       </ProposalTranslationProvider>
 

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -445,10 +445,6 @@ const ViewProposalsList = ({
   proposalsHidden,
   revisionRequestedProposalIds,
 }: ProposalsProps & {
-  /**
-   * Proposal IDs for which the current user has a pending revision request.
-   * Only computed in review phases; empty otherwise.
-   */
   revisionRequestedProposalIds?: Set<string>;
 }) => {
   const canManageProposals = permissions?.admin ?? false;
@@ -549,7 +545,6 @@ const Proposals = ({
     isVotingPhase || !!voteStatus?.votingConfiguration?.allowDecisions;
 
   if (isVotingEnabled) {
-    // Revisions are review-phase-only — never forward into the voting list.
     return <VotingProposalsList {...props} />;
   }
 
@@ -584,12 +579,7 @@ export const ProposalsList = ({
   initialFilter?: ProposalFilter;
   /** When set to 'results', all proposals are returned as non-editable */
   phase?: 'results';
-  /**
-   * The current phase of the decision instance. Used to derive
-   * capability-driven UI: voting cards in voting phases, the
-   * "Revision requested" chip + "Revise proposal" CTA in review
-   * phases. Omit in phases that have neither (e.g. results).
-   */
+  /** Current phase; capability flags are derived from `rules`. */
   currentPhase?: InstancePhaseData;
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
@@ -688,10 +678,6 @@ export const ProposalsList = ({
   const { proposals: allProposals } = proposalsData ?? {};
   const canManageProposals = permissions?.admin ?? false;
 
-  // Non-blocking lookup of the viewer's pending revision requests. Only
-  // fires in review phase — voting/results/standard phases don't render
-  // the chip or "Revise proposal" CTA, so the fetch is wasted otherwise.
-  // The endpoint is scoped server-side to the caller's own proposals.
   const { data: revisionRequestsData } =
     trpc.decision.listProposalsRevisionRequests.useQuery(
       { states: [ProposalReviewRequestState.REQUESTED] },

--- a/apps/app/src/components/decisions/RevisionRequestChip.tsx
+++ b/apps/app/src/components/decisions/RevisionRequestChip.tsx
@@ -1,14 +1,14 @@
 import { Chip } from '@op/ui/Chip';
 import { cn } from '@op/ui/utils';
-import { LuMail } from 'react-icons/lu';
+import { LuCircleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
 export function RevisionRequestChip({ className }: { className?: string }) {
   const t = useTranslations();
   return (
-    <Chip className={cn('inline-flex gap-1 bg-primary-orange2/10', className)}>
-      <LuMail className="size-3 text-primary-orange2" />
+    <Chip className={cn('inline-flex gap-1 bg-primary-orange2/5', className)}>
+      <LuCircleAlert className="size-3 text-primary-orange2" />
       {t('Revision requested')}
     </Chip>
   );

--- a/apps/app/src/components/decisions/RevisionRequestChip.tsx
+++ b/apps/app/src/components/decisions/RevisionRequestChip.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from '@/lib/i18n';
 export function RevisionRequestChip({ className }: { className?: string }) {
   const t = useTranslations();
   return (
-    <Chip className={cn('inline-flex gap-1 bg-primary-orange2/5', className)}>
+    <Chip className={cn('inline-flex gap-1 bg-primary-orange2/10', className)}>
       <LuCircleAlert className="size-3 text-primary-orange2" />
       {t('Revision requested')}
     </Chip>

--- a/apps/app/src/components/decisions/RevisionRequestChip.tsx
+++ b/apps/app/src/components/decisions/RevisionRequestChip.tsx
@@ -1,0 +1,15 @@
+import { Chip } from '@op/ui/Chip';
+import { cn } from '@op/ui/utils';
+import { LuMail } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+export function RevisionRequestChip({ className }: { className?: string }) {
+  const t = useTranslations();
+  return (
+    <Chip className={cn('inline-flex gap-1 bg-primary-orange2/10', className)}>
+      <LuMail className="size-3 text-primary-orange2" />
+      {t('Revision requested')}
+    </Chip>
+  );
+}

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -105,6 +105,7 @@ export function ReviewPage({
                   decisionSlug={decisionSlug}
                   decisionProfileId={decisionProfileId}
                   permissions={instance.access}
+                  isReviewPhase
                 />
               )}
             </Suspense>

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -105,7 +105,7 @@ export function ReviewPage({
                   decisionSlug={decisionSlug}
                   decisionProfileId={decisionProfileId}
                   permissions={instance.access}
-                  isReviewPhase
+                  currentPhase={currentPhase}
                 />
               )}
             </Suspense>

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -105,7 +105,7 @@ export function VotingPage({
                 instanceId={instanceId}
                 decisionSlug={decisionSlug}
                 permissions={instance.access}
-                isVotingPhase
+                currentPhase={currentPhase}
               />
             </Suspense>
           </div>

--- a/tests/e2e/tests/review-author-view.spec.ts
+++ b/tests/e2e/tests/review-author-view.spec.ts
@@ -1,12 +1,21 @@
 import type { DecisionSchemaDefinition } from '@op/common';
-import { ProposalStatus, processInstances, proposals } from '@op/db/schema';
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+  ProposalStatus,
+  processInstances,
+  proposals,
+} from '@op/db/schema';
 import { db, eq } from '@op/db/test';
 import {
   createDecisionInstance,
+  createInstanceMember,
   createOrganization,
   createProposal,
+  createReviewScenario,
   getSeededTemplate,
   grantDecisionProfileAccess,
+  grantInstanceReviewerRole,
 } from '@op/test';
 
 import {
@@ -175,5 +184,94 @@ test.describe('Non-reviewer review-phase view', () => {
     await expect(
       authenticatedPage.getByText('Proposals to review'),
     ).toBeVisible({ timeout: 36_000 });
+  });
+
+  test('author with a pending revision request sees the chip and Revise proposal CTA', async ({
+    browser,
+    org,
+    supabaseAdmin,
+  }, testInfo) => {
+    const testId = `review-author-revision-${testInfo.workerIndex}-${Date.now()}`;
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: REVIEW_SCHEMA,
+    });
+
+    await db
+      .update(processInstances)
+      .set({ currentStateId: 'review' })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    const { user: author } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-author`,
+      instanceProfileId: instance.profileId,
+    });
+    const { user: reviewer } = await createInstanceMember({
+      supabaseAdmin,
+      testId: `${testId}-reviewer`,
+      instanceProfileId: instance.profileId,
+    });
+
+    await grantInstanceReviewerRole({
+      instanceProfileId: instance.profileId,
+      authUserId: reviewer.authUserId,
+      email: reviewer.email,
+      roleName: `Reviewer-${testId}`,
+    });
+
+    await createReviewScenario({
+      instance: { id: instance.instance.id },
+      author,
+      reviewer: { profileId: reviewer.profileId },
+      proposalData: {
+        title: PROPOSAL_TITLE,
+        collaborationDocId: 'test-proposal-view-doc',
+      },
+      assignmentStatus: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
+      revisionRequest: {
+        state: ProposalReviewRequestState.REQUESTED,
+        requestComment: 'Please add a detailed budget breakdown.',
+      },
+    });
+
+    const authorContext = await browser.newContext();
+    const authorPage = await authorContext.newPage();
+    await authenticateAsUser(authorPage, {
+      email: author.email,
+      password: TEST_USER_DEFAULT_PASSWORD,
+    });
+
+    await authorPage.goto(`/en/decisions/${instance.slug}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // Author lands on the participant grid (not the reviewer assignments list)
+    await expect(
+      authorPage.getByRole('link', { name: PROPOSAL_TITLE }).first(),
+    ).toBeVisible({ timeout: 36_000 });
+    await expect(authorPage.getByText('Proposals to review')).toHaveCount(0);
+
+    // The chip + CTA replace the standard Like/Follow footer on the
+    // author's own card while a revision request is pending.
+    await expect(
+      authorPage.getByText('Revision requested').first(),
+    ).toBeVisible();
+    await expect(
+      authorPage.getByRole('link', { name: 'Revise proposal' }),
+    ).toBeVisible();
+    await expect(authorPage.getByRole('button', { name: 'Like' })).toHaveCount(
+      0,
+    );
+    await expect(
+      authorPage.getByRole('button', { name: 'Follow' }),
+    ).toHaveCount(0);
+
+    await authorContext.close();
   });
 });


### PR DESCRIPTION
Authors lose track of which of their proposals need attention once reviewers request revisions. This adds a "Revision requested" chip and primary "Revise proposal" CTA on the author's own cards during the review phase, gated behind a non-blocking query that only fires in that phase.


## Demo
<img width="1104" height="331" alt="CleanShot 2026-05-13 at 11 13 12" src="https://github.com/user-attachments/assets/cf19ee4d-c79b-44f7-a40b-3c6be07cb464" />



