### PR TITLE
fix(decisions): use toast message prop for proposal resubmit feedback

### DIFF
--- a/apps/app/src/components/decisions/proposalEditor/ResubmitProposalModal.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ResubmitProposalModal.tsx
@@ -30,13 +30,13 @@ export function ResubmitProposalModal({
   const submitRevisionResponse =
     trpc.decision.submitRevisionResponse.useMutation({
       onSuccess: () => {
-        toast.success({ title: t('Proposal resubmitted') });
+        toast.success({ message: t('Proposal resubmitted') });
         onOpenChange(false);
         setComment('');
         router.push(backHref);
       },
       onError: () => {
-        toast.error({ title: t('Failed to resubmit proposal') });
+        toast.error({ message: t('Failed to resubmit proposal') });
       },
     });
 


### PR DESCRIPTION
## Summary

- `ResubmitProposalModal` was passing the success/error string to `toast.success`/`toast.error` as `title`, which renders larger than the body styling used everywhere else in the decisions surface.
- Switched both calls to `message:` to match the convention used by `DecisionListItem`, `DecisionProcessStepper`, `ShareProposalModal`, etc.

Asana: https://app.asana.com/0/1209477276073375/1214710291986927

## Test plan

- [ ] Open a proposal in revision-requested state → resubmit → confirm the "Proposal resubmitted" toast renders at the smaller body size, matching toasts on other proposal actions (Share, Delete, etc.).
- [ ] Trigger the error path (e.g., simulate failure) → "Failed to resubmit proposal" toast renders at the same size.
