### PR TITLE
fix(decisions): scroll to top on process builder section change

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
@@ -3,10 +3,9 @@ import { createClient } from '@op/api/serverClient';
 import { forbidden, notFound } from 'next/navigation';
 
 import { ProcessBuilderAutosaveProvider } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
-import { ProcessBuilderContent } from '@/components/decisions/ProcessBuilder/ProcessBuilderContent';
+import { ProcessBuilderEditArea } from '@/components/decisions/ProcessBuilder/ProcessBuilderEditArea';
 import { ProcessBuilderFooter } from '@/components/decisions/ProcessBuilder/ProcessBuilderFooter';
 import { ProcessBuilderHeader } from '@/components/decisions/ProcessBuilder/ProcessBuilderHeader';
-import { ProcessBuilderSidebar } from '@/components/decisions/ProcessBuilder/ProcessBuilderSectionNav';
 import { ProcessBuilderShell } from '@/components/decisions/ProcessBuilder/ProcessBuilderShell';
 import { ProcessBuilderStoreInitializer } from '@/components/decisions/ProcessBuilder/ProcessBuilderStoreInitializer';
 import type { ProcessBuilderInstanceData } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
@@ -64,19 +63,11 @@ const EditDecisionPage = async ({
             isDraft={isDraft}
           />
           <ProcessBuilderHeader instanceId={instanceId} slug={slug} />
-          <div className="flex min-h-0 grow flex-col overflow-y-auto md:flex-row md:overflow-y-hidden">
-            <ProcessBuilderSidebar
-              instanceId={instanceId}
-              decisionProfileId={decisionProfile.id}
-            />
-            <main className="h-full grow overflow-y-auto">
-              <ProcessBuilderContent
-                decisionProfileId={decisionProfile.id}
-                instanceId={instanceId}
-                decisionName={decisionProfile.name}
-              />
-            </main>
-          </div>
+          <ProcessBuilderEditArea
+            decisionProfileId={decisionProfile.id}
+            instanceId={instanceId}
+            decisionName={decisionProfile.name}
+          />
           <ProcessBuilderFooter
             instanceId={instanceId}
             slug={slug}

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderContent.tsx
@@ -33,7 +33,10 @@ export function ProcessBuilderContent({
     while (el) {
       const { overflowY } = getComputedStyle(el);
       if (overflowY === 'auto' || overflowY === 'scroll') {
-        el.scrollTo({ top: 0 });
+        if (el.scrollTop !== 0) {
+          el.scrollTo({ top: 0 });
+        }
+        break;
       }
       el = el.parentElement;
     }
@@ -52,6 +55,9 @@ export function ProcessBuilderContent({
   }
 
   return (
+    // `contents` keeps the wrapper layout-neutral so children's `h-full`
+    // still cascades from the outer `<main>`. The ref exists solely to
+    // anchor the scroll-reset effect above.
     <div ref={wrapperRef} className="contents">
       <ContentComponent
         decisionProfileId={decisionProfileId}

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderContent.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useUser } from '@/utils/UserProvider';
-import { useEffect, useRef } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -26,22 +25,6 @@ export function ProcessBuilderContent({
   const access = useUser();
   const isAdmin = access.getPermissionsForProfile(decisionProfileId).admin;
 
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    let el: HTMLElement | null = wrapperRef.current;
-    while (el) {
-      const { overflowY } = getComputedStyle(el);
-      if (overflowY === 'auto' || overflowY === 'scroll') {
-        if (el.scrollTop !== 0) {
-          el.scrollTo({ top: 0 });
-        }
-        break;
-      }
-      el = el.parentElement;
-    }
-  }, [currentSection?.id]);
-
   if (!isAdmin) {
     throw new Error('UNAUTHORIZED');
   }
@@ -55,15 +38,10 @@ export function ProcessBuilderContent({
   }
 
   return (
-    // `contents` keeps the wrapper layout-neutral so children's `h-full`
-    // still cascades from the outer `<main>`. The ref exists solely to
-    // anchor the scroll-reset effect above.
-    <div ref={wrapperRef} className="contents">
-      <ContentComponent
-        decisionProfileId={decisionProfileId}
-        instanceId={instanceId}
-        decisionName={decisionName}
-      />
-    </div>
+    <ContentComponent
+      decisionProfileId={decisionProfileId}
+      instanceId={instanceId}
+      decisionName={decisionName}
+    />
   );
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderContent.tsx
@@ -52,7 +52,7 @@ export function ProcessBuilderContent({
   }
 
   return (
-    <div ref={wrapperRef}>
+    <div ref={wrapperRef} className="contents">
       <ContentComponent
         decisionProfileId={decisionProfileId}
         instanceId={instanceId}

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useUser } from '@/utils/UserProvider';
+import { useEffect, useRef } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -25,6 +26,19 @@ export function ProcessBuilderContent({
   const access = useUser();
   const isAdmin = access.getPermissionsForProfile(decisionProfileId).admin;
 
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let el: HTMLElement | null = wrapperRef.current;
+    while (el) {
+      const { overflowY } = getComputedStyle(el);
+      if (overflowY === 'auto' || overflowY === 'scroll') {
+        el.scrollTo({ top: 0 });
+      }
+      el = el.parentElement;
+    }
+  }, [currentSection?.id]);
+
   if (!isAdmin) {
     throw new Error('UNAUTHORIZED');
   }
@@ -38,10 +52,12 @@ export function ProcessBuilderContent({
   }
 
   return (
-    <ContentComponent
-      decisionProfileId={decisionProfileId}
-      instanceId={instanceId}
-      decisionName={decisionName}
-    />
+    <div ref={wrapperRef}>
+      <ContentComponent
+        decisionProfileId={decisionProfileId}
+        instanceId={instanceId}
+        decisionName={decisionName}
+      />
+    </div>
   );
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderEditArea.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderEditArea.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { ProcessBuilderContent } from './ProcessBuilderContent';
+import { ProcessBuilderSidebar } from './ProcessBuilderSectionNav';
+import { useNavigationConfig } from './useNavigationConfig';
+import { useProcessNavigation } from './useProcessNavigation';
+import { useProcessPhases } from './useProcessPhases';
+
+interface ProcessBuilderEditAreaProps {
+  decisionProfileId: string;
+  instanceId: string;
+  decisionName: string;
+}
+
+export function ProcessBuilderEditArea({
+  decisionProfileId,
+  instanceId,
+  decisionName,
+}: ProcessBuilderEditAreaProps) {
+  const outerRef = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLElement>(null);
+
+  const navigationConfig = useNavigationConfig(instanceId, decisionProfileId);
+  const phases = useProcessPhases(instanceId, decisionProfileId);
+  const { currentSection } = useProcessNavigation(navigationConfig, phases);
+
+  useEffect(() => {
+    outerRef.current?.scrollTo({ top: 0 });
+    mainRef.current?.scrollTo({ top: 0 });
+  }, [currentSection?.id]);
+
+  return (
+    <div
+      ref={outerRef}
+      className="flex min-h-0 grow flex-col overflow-y-auto md:flex-row md:overflow-y-hidden"
+    >
+      <ProcessBuilderSidebar
+        instanceId={instanceId}
+        decisionProfileId={decisionProfileId}
+      />
+      <main ref={mainRef} className="h-full grow overflow-y-auto">
+        <ProcessBuilderContent
+          decisionProfileId={decisionProfileId}
+          instanceId={instanceId}
+          decisionName={decisionName}
+        />
+      </main>
+    </div>
+  );
+}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
@@ -380,7 +380,7 @@ export function TemplateEditorContent({
 
   return (
     <SidebarProvider isOpen={sidebarOpen} onOpenChange={setMobileSidebarOpen}>
-      <div className="flex h-full flex-col md:flex-row">
+      <div className="flex h-full flex-col overflow-hidden md:flex-row">
         <div className="flex items-center justify-between gap-2 p-4 md:hidden">
           <Header2 className="font-serif text-title-sm">
             {t('Proposal template')}


### PR DESCRIPTION
## Summary
- Next/Back/sidebar navigation only flips a `?section=` query param, so the scrollable container kept its prior scroll position
- Reset all scrollable ancestors to top whenever `currentSection` changes

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213823490678546