### PR TITLE
fix(decisions): suppress results-phase email until selections are confirmed

### DIFF
--- a/packages/common/src/services/decision/onPhaseAdvanced.ts
+++ b/packages/common/src/services/decision/onPhaseAdvanced.ts
@@ -22,22 +22,28 @@ export async function onPhaseAdvanced(
 ): Promise<void> {
   const targetPhase = input.phases.find((p) => p.phaseId === input.toPhaseId);
 
-  // Notify participants about the phase transition (fire-and-forget)
-  event
-    .send({
-      name: Events.phaseTransitioned.name,
-      data: {
-        processInstanceId: input.instanceId,
-        fromPhaseId: input.fromPhaseId,
-        toPhaseId: input.toPhaseId,
-      },
-    })
-    .catch((err) => {
-      console.error(
-        `Failed to send phase transition event for instance ${input.instanceId}:`,
-        err,
-      );
-    });
+  // TEMP: suppress the results-phase email until manual-selection confirmation
+  // is wired into the notification trigger — otherwise participants get a
+  // "results are in" email before the admin has confirmed selections. Remove
+  // this guard once the email fires off `selectionsAreConfirmed` instead of
+  // the raw phase transition.
+  if (!isLastPhase(input.toPhaseId, input.phases)) {
+    event
+      .send({
+        name: Events.phaseTransitioned.name,
+        data: {
+          processInstanceId: input.instanceId,
+          fromPhaseId: input.fromPhaseId,
+          toPhaseId: input.toPhaseId,
+        },
+      })
+      .catch((err) => {
+        console.error(
+          `Failed to send phase transition event for instance ${input.instanceId}:`,
+          err,
+        );
+      });
+  }
 
   if (targetPhase?.rules?.proposals?.review) {
     await runGenerateReviewAssignments(input);

--- a/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
@@ -69,8 +69,9 @@ describe('transitionFromPhase', () => {
 
     expect(dbInstance!.currentStateId).toBe('final');
 
-    // Verify phase transition event was dispatched (filter by this instance
-    // to avoid interference from concurrent tests sharing the mock)
+    // The phase transition event is suppressed when advancing into the last
+    // phase (see onPhaseAdvanced) — `final` is the last phase in this schema,
+    // so no event should be dispatched for this instance.
     const transitionCalls = mockSend.mock.calls.filter(
       (call: unknown[]) =>
         (call[0] as { name: string; data: { processInstanceId: string } })
@@ -78,15 +79,7 @@ describe('transitionFromPhase', () => {
         (call[0] as { data: { processInstanceId: string } }).data
           .processInstanceId === instance.instance.id,
     );
-    expect(transitionCalls).toHaveLength(1);
-    expect(transitionCalls[0]![0]).toMatchObject({
-      name: 'decision/phase-transitioned',
-      data: {
-        processInstanceId: instance.instance.id,
-        fromPhaseId: 'initial',
-        toPhaseId: 'final',
-      },
-    });
+    expect(transitionCalls).toHaveLength(0);
   });
 
   it('should record transition in history with manual flag', async ({

--- a/services/api/src/routers/decision/instances/transitionMonitor.test.ts
+++ b/services/api/src/routers/decision/instances/transitionMonitor.test.ts
@@ -308,14 +308,23 @@ describe('processDecisionsTransitions', () => {
     const fromStates = historyRows.map((h) => h.fromStateId).sort();
     expect(fromStates).toEqual(['review', 'submission', 'voting']);
 
-    // Verify phase transition events were dispatched for each advance
-    expect(mockSend).toHaveBeenCalledTimes(3);
-    expect(mockSend).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'decision/phase-transitioned',
-        data: expect.objectContaining({ processInstanceId: instanceId }),
-      }),
+    // Phase transition events fire for each advance EXCEPT the one into the
+    // last phase (voting → results) — that email is intentionally suppressed
+    // in onPhaseAdvanced until manual-selection confirmation is wired up.
+    const phaseTransitionCalls = mockSend.mock.calls.filter(
+      (call: unknown[]) =>
+        (call[0] as { name: string; data: { processInstanceId: string } })
+          .name === 'decision/phase-transitioned' &&
+        (call[0] as { data: { processInstanceId: string } }).data
+          .processInstanceId === instanceId,
     );
+    expect(phaseTransitionCalls).toHaveLength(2);
+    const toPhaseIds = phaseTransitionCalls
+      .map(
+        (call) => (call[0] as { data: { toPhaseId: string } }).data.toPhaseId,
+      )
+      .sort();
+    expect(toPhaseIds).toEqual(['review', 'voting']);
   });
 
   it('should NOT process transitions for DRAFT instances', async ({


### PR DESCRIPTION
Otherwise participants get a "results are in" notification before the admin has actually confirmed manual selections. Temporary guard until the email fires off `selectionsAreConfirmed` instead of the raw phase transition.