### PR TITLE
fix(posts): prevent duplicate comment after submit

### DIFF
--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -311,7 +311,9 @@ const PostUpdateWithUser = ({
             // Drop our optimistic placeholder; if a realtime refetch already
             // inserted the real comment, return without re-prepending.
             const filtered = old.filter((c) => c.id !== context.tempId);
-            if (filtered.some((c) => c.id === enhancedData.id)) return filtered;
+            if (filtered.some((c) => c.id === enhancedData.id)) {
+              return filtered;
+            }
             return [enhancedData, ...filtered];
           });
 
@@ -370,7 +372,9 @@ const PostUpdateWithUser = ({
             // Drop our optimistic placeholder; if a realtime refetch already
             // inserted the real post, return without re-prepending.
             const filtered = old.filter((p) => p.id !== context.tempId);
-            if (filtered.some((p) => p.id === enhancedData.id)) return filtered;
+            if (filtered.some((p) => p.id === enhancedData.id)) {
+              return filtered;
+            }
             return [enhancedData, ...filtered];
           });
 

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -76,9 +76,6 @@ const PostUpdateWithUser = ({
     content: string;
     attachmentIds: string[];
   } | null>(null);
-  const [optimisticCommentId, setOptimisticCommentId] = useState<string | null>(
-    null,
-  );
   const optimisticCommentRef = useRef<string | null>(null);
   const t = useTranslations();
   const utils = trpc.useUtils();
@@ -142,7 +139,6 @@ const PostUpdateWithUser = ({
     onMutate: async (variables) => {
       const tempId = `optimistic-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
       optimisticCommentRef.current = tempId;
-      setOptimisticCommentId(tempId);
 
       // For comments (posts with parentPostId)
       if (variables.parentPostId) {
@@ -269,7 +265,6 @@ const PostUpdateWithUser = ({
 
         // Clear the optimistic comment ID
         optimisticCommentRef.current = null;
-        setOptimisticCommentId(null);
       }
 
       if (errorInfo.isConnectionError) {
@@ -288,17 +283,16 @@ const PostUpdateWithUser = ({
 
       console.log('ERROR', err);
     },
-    onSuccess: (data, variables) => {
+    onSuccess: (data, variables, context) => {
       // Clear form and failed post on success
       setContent('');
       setDetectedUrls([]);
       fileUpload.clearFiles();
       setLastFailedPost(null);
 
-      if (data && optimisticCommentRef.current) {
+      if (data && context?.tempId) {
         // Clear the optimistic comment ID since we have real data
         optimisticCommentRef.current = null;
-        setOptimisticCommentId(null);
 
         // Enhance server data with user profile if not present
         const enhancedData = {
@@ -314,19 +308,11 @@ const PostUpdateWithUser = ({
           );
           utils.posts.getPosts.setData(queryKey, (old) => {
             if (!old) return [enhancedData];
-            // Replace optimistic comment with real data, or add if not found
-            if (optimisticCommentId) {
-              const index = old.findIndex(
-                (comment) => comment.id === optimisticCommentId,
-              );
-              if (index >= 0) {
-                const newComments = [...old];
-                newComments[index] = enhancedData;
-                return newComments;
-              }
-            }
-            // Add the new comment to the beginning if no optimistic comment to replace
-            return [enhancedData, ...old];
+            // Drop our optimistic placeholder; if a realtime refetch already
+            // inserted the real comment, return without re-prepending.
+            const filtered = old.filter((c) => c.id !== context.tempId);
+            if (filtered.some((c) => c.id === enhancedData.id)) return filtered;
+            return [enhancedData, ...filtered];
           });
 
           // Update parent post's comment count in main feed caches
@@ -381,19 +367,11 @@ const PostUpdateWithUser = ({
           };
           utils.posts.getPosts.setData(queryKey, (old) => {
             if (!old) return [enhancedData];
-            // Replace optimistic post with real data, or add if not found
-            if (optimisticCommentId) {
-              const index = old.findIndex(
-                (post) => post.id === optimisticCommentId,
-              );
-              if (index >= 0) {
-                const newPosts = [...old];
-                newPosts[index] = enhancedData;
-                return newPosts;
-              }
-            }
-            // Add the new post to the beginning if no optimistic post to replace
-            return [enhancedData, ...old];
+            // Drop our optimistic placeholder; if a realtime refetch already
+            // inserted the real post, return without re-prepending.
+            const filtered = old.filter((p) => p.id !== context.tempId);
+            if (filtered.some((p) => p.id === enhancedData.id)) return filtered;
+            return [enhancedData, ...filtered];
           });
 
           // If this is a proposal comment, invalidate proposal queries to refresh comment counts


### PR DESCRIPTION
## Summary

- Clicking **Send** once on a comment could land the new comment in the list twice. The root cause was a stale-closure bug in `PostUpdate/index.tsx`: the `onSuccess` `setData` callbacks read `optimisticCommentId` from React state, which is **queued, not synchronous**. By the time the callback ran, the `setOptimisticCommentId(tempId)` from `onMutate` hadn't been committed yet, so `findIndex(c => c.id === optimisticCommentId)` returned -1 and the code fell through to `[enhancedData, ...old]`. When the Supabase realtime invalidation refetch landed before `onSuccess` (common on a fast network), the real comment was already in `old` — and we prepended it again.
- Route the temp id through React Query's mutation `context` (returned from `onMutate`) so `onSuccess` sees a synchronous, per-mutation value. Collapse each `setData` to a single pass: drop our optimistic placeholder, then prepend the real item unless a refetch already inserted it. Applied symmetrically to both the comment branch (`parentPostId`) and the top-level post branch (`profileId`).
- Removes the `useState<string | null>` for `optimisticCommentId` (the stale-state source) but keeps `optimisticCommentRef` — it's still read in `onError` (line ~236) as a concurrent-mutation guard so an in-flight mutation B's optimistic update isn't rolled back by mutation A's late-arriving error.
- Net: 12 insertions, 34 deletions.

Asana: https://app.asana.com/0/1209477276073375/1214854782844888

## Test plan

- [ ] On a slow-ish network, post a comment on a post that has the realtime channel subscribed — the comment appears exactly once after submit.
- [ ] On a fast network (realtime refetch can land before `onSuccess`), post a comment — still exactly once.
- [ ] Post a top-level proposal comment (`profileId` branch, no `parentPostId`) — appears once.
- [ ] Trigger an error path (e.g. disconnect mid-submit) — optimistic placeholder is rolled back; no orphan placeholder remains in the list.
- [ ] `pnpm w:app typecheck` passes.
- [ ] `CI=1 pnpm test` — all 676 @op/api + 52 @op/common + 2 @op/realtime tests pass.
