### PR TITLE
refactor(ui): simplify Menu component, fix styles and focus handling

### DIFF
--- a/apps/app/src/components/Feed/index.tsx
+++ b/apps/app/src/components/Feed/index.tsx
@@ -41,7 +41,9 @@ export const FeedHeader = ({
   className?: string;
 }) => {
   return (
-    <span className={cn('flex items-center gap-2 align-baseline', className)}>
+    <span
+      className={cn('flex items-center gap-2 pt-1 align-baseline', className)}
+    >
       {children}
     </span>
   );
@@ -66,7 +68,7 @@ export const FeedMain = ({
   return (
     <div
       className={cn(
-        'flex w-full flex-col items-start justify-start gap-2 overflow-hidden',
+        'flex w-full flex-col items-start justify-start gap-0.5 overflow-hidden',
         className,
       )}
       {...props}

--- a/apps/app/src/components/PostFeed/DeletePost.tsx
+++ b/apps/app/src/components/PostFeed/DeletePost.tsx
@@ -3,7 +3,7 @@
 import { createCommentsQueryKey } from '@/utils/queryKeys';
 import { trpc } from '@op/api/client';
 import type { Post } from '@op/api/encoders';
-import { Menu, MenuItem } from '@op/ui/Menu';
+import { MenuItem } from '@op/ui/Menu';
 import { toast } from '@op/ui/Toast';
 import { useRouter } from 'next/navigation';
 
@@ -61,20 +61,16 @@ export const DeletePost = ({ post }: { post: Post }) => {
   };
 
   return (
-    <Menu
+    <MenuItem
+      key="delete"
+      className="px-3 py-1 text-functional-red"
       onAction={() => {
         if (post.id) {
           handleDeletePost(post);
         }
       }}
-      className="min-w-28 p-2"
     >
-      <MenuItem
-        key="delete"
-        className="!bg-transparent px-3 py-1 ps-3 pe-3 text-functional-red"
-      >
-        {t('Delete')}
-      </MenuItem>
-    </Menu>
+      {t('Delete')}
+    </MenuItem>
   );
 };

--- a/apps/app/src/components/PostFeed/DeletePostMenuItem.tsx
+++ b/apps/app/src/components/PostFeed/DeletePostMenuItem.tsx
@@ -9,24 +9,20 @@ import { useRouter } from 'next/navigation';
 
 import { useTranslations } from '@/lib/i18n';
 
-export const DeletePost = ({ post }: { post: Post }) => {
+export const DeletePostMenuItem = ({ post }: { post: Post }) => {
   const t = useTranslations();
   const utils = trpc.useUtils();
   const router = useRouter();
 
   const deletePost = trpc.organization.deletePost.useMutation({
     onMutate: async () => {
-      // If this is a comment (has parentPostId), update the comments cache optimistically
       if (post.parentPostId) {
         const queryKey = createCommentsQueryKey(post.parentPostId);
 
-        // Cancel any outgoing refetches for comments
         await utils.posts.getPosts.cancel(queryKey);
 
-        // Snapshot previous comments
         const previousComments = utils.posts.getPosts.getData(queryKey);
 
-        // Optimistically remove the comment
         utils.posts.getPosts.setData(queryKey, (old) => {
           if (!old) return old;
           return old.filter((comment) => comment.id !== post.id);
@@ -44,7 +40,6 @@ export const DeletePost = ({ post }: { post: Post }) => {
       toast.success({ message: t('Post deleted') });
     },
     onError: (error, _variables, context) => {
-      // Rollback optimistic update for comments on error
       if (post.parentPostId && context?.previousComments) {
         const queryKey = createCommentsQueryKey(post.parentPostId);
         utils.posts.getPosts.setData(queryKey, context.previousComments);
@@ -54,19 +49,12 @@ export const DeletePost = ({ post }: { post: Post }) => {
     },
   });
 
-  const handleDeletePost = (post: Post) => {
-    deletePost.mutate({
-      id: post.id,
-    });
-  };
-
   return (
     <MenuItem
-      key="delete"
       className="px-3 py-1 text-functional-red"
       onAction={() => {
         if (post.id) {
-          handleDeletePost(post);
+          deletePost.mutate({ id: post.id });
         }
       }}
     >

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -34,7 +34,7 @@ import { DiscussionModal } from '../DiscussionModal';
 import { FeedContent, FeedHeader, FeedItem, FeedMain } from '../Feed';
 import { LinkPreview } from '../LinkPreview';
 import { OrganizationAvatar } from '../OrganizationAvatar';
-import { DeletePost } from './DeletePost';
+import { DeletePostMenuItem } from './DeletePostMenuItem';
 
 const PostDisplayName = ({
   displayName,
@@ -257,7 +257,7 @@ const PostMenu = ({
 
   return (
     <OptionMenu aria-label={t('Post options')} className="absolute end-0 top-0">
-      <DeletePost post={post} />
+      <DeletePostMenuItem post={post} />
     </OptionMenu>
   );
 };

--- a/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
@@ -3,7 +3,6 @@
 import { trpc } from '@op/api/client';
 import { IconButton } from '@op/ui/IconButton';
 import { Menu, MenuItem, MenuTrigger } from '@op/ui/Menu';
-import { Popover } from '@op/ui/Popover';
 import { Tab, TabList, TabPanel, Tabs } from '@op/ui/Tabs';
 import { Tag, TagGroup } from '@op/ui/TagGroup';
 import { toast } from '@op/ui/Toast';
@@ -163,24 +162,22 @@ const MemberMenu = ({
       >
         <LuEllipsis className="size-4" />
       </IconButton>
-      <Popover placement="bottom end">
-        <Menu className="min-w-48 p-2">
-          <MenuItem
-            key="toggle-role"
-            onAction={handleRoleToggle}
-            className="px-3 py-1"
-          >
-            {isCurrentlyAdmin ? t('Change to Member') : t('Change to Admin')}
-          </MenuItem>
-          <MenuItem
-            key="remove-from-org"
-            onAction={handleRemoveFromOrganization}
-            className="px-3 py-1 text-functional-red"
-          >
-            {t('Remove from organization')}
-          </MenuItem>
-        </Menu>
-      </Popover>
+      <Menu className="min-w-48 p-2" placement="bottom end">
+        <MenuItem
+          key="toggle-role"
+          onAction={handleRoleToggle}
+          className="px-3 py-1"
+        >
+          {isCurrentlyAdmin ? t('Change to Member') : t('Change to Admin')}
+        </MenuItem>
+        <MenuItem
+          key="remove-from-org"
+          onAction={handleRemoveFromOrganization}
+          className="px-3 py-1 text-functional-red"
+        >
+          {t('Remove from organization')}
+        </MenuItem>
+      </Menu>
     </MenuTrigger>
   );
 };

--- a/apps/app/src/components/SiteHeader/CreateMenu.tsx
+++ b/apps/app/src/components/SiteHeader/CreateMenu.tsx
@@ -9,7 +9,6 @@ import { screens } from '@op/styles/constants';
 import { Button } from '@op/ui/Button';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Menu, MenuItem, MenuSeparator, MenuTrigger } from '@op/ui/Menu';
-import { Popover } from '@op/ui/Popover';
 import { toast } from '@op/ui/Toast';
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
@@ -72,41 +71,39 @@ export const CreateMenu = () => {
           <LuPlus className="size-4" />
           <span className="hidden sm:block">{t('Create')}</span>
         </Button>
-        <Popover placement="bottom end">
-          <Menu>
+        <Menu>
+          <MenuItem
+            id="create-org"
+            onAction={() => setIsCreateOrganizationModalOpen(true)}
+          >
+            <LuUsers className="size-4" /> {t('Organization')}
+          </MenuItem>
+          {createDecisionEnabled && (
             <MenuItem
-              id="create-org"
-              onAction={() => setIsCreateOrganizationModalOpen(true)}
+              id="create-decision"
+              isDisabled={isCreatingDecision}
+              onAction={() => createDecisionMutation.mutate()}
             >
-              <LuUsers className="size-4" /> {t('Organization')}
+              {isCreatingDecision ? (
+                <LoadingSpinner className="size-4" />
+              ) : (
+                <LuMessageCircle className="size-4" />
+              )}{' '}
+              {t('Decision-making process')}
             </MenuItem>
-            {createDecisionEnabled && (
+          )}
+          {isOrg && (
+            <>
+              <MenuSeparator />
               <MenuItem
-                id="create-decision"
-                isDisabled={isCreatingDecision}
-                onAction={() => createDecisionMutation.mutate()}
+                id="invite-member"
+                onAction={() => setIsInviteModalOpen(true)}
               >
-                {isCreatingDecision ? (
-                  <LoadingSpinner className="size-4" />
-                ) : (
-                  <LuMessageCircle className="size-4" />
-                )}{' '}
-                {t('Decision-making process')}
+                <LuUserPlus className="size-4" /> {t('Invite member')}
               </MenuItem>
-            )}
-            {isOrg && (
-              <>
-                <MenuSeparator />
-                <MenuItem
-                  id="invite-member"
-                  onAction={() => setIsInviteModalOpen(true)}
-                >
-                  <LuUserPlus className="size-4" /> {t('Invite member')}
-                </MenuItem>
-              </>
-            )}
-          </Menu>
-        </Popover>
+            </>
+          )}
+        </Menu>
       </MenuTrigger>
       <CreateOrganizationModal
         isOpen={isCreateOrganizationModalOpen}

--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -11,9 +11,14 @@ import { screens } from '@op/styles/constants';
 import { Avatar } from '@op/ui/Avatar';
 import { Button } from '@op/ui/Button';
 import { Chip } from '@op/ui/Chip';
-import { Menu, MenuItem, MenuItemSimple, MenuSeparator } from '@op/ui/Menu';
+import {
+  Menu,
+  MenuItem,
+  MenuItemSimple,
+  MenuSeparator,
+  MenuTrigger,
+} from '@op/ui/Menu';
 import { Modal, ModalBody } from '@op/ui/Modal';
-import { MenuTrigger } from '@op/ui/RAC';
 import { SidebarTrigger } from '@op/ui/Sidebar';
 import { Skeleton } from '@op/ui/Skeleton';
 import { cn } from '@op/ui/utils';

--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -13,7 +13,6 @@ import { Button } from '@op/ui/Button';
 import { Chip } from '@op/ui/Chip';
 import { Menu, MenuItem, MenuItemSimple, MenuSeparator } from '@op/ui/Menu';
 import { Modal, ModalBody } from '@op/ui/Modal';
-import { Popover } from '@op/ui/Popover';
 import { MenuTrigger } from '@op/ui/RAC';
 import { SidebarTrigger } from '@op/ui/Sidebar';
 import { Skeleton } from '@op/ui/Skeleton';
@@ -442,16 +441,18 @@ export const UserAvatarMenu = ({ className }: { className?: string }) => {
     <>
       <MenuTrigger>
         {avatarButton}
-        <Popover className="min-w-[150px]" placement="bottom end">
-          <Menu className="flex min-w-72 flex-col p-4 pb-6">
-            <AvatarMenuContent
-              setIsProfileOpen={setIsProfileOpen}
-              setIsOrgDeletionOpen={setIsOrgDeletionOpen}
-              onClose={() => setIsProfileOpen(false)}
-              onProfileSwitch={handleProfileSwitch}
-            />
-          </Menu>
-        </Popover>
+        <Menu
+          className="flex min-w-72 flex-col p-4 pb-6"
+          popoverClassName="min-w-[150px]"
+          placement="bottom end"
+        >
+          <AvatarMenuContent
+            setIsProfileOpen={setIsProfileOpen}
+            setIsOrgDeletionOpen={setIsOrgDeletionOpen}
+            onClose={() => setIsProfileOpen(false)}
+            onProfileSwitch={handleProfileSwitch}
+          />
+        </Menu>
       </MenuTrigger>
       <UpdateProfileModal isOpen={isProfileOpen} setIsOpen={setIsProfileOpen} />
       <ProfileSwitchingModal

--- a/apps/app/src/components/decisions/DecisionListItem.tsx
+++ b/apps/app/src/components/decisions/DecisionListItem.tsx
@@ -3,7 +3,7 @@
 import { trpc } from '@op/api/client';
 import { DecisionProfile, ProcessStatus } from '@op/api/encoders';
 import { Button } from '@op/ui/Button';
-import { Menu, MenuItem } from '@op/ui/Menu';
+import { MenuItem } from '@op/ui/Menu';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
 import { OptionMenu } from '@op/ui/OptionMenu';
 import { toast } from '@op/ui/Toast';
@@ -118,33 +118,28 @@ export const DecisionListItem = ({ item }: { item: DecisionProfile }) => {
               className="rounded bg-white shadow-light"
               size="medium"
             >
-              <Menu className="min-w-28 p-2">
-                {canManage && (
-                  <MenuItem
-                    key="settings"
-                    href={`/decisions/${item.slug}/edit`}
-                  >
-                    {t('Settings')}
-                  </MenuItem>
-                )}
-                {canManage && (
-                  <MenuItem
-                    key="duplicate"
-                    onAction={() => setShowDuplicateModal(true)}
-                  >
-                    {t('Duplicate')}
-                  </MenuItem>
-                )}
-                {canDelete && (
-                  <MenuItem
-                    key="delete"
-                    onAction={() => setShowDeleteModal(true)}
-                    className="text-functional-red"
-                  >
-                    {t('Delete')}
-                  </MenuItem>
-                )}
-              </Menu>
+              {canManage && (
+                <MenuItem key="settings" href={`/decisions/${item.slug}/edit`}>
+                  {t('Settings')}
+                </MenuItem>
+              )}
+              {canManage && (
+                <MenuItem
+                  key="duplicate"
+                  onAction={() => setShowDuplicateModal(true)}
+                >
+                  {t('Duplicate')}
+                </MenuItem>
+              )}
+              {canDelete && (
+                <MenuItem
+                  key="delete"
+                  onAction={() => setShowDeleteModal(true)}
+                  className="text-functional-red"
+                >
+                  {t('Delete')}
+                </MenuItem>
+              )}
             </OptionMenu>
           </div>
         )}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/RolesSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/RolesSection.tsx
@@ -11,7 +11,7 @@ import { DialogTrigger } from '@op/ui/Dialog';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header2, Header3 } from '@op/ui/Header';
 import { IconButton } from '@op/ui/IconButton';
-import { Menu, MenuItem } from '@op/ui/Menu';
+import { MenuItem } from '@op/ui/Menu';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
 import { OptionMenu } from '@op/ui/OptionMenu';
 import { TextField } from '@op/ui/TextField';
@@ -295,20 +295,18 @@ function RoleRow({
             className="ms-auto rounded bg-white shadow-light"
             size="medium"
           >
-            <Menu className="min-w-28 p-2">
-              <MenuItem key="edit" onAction={() => setIsEditing(true)}>
-                <LuPencil className="size-4" />
-                {t('Edit')}
-              </MenuItem>
-              <MenuItem
-                key="delete"
-                onAction={() => onDelete(role)}
-                className="text-functional-red"
-              >
-                <LuTrash2 className="size-4" />
-                {t('Delete')}
-              </MenuItem>
-            </Menu>
+            <MenuItem key="edit" onAction={() => setIsEditing(true)}>
+              <LuPencil className="size-4" />
+              {t('Edit')}
+            </MenuItem>
+            <MenuItem
+              key="delete"
+              onAction={() => onDelete(role)}
+              className="text-functional-red"
+            >
+              <LuTrash2 className="size-4" />
+              {t('Delete')}
+            </MenuItem>
           </OptionMenu>
         )}
       </TableCell>
@@ -582,24 +580,22 @@ function MobileRoleCard({
             variant="outline"
             className="rounded-lg"
           >
-            <Menu className="min-w-28 p-2">
-              {onEdit && (
-                <MenuItem key="edit" onAction={() => onEdit(role)}>
-                  <LuPencil className="size-4" />
-                  {t('Edit')}
-                </MenuItem>
-              )}
-              {onDelete && (
-                <MenuItem
-                  key="delete"
-                  onAction={() => onDelete(role)}
-                  className="text-functional-red"
-                >
-                  <LuTrash2 className="size-4" />
-                  {t('Delete')}
-                </MenuItem>
-              )}
-            </Menu>
+            {onEdit && (
+              <MenuItem key="edit" onAction={() => onEdit(role)}>
+                <LuPencil className="size-4" />
+                {t('Edit')}
+              </MenuItem>
+            )}
+            {onDelete && (
+              <MenuItem
+                key="delete"
+                onAction={() => onDelete(role)}
+                className="text-functional-red"
+              >
+                <LuTrash2 className="size-4" />
+                {t('Delete')}
+              </MenuItem>
+            )}
           </OptionMenu>
         )}
       </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/AddFieldMenu.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/AddFieldMenu.tsx
@@ -3,7 +3,6 @@
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { Button } from '@op/ui/Button';
 import { Menu, MenuItem, MenuSeparator, MenuTrigger } from '@op/ui/Menu';
-import { Popover } from '@op/ui/Popover';
 import { Fragment } from 'react';
 import { LuPlus } from 'react-icons/lu';
 
@@ -41,40 +40,40 @@ export function AddFieldMenu({ onAddField, disabledTypes }: AddFieldMenuProps) {
         <LuPlus className="size-4" />
         {t('Add field')}
       </Button>
-      <Popover placement="bottom start" className="w-56">
-        <Menu
-          onAction={(key) => onAddField(key as FieldType)}
-          aria-label={t('Add field')}
-        >
-          {categories.map((category, categoryIndex) => (
-            <Fragment key={category.id}>
-              {categoryIndex > 0 && <MenuSeparator />}
-              <MenuItem
-                id={`header-${category.id}`}
-                isDisabled
-                className="px-4 py-1 text-xs font-medium text-neutral-gray4"
-              >
-                {t(category.labelKey)}
-              </MenuItem>
-              {category.types.map((type) => {
-                const config = FIELD_TYPE_REGISTRY[type];
-                const Icon = config.icon;
-                return (
-                  <MenuItem
-                    key={type}
-                    id={type}
-                    className="gap-2"
-                    isDisabled={disabledTypes?.includes(type)}
-                  >
-                    <Icon className="size-4 text-neutral-gray4" />
-                    {t(config.labelKey)}
-                  </MenuItem>
-                );
-              })}
-            </Fragment>
-          ))}
-        </Menu>
-      </Popover>
+      <Menu
+        onAction={(key) => onAddField(key as FieldType)}
+        aria-label={t('Add field')}
+        placement="bottom start"
+        popoverClassName="w-56"
+      >
+        {categories.map((category, categoryIndex) => (
+          <Fragment key={category.id}>
+            {categoryIndex > 0 && <MenuSeparator />}
+            <MenuItem
+              id={`header-${category.id}`}
+              isDisabled
+              className="px-4 py-1 text-xs font-medium text-neutral-gray4"
+            >
+              {t(category.labelKey)}
+            </MenuItem>
+            {category.types.map((type) => {
+              const config = FIELD_TYPE_REGISTRY[type];
+              const Icon = config.icon;
+              return (
+                <MenuItem
+                  key={type}
+                  id={type}
+                  className="gap-2"
+                  isDisabled={disabledTypes?.includes(type)}
+                >
+                  <Icon className="size-4 text-neutral-gray4" />
+                  {t(config.labelKey)}
+                </MenuItem>
+              );
+            })}
+          </Fragment>
+        ))}
+      </Menu>
     </MenuTrigger>
   );
 }

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardMenu.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardMenu.tsx
@@ -11,7 +11,6 @@ import { DialogTrigger } from '@op/ui/Dialog';
 import { IconButton } from '@op/ui/IconButton';
 import { Menu, MenuItem, MenuTrigger } from '@op/ui/Menu';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
-import { Popover } from '@op/ui/Popover';
 import { toast } from '@op/ui/Toast';
 import { useState } from 'react';
 import { LuTrash2 } from 'react-icons/lu';
@@ -314,9 +313,9 @@ export function ProposalCardMenu({
       ) : (
         <MenuTrigger>
           {menuTriggerButton}
-          <Popover placement="bottom end">
-            <Menu className="p-2">{renderMenuItems(false)}</Menu>
-          </Popover>
+          <Menu className="p-2" placement="bottom end">
+            {renderMenuItems(false)}
+          </Menu>
         </MenuTrigger>
       )}
       {(proposal.isEditable || canManage) && (

--- a/apps/app/src/components/decisions/ResponsiveSelect.tsx
+++ b/apps/app/src/components/decisions/ResponsiveSelect.tsx
@@ -3,7 +3,7 @@
 import { useMediaQuery } from '@op/hooks';
 import { screens } from '@op/styles/constants';
 import { Button } from '@op/ui/Button';
-import { Menu, MenuItem } from '@op/ui/Menu';
+import { MenuItem, MenuList } from '@op/ui/Menu';
 import { Modal, ModalBody } from '@op/ui/Modal';
 import { Select, SelectItem } from '@op/ui/Select';
 import { type ReactNode, useState } from 'react';
@@ -79,7 +79,7 @@ export function ResponsiveSelect<T extends string>({
           className={BOTTOM_SHEET_CLASS}
         >
           <ModalBody className="pb-safe p-0">
-            <Menu
+            <MenuList
               selectionMode="single"
               selectedKeys={[selectedKey]}
               className="flex min-w-full flex-col border-0 p-0 shadow-none"
@@ -98,7 +98,7 @@ export function ResponsiveSelect<T extends string>({
                   {item.label}
                 </MenuItem>
               ))}
-            </Menu>
+            </MenuList>
           </ModalBody>
         </Modal>
       </>

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
@@ -2,7 +2,7 @@
 
 import { DATE_TIME_UTC_FORMAT } from '@/utils/formatting';
 import type { AdminDecisionInstance } from '@op/common/client';
-import { Menu, MenuItem } from '@op/ui/Menu';
+import { MenuItem } from '@op/ui/Menu';
 import { Modal, ModalBody, ModalHeader } from '@op/ui/Modal';
 import { OptionMenu } from '@op/ui/OptionMenu';
 import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
@@ -108,16 +108,15 @@ export const DecisionsRowCells = ({
             aria-label={t('Decision options')}
             variant="outline"
             size="medium"
+            menuClassName="min-w-48 p-2"
           >
-            <Menu className="min-w-48 p-2">
-              <MenuItem
-                key="view-instance-data"
-                onAction={() => setIsDataModalOpen(true)}
-                className="px-3 py-1"
-              >
-                {t('View instance data')}
-              </MenuItem>
-            </Menu>
+            <MenuItem
+              key="view-instance-data"
+              onAction={() => setIsDataModalOpen(true)}
+              className="px-3 py-1"
+            >
+              {t('View instance data')}
+            </MenuItem>
           </OptionMenu>
         </div>
         <InstanceDataModal

--- a/apps/app/src/components/screens/PlatformAdmin/OrgsRow.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/OrgsRow.tsx
@@ -2,7 +2,7 @@
 
 import { DATE_TIME_UTC_FORMAT } from '@/utils/formatting';
 import type { AdminOrg } from '@op/api/encoders';
-import { Menu, MenuItem } from '@op/ui/Menu';
+import { MenuItem } from '@op/ui/Menu';
 import { OptionMenu } from '@op/ui/OptionMenu';
 import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
 import { TableCell } from '@op/ui/ui/table';
@@ -52,16 +52,15 @@ export const OrgsRowCells = ({ org }: { org: AdminOrg }) => {
             aria-label={t('Organization options')}
             variant="outline"
             size="medium"
+            menuClassName="min-w-48 p-2"
           >
-            <Menu className="min-w-48 p-2">
-              <MenuItem
-                key="view-members"
-                onAction={() => setIsMembersModalOpen(true)}
-                className="px-3 py-1"
-              >
-                {t('View members')}
-              </MenuItem>
-            </Menu>
+            <MenuItem
+              key="view-members"
+              onAction={() => setIsMembersModalOpen(true)}
+              className="px-3 py-1"
+            >
+              {t('View members')}
+            </MenuItem>
           </OptionMenu>
         </div>
         <OrgMembersModal

--- a/apps/app/src/components/screens/PlatformAdmin/UsersRow.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/UsersRow.tsx
@@ -5,7 +5,7 @@ import { getAnalyticsUserUrl } from '@op/analytics/client-utils';
 import type { RouterOutput } from '@op/api/client';
 import { trpc } from '@op/api/client';
 import { useRelativeTime } from '@op/hooks';
-import { Menu, MenuItem, MenuSeparator } from '@op/ui/Menu';
+import { MenuItem, MenuSeparator } from '@op/ui/Menu';
 import { OptionMenu } from '@op/ui/OptionMenu';
 import { Select, SelectItem } from '@op/ui/Select';
 import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
@@ -83,49 +83,48 @@ export const UsersRowCells = ({ user }: { user: User }) => {
             aria-label={t('User options')}
             variant="outline"
             size="medium"
+            menuClassName="min-w-48 p-2"
           >
-            <Menu className="min-w-48 p-2">
-              <MenuItem
-                key="view-analytics"
-                onAction={() => {
-                  window.open(getAnalyticsUserUrl(user.authUserId), '_blank');
-                }}
-                className="px-3 py-1"
-              >
-                {t('View analytics')}
-              </MenuItem>
-              <MenuItem
-                key="edit-profile"
-                onAction={() => {
-                  if (user.profile) {
-                    setIsEditModalOpen(true);
-                  }
-                }}
-                className="px-3 py-1"
-                isDisabled={!user.profile}
-              >
-                {t('Edit profile')}
-              </MenuItem>
-              <MenuItem
-                key="add-to-org"
-                onAction={() => {
-                  setIsAddToOrgModalOpen(true);
-                }}
-                className="px-3 py-1"
-              >
-                Add to Organization
-              </MenuItem>
-              <MenuSeparator />
-              <MenuItem
-                key="remove-user"
-                onAction={() => {
-                  alert('coming soon');
-                }}
-                className="px-3 py-1"
-              >
-                <span className="text-functional-red">{t('Remove user')}</span>
-              </MenuItem>
-            </Menu>
+            <MenuItem
+              key="view-analytics"
+              onAction={() => {
+                window.open(getAnalyticsUserUrl(user.authUserId), '_blank');
+              }}
+              className="px-3 py-1"
+            >
+              {t('View analytics')}
+            </MenuItem>
+            <MenuItem
+              key="edit-profile"
+              onAction={() => {
+                if (user.profile) {
+                  setIsEditModalOpen(true);
+                }
+              }}
+              className="px-3 py-1"
+              isDisabled={!user.profile}
+            >
+              {t('Edit profile')}
+            </MenuItem>
+            <MenuItem
+              key="add-to-org"
+              onAction={() => {
+                setIsAddToOrgModalOpen(true);
+              }}
+              className="px-3 py-1"
+            >
+              Add to Organization
+            </MenuItem>
+            <MenuSeparator />
+            <MenuItem
+              key="remove-user"
+              onAction={() => {
+                alert('coming soon');
+              }}
+              className="px-3 py-1"
+            >
+              <span className="text-functional-red">{t('Remove user')}</span>
+            </MenuItem>
           </OptionMenu>
         </div>
         {user.profile ? (

--- a/apps/app/src/components/screens/PlatformAdmin/UsersTable.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/UsersTable.tsx
@@ -3,7 +3,7 @@
 import { trpc } from '@op/api/client';
 import { useCursorPagination, useDebounce } from '@op/hooks';
 import { Header2 } from '@op/ui/Header';
-import { Menu, MenuItem } from '@op/ui/Menu';
+import { MenuItem } from '@op/ui/Menu';
 import { OptionMenu } from '@op/ui/OptionMenu';
 import { Pagination } from '@op/ui/Pagination';
 import { SearchField } from '@op/ui/SearchField';
@@ -110,15 +110,10 @@ export const UsersTable = () => {
             size="medium"
             className="me-1"
           >
-            <Menu>
-              <MenuItem
-                onAction={handleExportAllUsers}
-                isDisabled={isExporting}
-              >
-                <LuDownload className="size-4" />
-                {t('Export all users')}
-              </MenuItem>
-            </Menu>
+            <MenuItem onAction={handleExportAllUsers} isDisabled={isExporting}>
+              <LuDownload className="size-4" />
+              {t('Export all users')}
+            </MenuItem>
           </OptionMenu>
         </div>
       </div>

--- a/packages/ui/src/components/Menu.tsx
+++ b/packages/ui/src/components/Menu.tsx
@@ -22,12 +22,19 @@ import type { PopoverProps } from './Popover';
 
 export { AriaMenuTrigger as MenuTrigger };
 
-const menuListClasses =
-  'max-h-[inherit] overflow-auto rounded-md border bg-white p-2 text-neutral-charcoal shadow-light outline outline-0';
-
+/**
+ * Bare menu list. Use inside an existing popover container (`OptionMenu`,
+ * `Modal`, etc.). For a standalone trigger-and-popover combo use `Menu`.
+ */
 export const MenuList = <T extends object>(props: AriaMenuProps<T>) => {
   return (
-    <AriaMenu {...props} className={cn(menuListClasses, props.className)} />
+    <AriaMenu
+      {...props}
+      className={cn(
+        'max-h-[inherit] overflow-auto rounded-md border bg-white p-2 text-neutral-charcoal shadow-light outline outline-0',
+        props.className,
+      )}
+    />
   );
 };
 
@@ -38,6 +45,11 @@ interface MenuProps<T> extends AriaMenuProps<T> {
   popoverClassName?: PopoverProps['className'];
 }
 
+/**
+ * Trigger-target menu. Renders a `Popover` wrapping a `MenuList`, so consumers
+ * should NOT add their own `<Popover>` around it. For use inside a parent
+ * popover (e.g. `OptionMenu` body) use `MenuList` directly.
+ */
 export const Menu = <T extends object>({
   placement,
   showArrow,

--- a/packages/ui/src/components/Menu.tsx
+++ b/packages/ui/src/components/Menu.tsx
@@ -17,23 +17,43 @@ import { LuCheck, LuChevronRight } from 'react-icons/lu';
 import { VariantProps, cn, tv } from '../lib/utils';
 import { DropdownSection, dropdownItemStyles } from './ListBox';
 import type { DropdownSectionProps } from './ListBox';
+import { Popover } from './Popover';
 import type { PopoverProps } from './Popover';
 
 export { AriaMenuTrigger as MenuTrigger };
 
+const menuListClasses =
+  'max-h-[inherit] overflow-auto rounded-md border bg-white p-2 text-neutral-charcoal shadow-light outline outline-0';
+
+export const MenuList = <T extends object>(props: AriaMenuProps<T>) => {
+  return (
+    <AriaMenu {...props} className={cn(menuListClasses, props.className)} />
+  );
+};
+
 interface MenuProps<T> extends AriaMenuProps<T> {
   placement?: PopoverProps['placement'];
+  showArrow?: PopoverProps['showArrow'];
+  offset?: PopoverProps['offset'];
+  popoverClassName?: PopoverProps['className'];
 }
 
-export const Menu = <T extends object>(props: MenuProps<T>) => {
+export const Menu = <T extends object>({
+  placement,
+  showArrow,
+  offset,
+  popoverClassName,
+  ...menuProps
+}: MenuProps<T>) => {
   return (
-    <AriaMenu
-      {...props}
-      className={cn(
-        'max-h-[inherit] overflow-auto rounded-md border bg-white p-2 text-neutral-charcoal shadow-light outline outline-0',
-        props.className,
-      )}
-    />
+    <Popover
+      placement={placement}
+      showArrow={showArrow}
+      offset={offset}
+      className={popoverClassName}
+    >
+      <MenuList {...menuProps} />
+    </Popover>
   );
 };
 
@@ -41,28 +61,22 @@ export const menuItemStyles = tv({
   base: 'group flex cursor-pointer items-center gap-4 rounded-md px-4 py-2 text-neutral-charcoal outline outline-0 -outline-offset-1 forced-color-adjust-none select-none',
   variants: {
     unstyled: {
-      true: 'group flex cursor-pointer items-center px-0 py-0 ps-0 pe-0 pt-0 pb-0 text-neutral-charcoal outline outline-0 -outline-offset-1 forced-color-adjust-none select-none',
-      false: '',
+      true: 'px-0 py-0',
     },
     selected: {
       true: 'bg-primary-tealWhite outline-1 outline-primary-teal',
-      false: '',
     },
     isDisabled: {
       false: 'text-neutral-black',
       true: 'cursor-default text-neutral-gray2',
     },
-    isFocused: {
-      true: 'bg-neutral-offWhite outline-1 outline-neutral-gray1',
+    isHovered: {
+      true: 'bg-neutral-offWhite',
+    },
+    isFocusVisible: {
+      true: 'outline-2 outline-primary-teal',
     },
   },
-  compoundVariants: [
-    {
-      isFocused: false,
-      isOpen: true,
-      className: 'bg-neutral-gray1',
-    },
-  ],
 });
 type MenuItemVariants = VariantProps<typeof menuItemStyles>;
 

--- a/packages/ui/src/components/OptionMenu.tsx
+++ b/packages/ui/src/components/OptionMenu.tsx
@@ -7,11 +7,10 @@ import { LuEllipsis } from 'react-icons/lu';
 import { RequireAccessibleName } from '../lib/a11y';
 import { cn } from '../lib/utils';
 import { IconButton, IconButtonProps } from './IconButton';
-import { MenuList, MenuTrigger } from './Menu';
-import { Popover } from './Popover';
+import { Menu, MenuTrigger } from './Menu';
 import type { PopoverProps } from './Popover';
 
-type OptionMenuProps = RequireAccessibleName<{
+type OptionMenuProps<T extends object> = RequireAccessibleName<{
   children: ReactNode;
   className?: string;
   variant?: IconButtonProps['variant'];
@@ -19,10 +18,10 @@ type OptionMenuProps = RequireAccessibleName<{
   placement?: PopoverProps['placement'];
   popoverClassName?: PopoverProps['className'];
   menuClassName?: string;
-  onAction?: AriaMenuProps<object>['onAction'];
+  onAction?: AriaMenuProps<T>['onAction'];
 }>;
 
-export const OptionMenu = ({
+export const OptionMenu = <T extends object>({
   children,
   className,
   variant = 'ghost',
@@ -32,7 +31,7 @@ export const OptionMenu = ({
   menuClassName,
   onAction,
   ...rest
-}: OptionMenuProps) => {
+}: OptionMenuProps<T>) => {
   return (
     <MenuTrigger>
       <IconButton
@@ -46,14 +45,14 @@ export const OptionMenu = ({
       >
         <LuEllipsis className="size-4" />
       </IconButton>
-      <Popover placement={placement} className={popoverClassName}>
-        <MenuList
-          className={cn('min-w-28 p-2', menuClassName)}
-          onAction={onAction}
-        >
-          {children}
-        </MenuList>
-      </Popover>
+      <Menu
+        placement={placement}
+        popoverClassName={popoverClassName}
+        className={cn('min-w-28 p-2', menuClassName)}
+        onAction={onAction}
+      >
+        {children}
+      </Menu>
     </MenuTrigger>
   );
 };

--- a/packages/ui/src/components/OptionMenu.tsx
+++ b/packages/ui/src/components/OptionMenu.tsx
@@ -1,19 +1,25 @@
 'use client';
 
 import { ReactNode } from 'react';
+import type { MenuProps as AriaMenuProps } from 'react-aria-components';
 import { LuEllipsis } from 'react-icons/lu';
 
 import { RequireAccessibleName } from '../lib/a11y';
 import { cn } from '../lib/utils';
 import { IconButton, IconButtonProps } from './IconButton';
-import { MenuTrigger } from './Menu';
+import { MenuList, MenuTrigger } from './Menu';
 import { Popover } from './Popover';
+import type { PopoverProps } from './Popover';
 
 type OptionMenuProps = RequireAccessibleName<{
   children: ReactNode;
   className?: string;
   variant?: IconButtonProps['variant'];
   size?: IconButtonProps['size'];
+  placement?: PopoverProps['placement'];
+  popoverClassName?: PopoverProps['className'];
+  menuClassName?: string;
+  onAction?: AriaMenuProps<object>['onAction'];
 }>;
 
 export const OptionMenu = ({
@@ -21,6 +27,10 @@ export const OptionMenu = ({
   className,
   variant = 'ghost',
   size = 'small',
+  placement = 'bottom end',
+  popoverClassName,
+  menuClassName,
+  onAction,
   ...rest
 }: OptionMenuProps) => {
   return (
@@ -36,7 +46,14 @@ export const OptionMenu = ({
       >
         <LuEllipsis className="size-4" />
       </IconButton>
-      <Popover placement="bottom end">{children}</Popover>
+      <Popover placement={placement} className={popoverClassName}>
+        <MenuList
+          className={cn('min-w-28 p-2', menuClassName)}
+          onAction={onAction}
+        >
+          {children}
+        </MenuList>
+      </Popover>
     </MenuTrigger>
   );
 };


### PR DESCRIPTION
## Summary
- `Menu` now bundles `Popover + MenuList` so consumers stop nesting them by hand; `MenuList` exposed for use inside existing popovers (`OptionMenu`, modals).
- `OptionMenu` composes `<Menu>`, accepts `MenuItem` children directly, defaults `min-w-28 p-2` on its list, generic over `<T>` for typed `onAction`.
- `MenuItem` hover vs focus split: `isHovered` paints background, `isFocusVisible` paints the outline — pointer hover no longer renders a focus ring.
- `DeletePost` renamed to `DeletePostMenuItem` — it renders a `MenuItem` for `OptionMenu`, not a standalone control.
- Storybook stories work without manual `<Popover>` wrap; production `<Popover><Menu>` call sites collapsed to `<Menu>`.