### PR TITLE
fix(decisions): style Headers with design system typography in Rich Text

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/ForbiddenContent.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/ForbiddenContent.tsx
@@ -91,7 +91,7 @@ const ForbiddenWithInviteCheck = () => {
                 processInstanceName: matchingInvite.profile?.name,
               })}
             </Header1>
-            <Header2 className="text-neutral-gray4">
+            <Header2 className="font-sans text-neutral-gray4">
               {t('A decision-making process stewarded by {stewardName}.', {
                 stewardName: steward?.name ?? '',
               })}

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -399,7 +399,7 @@ export const PostItem = ({
       <FeedMain>
         <FeedHeader className="relative w-full justify-between">
           <div className="flex items-baseline gap-2">
-            <Header3 className="leading-3 font-semibold">
+            <Header3 className="font-sans leading-3 font-semibold">
               <PostDisplayName
                 displayName={displayName}
                 displaySlug={displaySlug}
@@ -477,7 +477,7 @@ export const PostItemOnDetailPage = ({
       <FeedMain>
         <FeedHeader className="relative w-full justify-between">
           <div className="flex items-baseline gap-2">
-            <Header3 className="leading-3 font-semibold">
+            <Header3 className="font-sans leading-3 font-semibold">
               <PostDisplayName
                 displayName={displayName}
                 displaySlug={displaySlug}
@@ -622,7 +622,7 @@ export const PostFeedSkeleton = ({
           <AvatarSkeleton className="!size-8 max-h-8 max-w-8 rounded-full" />
           <FeedMain>
             <FeedHeader className="w-1/2">
-              <Header3 className="w-full pb-1 leading-5 font-medium">
+              <Header3 className="w-full pb-1 font-sans leading-5 font-medium">
                 <Skeleton />
               </Header3>
               <Skeleton />

--- a/apps/app/src/components/Profile/ProfileContent/index.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/index.tsx
@@ -51,7 +51,7 @@ const FocusAreas = ({
 
   return (
     <section className="flex flex-col gap-2 text-neutral-charcoal">
-      <Header3>{t('Focus Areas')}</Header3>
+      <Header3 className="font-sans">{t('Focus Areas')}</Header3>
       <TagGroup>
         {focusAreas.map((term) => (
           <Tag key={term.label}>{term.label}</Tag>
@@ -97,7 +97,7 @@ const CommunitiesServed = ({ profileId }: { profileId: string }) => {
 
   return (
     <section className="flex flex-col gap-2 text-neutral-charcoal">
-      <Header3>{t('Communities We Serve')}</Header3>
+      <Header3 className="font-sans">{t('Communities We Serve')}</Header3>
       <TagGroup>
         {communitiesServed.map((term) => (
           <Tag key={term.label}>{term.label}</Tag>
@@ -128,7 +128,7 @@ const ProfileAbout = ({
       <div className="flex flex-col gap-4 rounded border p-4 sm:rounded-none sm:border-none sm:p-0">
         {email || website ? (
           <section className="flex flex-col gap-2">
-            <Header3>{t('Contact')}</Header3>
+            <Header3 className="font-sans">{t('Contact')}</Header3>
             <div className="flex flex-col text-teal">
               {website ? (
                 <ContactLink>
@@ -177,7 +177,9 @@ const ProfileAbout = ({
 
         {orgType ? (
           <section className="flex flex-col gap-2 text-neutral-charcoal">
-            <Header3>{t('Organizational Status')}</Header3>
+            <Header3 className="font-sans">
+              {t('Organizational Status')}
+            </Header3>
             <TagGroup>
               <Tag className="capitalize">{orgType}</Tag>
             </TagGroup>
@@ -186,14 +188,14 @@ const ProfileAbout = ({
 
         {mission ? (
           <section className="flex flex-col gap-2 text-neutral-charcoal">
-            <Header3>{t('Mission Statement')}</Header3>
+            <Header3 className="font-sans">{t('Mission Statement')}</Header3>
             <p>{mission}</p>
           </section>
         ) : null}
 
         {strategies?.length > 0 ? (
           <section className="flex flex-col gap-2 text-neutral-charcoal">
-            <Header3>{t('Strategies')}</Header3>
+            <Header3 className="font-sans">{t('Strategies')}</Header3>
             <TagGroup>
               {strategies.map((strategy) =>
                 strategy ? (
@@ -211,7 +213,7 @@ const ProfileAbout = ({
           <Suspense
             fallback={
               <section className="flex flex-col gap-2 text-neutral-charcoal">
-                <Header3>{t('Focus Areas')}</Header3>
+                <Header3 className="font-sans">{t('Focus Areas')}</Header3>
                 <div className="flex flex-wrap gap-2">
                   <Skeleton className="h-6 w-16" />
                   <Skeleton className="h-6 w-20" />
@@ -232,7 +234,9 @@ const ProfileAbout = ({
           <Suspense
             fallback={
               <section className="flex flex-col gap-2 text-neutral-charcoal">
-                <Header3>{t('Communities We Serve')}</Header3>
+                <Header3 className="font-sans">
+                  {t('Communities We Serve')}
+                </Header3>
                 <div className="flex flex-wrap gap-2">
                   <Skeleton className="h-6 w-18" />
                   <Skeleton className="h-6 w-24" />

--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -45,7 +45,7 @@ export function ProposalComments({
   return (
     <div ref={containerRef}>
       <div className="border-t pt-8">
-        <Header3 className="mb-6">
+        <Header3 className="mb-6 font-sans">
           {t('Comments')} ({comments.length})
         </Header3>
 

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -260,7 +260,7 @@ export function ProposalPreview({
       {/* Attachments Section */}
       {proposal.attachments && proposal.attachments.length > 0 && (
         <div className="border-t pt-8">
-          <Header3 className="mb-4">{t('Attachments')}</Header3>
+          <Header3 className="mb-4 font-sans">{t('Attachments')}</Header3>
           <ProposalAttachmentViewList attachments={proposal.attachments} />
         </div>
       )}

--- a/apps/app/src/components/decisions/VoteSuccessModal.tsx
+++ b/apps/app/src/components/decisions/VoteSuccessModal.tsx
@@ -68,7 +68,9 @@ const VoteSuccessModalSuspense = ({
 
               {nextSteps.length > 0 && (
                 <div className="flex w-full flex-col gap-6 text-start text-base text-neutral-charcoal">
-                  <Header3>{t("Here's what will happen next:")}</Header3>
+                  <Header3 className="font-sans">
+                    {t("Here's what will happen next:")}
+                  </Header3>
                   <ul className="flex flex-col gap-4 ps-4">
                     {nextSteps.map((step) => (
                       <li key={step.id} className="flex items-start gap-2">

--- a/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
+++ b/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
@@ -106,7 +106,7 @@ export const ComingSoonScreen = () => {
         </section>
         <FadeInWrapper>
           <section className="space-y-6">
-            <Header3 className="text-base">{t('Trusted by')}</Header3>
+            <Header3 className="font-sans text-base">{t('Trusted by')}</Header3>
             <LogoLoop
               logos={logos}
               speed={20}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -28,6 +28,7 @@
     "@op/db": "workspace:*",
     "@op/emails": "workspace:*",
     "@op/events": "workspace:*",
+    "@op/styles": "workspace:*",
     "@op/translation": "workspace:*",
     "@rjsf/utils": "catalog:",
     "@tiptap/core": "catalog:",

--- a/packages/common/src/services/decision/tiptapExtensions.ts
+++ b/packages/common/src/services/decision/tiptapExtensions.ts
@@ -1,3 +1,4 @@
+import { headingClasses } from '@op/styles/constants';
 import { Node, mergeAttributes } from '@tiptap/core';
 import Heading from '@tiptap/extension-heading';
 import Image from '@tiptap/extension-image';
@@ -5,6 +6,27 @@ import Link from '@tiptap/extension-link';
 import TextAlign from '@tiptap/extension-text-align';
 import Underline from '@tiptap/extension-underline';
 import StarterKit from '@tiptap/starter-kit';
+
+/**
+ * Server-side mirror of the `StyledHeading` extension in `@op/ui`. Bakes the
+ * shared `headingClasses` onto each rendered heading tag so `generateHTML()`
+ * output matches the live editor and the `Header1/2/3` design-system
+ * components exactly.
+ */
+const StyledHeading = Heading.extend({
+  renderHTML({ node, HTMLAttributes }) {
+    const level = node.attrs.level as 1 | 2 | 3;
+    const className =
+      headingClasses[`h${level}` as keyof typeof headingClasses];
+    return [
+      `h${level}`,
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        class: className,
+      }),
+      0,
+    ];
+  },
+});
 
 /**
  * Server-safe Iframely node extension for `generateHTML()`.
@@ -69,7 +91,7 @@ export const serverExtensions = [
   StarterKit.configure({
     heading: false,
   }),
-  Heading.configure({
+  StyledHeading.configure({
     levels: [1, 2, 3],
   }),
   TextAlign.configure({

--- a/packages/styles/constants.ts
+++ b/packages/styles/constants.ts
@@ -7,3 +7,15 @@ export const screens = {
   xl: '1280px', // 80rem
   xxl: '1536px', // 96rem
 };
+
+/**
+ * Canonical heading class strings shared between the `Header1/2/3` components
+ * in `@op/ui` and the TipTap rich text editor's `StyledHeading` extension.
+ * Keeping these as literal Tailwind class strings ensures the build-time
+ * scanner picks them up.
+ */
+export const headingClasses = {
+  h1: 'font-serif text-title-sm sm:text-title-lg',
+  h2: 'text-title-lg text-neutral-black',
+  h3: 'text-title-base text-neutral-black',
+} as const;

--- a/packages/styles/constants.ts
+++ b/packages/styles/constants.ts
@@ -9,7 +9,7 @@ export const screens = {
 };
 
 /**
- * Canonical heading class strings shared between the `Header1/2/3` components
+ * Canonical heading class strings shared between the `Header1/2/3/4` components
  * in `@op/ui` and the TipTap rich text editor's `StyledHeading` extension.
  * Keeping these as literal Tailwind class strings ensures the build-time
  * scanner picks them up.
@@ -18,4 +18,5 @@ export const headingClasses = {
   h1: 'font-serif text-title-sm sm:text-title-lg',
   h2: 'font-serif text-title-lg text-neutral-black',
   h3: 'font-serif text-title-base text-neutral-black',
+  h4: 'font-serif text-title-sm14 text-neutral-black',
 } as const;

--- a/packages/styles/constants.ts
+++ b/packages/styles/constants.ts
@@ -16,6 +16,6 @@ export const screens = {
  */
 export const headingClasses = {
   h1: 'font-serif text-title-sm sm:text-title-lg',
-  h2: 'text-title-lg text-neutral-black',
-  h3: 'text-title-base text-neutral-black',
+  h2: 'font-serif text-title-lg text-neutral-black',
+  h3: 'font-serif text-title-base text-neutral-black',
 } as const;

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -9,6 +9,7 @@
 @source '../ui/stories/**/*.{js,ts,jsx,tsx}';
 @source '../sense/src/**/*.{js,ts,jsx,tsx}';
 @source '../../apps/app/src/**/*.{js,ts,jsx,tsx}';
+@source './constants.ts';
 
 /* React Aria Components data attribute variants */
 @plugin 'tailwindcss-react-aria-components';

--- a/packages/ui/src/components/AvatarUploader.tsx
+++ b/packages/ui/src/components/AvatarUploader.tsx
@@ -82,7 +82,7 @@ export const AvatarUploader = ({
       </div>
 
       <div className="text-center">
-        <Header2 className="text-sm">{label}</Header2>
+        <Header2 className="font-sans text-sm">{label}</Header2>
       </div>
     </div>
   );

--- a/packages/ui/src/components/BannerUploader.tsx
+++ b/packages/ui/src/components/BannerUploader.tsx
@@ -76,7 +76,7 @@ export const BannerUploader = ({
       </div>
 
       <div className="text-center">
-        <Header2 className="text-xs">{label}</Header2>
+        <Header2 className="font-sans text-xs">{label}</Header2>
         {error && <p className="mt-2 text-functional-red">{error}</p>}
       </div>
     </div>

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -1,3 +1,5 @@
+import { headingClasses } from '@op/styles/constants';
+
 import { cn } from '../lib/utils';
 
 export const Header1 = ({
@@ -7,11 +9,7 @@ export const Header1 = ({
   children: React.ReactNode;
   className?: string;
 }) => {
-  return (
-    <h1 className={cn('font-serif text-title-sm sm:text-title-lg', className)}>
-      {children}
-    </h1>
-  );
+  return <h1 className={cn(headingClasses.h1, className)}>{children}</h1>;
 };
 
 export const Header2 = ({
@@ -21,11 +19,7 @@ export const Header2 = ({
   children: React.ReactNode;
   className?: string;
 }) => {
-  return (
-    <h2 className={cn('text-title-lg text-neutral-black', className)}>
-      {children}
-    </h2>
-  );
+  return <h2 className={cn(headingClasses.h2, className)}>{children}</h2>;
 };
 
 export const Header3 = ({
@@ -35,11 +29,7 @@ export const Header3 = ({
   children: React.ReactNode;
   className?: string;
 }) => {
-  return (
-    <h3 className={cn('text-title-base text-neutral-black', className)}>
-      {children}
-    </h3>
-  );
+  return <h3 className={cn(headingClasses.h3, className)}>{children}</h3>;
 };
 
 export const Header4 = ({

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -39,13 +39,7 @@ export const Header4 = ({
   children: React.ReactNode;
   className?: string;
 }) => {
-  return (
-    <h4
-      className={cn('font-serif text-title-sm14 text-neutral-black', className)}
-    >
-      {children}
-    </h4>
-  );
+  return <h4 className={cn(headingClasses.h4, className)}>{children}</h4>;
 };
 
 export const GradientHeader = ({

--- a/packages/ui/src/components/MediaDisplay/index.tsx
+++ b/packages/ui/src/components/MediaDisplay/index.tsx
@@ -31,7 +31,7 @@ export const MediaDisplay = ({
 
   if (title && mimeType?.match(/application\/pdf/)) {
     detailComponents.push(
-      <Header3 key="title" className="text-base text-neutral-black">
+      <Header3 key="title" className="font-sans text-base text-neutral-black">
         {title}
       </Header3>,
     );

--- a/packages/ui/src/components/RichTextEditor/editorConfig.ts
+++ b/packages/ui/src/components/RichTextEditor/editorConfig.ts
@@ -20,7 +20,7 @@ export const viewerProseStyles = [
   '[&_a:hover]:underline [&_a]:text-teal [&_a]:no-underline',
   '[&_li_p]:my-0',
   '[&_blockquote]:font-normal',
-  '[&_:is(h1,h2)]:my-4 [&_:is(h1,h2)]:font-serif',
+  '[&_:is(h1,h2,h3)]:my-4 [&_:is(h1,h2,h3)]:font-serif [&_:is(h1,h2,h3)]:text-neutral-black',
   '[&_h1]:text-title-lg [&_h2]:text-title-md [&_h3]:text-title-base',
   'leading-5 max-w-none break-words overflow-wrap-anywhere',
 ].join(' ');

--- a/packages/ui/src/components/RichTextEditor/editorConfig.ts
+++ b/packages/ui/src/components/RichTextEditor/editorConfig.ts
@@ -1,3 +1,5 @@
+import { headingClasses } from '@op/styles/constants';
+import { mergeAttributes } from '@tiptap/core';
 import Blockquote from '@tiptap/extension-blockquote';
 import Heading from '@tiptap/extension-heading';
 import HorizontalRule from '@tiptap/extension-horizontal-rule';
@@ -12,16 +14,17 @@ import StarterKit from '@tiptap/starter-kit';
  * Prose typography styles shared between the TipTap editor/viewer and the
  * static HTML proposal viewer (`ProposalHtmlContent`).
  *
- * Covers link colors, list spacing, blockquote weight, heading typography,
- * and general text layout. Does NOT include focus or placeholder styles.
+ * Covers link colors, list spacing, blockquote weight, prose-context heading
+ * margins, and general text layout. Heading typography itself is applied on
+ * the heading tags via `StyledHeading` so it stays in sync with the
+ * `Header*` design-system components.
  */
 export const viewerProseStyles = [
   'prose prose-lg !text-base text-neutral-black',
   '[&_a:hover]:underline [&_a]:text-teal [&_a]:no-underline',
   '[&_li_p]:my-0',
   '[&_blockquote]:font-normal',
-  '[&_:is(h1,h2,h3)]:my-4 [&_:is(h1,h2,h3)]:font-serif [&_:is(h1,h2,h3)]:text-neutral-black',
-  '[&_h1]:text-title-lg [&_h2]:text-title-md [&_h3]:text-title-base',
+  '[&_:is(h1,h2,h3)]:my-4',
   'leading-5 max-w-none break-words overflow-wrap-anywhere',
 ].join(' ');
 
@@ -40,6 +43,29 @@ const placeholderStyles = [
 ].join(' ');
 
 /**
+ * TipTap heading extension that bakes the design-system `headingClasses` onto
+ * each rendered `<h1>/<h2>/<h3>` tag, keeping editor output visually identical
+ * to the `Header1/2/3` components in `@op/ui`. Levels without a mapped class
+ * (e.g. h4) render without a baked class.
+ */
+export const StyledHeading = Heading.extend({
+  renderHTML({ node, HTMLAttributes }) {
+    const level = node.attrs.level as 1 | 2 | 3 | 4;
+    const className =
+      headingClasses[`h${level}` as keyof typeof headingClasses];
+    return [
+      `h${level}`,
+      mergeAttributes(
+        this.options.HTMLAttributes,
+        HTMLAttributes,
+        className ? { class: className } : {},
+      ),
+      0,
+    ];
+  },
+});
+
+/**
  * Styles applied to the editor element
  */
 export const baseEditorStyles = `${viewerProseStyles} outline-hidden placeholder:text-neutral-gray2 ${placeholderStyles}`;
@@ -56,7 +82,7 @@ const baseExtensions = [
     inline: true,
     allowBase64: true,
   }),
-  Heading.configure({
+  StyledHeading.configure({
     levels: [1, 2, 3, 4],
   }),
   Underline,

--- a/packages/ui/src/components/RichTextEditor/editorConfig.ts
+++ b/packages/ui/src/components/RichTextEditor/editorConfig.ts
@@ -44,9 +44,9 @@ const placeholderStyles = [
 
 /**
  * TipTap heading extension that bakes the design-system `headingClasses` onto
- * each rendered `<h1>/<h2>/<h3>` tag, keeping editor output visually identical
- * to the `Header1/2/3` components in `@op/ui`. Levels without a mapped class
- * (e.g. h4) render without a baked class.
+ * each rendered `<h1>`–`<h4>` tag, keeping editor output visually identical to
+ * the `Header1/2/3/4` components in `@op/ui`. Any level without a mapped class
+ * renders without a baked class.
  */
 export const StyledHeading = Heading.extend({
   renderHTML({ node, HTMLAttributes }) {

--- a/packages/ui/src/components/RichTextEditor/index.ts
+++ b/packages/ui/src/components/RichTextEditor/index.ts
@@ -8,4 +8,5 @@ export {
   viewerProseStyles,
   defaultEditorExtensions,
   defaultViewerExtensions,
+  StyledHeading,
 } from './editorConfig';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,6 +761,9 @@ importers:
       '@op/events':
         specifier: workspace:*
         version: link:../../services/events
+      '@op/styles':
+        specifier: workspace:*
+        version: link:../styles
       '@op/translation':
         specifier: workspace:*
         version: link:../../services/translation


### PR DESCRIPTION
## Summary

- H3 headings in the proposal content viewer (`viewerProseStyles`) were falling back to the default `prose` typography — Roboto, no top margin — while H1/H2 were getting the design-system serif treatment.
- Add H3 to the same group as H1/H2 so the serif font, vertical spacing, and neutral-black color apply uniformly. Headings rendered inside the proposal editor + the static HTML viewer (`ProposalHtmlContent`) both consume the same constant, so this fixes both.

Additionally, we set font-serif as default for all headings and override to font-sans where that was not the case before (we should rethink whether they should be `<Header>` components in the future.

Asana: https://app.asana.com/0/1209477276073375/1214854687303838

