### PR TITLE
fix(decisions): require pending decision invite when accepting proposal invite

### DIFF
--- a/packages/common/src/services/decision/acceptProposalInvite.ts
+++ b/packages/common/src/services/decision/acceptProposalInvite.ts
@@ -12,7 +12,6 @@ import {
   NotFoundError,
   UnauthorizedError,
 } from '../../utils/error';
-import { assertGlobalRole } from '../assert';
 
 /**
  * Accept a proposal invite and ensure the user is also added as a Member
@@ -56,14 +55,11 @@ export const acceptProposalInvite = async ({
     throw new CommonError('You are already a member of this profile');
   }
 
-  // Find the proposal (and its process instance) and the Member role in parallel
-  const [proposal, memberRole] = await Promise.all([
-    db.query.proposals.findFirst({
-      where: { profileId: invite.profileId },
-      with: { processInstance: true },
-    }),
-    assertGlobalRole('Member'),
-  ]);
+  // Find the proposal (and its process instance) to locate the parent decision
+  const proposal = await db.query.proposals.findFirst({
+    where: { profileId: invite.profileId },
+    with: { processInstance: true },
+  });
 
   // Check if we need to add the user to the parent decision process
   let decisionProfileIdToAdd: string | null = null;
@@ -88,6 +84,17 @@ export const acceptProposalInvite = async ({
             acceptedOn: { isNull: true },
           },
         })) ?? null;
+
+      // Without an explicit pending decision invite we have no role to assign
+      // on the parent decision profile. Fail rather than silently granting a
+      // global Member role (which produced process members with no role-
+      // specific assignment).
+      if (!pendingDecisionInvite) {
+        throw new NotFoundError(
+          'Pending decision invite',
+          decisionProfileIdToAdd,
+        );
+      }
     }
   }
 
@@ -139,21 +146,24 @@ export const acceptProposalInvite = async ({
     ];
 
     if (decisionProfileUser) {
+      // Guard ensured above: if we created a decision profile user, there is a
+      // pending decision invite whose role we use for the assignment.
+      if (!pendingDecisionInvite) {
+        throw new CommonError(
+          'Missing pending decision invite for decision membership',
+        );
+      }
+
       followUpWrites.push(
         tx.insert(profileUserToAccessRoles).values({
           profileUserId: decisionProfileUser.id,
-          accessRoleId: pendingDecisionInvite?.accessRoleId ?? memberRole.id,
+          accessRoleId: pendingDecisionInvite.accessRoleId,
         }),
+        tx
+          .update(profileInvites)
+          .set({ acceptedOn: now })
+          .where(eq(profileInvites.id, pendingDecisionInvite.id)),
       );
-
-      if (pendingDecisionInvite) {
-        followUpWrites.push(
-          tx
-            .update(profileInvites)
-            .set({ acceptedOn: now })
-            .where(eq(profileInvites.id, pendingDecisionInvite.id)),
-        );
-      }
     }
 
     await Promise.all(followUpWrites);

--- a/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
+++ b/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
@@ -20,7 +20,7 @@ async function createAuthenticatedCaller(email: string) {
 }
 
 describe.concurrent('decision.acceptProposalInvite', () => {
-  it('should add user as Member of the decision process when accepting a proposal invite', async ({
+  it('should fail when no pending decision invite exists for a non-member of the parent process', async ({
     task,
     onTestFinished,
   }) => {
@@ -63,45 +63,38 @@ describe.concurrent('decision.acceptProposalInvite', () => {
     profileData.trackProfileInvite(invitee.email, proposal.profileId);
 
     const caller = await createAuthenticatedCaller(invitee.email);
-    await caller.decision.acceptProposalInvite({
-      profileId: proposal.profileId,
+
+    await expect(
+      caller.decision.acceptProposalInvite({
+        profileId: proposal.profileId,
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'NotFoundError' },
     });
 
-    // Assert: user is a profileUser of the proposal profile
+    // Assert: no proposal profileUser was created
     const proposalProfileUser = await db.query.profileUsers.findFirst({
       where: {
         profileId: proposal.profileId,
         authUserId: invitee.authUserId,
       },
     });
-    expect(proposalProfileUser).toBeDefined();
-    expect(proposalProfileUser?.profileId).toBe(proposal.profileId);
-    expect(proposalProfileUser?.authUserId).toBe(invitee.authUserId);
+    expect(proposalProfileUser).toBeUndefined();
 
-    // Assert: proposal invite was marked as accepted
-    const updatedInvite = await db.query.profileInvites.findFirst({
+    // Assert: proposal invite was NOT marked accepted
+    const unchangedInvite = await db.query.profileInvites.findFirst({
       where: { id: invite.id },
     });
-    expect(updatedInvite?.acceptedOn).not.toBeNull();
+    expect(unchangedInvite?.acceptedOn).toBeNull();
 
-    // Assert: user is a profileUser of the decision process profile with Member role
+    // Assert: no decision profileUser was created
     const decisionProfileUser = await db.query.profileUsers.findFirst({
       where: {
         profileId: instance.profileId,
         authUserId: invitee.authUserId,
       },
-      with: {
-        roles: {
-          with: {
-            accessRole: true,
-          },
-        },
-      },
     });
-
-    expect(decisionProfileUser).toBeDefined();
-    expect(decisionProfileUser?.roles).toHaveLength(1);
-    expect(decisionProfileUser?.roles[0]?.accessRole.id).toBe(ROLES.MEMBER.id);
+    expect(decisionProfileUser).toBeUndefined();
   });
 
   it('should skip decision membership if user is already a member', async ({

--- a/tests/e2e/tests/proposal-invite.spec.ts
+++ b/tests/e2e/tests/proposal-invite.spec.ts
@@ -61,14 +61,25 @@ test.describe('Proposal Invite', () => {
       .set({ currentProfileId: org.organizationProfile.id })
       .where(eq(users.authUserId, invitee.id));
 
-    // Insert a pending proposal invite for the new user
-    await db.insert(profileInvites).values({
-      email: inviteeEmail,
-      profileId: proposal.profileId,
-      profileEntityType: EntityType.PROPOSAL,
-      accessRoleId: ROLES.MEMBER.id,
-      invitedBy: instance.profileId,
-    });
+    // Insert pending invites for both the decision process and the proposal —
+    // accepting the proposal invite also promotes the user into the parent
+    // decision process via the matching pending decision invite.
+    await db.insert(profileInvites).values([
+      {
+        email: inviteeEmail,
+        profileId: instance.profileId,
+        profileEntityType: EntityType.DECISION,
+        accessRoleId: ROLES.MEMBER.id,
+        invitedBy: instance.profileId,
+      },
+      {
+        email: inviteeEmail,
+        profileId: proposal.profileId,
+        profileEntityType: EntityType.PROPOSAL,
+        accessRoleId: ROLES.MEMBER.id,
+        invitedBy: instance.profileId,
+      },
+    ]);
 
     // Authenticate as the invitee
     await authenticateAsUser(page, {


### PR DESCRIPTION
## Summary

- Removes the `assertGlobalRole('Member')` fallback in `acceptProposalInvite` that silently granted the global Member role on a parent decision profile when no pending decision invite existed — surfaced process members without role-specific assignments.
- Now requires a pending `EntityType.DECISION` invite on the parent process for any non-member acceptor. Without one, the call throws `NotFoundError('Pending decision invite', ...)` and nothing is written (transaction never starts).
- Updates the existing `valid invite redirects to proposal page` e2e to seed both a decision and proposal pending invite, matching the new contract.

Fixes the [Asana P0 bug](https://app.asana.com/0/1213315744811204/1214689206582229).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 674/674 pass
- [x] `pnpm e2e proposal-invite.spec` — 2/2 pass
- [x] `fallow audit --base dev` — verdict warn, 0 introduced dead-code / 0 introduced complexity (2 introduced clones are test boilerplate already prevalent in the file)
- [ ] Manual: invitee with proposal invite + paired decision invite → acceptance redirects to proposal edit, lands as decision member with the invited role
- [ ] Manual: invitee with proposal invite but no decision invite → acceptance is a no-op, redirect to proposal edit shows access error (no silent global Member role)

## Deferred

Secondary scope from the task — preventing the invite-creation UI from offering a global Member role on a proposal — needs a separate architectural decision (proposal profiles have no scoped roles today, so this either requires seeding proposal-scoped roles in `createProposal` or restructuring the invite flow). Left as a follow-up.