### PR TITLE
fix(search): render search dropdown text at text-base size

### DIFF
--- a/apps/app/src/components/SearchInput/index.tsx
+++ b/apps/app/src/components/SearchInput/index.tsx
@@ -207,7 +207,7 @@ export const SearchInput = ({ onBlur }: { onBlur?: () => void } = {}) => {
       >
         {dropdownShowing ? (
           <div
-            className="absolute top-10 z-10 hidden !max-h-80 w-(--trigger-width) min-w-96 overflow-y-auto rounded-b border border-t-0 bg-white group-hover:border-neutral-gray2 sm:block"
+            className="absolute top-10 z-10 hidden !max-h-80 w-(--trigger-width) min-w-96 overflow-y-auto rounded-b border border-t-0 bg-white text-base group-hover:border-neutral-gray2 sm:block"
             role="listbox"
             aria-label={t('Search results')}
           >
@@ -253,7 +253,7 @@ export const SearchInput = ({ onBlur }: { onBlur?: () => void } = {}) => {
       {/* Mobile full-screen search results */}
       {dropdownShowing && (
         <div
-          className="fixed inset-x-0 top-[60px] bottom-0 z-10 block overflow-y-auto bg-white sm:hidden"
+          className="fixed inset-x-0 top-[60px] bottom-0 z-10 block overflow-y-auto bg-white text-base sm:hidden"
           role="listbox"
           aria-label={t('Search results')}
         >


### PR DESCRIPTION
## Summary

- Text inside the global search dropdown rendered smaller than `text-base` because both wrappers (desktop popover and mobile fullscreen sheet) inherited the `size: small` from the underlying `TextField`.
- Added `text-base` to both wrappers so the dropdown content — "search for {query}" CTA, profile names, "Recent Searches" header and recent items — render at body size. The explicit `text-sm` override on the profile subtitle keeps that line smaller.

Asana: https://app.asana.com/0/1209477276073375/1214781705603621

## Test plan

- [ ] Click the header search → type a query → confirm result names + "search for {query}" link render at `text-base` (16px), subtitle stays `text-sm`.
- [ ] Empty the input → "Recent Searches" header and recent items render at `text-base`.
- [ ] Mobile breakpoint (< 640px): fullscreen results sheet matches.
