### PR TITLE
fix(decisions): upload proposal attachments via direct-to-storage signed URL

### DIFF
--- a/apps/app/src/components/decisions/ProposalAttachments.tsx
+++ b/apps/app/src/components/decisions/ProposalAttachments.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { trpc } from '@op/api/client';
+import { createSBBrowserClient } from '@op/supabase/client';
 import { FileDropZone } from '@op/ui/FileDropZone';
 import { toast } from '@op/ui/Toast';
 import { type ReactNode, startTransition, useOptimistic } from 'react';
@@ -47,9 +48,6 @@ function attachmentsReducer(
   }
 }
 
-/**
- * Attachment section for proposals.
- */
 export function ProposalAttachments({
   proposalId,
   attachments,
@@ -66,7 +64,6 @@ export function ProposalAttachments({
 }) {
   const t = useTranslations();
 
-  // Normalize attachments to ensure fileSize is always a number
   const normalizedAttachments: Attachment[] = attachments.map((a) => ({
     id: a.id,
     fileName: a.fileName,
@@ -79,12 +76,10 @@ export function ProposalAttachments({
     attachmentsReducer,
   );
 
+  const createUploadUrlMutation =
+    trpc.decision.createProposalAttachmentUploadUrl.useMutation();
   const uploadMutation = trpc.decision.uploadProposalAttachment.useMutation({
     onSuccess: onMutate,
-    onError: (err) => {
-      toast.error({ message: err.message });
-      onMutate(); // Refetch to clear optimistic state on error
-    },
   });
 
   const deleteMutation = trpc.decision.deleteProposalAttachment.useMutation({
@@ -127,19 +122,38 @@ export function ProposalAttachments({
           },
         });
 
-        const reader = new FileReader();
-        const base64 = await new Promise<string>((resolve, reject) => {
-          reader.onload = () => resolve(reader.result as string);
-          reader.onerror = () => reject(new Error('Failed to read file'));
-          reader.readAsDataURL(file);
-        });
+        try {
+          const { path, token } = await createUploadUrlMutation.mutateAsync({
+            fileName: file.name,
+            mimeType: file.type,
+            proposalId,
+          });
 
-        await uploadMutation.mutateAsync({
-          file: base64,
-          fileName: file.name,
-          mimeType: file.type,
-          proposalId,
-        });
+          const supabase = createSBBrowserClient();
+          const { error: uploadError } = await supabase.storage
+            .from('assets')
+            .uploadToSignedUrl(path, token, file, {
+              contentType: file.type,
+              upsert: false,
+            });
+
+          if (uploadError) {
+            throw new Error(uploadError.message);
+          }
+
+          await uploadMutation.mutateAsync({
+            path,
+            fileName: file.name,
+            mimeType: file.type,
+            fileSize: file.size,
+            proposalId,
+          });
+        } catch (err) {
+          const message =
+            err instanceof Error ? err.message : t('Upload failed');
+          toast.error({ message });
+          onMutate();
+        }
       });
     }
   };

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -224,6 +224,7 @@
   "Search results": "Search results",
   "Recent Searches": "Recent Searches",
   "Failed to send invite": "Failed to send invite",
+  "Upload failed": "Upload failed",
   "Connection issue": "Connection issue",
   "Please try sending the invite again.": "Please try sending the invite again.",
   "No connection": "No connection",

--- a/services/api/src/routers/decision/createProposalAttachmentUploadUrl.ts
+++ b/services/api/src/routers/decision/createProposalAttachmentUploadUrl.ts
@@ -1,0 +1,106 @@
+import {
+  CommonError,
+  UnauthorizedError,
+  getCurrentProfileId,
+  getProfileAccessUser,
+} from '@op/common';
+import { db } from '@op/db/client';
+import { createServerClient } from '@op/supabase/lib';
+import { assertAccess, permission } from 'access-zones';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { sanitizeS3Filename } from '../../utils';
+
+const ALLOWED_MIME_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'video/mp4',
+];
+
+// Browser uploads the binary directly to storage via this signed URL,
+// bypassing the tRPC handler's platform body-size cap.
+export const createProposalAttachmentUploadUrl = router({
+  createProposalAttachmentUploadUrl: commonAuthedProcedure({
+    rateLimit: { windowSize: 10, maxRequests: 20 },
+  })
+    .input(
+      z.object({
+        fileName: z.string(),
+        mimeType: z.string(),
+        proposalId: z.string(),
+      }),
+    )
+    .output(
+      z.object({
+        token: z.string(),
+        path: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { fileName, mimeType, proposalId } = input;
+      const { user } = ctx;
+
+      if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
+        throw new CommonError(
+          'Unsupported file type. Allowed: PNG, JPEG, GIF, WebP, MP4, PDF, DOCX, XLSX.',
+        );
+      }
+
+      const proposal = await db.query.proposals.findFirst({
+        where: { id: proposalId },
+      });
+
+      if (!proposal) {
+        throw new CommonError('Proposal not found');
+      }
+
+      const profileUser = await getProfileAccessUser({
+        user: { id: user.id },
+        profileId: proposal.profileId,
+      });
+
+      if (!profileUser) {
+        throw new UnauthorizedError('Not authorized');
+      }
+
+      assertAccess({ profile: permission.UPDATE }, profileUser.roles);
+
+      const profileId = await getCurrentProfileId(user.id);
+      const sanitizedFileName = sanitizeS3Filename(fileName);
+      const path = `profile/${profileId}/proposals/${Date.now()}_${sanitizedFileName}`;
+
+      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const supabaseServiceRole = process.env.SUPABASE_SERVICE_ROLE;
+
+      if (!supabaseUrl || !supabaseServiceRole) {
+        throw new CommonError('Storage configuration missing');
+      }
+
+      const supabase = createServerClient(supabaseUrl, supabaseServiceRole, {
+        cookieOptions: {},
+        cookies: {
+          getAll: async () => [],
+          setAll: async () => {},
+        },
+      });
+
+      const { data, error } = await supabase.storage
+        .from('assets')
+        .createSignedUploadUrl(path);
+
+      if (error || !data) {
+        throw new CommonError(error?.message ?? 'Failed to create upload URL');
+      }
+
+      return {
+        token: data.token,
+        path: data.path,
+      };
+    }),
+});

--- a/services/api/src/routers/decision/deleteProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/deleteProposalAttachment.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '..';
 import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
+import { uploadTestAttachmentToStorage } from '../../test/helpers/uploadTestAttachment';
 import {
   createIsolatedSession,
   createTestContextWithSession,
@@ -45,11 +46,18 @@ describe.concurrent('deleteProposalAttachment', () => {
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
-    // Upload an attachment
-    const uploadResult = await caller.decision.uploadProposalAttachment({
-      file: VALID_PNG_BASE64,
+    const { path, fileSize } = await uploadTestAttachmentToStorage({
+      base64: VALID_PNG_BASE64,
       fileName: 'to-delete.png',
       mimeType: 'image/png',
+    });
+
+    // Upload an attachment
+    const uploadResult = await caller.decision.uploadProposalAttachment({
+      path,
+      fileName: 'to-delete.png',
+      mimeType: 'image/png',
+      fileSize,
       proposalId: proposal.id,
     });
 
@@ -102,11 +110,18 @@ describe.concurrent('deleteProposalAttachment', () => {
 
     const ownerCaller = await createAuthenticatedCaller(setup.userEmail);
 
-    // Owner uploads an attachment
-    const uploadResult = await ownerCaller.decision.uploadProposalAttachment({
-      file: VALID_PNG_BASE64,
+    const ownerUpload = await uploadTestAttachmentToStorage({
+      base64: VALID_PNG_BASE64,
       fileName: 'owner-file.png',
       mimeType: 'image/png',
+    });
+
+    // Owner uploads an attachment
+    const uploadResult = await ownerCaller.decision.uploadProposalAttachment({
+      path: ownerUpload.path,
+      fileName: 'owner-file.png',
+      mimeType: 'image/png',
+      fileSize: ownerUpload.fileSize,
       proposalId: proposal.id,
     });
 
@@ -172,11 +187,18 @@ describe.concurrent('deleteProposalAttachment', () => {
 
     const ownerCaller = await createAuthenticatedCaller(setup.userEmail);
 
-    // Owner uploads an attachment
-    const uploadResult = await ownerCaller.decision.uploadProposalAttachment({
-      file: VALID_PNG_BASE64,
+    const ownerUpload = await uploadTestAttachmentToStorage({
+      base64: VALID_PNG_BASE64,
       fileName: 'owner-file.png',
       mimeType: 'image/png',
+    });
+
+    // Owner uploads an attachment
+    const uploadResult = await ownerCaller.decision.uploadProposalAttachment({
+      path: ownerUpload.path,
+      fileName: 'owner-file.png',
+      mimeType: 'image/png',
+      fileSize: ownerUpload.fileSize,
       proposalId: proposal.id,
     });
 

--- a/services/api/src/routers/decision/index.ts
+++ b/services/api/src/routers/decision/index.ts
@@ -1,4 +1,5 @@
 import { mergeRouters } from '../../trpcFactory';
+import { createProposalAttachmentUploadUrl } from './createProposalAttachmentUploadUrl';
 import { deleteProposalAttachment } from './deleteProposalAttachment';
 import { instancesRouter } from './instances';
 import { processesRouter } from './processes';
@@ -14,6 +15,7 @@ export const decisionRouter = mergeRouters(
   proposalsRouter,
   reviewsRouter,
   resultsRouter,
+  createProposalAttachmentUploadUrl,
   uploadProposalAttachment,
   deleteProposalAttachment,
   votingRouter,

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -18,6 +18,7 @@ import { transformFormDataToProcessSchema as cowopSchema } from '../../../../../
 import { transformFormDataToProcessSchema as horizonSchema } from '../../../../../../apps/app/src/components/Profile/CreateDecisionProcessModal/schemas/horizon';
 import { transformFormDataToProcessSchema as simpleSchema } from '../../../../../../apps/app/src/components/Profile/CreateDecisionProcessModal/schemas/simple';
 import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import { uploadTestAttachmentToStorage } from '../../../test/helpers/uploadTestAttachment';
 import {
   createIsolatedSession,
   createTestContextWithSession,
@@ -1406,10 +1407,17 @@ describe.concurrent('getProposal', () => {
     const minimalPngBase64 =
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
-    const uploadResult = await caller.decision.uploadProposalAttachment({
-      file: minimalPngBase64,
+    const { path, fileSize } = await uploadTestAttachmentToStorage({
+      base64: minimalPngBase64,
       fileName: 'test-attachment.png',
       mimeType: 'image/png',
+    });
+
+    const uploadResult = await caller.decision.uploadProposalAttachment({
+      path,
+      fileName: 'test-attachment.png',
+      mimeType: 'image/png',
+      fileSize,
       proposalId: proposal.id,
     });
 

--- a/services/api/src/routers/decision/uploadProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '..';
 import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
+import { uploadTestAttachmentToStorage } from '../../test/helpers/uploadTestAttachment';
 import {
   createIsolatedSession,
   createTestContextWithSession,
@@ -45,10 +46,17 @@ describe.concurrent('uploadProposalAttachment', () => {
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
-    const result = await caller.decision.uploadProposalAttachment({
-      file: VALID_PNG_BASE64,
+    const { path, fileSize } = await uploadTestAttachmentToStorage({
+      base64: VALID_PNG_BASE64,
       fileName: 'test-image.png',
       mimeType: 'image/png',
+    });
+
+    const result = await caller.decision.uploadProposalAttachment({
+      path,
+      fileName: 'test-image.png',
+      mimeType: 'image/png',
+      fileSize,
       proposalId: proposal.id,
     });
 
@@ -105,11 +113,18 @@ describe.concurrent('uploadProposalAttachment', () => {
 
     const memberCaller = await createAuthenticatedCaller(member.email);
 
-    // Non-owner member WITH proposal permissions should be able to upload
-    const result = await memberCaller.decision.uploadProposalAttachment({
-      file: VALID_PNG_BASE64,
+    const { path, fileSize } = await uploadTestAttachmentToStorage({
+      base64: VALID_PNG_BASE64,
       fileName: 'member-upload.png',
       mimeType: 'image/png',
+    });
+
+    // Non-owner member WITH proposal permissions should be able to upload
+    const result = await memberCaller.decision.uploadProposalAttachment({
+      path,
+      fileName: 'member-upload.png',
+      mimeType: 'image/png',
+      fileSize,
       proposalId: proposal.id,
     });
 
@@ -161,12 +176,19 @@ describe.concurrent('uploadProposalAttachment', () => {
 
     const nonOwnerCaller = await createAuthenticatedCaller(setupB.userEmail);
 
+    const { path, fileSize } = await uploadTestAttachmentToStorage({
+      base64: VALID_PNG_BASE64,
+      fileName: 'malicious.png',
+      mimeType: 'image/png',
+    });
+
     // User without proposal permissions should NOT be able to upload
     await expect(
       nonOwnerCaller.decision.uploadProposalAttachment({
-        file: VALID_PNG_BASE64,
+        path,
         fileName: 'malicious.png',
         mimeType: 'image/png',
+        fileSize,
         proposalId: proposal.id,
       }),
     ).rejects.toMatchObject({

--- a/services/api/src/routers/decision/uploadProposalAttachment.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.ts
@@ -1,14 +1,12 @@
 import {
   CommonError,
-  getCurrentProfileId,
   uploadProposalAttachment as uploadProposalAttachmentService,
 } from '@op/common';
-import { createServerClient } from '@op/supabase/lib';
-import { Buffer } from 'node:buffer';
+import { db } from '@op/db/client';
 import { z } from 'zod';
 
 import { commonAuthedProcedure, router } from '../../trpcFactory';
-import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
+import { MAX_FILE_SIZE } from '../../utils';
 
 const ALLOWED_MIME_TYPES = [
   'image/png',
@@ -27,9 +25,10 @@ export const uploadProposalAttachment = router({
   })
     .input(
       z.object({
-        file: z.string(), // base64 encoded
+        path: z.string(),
         fileName: z.string(),
         mimeType: z.string(),
+        fileSize: z.number().int().nonnegative(),
         proposalId: z.string(),
       }),
     )
@@ -42,11 +41,8 @@ export const uploadProposalAttachment = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const { file, fileName, mimeType, proposalId } = input;
+      const { path, fileName, mimeType, fileSize, proposalId } = input;
       const { user } = ctx;
-      const profileId = await getCurrentProfileId(user.id);
-
-      const sanitizedFileName = sanitizeS3Filename(fileName);
 
       if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
         throw new CommonError(
@@ -54,74 +50,29 @@ export const uploadProposalAttachment = router({
         );
       }
 
-      let buffer: Buffer;
-
-      try {
-        // Accept data URLs or plain base64
-        let base64 = file;
-
-        if (file.startsWith('data:')) {
-          const commaIndex = file.indexOf(',');
-
-          if (commaIndex === -1) {
-            throw new Error('Invalid data URL');
-          }
-
-          base64 = file.slice(commaIndex + 1);
-        }
-
-        buffer = Buffer.from(base64, 'base64');
-      } catch (_err) {
-        throw new CommonError('Invalid base64 encoding');
-      }
-
-      // Check file size
-      if (buffer.length > MAX_FILE_SIZE) {
+      if (fileSize > MAX_FILE_SIZE) {
         throw new CommonError(
           `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
         );
       }
 
-      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-      const supabaseServiceRole = process.env.SUPABASE_SERVICE_ROLE;
-
-      if (!supabaseUrl || !supabaseServiceRole) {
-        throw new CommonError('Storage configuration missing');
-      }
-
-      const supabase = createServerClient(supabaseUrl, supabaseServiceRole, {
-        cookieOptions: {},
-        cookies: {
-          getAll: async () => [],
-          setAll: async () => {},
+      const storageObject = await db.query.objectsInStorage.findFirst({
+        where: {
+          bucketId: 'assets',
+          name: path,
         },
       });
 
-      const bucket = 'assets';
-      const filePath = `profile/${profileId}/proposals/${Date.now()}_${sanitizedFileName}`;
-
-      const { error: uploadError, data } = await supabase.storage
-        .from(bucket)
-        .upload(filePath, buffer, {
-          contentType: mimeType,
-          upsert: false,
-        });
-
-      if (uploadError) {
-        throw new CommonError(uploadError.message);
+      if (!storageObject) {
+        throw new CommonError('Uploaded file not found in storage');
       }
 
-      if (!data) {
-        throw new CommonError('Upload failed - no data returned');
-      }
-
-      // Create attachment record and link to proposal
       const result = await uploadProposalAttachmentService({
         input: {
-          fileName: sanitizedFileName,
+          fileName,
           mimeType,
-          fileSize: buffer.length,
-          storageObjectId: data.id,
+          fileSize,
+          storageObjectId: storageObject.id,
           proposalId,
         },
         user,

--- a/services/api/src/test/helpers/uploadTestAttachment.ts
+++ b/services/api/src/test/helpers/uploadTestAttachment.ts
@@ -1,0 +1,36 @@
+import { Buffer } from 'node:buffer';
+
+import { supabaseTestAdminClient } from '../supabase-utils';
+
+/**
+ * Uploads a base64-encoded file to the assets bucket using the admin client
+ * (bypasses RLS). Mirrors the client-side direct-upload path: the binary
+ * lands in storage independently of the tRPC handler, then tests pass the
+ * resulting `path` to `uploadProposalAttachment`.
+ */
+export async function uploadTestAttachmentToStorage({
+  base64,
+  fileName,
+  mimeType,
+}: {
+  base64: string;
+  fileName: string;
+  mimeType: string;
+}): Promise<{ path: string; fileSize: number }> {
+  if (!supabaseTestAdminClient) {
+    throw new Error('Supabase admin client not initialized');
+  }
+
+  const buffer = Buffer.from(base64, 'base64');
+  const path = `test/${Date.now()}_${Math.random().toString(36).slice(2)}_${fileName}`;
+
+  const { error } = await supabaseTestAdminClient.storage
+    .from('assets')
+    .upload(path, buffer, { contentType: mimeType, upsert: false });
+
+  if (error) {
+    throw new Error(`Test storage upload failed: ${error.message}`);
+  }
+
+  return { path, fileSize: buffer.length };
+}


### PR DESCRIPTION
## Summary
- Uploading larger files (PDFs in particular) to a proposal hit Vercel's serverless function body-size cap. The edge returned a non-JSON response, tRPC's `.json()` choked on it, and users saw a raw `"JSON Parse error: Unexpected identifier"` toast.
- Replaced the base64-over-tRPC upload with a two-step flow: the browser asks tRPC for a Supabase signed upload URL, uploads the binary directly to storage, then calls `uploadProposalAttachment` with just the resulting `path`. Same proposal-access check still runs at finalize time (via the shared service in `@op/common`).
- Tightened the client error path so failures from either step surface a localized toast and refresh the optimistic state once.

Asana: https://app.asana.com/0/1208872251341897/1214854687303842

## Test plan
- [x] `pnpm typecheck` — all 21 workspaces green
- [x] `pnpm test` — full integration suite (676 tests) green
- [x] `pnpm -C ./services/api test -- --run src/routers/decision/uploadProposalAttachment.test.ts src/routers/decision/deleteProposalAttachment.test.ts` — 6/6 green after updating tests to pre-upload via the new test helper
- [x] `pnpm -C ./services/api test -- --run src/routers/decision/proposals/get.test.ts` — 27/27 green
- [x] `pnpm e2e` — 54 passed, 1 unrelated pre-existing failure in `review-summary.spec.ts` (file identical to `dev`)
- [x] `mcp__fallow__audit` — no findings touch the diff
- [ ] Manual: upload a multi-megabyte PDF to a proposal in dev and confirm the upload completes without the JSON parse error
