### PR TITLE
fix(ui): hug content on pill Select dropdowns

### DIFF
--- a/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
@@ -86,7 +86,7 @@ export function CollaborativeDropdownField({
       selectedKey={selectedValue}
       onSelectionChange={handleSelectionChange}
       selectValueClassName="text-primary-teal data-[placeholder]:text-primary-teal"
-      className="w-auto max-w-36 overflow-hidden sm:max-w-96"
+      className="w-fit max-w-full"
       popoverProps={{ className: 'sm:min-w-fit sm:max-w-2xl' }}
     >
       {allowEmpty && (

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
@@ -115,7 +115,7 @@ function RubricField({ field }: { field: FieldDescriptor }) {
             size="medium"
             placeholder={t('Select option')}
             selectValueClassName="text-primary-teal data-[placeholder]:text-primary-teal"
-            className="w-auto max-w-56 overflow-hidden sm:max-w-96"
+            className="w-fit max-w-full"
           >
             {[]}
           </Select>

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -33,7 +33,7 @@ const selectStyles = tv({
     },
     variant: {
       default: '',
-      pill: 'h-auto border-0 bg-primary-tealWhite text-primary-teal hover:bg-teal-50 hover:text-primary-tealBlack focus-visible:outline-data-blue active:bg-teal-50 active:text-primary-tealBlack',
+      pill: 'h-auto w-fit border-0 bg-primary-tealWhite text-primary-teal hover:bg-teal-50 hover:text-primary-tealBlack focus-visible:outline-data-blue active:bg-teal-50 active:text-primary-tealBlack',
     },
     size: {
       small: 'h-8 rounded-md p-2 px-3',
@@ -129,7 +129,7 @@ export const Select = <T extends object, M extends SelectionMode = 'single'>({
             >
               {({ defaultChildren, selectedText, isPlaceholder }) => {
                 if (isPlaceholder) {
-                  return variant === 'pill' ? null : defaultChildren;
+                  return defaultChildren;
                 }
                 return selectedText;
               }}


### PR DESCRIPTION
## Summary

- Pill-variant `Select` in the proposal editor (Category dropdown and any `dropdown` field rendered by `ProposalFormRenderer`) appeared oversized: the trigger was forced wide by its flex parent, and the placeholder rendered as `null` instead of the placeholder text, so users saw an empty teal pill that didn't communicate what it was.
- Root cause was in `packages/ui/src/components/Select.tsx`: the pill variant explicitly returned `null` for the placeholder render-prop branch (`return variant === 'pill' ? null : defaultChildren`), and the pill button had no width cap, so its width came from the parent flex container.
- Fix:
  - Pill `Select` now renders `defaultChildren` for the placeholder (parity with the Button-based pills used by `CollaborativeMultiSelectField`, `CollaborativeBudgetField`, and `ReadonlyDropdownField`).
  - Pill variant gets `w-fit`, so the trigger sizes to its placeholder/selection text.
  - `CollaborativeDropdownField` and `RubricFormPreviewRenderer` drop their `w-auto max-w-36 sm:max-w-96` caps (no longer needed now that the trigger hugs content).
- Net: 4 inserts, 4 deletes across 3 files.

Asana: https://app.asana.com/0/1209477276073375/1214781797855074

### Demo
<img width="385" height="455" alt="Screenshot 2026-05-20 at 11 27 59" src="https://github.com/user-attachments/assets/6ed7ea15-e4b1-40af-9132-b44cdb5fa6ea" />

