### PR TITLE
fix(decisions): wire up review-phase "Learn more" CTA

### DIFF
--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -18,11 +18,13 @@ import { getViewerExtensions } from '../RichTextEditor/editorConfig';
 export const DecisionActionBar = ({
   instanceId,
   description,
+  label,
   markup = false,
   showSubmitButton = false,
 }: {
   instanceId: string;
   description?: string;
+  label?: string;
   markup?: boolean;
   showSubmitButton?: boolean;
 }) => {
@@ -59,12 +61,12 @@ export const DecisionActionBar = ({
         {description ? (
           <DialogTrigger>
             <Button color="secondary" className="w-full">
-              {t('Learn more')}
+              {label ?? t('Learn more')}
             </Button>
 
             <Modal isDismissable>
               <Dialog>
-                <ModalHeader>{t('About the process')}</ModalHeader>
+                <ModalHeader>{label ?? t('About the process')}</ModalHeader>
                 <ModalBody>
                   {markup && description ? (
                     <div

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -8,6 +8,8 @@ import { Header3 } from '@op/ui/Header';
 import { Suspense } from 'react';
 import { LuLeaf } from 'react-icons/lu';
 
+import { useTranslations } from '@/lib/i18n/routing';
+
 import { TranslatedText } from '@/components/TranslatedText';
 
 import { DecisionActionBar } from '../DecisionActionBar';
@@ -43,14 +45,17 @@ export function ReviewPage({
   const canReview = Boolean(instance.access?.review);
   const isAdmin = Boolean(instance.access?.admin);
 
+  const t = useTranslations();
   const translation = useDecisionTranslation();
   const description =
     instance.description ?? instance.instanceData?.templateDescription;
+  const phaseAdditionalInfo =
+    translation?.additionalInfo ?? currentPhase.additionalInfo;
   const actionBarDescription =
-    translation?.additionalInfo ??
-    currentPhase.additionalInfo ??
-    translation?.description ??
-    description;
+    phaseAdditionalInfo ?? translation?.description ?? description;
+  const actionBarLabel = phaseAdditionalInfo
+    ? t('About this phase')
+    : t('About the process');
 
   return (
     <div className="min-h-full">
@@ -81,6 +86,7 @@ export function ReviewPage({
             <DecisionActionBar
               instanceId={instance.id}
               description={actionBarDescription}
+              label={actionBarLabel}
               markup={!!translation?.additionalInfo}
               showSubmitButton={false}
             />

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -1,7 +1,8 @@
+'use client';
+
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import type { RouterOutput } from '@op/api';
 import { type InstancePhaseData } from '@op/api/encoders';
-import { ButtonLink } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header3 } from '@op/ui/Header';
 import { Suspense } from 'react';
@@ -9,7 +10,9 @@ import { LuLeaf } from 'react-icons/lu';
 
 import { TranslatedText } from '@/components/TranslatedText';
 
+import { DecisionActionBar } from '../DecisionActionBar';
 import { DecisionHero } from '../DecisionHero';
+import { useDecisionTranslation } from '../DecisionTranslationContext';
 import { ProposalListSkeleton, ProposalsList } from '../ProposalsList';
 import { ReviewProgressStats } from '../Review/ReviewProgressStats';
 import { ReviewAssignmentsList } from '../ReviewAssignmentsList';
@@ -40,6 +43,15 @@ export function ReviewPage({
   const canReview = Boolean(instance.access?.review);
   const isAdmin = Boolean(instance.access?.admin);
 
+  const translation = useDecisionTranslation();
+  const description =
+    instance.description ?? instance.instanceData?.templateDescription;
+  const actionBarDescription =
+    translation?.additionalInfo ??
+    currentPhase.additionalInfo ??
+    translation?.description ??
+    description;
+
   return (
     <div className="min-h-full">
       <div className="mx-auto flex max-w-3xl flex-col items-center justify-center gap-4 px-4 py-8">
@@ -66,11 +78,12 @@ export function ReviewPage({
               phaseId={currentPhase.phaseId}
             />
           ) : (
-            <div className="flex justify-center pt-2">
-              <ButtonLink color="secondary" size="medium" href="#">
-                <TranslatedText text="Learn more" />
-              </ButtonLink>
-            </div>
+            <DecisionActionBar
+              instanceId={instance.id}
+              description={actionBarDescription}
+              markup={!!translation?.additionalInfo}
+              showSubmitButton={false}
+            />
           )}
         </DecisionHero>
       </div>

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -55,7 +55,7 @@ export function ReviewPage({
     phaseAdditionalInfo ?? translation?.description ?? description;
   const actionBarLabel = phaseAdditionalInfo
     ? t('About this phase')
-    : t('About the process');
+    : undefined;
 
   return (
     <div className="min-h-full">

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -309,6 +309,7 @@
   "Invalid emails": "অবৈধ ইমেইল",
   "are not valid email addresses": "বৈধ ইমেইল ঠিকানা নয়",
   "About the process": "এই প্রক্রিয়া সম্পর্কে",
+  "About this phase": "এই পর্যায় সম্পর্কে",
   "Delete Proposal": "প্রস্তাব মুছুন",
   "Delete phase": "পর্যায় মুছুন",
   "Delete phase?": "পর্যায় মুছবেন?",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -308,6 +308,7 @@
   "Invalid emails": "Invalid emails",
   "are not valid email addresses": "are not valid email addresses",
   "About the process": "About the process",
+  "About this phase": "About this phase",
   "Delete Proposal": "Delete Proposal",
   "Delete phase": "Delete phase",
   "Delete phase?": "Delete phase?",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -309,6 +309,7 @@
   "Invalid emails": "Correos inválidos",
   "are not valid email addresses": "no son direcciones de correo válidas",
   "About the process": "Acerca del proceso",
+  "About this phase": "Acerca de esta fase",
   "Delete Proposal": "Eliminar propuesta",
   "Delete phase": "Eliminar fase",
   "Delete phase?": "¿Eliminar fase?",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -310,6 +310,7 @@
   "Invalid emails": "Courriels invalides",
   "are not valid email addresses": "ne sont pas des adresses de courriel valides",
   "About the process": "À propos du processus",
+  "About this phase": "À propos de cette phase",
   "Delete Proposal": "Supprimer la proposition",
   "Delete phase": "Supprimer la phase",
   "Delete phase?": "Supprimer la phase ?",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -310,6 +310,7 @@
   "Invalid emails": "E-mails inválidos",
   "are not valid email addresses": "não são endereços de e-mail válidos",
   "About the process": "Sobre o processo",
+  "About this phase": "Sobre esta fase",
   "Delete Proposal": "Excluir proposta",
   "Delete phase": "Excluir fase",
   "Delete phase?": "Excluir fase?",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -293,6 +293,7 @@
   "Invalid emails": "Iimaallad aan sax aheyn",
   "are not valid email addresses": "maaha cinwaano iimeel sax ah",
   "About the process": "Ku saabsan habka",
+  "About this phase": "Ku saabsan marxaladdan",
   "Delete Proposal": "Tirtir Soo Jeedinta",
   "Delete phase": "Tirtir marxaladda",
   "Delete phase?": "Tirtir marxaladda?",

--- a/tests/e2e/tests/review-author-view.spec.ts
+++ b/tests/e2e/tests/review-author-view.spec.ts
@@ -1,4 +1,7 @@
-import type { DecisionSchemaDefinition } from '@op/common';
+import type {
+  DecisionInstanceData,
+  DecisionSchemaDefinition,
+} from '@op/common';
 import {
   ProposalReviewAssignmentStatus,
   ProposalReviewRequestState,
@@ -68,6 +71,8 @@ const REVIEW_SCHEMA = {
     },
   ],
 } satisfies DecisionSchemaDefinition;
+
+const PHASE_ADDITIONAL_INFO = 'Phase-specific reviewer guidance.';
 
 // The card title is resolved from the collab doc fragment mock, which returns
 // 'Community Solar Initiative' for any proposal using `test-proposal-view-doc`.
@@ -167,6 +172,82 @@ test.describe('Non-reviewer review-phase view', () => {
     await expect(
       memberPage.getByRole('heading', { name: 'About the process' }),
     ).toBeVisible();
+
+    await memberContext.close();
+  });
+
+  test('non-reviewer member sees "About this phase" CTA when phase has additionalInfo', async ({
+    browser,
+    org,
+    supabaseAdmin,
+  }) => {
+    const template = await getSeededTemplate();
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: REVIEW_SCHEMA,
+    });
+
+    // `additionalInfo` lives on instance phase data (not the schema), so we
+    // inject it directly after instance creation — matching how
+    // `updateDecisionInstance` writes it in production.
+    const instanceData = instance.instance.instanceData as DecisionInstanceData;
+    const patchedInstanceData: DecisionInstanceData = {
+      ...instanceData,
+      phases: instanceData.phases.map((phase) =>
+        phase.phaseId === 'review'
+          ? { ...phase, additionalInfo: PHASE_ADDITIONAL_INFO }
+          : phase,
+      ),
+    };
+    await db
+      .update(processInstances)
+      .set({ currentStateId: 'review', instanceData: patchedInstanceData })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    const memberOrg = await createOrganization({
+      testId: `review-author-phase-${Date.now()}`,
+      supabaseAdmin,
+      users: { admin: 1, member: 0 },
+    });
+    const memberUser = memberOrg.adminUser;
+
+    await grantDecisionProfileAccess({
+      profileId: instance.profileId,
+      authUserId: memberUser.authUserId,
+      email: memberUser.email,
+      isAdmin: false,
+    });
+
+    const memberContext = await browser.newContext();
+    const memberPage = await memberContext.newPage();
+    await authenticateAsUser(memberPage, {
+      email: memberUser.email,
+      password: TEST_USER_DEFAULT_PASSWORD,
+    });
+
+    await memberPage.goto(`/en/decisions/${instance.slug}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const aboutButton = memberPage.getByRole('button', {
+      name: 'About this phase',
+    });
+    await expect(aboutButton).toBeVisible({ timeout: 36_000 });
+    await expect(
+      memberPage.getByRole('button', { name: 'About the process' }),
+    ).toHaveCount(0);
+
+    await aboutButton.click();
+    await expect(
+      memberPage.getByRole('dialog', { name: 'About this phase' }).first(),
+    ).toBeVisible();
+    await expect(
+      memberPage.getByRole('heading', { name: 'About this phase' }),
+    ).toBeVisible();
+    await expect(memberPage.getByText(PHASE_ADDITIONAL_INFO)).toBeVisible();
 
     await memberContext.close();
   });

--- a/tests/e2e/tests/review-author-view.spec.ts
+++ b/tests/e2e/tests/review-author-view.spec.ts
@@ -155,6 +155,17 @@ test.describe('Non-reviewer review-phase view', () => {
       memberPage.getByRole('button', { name: 'Follow' }),
     ).toHaveCount(1);
 
+    // Hero CTA: "About the process" button opens description modal
+    const aboutButton = memberPage.getByRole('button', {
+      name: 'About the process',
+    });
+    await expect(aboutButton).toBeVisible();
+    await aboutButton.click();
+    await expect(memberPage.getByRole('dialog')).toBeVisible();
+    await expect(
+      memberPage.getByRole('heading', { name: 'About the process' }),
+    ).toBeVisible();
+
     await memberContext.close();
   });
 

--- a/tests/e2e/tests/review-author-view.spec.ts
+++ b/tests/e2e/tests/review-author-view.spec.ts
@@ -160,9 +160,10 @@ test.describe('Non-reviewer review-phase view', () => {
       memberPage.getByRole('button', { name: 'Follow' }),
     ).toHaveCount(1);
 
-    // Hero CTA: "About the process" button opens description modal
+    // Hero CTA: "Learn more" button opens description modal whose header
+    // still reads "About the process" (per PR #1163 — only the CTA renamed).
     const aboutButton = memberPage.getByRole('button', {
-      name: 'About the process',
+      name: 'Learn more',
     });
     await expect(aboutButton).toBeVisible();
     await aboutButton.click();
@@ -237,7 +238,7 @@ test.describe('Non-reviewer review-phase view', () => {
     });
     await expect(aboutButton).toBeVisible({ timeout: 36_000 });
     await expect(
-      memberPage.getByRole('button', { name: 'About the process' }),
+      memberPage.getByRole('button', { name: 'Learn more' }),
     ).toHaveCount(0);
 
     await aboutButton.click();

--- a/tests/e2e/tests/review-author-view.spec.ts
+++ b/tests/e2e/tests/review-author-view.spec.ts
@@ -161,7 +161,9 @@ test.describe('Non-reviewer review-phase view', () => {
     });
     await expect(aboutButton).toBeVisible();
     await aboutButton.click();
-    await expect(memberPage.getByRole('dialog')).toBeVisible();
+    await expect(
+      memberPage.getByRole('dialog', { name: 'About the process' }).first(),
+    ).toBeVisible();
     await expect(
       memberPage.getByRole('heading', { name: 'About the process' }),
     ).toBeVisible();


### PR DESCRIPTION
## Summary
- Replace dead `href="#"` placeholder in `ReviewPage` with `DecisionActionBar`, matching `VotingPage` / `StandardDecisionPage`.
- CTA label switches to "About this phase" when modal content comes from `currentPhase.additionalInfo` (or its translation); falls back to "About the process" for instance-level descriptions.
- Adds e2e assertion that the CTA renders and opens the modal.
- Empty description chain → button hidden (graceful).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214137998286187