### PR TITLE
fix(decisions): rename "About the process" CTA to "Learn more"

### DIFF
--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -59,7 +59,7 @@ export const DecisionActionBar = ({
         {description ? (
           <DialogTrigger>
             <Button color="secondary" className="w-full">
-              {t('About the process')}
+              {t('Learn more')}
             </Button>
 
             <Modal isDismissable>


### PR DESCRIPTION
## Summary

- Renames the modal trigger button on the decision process page from "About the process" to "Learn more".
- Reuses the existing `Learn more` i18n key — no new translation strings needed.
- Modal header still reads "About the process" since the modal describes the process itself; only the CTA changed.

## Test plan

- [x] Open a decision process page (with a description set) and confirm the secondary button reads "Learn more".
- [x] Click the button and confirm the modal still opens with the same content and "About the process" header.

<img width="1017" height="529" alt="Screenshot 2026-05-15 at 3 27 56 PM" src="https://github.com/user-attachments/assets/3724b552-3898-4a09-8ea8-8364d543d900" />
