### PR TITLE
fix(decisions): surface review-assignment auth errors as 403

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewLayout.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayout.tsx
@@ -33,7 +33,7 @@ export async function ReviewLayout({
   try {
     [decisionProfile] = await Promise.all([
       client.decision.getDecisionBySlug({ slug: decisionSlug }),
-      utils.decision.getReviewAssignment.prefetch({ assignmentId }),
+      utils.decision.getReviewAssignment.fetch({ assignmentId }),
     ]);
   } catch (error) {
     const cause = error instanceof Error ? error.cause : null;


### PR DESCRIPTION
Unauthorized review-assignment URLs were rendering as 500 because the layout's prefetch swallowed the error and the child useSuspenseQuery rethrew during SSR.

before/after

<img width="3024" height="1808" alt="CleanShot 2026-05-12 at 13 11 10@2x" src="https://github.com/user-attachments/assets/f2f2d5f5-9a10-42dd-9c71-8b02b16b7860" />
