### PR TITLE
fix(onboarding): use text-base for subtitle in shared center layout

### DIFF
--- a/apps/app/src/components/Onboarding/OnboardingCenterLayout.tsx
+++ b/apps/app/src/components/Onboarding/OnboardingCenterLayout.tsx
@@ -15,7 +15,7 @@ export const OnboardingCenterLayout = ({
       <div className="flex w-full max-w-lg flex-col items-center gap-8 px-4 sm:px-0">
         <div className="flex flex-col gap-2 text-center">
           <Header1 className="text-neutral-black">{title}</Header1>
-          <p className="text-sm leading-normal text-neutral-gray4">
+          <p className="text-base leading-normal text-neutral-gray4">
             {subtitle}
           </p>
         </div>


### PR DESCRIPTION
## Summary

- The onboarding "One last step" screen rendered its description ("Our community shaped these policies…") at `text-sm` instead of `text-base`.
- The size lives on the shared `OnboardingCenterLayout`, so the same fix also normalizes the org-search onboarding screens that use the layout.

Asana: https://app.asana.com/0/1209477276073375/1214781705603625

## Test plan

- [ ] Walk through onboarding to the "One last step" screen → description renders at `text-base`.
- [ ] Org-search onboarding screens that use `OnboardingCenterLayout` → subtitle (if any) renders at `text-base`; no layout regression.
