### PR TITLE
fix(security): reject CR/LF in email recipients before send

### DIFF
--- a/services/emails/index.tsx
+++ b/services/emails/index.tsx
@@ -6,6 +6,16 @@ import z from 'zod';
 
 type RenderParameter = Parameters<typeof render>;
 
+// Reject CR/LF before passing addresses to nodemailer/Resend — prevents
+// SMTP header injection (extra Bcc:, Subject:, etc.) since z.string().email()
+// alone does not strip control chars from every accepted shape.
+const safeEmailSchema = z
+  .string()
+  .email()
+  .refine((value) => !/[\r\n]/.test(value), {
+    message: 'Email must not contain CR or LF characters',
+  });
+
 export const OPNodemailer = async ({
   to,
   from,
@@ -21,7 +31,7 @@ export const OPNodemailer = async ({
   };
   renderOptions?: RenderParameter[1];
 }) => {
-  const safeEmail = z.string().email().parse(to);
+  const safeEmail = safeEmailSchema.parse(to);
 
   const { RESEND_PASSWORD } = process.env;
 
@@ -85,7 +95,7 @@ export const OPBatchSend = async (emails: BatchEmailItem[]) => {
     try {
       const batchPayload = batch.map(({ to, subject, from, component }) => ({
         from: `${from ?? APP_NAME} <${genericEmail}>`,
-        to: z.string().email().parse(to),
+        to: safeEmailSchema.parse(to),
         subject,
         react: component(),
       }));


### PR DESCRIPTION
## Summary

- `z.string().email()` accepts certain shapes containing embedded CR/LF characters, which would pass through to nodemailer/Resend and enable SMTP header injection (additional `Bcc:`, `Subject:`, or body content via a single malicious `to` value).
- Adds a shared `safeEmailSchema` in `services/emails/index.tsx` that chains a `.refine()` rejecting any value containing `\r` or `\n`. Both send paths (`OPNodemailer` and `OPBatchSend`) now validate through this schema instead of the bare email schema.
- Fix is at the SMTP sink — the architectural boundary where header concatenation happens — not duplicated against the existing frontend UX validators in `apps/app/src/components/decisions/emailUtils.ts`.

Asana: https://app.asana.com/0/1209477276073375/1214783954553696

## Test plan

- [ ] `pnpm w:emails typecheck` passes.
- [ ] A `to` value containing `\r\n` is rejected with a Zod validation error before nodemailer/Resend is called.
- [ ] Normal email addresses continue to send successfully through both `OPNodemailer` and `OPBatchSend`.
- [ ] `pnpm test` passes under `CI=1` (single-worker mode required locally).