### PR TITLE
fix(decisions): restore outline on inactive Like/Follow buttons

### DIFF
--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
@@ -53,7 +53,6 @@ export function ProposalCardActions({
       <Button
         onPress={handleLikeClick}
         size="small"
-        surface="outline"
         color={isLikedByUser ? 'verified' : 'secondary'}
         className="w-full text-nowrap"
         isDisabled={isLoading}
@@ -64,7 +63,6 @@ export function ProposalCardActions({
       <Button
         onPress={handleFollowClick}
         size="small"
-        surface="outline"
         color={isFollowedByUser ? 'verified' : 'secondary'}
         className="w-full text-nowrap"
         isDisabled={isLoading}
@@ -135,7 +133,6 @@ export function ProposalCardOwnerActions({
         <ButtonLink
           href={editHref}
           color="secondary"
-          surface="outline"
           size="small"
           className="w-full"
         >
@@ -149,7 +146,6 @@ export function ProposalCardOwnerActions({
           <Button
             onPress={() => setIsDeleteModalOpen(true)}
             color="secondary"
-            surface="outline"
             size="small"
             className="w-full"
             isDisabled={deleteProposalMutation.isPending}

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
@@ -53,6 +53,7 @@ export function ProposalCardActions({
       <Button
         onPress={handleLikeClick}
         size="small"
+        surface="outline"
         color={isLikedByUser ? 'verified' : 'secondary'}
         className="w-full text-nowrap"
         isDisabled={isLoading}
@@ -63,6 +64,7 @@ export function ProposalCardActions({
       <Button
         onPress={handleFollowClick}
         size="small"
+        surface="outline"
         color={isFollowedByUser ? 'verified' : 'secondary'}
         className="w-full text-nowrap"
         isDisabled={isLoading}
@@ -133,6 +135,7 @@ export function ProposalCardOwnerActions({
         <ButtonLink
           href={editHref}
           color="secondary"
+          surface="outline"
           size="small"
           className="w-full"
         >
@@ -146,6 +149,7 @@ export function ProposalCardOwnerActions({
           <Button
             onPress={() => setIsDeleteModalOpen(true)}
             color="secondary"
+            surface="outline"
             size="small"
             className="w-full"
             isDisabled={deleteProposalMutation.isPending}

--- a/apps/app/src/components/decisions/ProposalViewLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalViewLayout.tsx
@@ -83,7 +83,7 @@ export function ProposalViewLayout({
             </Button>
           )}
           <Button
-            surface={isLiked ? undefined : 'outline'}
+            surface="outline"
             color={isLiked ? 'verified' : 'secondary'}
             size="small"
             onPress={onLike}
@@ -93,7 +93,7 @@ export function ProposalViewLayout({
             {isLiked ? t('Liked') : t('Like')}
           </Button>
           <Button
-            surface={isFollowing ? undefined : 'outline'}
+            surface="outline"
             color={isFollowing ? 'verified' : 'secondary'}
             size="small"
             onPress={onFollow}

--- a/apps/app/src/components/decisions/ProposalViewLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalViewLayout.tsx
@@ -83,7 +83,7 @@ export function ProposalViewLayout({
             </Button>
           )}
           <Button
-            surface={isLiked ? undefined : 'ghost'}
+            surface={isLiked ? undefined : 'outline'}
             color={isLiked ? 'verified' : 'secondary'}
             size="small"
             onPress={onLike}
@@ -93,7 +93,7 @@ export function ProposalViewLayout({
             {isLiked ? t('Liked') : t('Like')}
           </Button>
           <Button
-            surface={isFollowing ? undefined : 'ghost'}
+            surface={isFollowing ? undefined : 'outline'}
             color={isFollowing ? 'verified' : 'secondary'}
             size="small"
             onPress={onFollow}


### PR DESCRIPTION
## Summary

Top header buttons on the proposal-view page (Like / Follow when inactive) were rendering without a visible outline, while the Edit button next to them rendered correctly.

Root cause: in `ProposalViewLayout.tsx`, the inactive Like and Follow buttons used `surface="ghost"`. The `ghost` surface variant in `packages/ui/src/components/Button.tsx` adds `border-transparent`, which overrides the gray border that comes from `color="secondary"`. The Edit button in the same header uses `surface="outline"` (transparent background, border preserved) and already looked correct — this PR brings Like and Follow in line.

Two-character diff per button. No behavior change beyond the visual outline.

Asana: https://app.asana.com/0/1213315744811204/1214781797855076