### PR TITLE
fix(posts): Allow profile admins and post authors to delete posts

### DIFF
--- a/apps/app/src/components/PostFeed/DeletePost.tsx
+++ b/apps/app/src/components/PostFeed/DeletePost.tsx
@@ -9,13 +9,7 @@ import { useRouter } from 'next/navigation';
 
 import { useTranslations } from '@/lib/i18n';
 
-export const DeletePost = ({
-  post,
-  profileId,
-}: {
-  post: Post;
-  profileId: string;
-}) => {
+export const DeletePost = ({ post }: { post: Post }) => {
   const t = useTranslations();
   const utils = trpc.useUtils();
   const router = useRouter();
@@ -60,18 +54,17 @@ export const DeletePost = ({
     },
   });
 
-  const handleDeletePost = (post: Post, profileId: string) => {
+  const handleDeletePost = (post: Post) => {
     deletePost.mutate({
       id: post.id,
-      profileId: profileId,
     });
   };
 
   return (
     <Menu
       onAction={() => {
-        if (post.id && profileId) {
-          handleDeletePost(post, profileId);
+        if (post.id) {
+          handleDeletePost(post);
         }
       }}
       className="min-w-28 p-2"

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { getPublicUrl } from '@/utils';
-import { OrganizationUser } from '@/utils/UserProvider';
+import { OrganizationUser, useUser } from '@/utils/UserProvider';
 import { detectLinks, linkifyText } from '@/utils/linkDetection';
 import { trpc } from '@op/api/client';
 import type { Organization, Post, PostAttachment } from '@op/api/encoders';
@@ -193,11 +193,18 @@ const PostMenu = ({
   user?: OrganizationUser;
 }) => {
   const t = useTranslations();
-  // We check against whether this is the user's post, or whether the org that it was posted to currently matches the user's context
+  const { getPermissionsForProfile } = useUser();
+
+  // Author, current org context owner, or a profile admin on the post's
+  // root profile (mirrors deletePostById's server-side auth).
+  const isProfileAdmin = post?.rootProfileId
+    ? getPermissionsForProfile(post.rootProfileId).profile.admin
+    : false;
   const canShowMenu =
-    (post?.profileId === user?.currentProfileId ||
-      (organization && organization?.profile.id === user?.currentProfileId)) &&
-    !!post?.id;
+    !!post?.id &&
+    (post.profileId === user?.currentProfileId ||
+      (organization && organization.profile.id === user?.currentProfileId) ||
+      isProfileAdmin);
 
   if (!canShowMenu) {
     return null;
@@ -208,23 +215,9 @@ const PostMenu = ({
       aria-label={t('Post options')}
       className="absolute top-0 right-0"
     >
-      <PostMenuContent post={post} canDelete={canShowMenu} />
+      <DeletePost post={post} />
     </OptionMenu>
   );
-};
-
-const PostMenuContent = ({
-  post,
-  canDelete,
-}: {
-  post: Post;
-  canDelete: boolean;
-}) => {
-  if (!canDelete) {
-    return null;
-  }
-
-  return <DeletePost post={post} />;
 };
 
 export const EmptyPostsState = () => {

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -208,29 +208,23 @@ const PostMenu = ({
       aria-label={t('Post options')}
       className="absolute top-0 right-0"
     >
-      <PostMenuContent
-        post={post}
-        profileId={user?.currentProfileId || ''}
-        canDelete={canShowMenu}
-      />
+      <PostMenuContent post={post} canDelete={canShowMenu} />
     </OptionMenu>
   );
 };
 
 const PostMenuContent = ({
   post,
-  profileId,
   canDelete,
 }: {
   post: Post;
-  profileId: string;
   canDelete: boolean;
 }) => {
   if (!canDelete) {
     return null;
   }
 
-  return <DeletePost post={post} profileId={profileId} />;
+  return <DeletePost post={post} />;
 };
 
 export const EmptyPostsState = () => {

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -197,14 +197,13 @@ const PostMenu = ({
 
   // Author, current org context owner, or a profile admin on the post's
   // root profile (mirrors deletePostById's server-side auth).
-  const isProfileAdmin = post?.rootProfileId
+  const isProfileAdmin = post.rootProfileId
     ? getPermissionsForProfile(post.rootProfileId).profile.admin
     : false;
   const canShowMenu =
-    !!post?.id &&
-    (post.profileId === user?.currentProfileId ||
-      (organization && organization.profile.id === user?.currentProfileId) ||
-      isProfileAdmin);
+    post.profileId === user?.currentProfileId ||
+    (organization && organization.profile.id === user?.currentProfileId) ||
+    isProfileAdmin;
 
   if (!canShowMenu) {
     return null;

--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -1,12 +1,17 @@
 import { db, eq } from '@op/db/client';
-import { posts, postsToOrganizations, postsToProfiles } from '@op/db/schema';
+import {
+  organizations,
+  posts,
+  postsToOrganizations,
+  postsToProfiles,
+} from '@op/db/schema';
 import type { User } from '@supabase/supabase-js';
-import { checkPermission, permission } from 'access-zones';
+import { permission } from 'access-zones';
 
 import { UnauthorizedError } from '../../utils';
 import {
+  assertInstanceProfileAccess,
   getCurrentProfileId,
-  getOrgAccessUser,
   getProfileAccessUser,
 } from '../access';
 
@@ -18,18 +23,29 @@ export interface DeletePostByIdOptions {
 export const deletePostById = async (options: DeletePostByIdOptions) => {
   const { postId, user } = options;
 
-  const [[post], currentProfileId] = await Promise.all([
+  // Pull the post plus the linked org's profileId in one round trip. The org
+  // profile stands in as the gate for legacy postsToOrganizations posts and
+  // is what assertInstanceProfileAccess looks up to resolve the org for the
+  // organizationUsers fallback.
+  const [postRows, currentProfileId] = await Promise.all([
     db
       .select({
         id: posts.id,
         profileId: posts.profileId,
         rootProfileId: posts.rootProfileId,
+        orgProfileId: organizations.profileId,
       })
       .from(posts)
+      .leftJoin(postsToOrganizations, eq(postsToOrganizations.postId, posts.id))
+      .leftJoin(
+        organizations,
+        eq(organizations.id, postsToOrganizations.organizationId),
+      )
       .where(eq(posts.id, postId))
       .limit(1),
     getCurrentProfileId(user.id),
   ]);
+  const post = postRows[0];
 
   if (!post) {
     // Mirror the unauthorized branch to avoid leaking post existence to
@@ -37,14 +53,14 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
     throw new UnauthorizedError();
   }
 
-  // Author fast-path: the actor's current profile matches the post's
-  // recorded profileId. The currentProfileId match alone is NOT sufficient —
-  // `account.switchOrganization` only requires org membership, so any member
-  // can land on `currentProfileId = orgProfileId`. We additionally require a
-  // `profileUsers` row on that profile, which org members never have (orgs
-  // grant access via `organizationUsers`). Individual profiles and decision
-  // instance profiles do issue `profileUsers` rows to their authors, so this
-  // preserves the legitimate self-delete path.
+  // Author fast-path: actor's current profile matches the post's profileId
+  // AND they hold a profileUsers row on it. The currentProfileId match alone
+  // is NOT sufficient — `account.switchOrganization` only requires org
+  // membership, so any member can land on `currentProfileId = orgProfileId`.
+  // Org members never get a profileUsers row on org profiles (orgs grant
+  // access via organizationUsers), so the extra check blocks the spoof while
+  // preserving the legitimate self-delete path for individual and decision-
+  // instance authors.
   if (post.profileId && post.profileId === currentProfileId) {
     const profileUser = await getProfileAccessUser({
       user,
@@ -56,85 +72,34 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
     }
   }
 
-  const [isProfileAdmin, isOrgAdmin] = await Promise.all([
-    checkProfileAdmin({
-      user,
-      postId,
-      rootProfileId: post.rootProfileId,
-    }),
-    checkOrgAdmin({ user, postId }),
-  ]);
-
-  if (!isProfileAdmin && !isOrgAdmin) {
-    throw new UnauthorizedError();
+  // Pre-`rootProfileId` posts (e.g. `createPostOnProfile`) stored the gate
+  // as a postsToProfiles row instead. Read it lazily so the join above
+  // stays the common-case single round trip.
+  let gateProfileId: string | null =
+    post.rootProfileId ?? post.orgProfileId ?? null;
+  if (!gateProfileId) {
+    const [legacy] = await db
+      .select({ profileId: postsToProfiles.profileId })
+      .from(postsToProfiles)
+      .where(eq(postsToProfiles.postId, postId))
+      .limit(1);
+    gateProfileId = legacy?.profileId ?? null;
   }
+
+  // ADMIN on the gate profile, falling back to organizationUsers ADMIN when
+  // the gate IS an org's profile (rootProfileId on a top-level org-feed post,
+  // or the org profile we substituted for a legacy postsToOrganizations
+  // post). For decision-instance and individual gate profiles the org lookup
+  // returns no rows and the fallback fails, matching the previous behavior.
+  await assertInstanceProfileAccess({
+    user,
+    instance: {
+      profileId: gateProfileId,
+      ownerProfileId: gateProfileId,
+    },
+    profilePermissions: { profile: permission.ADMIN },
+    orgFallbackPermissions: { profile: permission.ADMIN },
+  });
 
   await db.delete(posts).where(eq(posts.id, postId));
-};
-
-// Prefer the pinned rootProfileId gate (mirrors getPost). Fall back to the
-// postsToProfiles index for legacy posts written before the gate was added.
-const checkProfileAdmin = async ({
-  user,
-  postId,
-  rootProfileId,
-}: {
-  user: User;
-  postId: string;
-  rootProfileId: string | null;
-}): Promise<boolean> => {
-  const profileIdsToCheck = rootProfileId
-    ? [rootProfileId]
-    : (
-        await db
-          .select({ profileId: postsToProfiles.profileId })
-          .from(postsToProfiles)
-          .where(eq(postsToProfiles.postId, postId))
-      ).map((row) => row.profileId);
-
-  if (profileIdsToCheck.length === 0) {
-    return false;
-  }
-
-  const profileUsers = await Promise.all(
-    profileIdsToCheck.map((profileId) =>
-      getProfileAccessUser({ user, profileId }),
-    ),
-  );
-  return profileUsers.some((profileUser) =>
-    checkPermission({ profile: permission.ADMIN }, profileUser?.roles ?? []),
-  );
-};
-
-// Legacy org-linked posts: only `createPostInOrganization` writes
-// `postsToOrganizations` rows, and it never sets `posts.profileId`, so the
-// fast-path above can't fire for them. (Posts created via `createPost` —
-// including comments under those legacy posts — always have `profileId` set
-// and never get a `postsToOrganizations` row, so they fall through to
-// `checkProfileAdmin` instead.) Require org admin, not just membership, to
-// stay symmetric with the profile-linked path.
-const checkOrgAdmin = async ({
-  user,
-  postId,
-}: {
-  user: User;
-  postId: string;
-}): Promise<boolean> => {
-  const orgLinks = await db
-    .select({ organizationId: postsToOrganizations.organizationId })
-    .from(postsToOrganizations)
-    .where(eq(postsToOrganizations.postId, postId));
-
-  if (orgLinks.length === 0) {
-    return false;
-  }
-
-  const orgUsers = await Promise.all(
-    orgLinks.map(({ organizationId }) =>
-      getOrgAccessUser({ organizationId, user }),
-    ),
-  );
-  return orgUsers.some((orgUser) =>
-    checkPermission({ profile: permission.ADMIN }, orgUser?.roles ?? []),
-  );
 };

--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -18,31 +18,57 @@ export interface DeletePostByIdOptions {
 export const deletePostById = async (options: DeletePostByIdOptions) => {
   const { postId, user } = options;
 
-  const [post] = await db
-    .select({
-      id: posts.id,
-      profileId: posts.profileId,
-      rootProfileId: posts.rootProfileId,
-    })
-    .from(posts)
-    .where(eq(posts.id, postId))
-    .limit(1);
+  const [[post], currentProfileId] = await Promise.all([
+    db
+      .select({
+        id: posts.id,
+        profileId: posts.profileId,
+        rootProfileId: posts.rootProfileId,
+      })
+      .from(posts)
+      .where(eq(posts.id, postId))
+      .limit(1),
+    getCurrentProfileId(user.id),
+  ]);
 
   if (!post) {
     throw new NotFoundError('Post', postId);
   }
-
-  const currentProfileId = await getCurrentProfileId(user.id);
 
   if (post.profileId && post.profileId === currentProfileId) {
     await db.delete(posts).where(eq(posts.id, postId));
     return;
   }
 
-  // Prefer the pinned rootProfileId gate (mirrors getPost). Fall back to the
-  // postsToProfiles index for legacy posts written before the gate was added.
-  const profileIdsToCheck = post.rootProfileId
-    ? [post.rootProfileId]
+  const [isProfileAdmin, isOrgAdmin] = await Promise.all([
+    checkProfileAdmin({
+      user,
+      postId,
+      rootProfileId: post.rootProfileId,
+    }),
+    checkOrgAdmin({ user, postId }),
+  ]);
+
+  if (!isProfileAdmin && !isOrgAdmin) {
+    throw new UnauthorizedError();
+  }
+
+  await db.delete(posts).where(eq(posts.id, postId));
+};
+
+// Prefer the pinned rootProfileId gate (mirrors getPost). Fall back to the
+// postsToProfiles index for legacy posts written before the gate was added.
+const checkProfileAdmin = async ({
+  user,
+  postId,
+  rootProfileId,
+}: {
+  user: User;
+  postId: string;
+  rootProfileId: string | null;
+}): Promise<boolean> => {
+  const profileIdsToCheck = rootProfileId
+    ? [rootProfileId]
     : (
         await db
           .select({ profileId: postsToProfiles.profileId })
@@ -50,44 +76,46 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
           .where(eq(postsToProfiles.postId, postId))
       ).map((row) => row.profileId);
 
-  if (profileIdsToCheck.length > 0) {
-    const profileUsers = await Promise.all(
-      profileIdsToCheck.map((profileId) =>
-        getProfileAccessUser({ user, profileId }),
-      ),
-    );
-    const isProfileAdmin = profileUsers.some((profileUser) =>
-      checkPermission({ profile: permission.ADMIN }, profileUser?.roles ?? []),
-    );
-    if (isProfileAdmin) {
-      await db.delete(posts).where(eq(posts.id, postId));
-      return;
-    }
+  if (profileIdsToCheck.length === 0) {
+    return false;
   }
 
-  // Legacy org-linked posts: createPostInOrganization does not set
-  // posts.profileId, so the author check above can't fire for them. Require
-  // org admin (not just membership) to keep the policy symmetric with
-  // profile-linked posts.
+  const profileUsers = await Promise.all(
+    profileIdsToCheck.map((profileId) =>
+      getProfileAccessUser({ user, profileId }),
+    ),
+  );
+  return profileUsers.some((profileUser) =>
+    checkPermission({ profile: permission.ADMIN }, profileUser?.roles ?? []),
+  );
+};
+
+// Legacy org-linked posts: createPostInOrganization does not set
+// posts.profileId, so the author check above can't fire for them. Require
+// org admin (not just membership) to keep the policy symmetric with
+// profile-linked posts.
+const checkOrgAdmin = async ({
+  user,
+  postId,
+}: {
+  user: User;
+  postId: string;
+}): Promise<boolean> => {
   const orgLinks = await db
     .select({ organizationId: postsToOrganizations.organizationId })
     .from(postsToOrganizations)
     .where(eq(postsToOrganizations.postId, postId));
 
-  if (orgLinks.length > 0) {
-    const orgUsers = await Promise.all(
-      orgLinks.map(({ organizationId }) =>
-        getOrgAccessUser({ organizationId, user }),
-      ),
-    );
-    const isOrgAdmin = orgUsers.some((orgUser) =>
-      checkPermission({ profile: permission.ADMIN }, orgUser?.roles ?? []),
-    );
-    if (isOrgAdmin) {
-      await db.delete(posts).where(eq(posts.id, postId));
-      return;
-    }
+  if (orgLinks.length === 0) {
+    return false;
   }
 
-  throw new UnauthorizedError();
+  const orgUsers = await Promise.all(
+    orgLinks.map(({ organizationId }) =>
+      getOrgAccessUser({ organizationId, user }),
+    ),
+  );
+  return orgUsers.some((orgUser) =>
+    checkPermission({ profile: permission.ADMIN }, orgUser?.roles ?? []),
+  );
 };

--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -3,7 +3,7 @@ import { posts, postsToOrganizations, postsToProfiles } from '@op/db/schema';
 import type { User } from '@supabase/supabase-js';
 import { checkPermission, permission } from 'access-zones';
 
-import { NotFoundError, UnauthorizedError } from '../../utils';
+import { UnauthorizedError } from '../../utils';
 import {
   getCurrentProfileId,
   getOrgAccessUser,
@@ -32,12 +32,28 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
   ]);
 
   if (!post) {
-    throw new NotFoundError('Post', postId);
+    // Mirror the unauthorized branch to avoid leaking post existence to
+    // outsiders who guess IDs.
+    throw new UnauthorizedError();
   }
 
+  // Author fast-path: the actor's current profile matches the post's
+  // recorded profileId. The currentProfileId match alone is NOT sufficient —
+  // `account.switchOrganization` only requires org membership, so any member
+  // can land on `currentProfileId = orgProfileId`. We additionally require a
+  // `profileUsers` row on that profile, which org members never have (orgs
+  // grant access via `organizationUsers`). Individual profiles and decision
+  // instance profiles do issue `profileUsers` rows to their authors, so this
+  // preserves the legitimate self-delete path.
   if (post.profileId && post.profileId === currentProfileId) {
-    await db.delete(posts).where(eq(posts.id, postId));
-    return;
+    const profileUser = await getProfileAccessUser({
+      user,
+      profileId: post.profileId,
+    });
+    if (profileUser) {
+      await db.delete(posts).where(eq(posts.id, postId));
+      return;
+    }
   }
 
   const [isProfileAdmin, isOrgAdmin] = await Promise.all([
@@ -90,10 +106,13 @@ const checkProfileAdmin = async ({
   );
 };
 
-// Legacy org-linked posts: createPostInOrganization does not set
-// posts.profileId, so the author check above can't fire for them. Require
-// org admin (not just membership) to keep the policy symmetric with
-// profile-linked posts.
+// Legacy org-linked posts: only `createPostInOrganization` writes
+// `postsToOrganizations` rows, and it never sets `posts.profileId`, so the
+// fast-path above can't fire for them. (Posts created via `createPost` —
+// including comments under those legacy posts — always have `profileId` set
+// and never get a `postsToOrganizations` row, so they fall through to
+// `checkProfileAdmin` instead.) Require org admin, not just membership, to
+// stay symmetric with the profile-linked path.
 const checkOrgAdmin = async ({
   user,
   postId,

--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -19,7 +19,11 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
   const { postId, user } = options;
 
   const [post] = await db
-    .select({ id: posts.id, profileId: posts.profileId })
+    .select({
+      id: posts.id,
+      profileId: posts.profileId,
+      rootProfileId: posts.rootProfileId,
+    })
     .from(posts)
     .where(eq(posts.id, postId))
     .limit(1);
@@ -30,44 +34,60 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
 
   const currentProfileId = await getCurrentProfileId(user.id);
 
-  let authorized =
-    post.profileId !== null && post.profileId === currentProfileId;
+  if (post.profileId && post.profileId === currentProfileId) {
+    await db.delete(posts).where(eq(posts.id, postId));
+    return;
+  }
 
-  if (!authorized) {
-    const profileLinks = await db
-      .select({ profileId: postsToProfiles.profileId })
-      .from(postsToProfiles)
-      .where(eq(postsToProfiles.postId, postId));
+  // Prefer the pinned rootProfileId gate (mirrors getPost). Fall back to the
+  // postsToProfiles index for legacy posts written before the gate was added.
+  const profileIdsToCheck = post.rootProfileId
+    ? [post.rootProfileId]
+    : (
+        await db
+          .select({ profileId: postsToProfiles.profileId })
+          .from(postsToProfiles)
+          .where(eq(postsToProfiles.postId, postId))
+      ).map((row) => row.profileId);
 
-    for (const { profileId } of profileLinks) {
-      const profileUser = await getProfileAccessUser({ user, profileId });
-      if (
-        checkPermission({ profile: permission.ADMIN }, profileUser?.roles ?? [])
-      ) {
-        authorized = true;
-        break;
-      }
+  if (profileIdsToCheck.length > 0) {
+    const profileUsers = await Promise.all(
+      profileIdsToCheck.map((profileId) =>
+        getProfileAccessUser({ user, profileId }),
+      ),
+    );
+    const isProfileAdmin = profileUsers.some((profileUser) =>
+      checkPermission({ profile: permission.ADMIN }, profileUser?.roles ?? []),
+    );
+    if (isProfileAdmin) {
+      await db.delete(posts).where(eq(posts.id, postId));
+      return;
     }
   }
 
-  if (!authorized) {
-    const orgLinks = await db
-      .select({ organizationId: postsToOrganizations.organizationId })
-      .from(postsToOrganizations)
-      .where(eq(postsToOrganizations.postId, postId));
+  // Legacy org-linked posts: createPostInOrganization does not set
+  // posts.profileId, so the author check above can't fire for them. Require
+  // org admin (not just membership) to keep the policy symmetric with
+  // profile-linked posts.
+  const orgLinks = await db
+    .select({ organizationId: postsToOrganizations.organizationId })
+    .from(postsToOrganizations)
+    .where(eq(postsToOrganizations.postId, postId));
 
-    for (const { organizationId } of orgLinks) {
-      const orgUser = await getOrgAccessUser({ organizationId, user });
-      if (orgUser) {
-        authorized = true;
-        break;
-      }
+  if (orgLinks.length > 0) {
+    const orgUsers = await Promise.all(
+      orgLinks.map(({ organizationId }) =>
+        getOrgAccessUser({ organizationId, user }),
+      ),
+    );
+    const isOrgAdmin = orgUsers.some((orgUser) =>
+      checkPermission({ profile: permission.ADMIN }, orgUser?.roles ?? []),
+    );
+    if (isOrgAdmin) {
+      await db.delete(posts).where(eq(posts.id, postId));
+      return;
     }
   }
 
-  if (!authorized) {
-    throw new UnauthorizedError();
-  }
-
-  await db.delete(posts).where(eq(posts.id, postId));
+  throw new UnauthorizedError();
 };

--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -1,4 +1,4 @@
-import { db, eq } from '@op/db/client';
+import { db, eq, sql } from '@op/db/client';
 import {
   organizations,
   posts,
@@ -26,7 +26,11 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
   // Pull the post plus the linked org's profileId in one round trip. The org
   // profile stands in as the gate for legacy postsToOrganizations posts and
   // is what assertInstanceProfileAccess looks up to resolve the org for the
-  // organizationUsers fallback.
+  // organizationUsers fallback. The join walks up via `rootPostId` so a
+  // comment on a legacy org-feed post inherits its root post's org link —
+  // comments never get their own postsToOrganizations row, and legacy roots
+  // never set rootProfileId, so without this walk org admins can't moderate
+  // replies under legacy posts.
   const [postRows, currentProfileId] = await Promise.all([
     db
       .select({
@@ -36,7 +40,10 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
         orgProfileId: organizations.profileId,
       })
       .from(posts)
-      .leftJoin(postsToOrganizations, eq(postsToOrganizations.postId, posts.id))
+      .leftJoin(
+        postsToOrganizations,
+        sql`${postsToOrganizations.postId} = coalesce(${posts.rootPostId}, ${posts.id})`,
+      )
       .leftJoin(
         organizations,
         eq(organizations.id, postsToOrganizations.organizationId),

--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -1,44 +1,72 @@
-import { and, db, eq } from '@op/db/client';
-import { organizations, posts, postsToOrganizations } from '@op/db/schema';
+import { db, eq } from '@op/db/client';
+import { posts, postsToOrganizations, postsToProfiles } from '@op/db/schema';
+import type { User } from '@supabase/supabase-js';
+import { checkPermission, permission } from 'access-zones';
+
+import { NotFoundError, UnauthorizedError } from '../../utils';
+import {
+  getCurrentProfileId,
+  getOrgAccessUser,
+  getProfileAccessUser,
+} from '../access';
 
 export interface DeletePostByIdOptions {
   postId: string;
-  profileId?: string;
-  organizationId?: string;
+  user: User;
 }
 
 export const deletePostById = async (options: DeletePostByIdOptions) => {
-  const { postId, profileId, organizationId } = options;
+  const { postId, user } = options;
 
-  if (!profileId && !organizationId) {
-    throw new Error('Either profileId or organizationId must be provided');
-  }
-
-  let query = db
-    .select({ postId: posts.id })
+  const [post] = await db
+    .select({ id: posts.id, profileId: posts.profileId })
     .from(posts)
-    .innerJoin(postsToOrganizations, eq(posts.id, postsToOrganizations.postId));
+    .where(eq(posts.id, postId))
+    .limit(1);
 
-  let whereConditions = [eq(posts.id, postId)];
-
-  if (organizationId) {
-    whereConditions.push(
-      eq(postsToOrganizations.organizationId, organizationId),
-    );
-  } else if (profileId) {
-    query = query.innerJoin(
-      organizations,
-      eq(postsToOrganizations.organizationId, organizations.id),
-    );
-    whereConditions.push(eq(organizations.profileId, profileId));
+  if (!post) {
+    throw new NotFoundError('Post', postId);
   }
 
-  const postExists = await query.where(and(...whereConditions)).limit(1);
+  const currentProfileId = await getCurrentProfileId(user.id);
 
-  if (!postExists.length) {
-    throw new Error(
-      'Post not found or does not belong to the specified organization',
-    );
+  let authorized =
+    post.profileId !== null && post.profileId === currentProfileId;
+
+  if (!authorized) {
+    const profileLinks = await db
+      .select({ profileId: postsToProfiles.profileId })
+      .from(postsToProfiles)
+      .where(eq(postsToProfiles.postId, postId));
+
+    for (const { profileId } of profileLinks) {
+      const profileUser = await getProfileAccessUser({ user, profileId });
+      if (
+        checkPermission({ profile: permission.ADMIN }, profileUser?.roles ?? [])
+      ) {
+        authorized = true;
+        break;
+      }
+    }
+  }
+
+  if (!authorized) {
+    const orgLinks = await db
+      .select({ organizationId: postsToOrganizations.organizationId })
+      .from(postsToOrganizations)
+      .where(eq(postsToOrganizations.postId, postId));
+
+    for (const { organizationId } of orgLinks) {
+      const orgUser = await getOrgAccessUser({ organizationId, user });
+      if (orgUser) {
+        authorized = true;
+        break;
+      }
+    }
+  }
+
+  if (!authorized) {
+    throw new UnauthorizedError();
   }
 
   await db.delete(posts).where(eq(posts.id, postId));

--- a/services/api/src/routers/organization/deletePost.ts
+++ b/services/api/src/routers/organization/deletePost.ts
@@ -1,11 +1,4 @@
-import {
-  NotFoundError,
-  UnauthorizedError,
-  deletePostById,
-  getOrgAccessUser,
-} from '@op/common';
-import { db, eq } from '@op/db/client';
-import { organizations } from '@op/db/schema';
+import { deletePostById } from '@op/common';
 import { z } from 'zod';
 
 import { commonAuthedProcedure, router } from '../../trpcFactory';
@@ -17,36 +10,9 @@ export const deletePost = router({
     .input(
       z.object({
         id: z.string().describe('The ID of the post to delete'),
-        profileId: z
-          .string()
-          .describe('The ID of the profile the post belongs to'),
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const { id, profileId } = input;
-
-      // Look up the organization by profileId for access control
-      const organization = await db
-        .select({ id: organizations.id })
-        .from(organizations)
-        .where(eq(organizations.profileId, profileId))
-        .limit(1);
-
-      if (!organization.length) {
-        throw new NotFoundError('Organization', profileId);
-      }
-
-      const organizationId = organization[0]!.id;
-
-      const user = await getOrgAccessUser({
-        organizationId,
-        user: ctx.user,
-      });
-
-      if (!user) {
-        throw new UnauthorizedError();
-      }
-
-      await deletePostById({ postId: id, organizationId });
+      await deletePostById({ postId: input.id, user: ctx.user });
     }),
 });

--- a/services/api/src/routers/posts/deletePost.test.ts
+++ b/services/api/src/routers/posts/deletePost.test.ts
@@ -48,7 +48,7 @@ const postExists = async (postId: string): Promise<boolean> => {
 };
 
 describe.concurrent('organization post deletion (legacy postsToOrganizations)', () => {
-  it('allows an org member to delete a post in their organization', async ({
+  it('allows an org admin to delete a post in their organization', async ({
     task,
     onTestFinished,
   }) => {
@@ -64,6 +64,32 @@ describe.concurrent('organization post deletion (legacy postsToOrganizations)', 
     await ownerCaller.organization.deletePost({ id: orgPost.id });
 
     expect(await postExists(orgPost.id)).toBe(false);
+  });
+
+  it('rejects a non-admin org member from deleting an org post', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const ownerCaller = await createAuthenticatedCaller(setup.userEmail);
+    const orgPost = await ownerCaller.organization.createPost({
+      id: setup.organization.id,
+      content: 'Org feed post.',
+    });
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+
+    await expect(
+      memberCaller.organization.deletePost({ id: orgPost.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    expect(await postExists(orgPost.id)).toBe(true);
   });
 
   it('rejects an outsider from deleting an org post', async ({

--- a/services/api/src/routers/posts/deletePost.test.ts
+++ b/services/api/src/routers/posts/deletePost.test.ts
@@ -109,6 +109,11 @@ describe.concurrent('organization post deletion (legacy postsToOrganizations)', 
       id: setup.organization.id,
       content: 'Org feed post.',
     });
+    // Legacy posts have profileId=NULL with no rootProfileId, so the
+    // TestDecisionsDataManager profile-cascade cleanup can't reach them.
+    onTestFinished(async () => {
+      await db.delete(posts).where(eq(posts.id, orgPost.id));
+    });
 
     const member = await testData.createMemberUser({
       organization: setup.organization,
@@ -134,6 +139,9 @@ describe.concurrent('organization post deletion (legacy postsToOrganizations)', 
     const orgPost = await ownerCaller.organization.createPost({
       id: setup.organization.id,
       content: 'Org feed post.',
+    });
+    onTestFinished(async () => {
+      await db.delete(posts).where(eq(posts.id, orgPost.id));
     });
 
     const outsiderCaller = await createOutsiderCaller(testData);

--- a/services/api/src/routers/posts/deletePost.test.ts
+++ b/services/api/src/routers/posts/deletePost.test.ts
@@ -458,3 +458,137 @@ describe.concurrent('proposal comment deletion', () => {
     expect(await postExists(comment.id)).toBe(true);
   });
 });
+
+describe.concurrent('regression: account.switchOrganization spoof', () => {
+  // `account.switchOrganization` only requires membership — anyone in the
+  // org can land on `currentProfileId = orgProfileId`. The author fast-path
+  // must therefore require a `profileUsers` row on `post.profileId`, since
+  // org members never get one for org profiles (they hold organizationUsers
+  // rows instead). Without that check, any member could delete any post
+  // whose `posts.profileId` equals the org's profile id.
+  it('rejects a non-admin org member who switched into the org from deleting an admin-authored org-profile post', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    await adminCaller.account.switchOrganization({
+      organizationId: setup.organization.id,
+    });
+    // posts.createPost stamps posts.profileId from currentProfileId, so the
+    // resulting post has profileId = orgProfileId — the exact shape an
+    // attacker needs to exploit the fast-path.
+    const adminPost = await adminCaller.posts.createPost({
+      content: 'Org-profile post via posts.createPost.',
+      profileId: setup.organization.profileId,
+    });
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+    await memberCaller.account.switchOrganization({
+      organizationId: setup.organization.id,
+    });
+
+    await expect(
+      memberCaller.organization.deletePost({ id: adminPost.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    expect(await postExists(adminPost.id)).toBe(true);
+  });
+});
+
+describe.concurrent('regression: legacy org post moderation gap', () => {
+  // Legacy `organization.createPost` writes a postsToOrganizations row but
+  // no posts.profileId / no postsToProfiles / no rootProfileId. Comments
+  // added via the new `posts.createPost` inherit the legacy post's null
+  // rootProfileId and (because parent has no postsToProfiles) get no
+  // postsToProfiles either. The comment itself has no postsToOrganizations
+  // link, so checkOrgAdmin never fires. This test pins that gap — flip it
+  // to `resolves.toBeUndefined()` if moderation gets wired up.
+  it('does NOT let an org admin delete a comment under a legacy postsToOrganizations post', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const ownerCaller = await createAuthenticatedCaller(setup.userEmail);
+    const legacyPost = await ownerCaller.organization.createPost({
+      id: setup.organization.id,
+      content: 'Legacy org feed post.',
+    });
+    // Legacy posts have profileId=NULL with no rootProfileId, so the
+    // TestDecisionsDataManager profile-cascade cleanup can't reach them.
+    // Tear it down manually to keep the suite-wide leftover-row check happy.
+    onTestFinished(async () => {
+      await db.delete(posts).where(eq(posts.id, legacyPost.id));
+    });
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+    const comment = await memberCaller.posts.createPost({
+      content: 'Member comment under legacy post.',
+      parentPostId: legacyPost.id,
+    });
+
+    await expect(
+      ownerCaller.organization.deletePost({ id: comment.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    expect(await postExists(comment.id)).toBe(true);
+  });
+});
+
+describe.concurrent('regression: orphan author post', () => {
+  // Direct-DB-insert simulates a post whose only linkage is posts.profileId
+  // (no rootProfileId, no postsToProfiles, no postsToOrganizations). The
+  // fast-path must still permit the author (who holds a profileUsers row on
+  // their own individual profile via the signup trigger) and reject anyone
+  // else.
+  it('lets the author delete an orphan post linked only by posts.profileId', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    // Use a fresh org member: joinOrganization doesn't touch currentProfileId
+    // (only `account.switchOrganization` does), so the member's
+    // currentProfileId stays pinned to their individual profile — the same
+    // profile that posts.profileId points at and that the signup trigger
+    // gave a profileUsers row on. That's exactly the fast-path shape we
+    // need to exercise.
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+    const author = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+    });
+
+    const [orphan] = await db
+      .insert(posts)
+      .values({
+        content: 'Orphan author post.',
+        profileId: author.profileId,
+      })
+      .returning();
+    if (!orphan) {
+      throw new Error('Failed to insert orphan post');
+    }
+
+    const outsiderCaller = await createOutsiderCaller(testData);
+    await expect(
+      outsiderCaller.organization.deletePost({ id: orphan.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+    expect(await postExists(orphan.id)).toBe(true);
+
+    const authorCaller = await createAuthenticatedCaller(author.email);
+    await authorCaller.organization.deletePost({ id: orphan.id });
+    expect(await postExists(orphan.id)).toBe(false);
+  });
+});

--- a/services/api/src/routers/posts/deletePost.test.ts
+++ b/services/api/src/routers/posts/deletePost.test.ts
@@ -394,6 +394,12 @@ describe.concurrent('proposal comment deletion', () => {
       proposalData: { title: 'Proposal under discussion' },
     });
 
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const proposalPost = await adminCaller.posts.createPost({
+      content: 'Discussion thread root.',
+      profileId: proposal.profileId,
+    });
+
     const member = await testData.createMemberUser({
       organization: setup.organization,
       instanceProfileIds: [instance.profileId],
@@ -401,12 +407,13 @@ describe.concurrent('proposal comment deletion', () => {
     const memberCaller = await createAuthenticatedCaller(member.email);
     const comment = await memberCaller.posts.createPost({
       content: 'Looks good.',
-      profileId: proposal.profileId,
+      parentPostId: proposalPost.id,
     });
 
     await memberCaller.organization.deletePost({ id: comment.id });
 
     expect(await postExists(comment.id)).toBe(false);
+    expect(await postExists(proposalPost.id)).toBe(true);
   });
 
   it('rejects an outsider from deleting a proposal comment', async ({
@@ -426,6 +433,12 @@ describe.concurrent('proposal comment deletion', () => {
       proposalData: { title: 'Proposal under discussion' },
     });
 
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const proposalPost = await adminCaller.posts.createPost({
+      content: 'Discussion thread root.',
+      profileId: proposal.profileId,
+    });
+
     const member = await testData.createMemberUser({
       organization: setup.organization,
       instanceProfileIds: [instance.profileId],
@@ -433,7 +446,7 @@ describe.concurrent('proposal comment deletion', () => {
     const memberCaller = await createAuthenticatedCaller(member.email);
     const comment = await memberCaller.posts.createPost({
       content: 'Looks good.',
-      profileId: proposal.profileId,
+      parentPostId: proposalPost.id,
     });
 
     const outsiderCaller = await createOutsiderCaller(testData);

--- a/services/api/src/routers/posts/deletePost.test.ts
+++ b/services/api/src/routers/posts/deletePost.test.ts
@@ -1,5 +1,6 @@
 import { db, eq } from '@op/db/client';
 import { posts } from '@op/db/schema';
+import { ROLES } from '@op/db/seedData/accessControl';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '..';
@@ -62,6 +63,36 @@ describe.concurrent('organization post deletion (legacy postsToOrganizations)', 
     });
 
     await ownerCaller.organization.deletePost({ id: orgPost.id });
+
+    expect(await postExists(orgPost.id)).toBe(false);
+  });
+
+  it('allows a second org admin (different user) to delete a legacy org post', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const firstAdminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const orgPost = await firstAdminCaller.organization.createPost({
+      id: setup.organization.id,
+      content: 'Org feed post by first admin.',
+    });
+
+    const secondAdmin = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+      orgRoleId: ROLES.ADMIN.id,
+    });
+    const secondAdminCaller = await createAuthenticatedCaller(
+      secondAdmin.email,
+    );
+    await secondAdminCaller.account.switchOrganization({
+      organizationId: setup.organization.id,
+    });
+
+    await secondAdminCaller.organization.deletePost({ id: orgPost.id });
 
     expect(await postExists(orgPost.id)).toBe(false);
   });
@@ -500,17 +531,56 @@ describe.concurrent('regression: account.switchOrganization spoof', () => {
 
     expect(await postExists(adminPost.id)).toBe(true);
   });
+
+  // Counterpart to the spoof test above: an admin (organizationUsers ADMIN)
+  // who switched into the org SHOULD be able to delete an org-profile post
+  // authored by another admin. posts.createPost stamps posts.profileId from
+  // currentProfileId — for a switched-in admin that's the org profile — and
+  // the deleter's fast-path correctly skips (no profileUsers row on the org
+  // profile), falling through to assertInstanceProfileAccess's org fallback.
+  it('lets an org admin delete an admin-authored org-profile post via the org-membership fallback', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const firstAdminCaller = await createAuthenticatedCaller(setup.userEmail);
+    await firstAdminCaller.account.switchOrganization({
+      organizationId: setup.organization.id,
+    });
+    const adminPost = await firstAdminCaller.posts.createPost({
+      content: 'Org-profile post via posts.createPost.',
+      profileId: setup.organization.profileId,
+    });
+
+    const secondAdmin = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+      orgRoleId: ROLES.ADMIN.id,
+    });
+    const secondAdminCaller = await createAuthenticatedCaller(
+      secondAdmin.email,
+    );
+    await secondAdminCaller.account.switchOrganization({
+      organizationId: setup.organization.id,
+    });
+
+    await secondAdminCaller.organization.deletePost({ id: adminPost.id });
+
+    expect(await postExists(adminPost.id)).toBe(false);
+  });
 });
 
-describe.concurrent('regression: legacy org post moderation gap', () => {
+describe.concurrent('regression: legacy org post moderation', () => {
   // Legacy `organization.createPost` writes a postsToOrganizations row but
   // no posts.profileId / no postsToProfiles / no rootProfileId. Comments
   // added via the new `posts.createPost` inherit the legacy post's null
   // rootProfileId and (because parent has no postsToProfiles) get no
   // postsToProfiles either. The comment itself has no postsToOrganizations
-  // link, so checkOrgAdmin never fires. This test pins that gap — flip it
-  // to `resolves.toBeUndefined()` if moderation gets wired up.
-  it('does NOT let an org admin delete a comment under a legacy postsToOrganizations post', async ({
+  // link, so the deletePost query walks up via posts.rootPostId to pick up
+  // the legacy root's org link and run the org-membership ADMIN fallback.
+  it('lets an org admin delete a comment under a legacy postsToOrganizations post', async ({
     task,
     onTestFinished,
   }) => {
@@ -541,6 +611,45 @@ describe.concurrent('regression: legacy org post moderation gap', () => {
 
     await expect(
       ownerCaller.organization.deletePost({ id: comment.id }),
+    ).resolves.toBeUndefined();
+
+    expect(await postExists(comment.id)).toBe(false);
+  });
+
+  it('does NOT let a non-admin org member delete a comment under a legacy postsToOrganizations post', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const ownerCaller = await createAuthenticatedCaller(setup.userEmail);
+    const legacyPost = await ownerCaller.organization.createPost({
+      id: setup.organization.id,
+      content: 'Legacy org feed post.',
+    });
+    onTestFinished(async () => {
+      await db.delete(posts).where(eq(posts.id, legacyPost.id));
+    });
+
+    const author = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+    });
+    const authorCaller = await createAuthenticatedCaller(author.email);
+    const comment = await authorCaller.posts.createPost({
+      content: 'Member comment under legacy post.',
+      parentPostId: legacyPost.id,
+    });
+
+    const bystander = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+    });
+    const bystanderCaller = await createAuthenticatedCaller(bystander.email);
+
+    await expect(
+      bystanderCaller.organization.deletePost({ id: comment.id }),
     ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
 
     expect(await postExists(comment.id)).toBe(true);

--- a/services/api/src/routers/posts/deletePost.test.ts
+++ b/services/api/src/routers/posts/deletePost.test.ts
@@ -1,0 +1,421 @@
+import { db, eq } from '@op/db/client';
+import { posts } from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '..';
+import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../test/supabase-utils';
+import { createCallerFactory } from '../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+const createAuthenticatedCaller = async (email: string) => {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+};
+
+const createOutsiderCaller = async (testData: TestDecisionsDataManager) => {
+  const outsiderSetup = await testData.createDecisionSetup({
+    instanceCount: 0,
+  });
+  const outsider = await testData.createMemberUser({
+    organization: outsiderSetup.organization,
+    instanceProfileIds: [],
+  });
+  return createAuthenticatedCaller(outsider.email);
+};
+
+const requireFirstInstance = <T extends { profileId: string }>(
+  instances: T[],
+): T => {
+  const instance = instances[0];
+  if (!instance) {
+    throw new Error('No instance created');
+  }
+  return instance;
+};
+
+const postExists = async (postId: string): Promise<boolean> => {
+  const [row] = await db
+    .select({ id: posts.id })
+    .from(posts)
+    .where(eq(posts.id, postId))
+    .limit(1);
+  return Boolean(row);
+};
+
+describe.concurrent('organization post deletion (legacy postsToOrganizations)', () => {
+  it('allows an org member to delete a post in their organization', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const ownerCaller = await createAuthenticatedCaller(setup.userEmail);
+    const orgPost = await ownerCaller.organization.createPost({
+      id: setup.organization.id,
+      content: 'Org feed post.',
+    });
+
+    await ownerCaller.organization.deletePost({ id: orgPost.id });
+
+    expect(await postExists(orgPost.id)).toBe(false);
+  });
+
+  it('rejects an outsider from deleting an org post', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+
+    const ownerCaller = await createAuthenticatedCaller(setup.userEmail);
+    const orgPost = await ownerCaller.organization.createPost({
+      id: setup.organization.id,
+      content: 'Org feed post.',
+    });
+
+    const outsiderCaller = await createOutsiderCaller(testData);
+
+    await expect(
+      outsiderCaller.organization.deletePost({ id: orgPost.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    expect(await postExists(orgPost.id)).toBe(true);
+  });
+});
+
+describe.concurrent('decision update post deletion (postsToProfiles)', () => {
+  it('allows the author (decision admin) to delete their own update', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const update = await adminCaller.posts.createPost({
+      content: 'Admin update.',
+      profileId: instance.profileId,
+    });
+
+    await adminCaller.organization.deletePost({ id: update.id });
+
+    expect(await postExists(update.id)).toBe(false);
+  });
+
+  it('allows a second decision admin to delete another admin’s update', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const firstAdminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const update = await firstAdminCaller.posts.createPost({
+      content: 'First admin update.',
+      profileId: instance.profileId,
+    });
+
+    const secondAdmin = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+    });
+    await testData.grantProfileAccess(
+      instance.profileId,
+      secondAdmin.authUserId,
+      secondAdmin.email,
+      true,
+    );
+
+    const secondAdminCaller = await createAuthenticatedCaller(
+      secondAdmin.email,
+    );
+    await secondAdminCaller.organization.deletePost({ id: update.id });
+
+    expect(await postExists(update.id)).toBe(false);
+  });
+
+  it('rejects a non-admin member from deleting an admin update', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const update = await adminCaller.posts.createPost({
+      content: 'Admin update.',
+      profileId: instance.profileId,
+    });
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+
+    await expect(
+      memberCaller.organization.deletePost({ id: update.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    expect(await postExists(update.id)).toBe(true);
+  });
+
+  it('rejects an outsider from deleting an admin update', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const update = await adminCaller.posts.createPost({
+      content: 'Admin update.',
+      profileId: instance.profileId,
+    });
+
+    const outsiderCaller = await createOutsiderCaller(testData);
+
+    await expect(
+      outsiderCaller.organization.deletePost({ id: update.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    expect(await postExists(update.id)).toBe(true);
+  });
+});
+
+describe.concurrent('decision comment deletion', () => {
+  it('allows a member to delete their own comment', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const update = await adminCaller.posts.createPost({
+      content: 'Admin update.',
+      profileId: instance.profileId,
+    });
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+    const comment = await memberCaller.posts.createPost({
+      content: 'Member comment.',
+      parentPostId: update.id,
+    });
+
+    await memberCaller.organization.deletePost({ id: comment.id });
+
+    expect(await postExists(comment.id)).toBe(false);
+    expect(await postExists(update.id)).toBe(true);
+  });
+
+  it('allows a decision admin to delete a member’s comment', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const update = await adminCaller.posts.createPost({
+      content: 'Admin update.',
+      profileId: instance.profileId,
+    });
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+    const comment = await memberCaller.posts.createPost({
+      content: 'Member comment.',
+      parentPostId: update.id,
+    });
+
+    await adminCaller.organization.deletePost({ id: comment.id });
+
+    expect(await postExists(comment.id)).toBe(false);
+  });
+
+  it('rejects a different member from deleting another member’s comment', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const update = await adminCaller.posts.createPost({
+      content: 'Admin update.',
+      profileId: instance.profileId,
+    });
+
+    const author = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const authorCaller = await createAuthenticatedCaller(author.email);
+    const comment = await authorCaller.posts.createPost({
+      content: 'Author comment.',
+      parentPostId: update.id,
+    });
+
+    const otherMember = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const otherMemberCaller = await createAuthenticatedCaller(
+      otherMember.email,
+    );
+
+    await expect(
+      otherMemberCaller.organization.deletePost({ id: comment.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    expect(await postExists(comment.id)).toBe(true);
+  });
+
+  it('rejects an outsider from deleting a comment', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+    const update = await adminCaller.posts.createPost({
+      content: 'Admin update.',
+      profileId: instance.profileId,
+    });
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+    const comment = await memberCaller.posts.createPost({
+      content: 'Member comment.',
+      parentPostId: update.id,
+    });
+
+    const outsiderCaller = await createOutsiderCaller(testData);
+
+    await expect(
+      outsiderCaller.organization.deletePost({ id: comment.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    expect(await postExists(comment.id)).toBe(true);
+  });
+});
+
+describe.concurrent('proposal comment deletion', () => {
+  it('allows the comment author to delete their own proposal comment', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Proposal under discussion' },
+    });
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+    const comment = await memberCaller.posts.createPost({
+      content: 'Looks good.',
+      profileId: proposal.profileId,
+    });
+
+    await memberCaller.organization.deletePost({ id: comment.id });
+
+    expect(await postExists(comment.id)).toBe(false);
+  });
+
+  it('rejects an outsider from deleting a proposal comment', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = requireFirstInstance(setup.instances);
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Proposal under discussion' },
+    });
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+    const comment = await memberCaller.posts.createPost({
+      content: 'Looks good.',
+      profileId: proposal.profileId,
+    });
+
+    const outsiderCaller = await createOutsiderCaller(testData);
+
+    await expect(
+      outsiderCaller.organization.deletePost({ id: comment.id }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    expect(await postExists(comment.id)).toBe(true);
+  });
+});

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -488,11 +488,14 @@ export class TestDecisionsDataManager {
     organization,
     instanceProfileIds = [],
     roleIds = {},
+    orgRoleId = ROLES.MEMBER.id,
   }: {
     organization: { id: string };
     instanceProfileIds?: string[];
     /** Map of profileId → roleId to assign after granting profile access. */
     roleIds?: Record<string, string>;
+    /** Org-level role to assign on join. Defaults to MEMBER. */
+    orgRoleId?: string;
   }): Promise<MemberUserOutput> {
     this.ensureCleanupRegistered();
 
@@ -533,7 +536,7 @@ export class TestDecisionsDataManager {
     const orgUser = await joinOrganization({
       user: userRecord,
       organization: orgRecord,
-      roleId: ROLES.MEMBER.id,
+      roleId: orgRoleId,
     });
 
     if (!orgUser) {


### PR DESCRIPTION
## Summary
- Rewrite `deletePostById` with three-tier auth: author -> profile admin -> legacy org member, so posts created via the unified `posts.createPost` path (decision updates, proposal comments) can actually be deleted.
- Simplify `organization.deletePost` to take only `{ id }`; drop the broken `organizations.profileId` lookup.
- Drop the dead `profileId` prop from `DeletePost` / `PostFeed`.
- Add `services/api/src/routers/posts/deletePost.test.ts` with 12 integration tests across legacy org posts, decision update posts, decision comments, and proposal comments.

