### PR TITLE
feat(app): add baseline HTTP security headers

### DIFF
--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -133,6 +133,12 @@ const config = {
       "media-src 'self' blob: https:",
       "worker-src 'self' blob:",
       "frame-src 'self' https:",
+      // Ship violations to /api/csp-report, which forwards them to PostHog.
+      // report-uri is deprecated but still the only reporting channel Firefox
+      // honors; report-to (paired with the Reporting-Endpoints header below)
+      // is the modern channel used by Chromium.
+      'report-uri /api/csp-report',
+      'report-to csp-endpoint',
     ].join('; ');
 
     return [
@@ -146,7 +152,12 @@ const config = {
         ],
       },
       {
-        source: '/:path*',
+        // Everything except /api/embeds/*: that route proxies iframely's embed
+        // document and is framed same-origin (embed.js derives its iframe API
+        // base from its own /api/embeds origin), so a global X-Frame-Options:
+        // DENY / frame-ancestors 'none' would blank out every link-preview
+        // embed. The proxy sets its own sandbox CSP instead.
+        source: '/((?!api/embeds).*)',
         headers: [
           {
             key: 'Strict-Transport-Security',
@@ -165,9 +176,17 @@ const config = {
             value: 'strict-origin-when-cross-origin',
           },
           {
+            // geolocation=(self): the proposal location picker's "Use my
+            // location" button calls navigator.geolocation.getCurrentPosition.
+            // Locking it to () disables geolocation for our own origin too.
             key: 'Permissions-Policy',
             value:
-              'camera=(), microphone=(), geolocation=(), interest-cohort=()',
+              'camera=(), microphone=(), geolocation=(self), interest-cohort=()',
+          },
+          {
+            // Names the report-to group referenced by the CSP above.
+            key: 'Reporting-Endpoints',
+            value: 'csp-endpoint="/api/csp-report"',
           },
           {
             key: 'Content-Security-Policy-Report-Only',

--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -115,6 +115,26 @@ const config = {
     return config;
   },
   async headers() {
+    // Content-Security-Policy is left in Report-Only mode for now while we
+    // enumerate the inline-script needs (next/script, PostHog, TipTap collab,
+    // Supabase). Move to `Content-Security-Policy` (enforcing) once reports
+    // are clean.
+    const reportOnlyCsp = [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "frame-ancestors 'none'",
+      "form-action 'self'",
+      "object-src 'none'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://eu-assets.i.posthog.com",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https: wss:",
+      "media-src 'self' blob: https:",
+      "worker-src 'self' blob:",
+      "frame-src 'self' https:",
+    ].join('; ');
+
     return [
       {
         source: '/assets/:path*',
@@ -122,6 +142,36 @@ const config = {
           {
             key: 'Cache-Control',
             value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value:
+              'camera=(), microphone=(), geolocation=(), interest-cohort=()',
+          },
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: reportOnlyCsp,
           },
         ],
       },

--- a/apps/app/src/app/api/csp-report/route.ts
+++ b/apps/app/src/app/api/csp-report/route.ts
@@ -1,0 +1,92 @@
+import { trackEvent } from '@op/analytics';
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+// CSP violation reports arrive in two shapes: the legacy `report-uri` channel
+// (Firefox + older Chromium) POSTs `{ "csp-report": {...} }` with hyphenated
+// keys, while the modern `report-to` Reporting API (Chromium) POSTs an array of
+// `{ type, body }` entries with camelCase keys. Normalize both to one snake_case
+// bag so PostHog gets consistent properties regardless of browser.
+
+const cspReportSchema = z
+  .object({
+    'document-uri': z.string().optional(),
+    documentURL: z.string().optional(),
+    'violated-directive': z.string().optional(),
+    'effective-directive': z.string().optional(),
+    effectiveDirective: z.string().optional(),
+    'blocked-uri': z.string().optional(),
+    blockedURL: z.string().optional(),
+    disposition: z.string().optional(),
+    'source-file': z.string().optional(),
+    sourceFile: z.string().optional(),
+    'line-number': z.number().optional(),
+    lineNumber: z.number().optional(),
+    'column-number': z.number().optional(),
+    columnNumber: z.number().optional(),
+  })
+  .passthrough();
+
+type CspReport = z.infer<typeof cspReportSchema>;
+
+const payloadSchema = z.union([
+  z.array(
+    z.object({
+      type: z.string().optional(),
+      body: cspReportSchema.optional(),
+    }),
+  ),
+  z.object({ 'csp-report': cspReportSchema }),
+]);
+
+const normalize = (report: CspReport) => ({
+  document_uri: report['document-uri'] ?? report.documentURL,
+  effective_directive:
+    report['effective-directive'] ??
+    report.effectiveDirective ??
+    report['violated-directive'],
+  blocked_uri: report['blocked-uri'] ?? report.blockedURL,
+  disposition: report.disposition,
+  source_file: report['source-file'] ?? report.sourceFile,
+  line_number: report['line-number'] ?? report.lineNumber,
+  column_number: report['column-number'] ?? report.columnNumber,
+});
+
+export async function POST(request: NextRequest): Promise<Response> {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return new Response(null, { status: 204 });
+  }
+
+  const parsed = payloadSchema.safeParse(payload);
+  if (!parsed.success) {
+    return new Response(null, { status: 204 });
+  }
+
+  const reports = Array.isArray(parsed.data)
+    ? parsed.data.flatMap((entry) =>
+        entry.type === 'csp-violation' && entry.body ? [entry.body] : [],
+      )
+    : [parsed.data['csp-report']];
+
+  const userAgent = request.headers.get('user-agent') ?? undefined;
+
+  try {
+    await Promise.all(
+      reports.map((report) =>
+        trackEvent({
+          distinctId: 'csp-report',
+          event: 'csp_violation',
+          properties: { ...normalize(report), user_agent: userAgent },
+        }),
+      ),
+    );
+  } catch {
+    // Reporting is best-effort; a PostHog hiccup must never surface to the
+    // browser (and would just be retried on the next violation anyway).
+  }
+
+  return new Response(null, { status: 204 });
+}


### PR DESCRIPTION
## Summary

`apps/app/next.config.mjs` only set `Cache-Control` for `/assets/:path*` and shipped no security headers for the rest of the app. Add a global `/:path*` headers block covering the standard baseline:

- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()`
- `Content-Security-Policy-Report-Only` with a starter policy to enumerate what `next/script`, PostHog, TipTap collab, and Supabase need before we move to an enforcing CSP

CSP intentionally ships as **Report-Only** so we observe what trips it on real traffic before flipping to enforcing.

Asana: https://app.asana.com/0/1209477276073375/1214784071765159

## Test plan

- [ ] `pnpm w:app build && pnpm w:app start` → `curl -sI http://localhost:3100/` shows all six headers.
- [ ] `curl -sI http://localhost:3100/assets/some-key` still returns the immutable `Cache-Control` (existing rule preserved).
- [ ] App loads in the browser; check devtools console for `Content-Security-Policy-Report-Only` violations and triage before promoting to enforcing.
- [ ] PostHog stats, TipTap collab editing, Supabase auth callbacks, and uploaded image rendering all still work — collect any CSP-RO warnings to inform the eventual enforcing policy.
