### PR TITLE
feat(account): allow self-delete for users without organizations

### DIFF
--- a/apps/app/src/components/DeleteOrganizationModal/index.tsx
+++ b/apps/app/src/components/DeleteOrganizationModal/index.tsx
@@ -6,6 +6,7 @@ import { RouterOutput } from '@op/api';
 import { trpc } from '@op/api/client';
 import { EntityType } from '@op/api/encoders';
 import { match } from '@op/core';
+import { useAuthLogout } from '@op/hooks';
 import { Avatar } from '@op/ui/Avatar';
 import { Button } from '@op/ui/Button';
 import { Modal, ModalFooter, ModalHeader } from '@op/ui/Modal';
@@ -39,16 +40,13 @@ export const DeleteOrganizationModal = ({
   const utils = trpc.useUtils();
   const { user } = useUser();
   const deleteProfile = trpc.organization.deleteOrganization.useMutation();
+  const deleteAccount = trpc.account.deleteAccount.useMutation();
   const switchProfile = trpc.account.switchProfile.useMutation();
+  const logout = useAuthLogout();
 
   const router = useRouter();
 
-  const userProfiles =
-    profiles?.filter(
-      (profile) =>
-        // Filter out everything that's not an ORG profile
-        profile && profile?.type === EntityType.ORG,
-    ) ?? [];
+  const userProfiles = profiles ?? [];
 
   const closeModal = () => {
     onOpenChange?.(false);
@@ -57,17 +55,23 @@ export const DeleteOrganizationModal = ({
   };
 
   const handleSubmit = () => {
-    if (!selectedProfileId) {
-      throw new Error('handleSubmit called without selectedProfileId');
+    if (!selectedProfileId || !profileToDelete) {
+      throw new Error('handleSubmit called without a selected profile');
     }
+    const isIndividual = profileToDelete.type === EntityType.INDIVIDUAL;
     startTransition(async () => {
       try {
+        if (isIndividual) {
+          await deleteAccount.mutateAsync();
+          await logout.refetch();
+          router.push('/');
+          return;
+        }
+
         await deleteProfile.mutateAsync({
           organizationProfileId: selectedProfileId,
         });
 
-        // Check if the deletedProfile is the user's current profile
-        // if so, switch to the user's individual profile
         if (user.currentProfile?.id === selectedProfileId) {
           const personalProfile = profiles?.find(
             (profile) => profile.type === EntityType.INDIVIDUAL,

--- a/packages/common/src/services/user/deleteAccount.ts
+++ b/packages/common/src/services/user/deleteAccount.ts
@@ -1,0 +1,52 @@
+import { invalidate } from '@op/cache';
+import { db, eq } from '@op/db/client';
+import { organizationUsers, profiles, users } from '@op/db/schema';
+import { createSBServiceClient } from '@op/supabase/server';
+import type { User } from '@supabase/supabase-js';
+
+import { NotFoundError } from '../../utils';
+
+export async function deleteAccount({ user }: { user: User }) {
+  const [dbUser] = await db
+    .select({ profileId: users.profileId })
+    .from(users)
+    .where(eq(users.authUserId, user.id));
+
+  if (!dbUser) {
+    throw new NotFoundError('User', user.id);
+  }
+
+  const orgMemberships = await db
+    .select({ organizationId: organizationUsers.organizationId })
+    .from(organizationUsers)
+    .where(eq(organizationUsers.authUserId, user.id));
+
+  // Delete the individual profile first. users.profileId is ON DELETE SET NULL,
+  // so the subsequent auth-user cascade still removes the users row cleanly.
+  if (dbUser.profileId) {
+    const [deletedProfile] = await db
+      .delete(profiles)
+      .where(eq(profiles.id, dbUser.profileId))
+      .returning();
+
+    if (deletedProfile) {
+      invalidate({ type: 'profile', params: [deletedProfile.id] });
+      invalidate({ type: 'profile', params: [deletedProfile.slug] });
+    }
+  }
+
+  // Deleting the auth user cascades to public.users and organization_users.
+  const supabase = createSBServiceClient();
+  const { error } = await supabase.auth.admin.deleteUser(user.id);
+
+  if (error) {
+    throw error;
+  }
+
+  invalidate({ type: 'user', params: [user.id] });
+  for (const { organizationId } of orgMemberships) {
+    invalidate({ type: 'orgUser', params: [organizationId, user.id] });
+  }
+
+  return { deletedId: user.id };
+}

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -429,3 +429,5 @@ export const completeOnboarding = async ({
     })
     .where(eq(users.authUserId, authUserId));
 };
+
+export { deleteAccount } from './deleteAccount';

--- a/services/api/src/routers/account/deleteAccount.test.ts
+++ b/services/api/src/routers/account/deleteAccount.test.ts
@@ -1,0 +1,85 @@
+import { db } from '@op/db/client';
+import { users } from '@op/db/schema';
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { TestOrganizationDataManager } from '../../test/helpers/TestOrganizationDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+  supabaseTestAdminClient,
+} from '../../test/supabase-utils';
+import { createCallerFactory } from '../../trpcFactory';
+import accountRouter from '.';
+
+describe.concurrent('account.deleteAccount', () => {
+  const createCaller = createCallerFactory(accountRouter);
+
+  it('reject unauthenticated callers', async () => {
+    const caller = createCaller(await createTestContextWithSession(null));
+
+    await expect(caller.deleteAccount()).rejects.toMatchObject({
+      cause: {
+        name: 'UnauthorizedError',
+      },
+    });
+  });
+
+  it('deletes the current user, their individual profile, and the auth user', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestOrganizationDataManager(task.id, onTestFinished);
+    const { adminUser } = await testData.createOrganization({
+      users: { admin: 1 },
+      organizationName: 'Delete Account Test Org',
+    });
+
+    // Hydrate the user's individual profile by calling getMyAccount once.
+    // The public.users row + individual profile are created lazily on first
+    // authenticated request.
+    const setupSession = await createIsolatedSession(adminUser.email);
+    const setupCaller = createCaller(
+      await createTestContextWithSession(setupSession.session),
+    );
+    await setupCaller.getMyAccount();
+
+    const [beforeUser] = await db
+      .select({ id: users.id, profileId: users.profileId })
+      .from(users)
+      .where(eq(users.authUserId, adminUser.authUserId));
+    expect(beforeUser).toBeDefined();
+    const individualProfileId = beforeUser?.profileId;
+    expect(individualProfileId).toBeTruthy();
+
+    const { session } = await createIsolatedSession(adminUser.email);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    const result = await caller.deleteAccount();
+    expect(result.deletedId).toBe(adminUser.authUserId);
+
+    // Individual profile is gone
+    if (individualProfileId) {
+      const remainingProfile = await db.query.profiles.findFirst({
+        where: { id: individualProfileId },
+      });
+      expect(remainingProfile).toBeUndefined();
+    }
+
+    // public.users row is gone (cascade from auth user delete)
+    const [remainingUser] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.authUserId, adminUser.authUserId));
+    expect(remainingUser).toBeUndefined();
+
+    // Auth user is gone
+    if (supabaseTestAdminClient) {
+      const { data, error } =
+        await supabaseTestAdminClient.auth.admin.getUserById(
+          adminUser.authUserId,
+        );
+      expect(error ?? !data.user).toBeTruthy();
+    }
+  });
+});

--- a/services/api/src/routers/account/deleteAccount.ts
+++ b/services/api/src/routers/account/deleteAccount.ts
@@ -1,0 +1,17 @@
+import { deleteAccount } from '@op/common';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../trpcFactory';
+
+const outputSchema = z.object({
+  deletedId: z.string(),
+});
+
+export const deleteAccountRouter = router({
+  deleteAccount: commonAuthedProcedure({
+    rateLimit: { windowSize: 60, maxRequests: 3 },
+  })
+    .input(z.undefined())
+    .output(outputSchema)
+    .mutation(({ ctx }) => deleteAccount({ user: ctx.user })),
+});

--- a/services/api/src/routers/account/index.ts
+++ b/services/api/src/routers/account/index.ts
@@ -1,5 +1,6 @@
 import { mergeRouters } from '../../trpcFactory';
 import { completeOnboarding } from './completeOnboarding';
+import { deleteAccountRouter } from './deleteAccount';
 import { getMyAccount } from './getMyAccount';
 import { getUserProfiles } from './getUserProfiles';
 import { listUserInvitesRouter } from './listUserInvites';
@@ -15,6 +16,7 @@ const accountRouter = mergeRouters(
   login,
   getMyAccount,
   completeOnboarding,
+  deleteAccountRouter,
   getUserProfiles,
   listUserInvitesRouter,
   updateUserProfile,


### PR DESCRIPTION
## Summary

- Users with zero organizations could not delete their account: the modal filtered to ORG profiles only, leaving the Remove button permanently disabled.
- Adds `account.deleteAccount` tRPC mutation that deletes the individual profile and the Supabase auth user (cascading to `public.users` and `organization_users`).
- Routes the modal's `INDIVIDUAL` branch to the new mutation, then signs the user out and redirects to `/`.

Asana: https://app.asana.com/0/1209477276073375/1214710291141669

## Test plan

- [ ] Sign in as a user with **no organizations** → open user menu → "Delete my account" → individual profile is listed → confirm → user is signed out and redirected to `/`; account is gone in Supabase + DB.
- [ ] Sign in as a user with one or more orgs → open delete modal → individual + org profiles both listed → deleting an org still works (no regression to existing org-delete flow).
- [ ] Verify rate limit: 3 deleteAccount attempts within 60s should rate-limit.
- [ ] `services/api`: `pnpm vitest run src/routers/account/deleteAccount.test.ts` passes.
