### PR TITLE
refactor(uploads): apply signed-URL pattern to remaining attachment endpoints

### DIFF
--- a/apps/app/src/components/Onboarding/PersonalDetailsForm.tsx
+++ b/apps/app/src/components/Onboarding/PersonalDetailsForm.tsx
@@ -12,6 +12,7 @@ import { z } from 'zod';
 
 import { useTranslations } from '@/lib/i18n';
 import type { TranslateFn } from '@/lib/i18n';
+import { uploadFileViaSignedUrl } from '@/lib/uploadViaSignedUrl';
 
 import { StepProps } from '../MultiStepForm';
 import { FocusAreasField } from '../Profile/ProfileDetails/FocusAreasField';
@@ -116,7 +117,10 @@ export const PersonalDetailsForm = ({
   );
   const t = useTranslations();
   const utils = trpc.useUtils();
+  const createAvatarUploadUrl = trpc.account.createImageUploadUrl.useMutation();
   const uploadImage = trpc.account.uploadImage.useMutation();
+  const createBannerUploadUrl =
+    trpc.account.createBannerImageUploadUrl.useMutation();
   const uploadBannerImage = trpc.account.uploadBannerImage.useMutation();
   const updateProfile = trpc.account.updateUserProfile.useMutation();
   // Get current user's profile ID for the focus areas component
@@ -134,63 +138,59 @@ export const PersonalDetailsForm = ({
   const handleImageUpload = async (
     file: File,
     setImageUrl: (url: string | undefined) => void,
-    uploadMutation: typeof uploadBannerImage | typeof uploadImage,
+    target: 'avatar' | 'banner',
   ): Promise<void> => {
-    const reader = new FileReader();
+    if (!acceptedTypes.includes(file.type)) {
+      const types = acceptedTypes.map((type) => type.split('/')[1]).join(', ');
+      toast.error({
+        message: t('That file type is not supported. Accepted types: {types}', {
+          types,
+        }),
+      });
+      return;
+    }
 
-    reader.onload = async (e) => {
-      const base64 = (e.target?.result as string)?.split(',')[1];
+    if (file.size > DEFAULT_MAX_SIZE) {
+      const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
+      toast.error({
+        message: t('File too large. Maximum size: {size}MB', {
+          size: maxSizeMB,
+        }),
+      });
+      return;
+    }
 
-      if (!base64) {
-        return;
-      }
+    const previousUrl = target === 'banner' ? bannerImageUrl : profileImageUrl;
+    const previewUrl = URL.createObjectURL(file);
+    setImageUrl(previewUrl);
 
-      if (!acceptedTypes.includes(file.type)) {
-        const types = acceptedTypes
-          .map((type) => type.split('/')[1])
-          .join(', ');
-        toast.error({
-          message: t(
-            'That file type is not supported. Accepted types: {types}',
-            { types },
-          ),
-        });
-        return;
-      }
+    const createUrl =
+      target === 'banner' ? createBannerUploadUrl : createAvatarUploadUrl;
+    const recordUpload = target === 'banner' ? uploadBannerImage : uploadImage;
 
-      if (file.size > DEFAULT_MAX_SIZE) {
-        const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
-        toast.error({
-          message: t('File too large. Maximum size: {size}MB', {
-            size: maxSizeMB,
-          }),
-        });
-        return;
-      }
-
-      const dataUrl = `data:${file.type};base64,${base64}`;
-      setImageUrl(dataUrl);
-
-      const res = await uploadMutation.mutateAsync(
-        {
-          file: base64,
-          fileName: file.name,
-          mimeType: file.type,
-        },
-        {
-          onSuccess: () => {
-            utils.account.getMyAccount.invalidate();
-            utils.account.getUserProfiles.invalidate();
-          },
-        },
-      );
+    try {
+      const res = await uploadFileViaSignedUrl(file, {
+        createUploadUrl: (args) => createUrl.mutateAsync(args),
+        recordUpload: (args) => recordUpload.mutateAsync(args),
+      });
 
       if (res?.url) {
         setImageUrl(res.url);
       }
-    };
 
-    reader.readAsDataURL(file);
+      utils.account.getMyAccount.invalidate();
+      utils.account.getUserProfiles.invalidate();
+    } catch (err) {
+      setImageUrl(previousUrl);
+      toast.error({
+        message:
+          err instanceof Error && err.message
+            ? err.message
+            : t('Image upload failed'),
+      });
+    } finally {
+      URL.revokeObjectURL(previewUrl);
+    }
   };
 
   // Hydrate form from store if present
@@ -252,7 +252,7 @@ export const PersonalDetailsForm = ({
           <BannerUploader
             value={bannerImageUrl ?? undefined}
             onChange={(file: File) =>
-              handleImageUpload(file, setBannerImageUrl, uploadBannerImage)
+              handleImageUpload(file, setBannerImageUrl, 'banner')
             }
             uploading={uploadBannerImage.isPending}
             error={uploadBannerImage.error?.message || undefined}
@@ -262,7 +262,7 @@ export const PersonalDetailsForm = ({
             className="absolute start-4 bottom-0 aspect-square size-20 sm:size-28"
             value={profileImageUrl ?? undefined}
             onChange={(file: File) =>
-              handleImageUpload(file, setProfileImageUrl, uploadImage)
+              handleImageUpload(file, setProfileImageUrl, 'avatar')
             }
             uploading={uploadImage.isPending}
             error={uploadImage.error?.message || undefined}

--- a/apps/app/src/components/Onboarding/shared/OrganizationFormFields.tsx
+++ b/apps/app/src/components/Onboarding/shared/OrganizationFormFields.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 import { LuLink } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
+import { uploadFileViaSignedUrl } from '@/lib/uploadViaSignedUrl';
 
 import { GeoNamesMultiSelect } from '../../GeoNamesMultiSelect';
 import { TermsMultiSelect } from '../../TermsMultiSelect';
@@ -44,8 +45,12 @@ export const OrganizationFormFields = ({
   children,
 }: OrganizationFormFieldsProps) => {
   const t = useTranslations();
+  const createAvatarUploadUrl =
+    trpc.organization.createAvatarImageUploadUrl.useMutation();
   const uploadAvatarImage = trpc.organization.uploadAvatarImage.useMutation();
-  const uploadImage = trpc.organization.uploadAvatarImage.useMutation();
+  const createBannerUploadUrl =
+    trpc.organization.createBannerImageUploadUrl.useMutation();
+  const uploadBannerImage = trpc.organization.uploadBannerImage.useMutation();
 
   const [profileImage, setProfileImage] = useState<ImageData | undefined>(
     initialProfileImage,
@@ -74,59 +79,63 @@ export const OrganizationFormFields = ({
   const handleImageUpload = async (
     file: File,
     setImage: (image: ImageData | undefined) => void,
-    uploadMutation: any,
+    target: 'avatar' | 'banner',
   ): Promise<void> => {
-    const reader = new FileReader();
+    const acceptedTypes = [
+      'image/gif',
+      'image/png',
+      'image/jpeg',
+      'image/webp',
+    ];
+    if (!acceptedTypes.includes(file.type)) {
+      const types = acceptedTypes.map((t) => t.split('/')[1]).join(', ');
+      toast.error({
+        message: t('That file type is not supported. Accepted types: {types}', {
+          types,
+        }),
+      });
+      return;
+    }
 
-    reader.onload = async (e) => {
-      const base64 = (e.target?.result as string)?.split(',')[1];
+    if (file.size > DEFAULT_MAX_SIZE) {
+      const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
+      toast.error({
+        message: t('File too large. Maximum size: {size}MB', {
+          size: maxSizeMB,
+        }),
+      });
+      return;
+    }
 
-      if (!base64) {
-        return;
-      }
+    const previousImage = target === 'banner' ? bannerImage : profileImage;
+    const previewUrl = URL.createObjectURL(file);
+    setImage({ url: previewUrl });
 
-      const acceptedTypes = [
-        'image/gif',
-        'image/png',
-        'image/jpeg',
-        'image/webp',
-      ];
-      if (!acceptedTypes.includes(file.type)) {
-        const types = acceptedTypes.map((t) => t.split('/')[1]).join(', ');
-        toast.error({
-          message: t(
-            'That file type is not supported. Accepted types: {types}',
-            { types },
-          ),
-        });
-        return;
-      }
+    const createUrl =
+      target === 'banner' ? createBannerUploadUrl : createAvatarUploadUrl;
+    const recordUpload =
+      target === 'banner' ? uploadBannerImage : uploadAvatarImage;
 
-      if (file.size > DEFAULT_MAX_SIZE) {
-        const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
-        toast.error({
-          message: t('File too large. Maximum size: {size}MB', {
-            size: maxSizeMB,
-          }),
-        });
-        return;
-      }
-
-      const dataUrl = `data:${file.type};base64,${base64}`;
-
-      setImage({ url: dataUrl });
-      const res = await uploadMutation.mutateAsync({
-        file: base64,
-        fileName: file.name,
-        mimeType: file.type,
+    try {
+      const res = await uploadFileViaSignedUrl(file, {
+        createUploadUrl: (args) => createUrl.mutateAsync(args),
+        recordUpload: (args) => recordUpload.mutateAsync(args),
       });
 
       if (res?.url) {
         setImage(res);
       }
-    };
-
-    reader.readAsDataURL(file);
+    } catch (err) {
+      setImage(previousImage);
+      toast.error({
+        message:
+          err instanceof Error && err.message
+            ? err.message
+            : t('Image upload failed'),
+      });
+    } finally {
+      URL.revokeObjectURL(previewUrl);
+    }
   };
 
   const formFields = (
@@ -135,16 +144,16 @@ export const OrganizationFormFields = ({
         <BannerUploader
           value={bannerImage?.url ?? undefined}
           onChange={(file: File) =>
-            handleImageUpload(file, setBannerImage, uploadImage)
+            handleImageUpload(file, setBannerImage, 'banner')
           }
-          uploading={uploadImage.isPending}
-          error={uploadImage.error?.message || undefined}
+          uploading={uploadBannerImage.isPending}
+          error={uploadBannerImage.error?.message || undefined}
         />
         <AvatarUploader
           className="absolute start-4 bottom-0 aspect-square size-20 sm:size-28"
           value={profileImage?.url ?? undefined}
           onChange={(file: File) =>
-            handleImageUpload(file, setProfileImage, uploadAvatarImage)
+            handleImageUpload(file, setProfileImage, 'avatar')
           }
           uploading={uploadAvatarImage.isPending}
           error={uploadAvatarImage.error?.message || undefined}

--- a/apps/app/src/components/Profile/ProfileDetails/CreateOrganizationForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/CreateOrganizationForm.tsx
@@ -16,6 +16,7 @@ import { forwardRef, useState } from 'react';
 import { LuLink } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
+import { uploadFileViaSignedUrl } from '@/lib/uploadViaSignedUrl';
 
 import { organizationFormValidator } from '@/components/Onboarding/shared/organizationValidation';
 import { sendOnboardingAnalytics } from '@/components/Onboarding/utils';
@@ -59,8 +60,12 @@ export const CreateOrganizationForm = forwardRef<
     },
   });
 
+  const createAvatarUploadUrl =
+    trpc.organization.createAvatarImageUploadUrl.useMutation();
   const uploadAvatarImage = trpc.organization.uploadAvatarImage.useMutation();
-  const uploadBannerImage = trpc.organization.uploadAvatarImage.useMutation();
+  const createBannerUploadUrl =
+    trpc.organization.createBannerImageUploadUrl.useMutation();
+  const uploadBannerImage = trpc.organization.uploadBannerImage.useMutation();
 
   const [profileImage, setProfileImage] = useState<ImageData | undefined>();
   const [bannerImage, setBannerImage] = useState<ImageData | undefined>();
@@ -122,60 +127,62 @@ export const CreateOrganizationForm = forwardRef<
   const handleImageUpload = async (
     file: File,
     setImage: (image: ImageData | undefined) => void,
-    uploadMutation: any,
+    target: 'avatar' | 'banner',
   ): Promise<void> => {
-    const reader = new FileReader();
+    const acceptedTypes = [
+      'image/gif',
+      'image/png',
+      'image/jpeg',
+      'image/webp',
+    ];
+    if (!acceptedTypes.includes(file.type)) {
+      toast.error({
+        message: t('That file type is not supported. Accepted types: {types}', {
+          types: acceptedTypes.map((type) => type.split('/')[1]).join(', '),
+        }),
+      });
+      return;
+    }
 
-    reader.onload = async (e) => {
-      const base64 = (e.target?.result as string)?.split(',')[1];
+    if (file.size > DEFAULT_MAX_SIZE) {
+      const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
+      toast.error({
+        message: t('File too large. Maximum size: {size}MB', {
+          size: maxSizeMB,
+        }),
+      });
+      return;
+    }
 
-      if (!base64) {
-        return;
-      }
+    const previousImage = target === 'banner' ? bannerImage : profileImage;
+    const previewUrl = URL.createObjectURL(file);
+    setImage({ url: previewUrl });
 
-      const acceptedTypes = [
-        'image/gif',
-        'image/png',
-        'image/jpeg',
-        'image/webp',
-      ];
-      if (!acceptedTypes.includes(file.type)) {
-        toast.error({
-          message: t(
-            'That file type is not supported. Accepted types: {types}',
-            {
-              types: acceptedTypes.map((type) => type.split('/')[1]).join(', '),
-            },
-          ),
-        });
-        return;
-      }
+    const createUrl =
+      target === 'banner' ? createBannerUploadUrl : createAvatarUploadUrl;
+    const recordUpload =
+      target === 'banner' ? uploadBannerImage : uploadAvatarImage;
 
-      if (file.size > DEFAULT_MAX_SIZE) {
-        const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
-        toast.error({
-          message: t('File too large. Maximum size: {size}MB', {
-            size: maxSizeMB,
-          }),
-        });
-        return;
-      }
-
-      const dataUrl = `data:${file.type};base64,${base64}`;
-
-      setImage({ url: dataUrl });
-      const res = await uploadMutation.mutateAsync({
-        file: base64,
-        fileName: file.name,
-        mimeType: file.type,
+    try {
+      const res = await uploadFileViaSignedUrl(file, {
+        createUploadUrl: (args) => createUrl.mutateAsync(args),
+        recordUpload: (args) => recordUpload.mutateAsync(args),
       });
 
       if (res?.url) {
         setImage(res);
       }
-    };
-
-    reader.readAsDataURL(file);
+    } catch (err) {
+      setImage(previousImage);
+      toast.error({
+        message:
+          err instanceof Error && err.message
+            ? err.message
+            : t('Image upload failed'),
+      });
+    } finally {
+      URL.revokeObjectURL(previewUrl);
+    }
   };
 
   return (
@@ -194,7 +201,7 @@ export const CreateOrganizationForm = forwardRef<
           <BannerUploader
             value={bannerImage?.url ?? undefined}
             onChange={(file: File) =>
-              handleImageUpload(file, setBannerImage, uploadBannerImage)
+              handleImageUpload(file, setBannerImage, 'banner')
             }
             uploading={uploadBannerImage.isPending}
             error={uploadBannerImage.error?.message || undefined}
@@ -203,7 +210,7 @@ export const CreateOrganizationForm = forwardRef<
             className="absolute start-4 bottom-0 aspect-square size-20 sm:size-28"
             value={profileImage?.url ?? undefined}
             onChange={(file: File) =>
-              handleImageUpload(file, setProfileImage, uploadAvatarImage)
+              handleImageUpload(file, setProfileImage, 'avatar')
             }
             uploading={uploadAvatarImage.isPending}
             error={uploadAvatarImage.error?.message || undefined}

--- a/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationForm.tsx
@@ -18,6 +18,7 @@ import { forwardRef, useState } from 'react';
 import { LuLink } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
+import { uploadFileViaSignedUrl } from '@/lib/uploadViaSignedUrl';
 
 import { GeoNamesMultiSelect } from '../../GeoNamesMultiSelect';
 import { type ImageData } from '../../Onboarding/shared/OrganizationFormFields';
@@ -124,8 +125,12 @@ export const UpdateOrganizationForm = forwardRef<
     : undefined;
 
   const updateOrganization = trpc.organization.update.useMutation();
+  const createAvatarUploadUrl =
+    trpc.organization.createAvatarImageUploadUrl.useMutation();
   const uploadAvatarImage = trpc.organization.uploadAvatarImage.useMutation();
-  const uploadImage = trpc.organization.uploadAvatarImage.useMutation();
+  const createBannerUploadUrl =
+    trpc.organization.createBannerImageUploadUrl.useMutation();
+  const uploadBannerImage = trpc.organization.uploadBannerImage.useMutation();
 
   const [profileImage, setProfileImage] = useState<ImageData | undefined>(
     initialProfileImage,
@@ -196,60 +201,62 @@ export const UpdateOrganizationForm = forwardRef<
   const handleImageUpload = async (
     file: File,
     setImage: (image: ImageData | undefined) => void,
-    uploadMutation: any,
+    target: 'avatar' | 'banner',
   ): Promise<void> => {
-    const reader = new FileReader();
+    const acceptedTypes = [
+      'image/gif',
+      'image/png',
+      'image/jpeg',
+      'image/webp',
+    ];
+    if (!acceptedTypes.includes(file.type)) {
+      toast.error({
+        message: t('That file type is not supported. Accepted types: {types}', {
+          types: acceptedTypes.map((type) => type.split('/')[1]).join(', '),
+        }),
+      });
+      return;
+    }
 
-    reader.onload = async (e) => {
-      const base64 = (e.target?.result as string)?.split(',')[1];
+    if (file.size > DEFAULT_MAX_SIZE) {
+      const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
+      toast.error({
+        message: t('File too large. Maximum size: {size}MB', {
+          size: maxSizeMB,
+        }),
+      });
+      return;
+    }
 
-      if (!base64) {
-        return;
-      }
+    const previousImage = target === 'banner' ? bannerImage : profileImage;
+    const previewUrl = URL.createObjectURL(file);
+    setImage({ url: previewUrl });
 
-      const acceptedTypes = [
-        'image/gif',
-        'image/png',
-        'image/jpeg',
-        'image/webp',
-      ];
-      if (!acceptedTypes.includes(file.type)) {
-        toast.error({
-          message: t(
-            'That file type is not supported. Accepted types: {types}',
-            {
-              types: acceptedTypes.map((type) => type.split('/')[1]).join(', '),
-            },
-          ),
-        });
-        return;
-      }
+    const createUrl =
+      target === 'banner' ? createBannerUploadUrl : createAvatarUploadUrl;
+    const recordUpload =
+      target === 'banner' ? uploadBannerImage : uploadAvatarImage;
 
-      if (file.size > DEFAULT_MAX_SIZE) {
-        const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
-        toast.error({
-          message: t('File too large. Maximum size: {size}MB', {
-            size: maxSizeMB,
-          }),
-        });
-        return;
-      }
-
-      const dataUrl = `data:${file.type};base64,${base64}`;
-
-      setImage({ url: dataUrl });
-      const res = await uploadMutation.mutateAsync({
-        file: base64,
-        fileName: file.name,
-        mimeType: file.type,
+    try {
+      const res = await uploadFileViaSignedUrl(file, {
+        createUploadUrl: (args) => createUrl.mutateAsync(args),
+        recordUpload: (args) => recordUpload.mutateAsync(args),
       });
 
       if (res?.url) {
         setImage(res);
       }
-    };
-
-    reader.readAsDataURL(file);
+    } catch (err) {
+      setImage(previousImage);
+      toast.error({
+        message:
+          err instanceof Error && err.message
+            ? err.message
+            : t('Image upload failed'),
+      });
+    } finally {
+      URL.revokeObjectURL(previewUrl);
+    }
   };
 
   return (
@@ -268,16 +275,16 @@ export const UpdateOrganizationForm = forwardRef<
           <BannerUploader
             value={bannerImage?.url ?? undefined}
             onChange={(file: File) =>
-              handleImageUpload(file, setBannerImage, uploadImage)
+              handleImageUpload(file, setBannerImage, 'banner')
             }
-            uploading={uploadImage.isPending}
-            error={uploadImage.error?.message || undefined}
+            uploading={uploadBannerImage.isPending}
+            error={uploadBannerImage.error?.message || undefined}
           />
           <AvatarUploader
             className="absolute start-4 bottom-0 aspect-square size-20 sm:size-28"
             value={profileImage?.url ?? undefined}
             onChange={(file: File) =>
-              handleImageUpload(file, setProfileImage, uploadAvatarImage)
+              handleImageUpload(file, setProfileImage, 'avatar')
             }
             uploading={uploadAvatarImage.isPending}
             error={uploadAvatarImage.error?.message || undefined}

--- a/apps/app/src/components/Profile/ProfileDetails/UpdateProfile/BaseUpdateProfileForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/UpdateProfile/BaseUpdateProfileForm.tsx
@@ -16,6 +16,7 @@ import { ReactNode, Suspense, forwardRef, useState } from 'react';
 import { z } from 'zod';
 
 import { useTranslations } from '@/lib/i18n';
+import { uploadFileViaSignedUrl } from '@/lib/uploadViaSignedUrl';
 
 import { FormContainer } from '../../../form/FormContainer';
 import { getFieldErrorMessage, useAppForm } from '../../../form/utils';
@@ -58,7 +59,11 @@ export const BaseUpdateProfileForm = forwardRef<
     const t = useTranslations();
     const router = useRouter();
 
+    const createAvatarUploadUrl =
+      trpc.account.createImageUploadUrl.useMutation();
     const uploadImage = trpc.account.uploadImage.useMutation();
+    const createBannerUploadUrl =
+      trpc.account.createBannerImageUploadUrl.useMutation();
     const uploadBannerImage = trpc.account.uploadBannerImage.useMutation();
 
     const profileId = profile.id;
@@ -107,64 +112,65 @@ export const BaseUpdateProfileForm = forwardRef<
     const handleImageUpload = async (
       file: File,
       setImageUrl: (url: string | undefined) => void,
-      uploadMutation: typeof uploadImage | typeof uploadBannerImage,
+      target: 'avatar' | 'banner',
     ): Promise<void> => {
-      const reader = new FileReader();
-
-      reader.onload = async (e) => {
-        const base64 = (e.target?.result as string)?.split(',')[1];
-
-        if (!base64) {
-          return;
-        }
-
-        if (!acceptedImageTypes.includes(file.type)) {
-          toast.error({
-            message: t(
-              'That file type is not supported. Accepted types: {types}',
-              {
-                types: acceptedImageTypes
-                  .map((type) => type.split('/')[1])
-                  .join(', '),
-              },
-            ),
-          });
-          return;
-        }
-
-        if (file.size > DEFAULT_MAX_SIZE) {
-          const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
-          toast.error({
-            message: t('File too large. Maximum size: {size}MB', {
-              size: maxSizeMB,
-            }),
-          });
-          return;
-        }
-
-        const dataUrl = `data:${file.type};base64,${base64}`;
-        setImageUrl(dataUrl);
-
-        const res = await uploadMutation.mutateAsync(
-          {
-            file: base64,
-            fileName: file.name,
-            mimeType: file.type,
-          },
-          {
-            onSuccess: () => {
-              onImageUploadSuccess?.();
-              router.refresh();
+      if (!acceptedImageTypes.includes(file.type)) {
+        toast.error({
+          message: t(
+            'That file type is not supported. Accepted types: {types}',
+            {
+              types: acceptedImageTypes
+                .map((type) => type.split('/')[1])
+                .join(', '),
             },
-          },
-        );
+          ),
+        });
+        return;
+      }
+
+      if (file.size > DEFAULT_MAX_SIZE) {
+        const maxSizeMB = (DEFAULT_MAX_SIZE / 1024 / 1024).toFixed(2);
+        toast.error({
+          message: t('File too large. Maximum size: {size}MB', {
+            size: maxSizeMB,
+          }),
+        });
+        return;
+      }
+
+      const previousUrl =
+        target === 'banner' ? bannerImageUrl : profileImageUrl;
+      const previewUrl = URL.createObjectURL(file);
+      setImageUrl(previewUrl);
+
+      const createUrl =
+        target === 'banner' ? createBannerUploadUrl : createAvatarUploadUrl;
+      const recordUpload =
+        target === 'banner' ? uploadBannerImage : uploadImage;
+
+      try {
+        const res = await uploadFileViaSignedUrl(file, {
+          createUploadUrl: (args) => createUrl.mutateAsync(args),
+          recordUpload: (args) => recordUpload.mutateAsync(args),
+        });
 
         if (res?.url) {
           setImageUrl(res.url);
         }
-      };
 
-      reader.readAsDataURL(file);
+        onImageUploadSuccess?.();
+        router.refresh();
+      } catch (err) {
+        setImageUrl(previousUrl);
+        toast.error({
+          message:
+            err instanceof Error && err.message
+              ? err.message
+              : t('Image upload failed'),
+        });
+      } finally {
+        URL.revokeObjectURL(previewUrl);
+      }
     };
 
     return (
@@ -182,7 +188,7 @@ export const BaseUpdateProfileForm = forwardRef<
             <BannerUploader
               value={bannerImageUrl ?? undefined}
               onChange={(file: File) =>
-                handleImageUpload(file, setBannerImageUrl, uploadBannerImage)
+                handleImageUpload(file, setBannerImageUrl, 'banner')
               }
               uploading={uploadBannerImage.isPending}
               error={uploadBannerImage.error?.message || undefined}
@@ -192,7 +198,7 @@ export const BaseUpdateProfileForm = forwardRef<
               className="absolute start-4 bottom-0 aspect-square size-20 sm:size-28"
               value={profileImageUrl ?? undefined}
               onChange={(file: File) =>
-                handleImageUpload(file, setProfileImageUrl, uploadImage)
+                handleImageUpload(file, setProfileImageUrl, 'avatar')
               }
               uploading={uploadImage.isPending}
               error={uploadImage.error?.message || undefined}

--- a/apps/app/src/hooks/useFileUpload.ts
+++ b/apps/app/src/hooks/useFileUpload.ts
@@ -2,6 +2,8 @@ import { trpc } from '@op/api/client';
 import { toast } from '@op/ui/Toast';
 import { useCallback, useState } from 'react';
 
+import { uploadFileViaSignedUrl } from '@/lib/uploadViaSignedUrl';
+
 export interface FilePreview {
   id: string;
   file: File;
@@ -30,6 +32,13 @@ const DEFAULT_ACCEPTED_TYPES = [
 const DEFAULT_MAX_FILES = 10;
 export const DEFAULT_MAX_SIZE = 25 * 1024 * 1024; // 25MB
 
+function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message) {
+    return err.message;
+  }
+  return fallback;
+}
+
 export const useFileUpload = (options: UseFileUploadOptions) => {
   const {
     acceptedTypes = DEFAULT_ACCEPTED_TYPES,
@@ -40,6 +49,8 @@ export const useFileUpload = (options: UseFileUploadOptions) => {
   const [filePreviews, setFilePreviews] = useState<FilePreview[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
 
+  const createUploadUrl =
+    trpc.posts.createPostAttachmentUploadUrl.useMutation();
   const uploadAttachment = trpc.posts.uploadPostAttachment.useMutation();
 
   const validateFile = (file: File): string | null => {
@@ -65,13 +76,12 @@ export const useFileUpload = (options: UseFileUploadOptions) => {
   }> => {
     const validationError = validateFile(file);
     if (validationError) {
-      toast.status({ code: 500, message: validationError });
+      toast.error({ message: validationError });
       throw new Error(validationError);
     }
 
     const previewId = `${Date.now()}-${Math.random()}`;
 
-    // Create initial preview
     const preview: FilePreview = {
       id: previewId,
       file,
@@ -85,26 +95,11 @@ export const useFileUpload = (options: UseFileUploadOptions) => {
     setFilePreviews((prev) => [...prev, preview]);
 
     try {
-      // Convert file to base64
-      const reader = new FileReader();
-      const base64 = await new Promise<string>((resolve, reject) => {
-        reader.onload = () => resolve(reader.result as string);
-        reader.onerror = () => reject(new Error('Failed to read file'));
-        reader.readAsDataURL(file);
+      const result = await uploadFileViaSignedUrl(file, {
+        createUploadUrl: (args) => createUploadUrl.mutateAsync(args),
+        recordUpload: (args) => uploadAttachment.mutateAsync(args),
       });
 
-      const result = await uploadAttachment
-        .mutateAsync({
-          file: base64,
-          fileName: file.name,
-          mimeType: file.type,
-        })
-        .catch((err) => {
-          toast.status(err);
-          throw err;
-        });
-
-      // Update preview with success
       setFilePreviews((prev) =>
         prev.map((f) =>
           f.id === previewId
@@ -115,16 +110,9 @@ export const useFileUpload = (options: UseFileUploadOptions) => {
 
       return result;
     } catch (error) {
-      // Update preview with error
+      toast.error({ message: errorMessage(error, 'Upload failed') });
       setFilePreviews((prev) =>
-        prev.map((f) =>
-          f.id === previewId
-            ? {
-                ...f,
-                uploading: false,
-              }
-            : f,
-        ),
+        prev.map((f) => (f.id === previewId ? { ...f, uploading: false } : f)),
       );
       throw error;
     }
@@ -152,7 +140,6 @@ export const useFileUpload = (options: UseFileUploadOptions) => {
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    // Only set drag over to false if we're leaving the main container
     if (!e.currentTarget.contains(e.relatedTarget as Node)) {
       setIsDragOver(false);
     }
@@ -166,9 +153,8 @@ export const useFileUpload = (options: UseFileUploadOptions) => {
 
       const files = Array.from(e.dataTransfer.files);
 
-      // Check file limit
       if (filePreviews.length + files.length > maxFiles) {
-        alert(`Maximum ${maxFiles} files allowed`);
+        toast.error({ message: `Maximum ${maxFiles} files allowed` });
         return;
       }
 
@@ -176,14 +162,13 @@ export const useFileUpload = (options: UseFileUploadOptions) => {
         acceptedTypes.includes(file.type),
       );
 
-      if (validFiles.length === 0) {
-        alert(
-          `Please drop only supported file types: ${acceptedTypes.join(', ')}`,
-        );
-        return;
+      const invalidCount = files.length - validFiles.length;
+      if (invalidCount > 0) {
+        toast.error({
+          message: `${invalidCount} file(s) skipped. Supported types: ${acceptedTypes.join(', ')}`,
+        });
       }
 
-      // Upload each valid file
       for (const file of validFiles) {
         try {
           await uploadFile(file);
@@ -208,26 +193,17 @@ export const useFileUpload = (options: UseFileUploadOptions) => {
   };
 
   return {
-    // State
     filePreviews,
     isDragOver,
-
-    // Actions
     uploadFile,
     removeFile,
     clearFiles,
-
-    // Drag and drop handlers
     handleDragOver,
     handleDragLeave,
     handleDrop,
-
-    // Computed values
     getUploadedAttachmentIds,
     hasUploadedFiles,
     isUploading,
-
-    // Configuration
     acceptedTypes,
     maxFiles,
     maxSizePerFile,

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -945,6 +945,7 @@
   "File too large: {name}": "File too large: {name}",
   "Unsupported file type: {name}": "Unsupported file type: {name}",
   "Upload failed": "Upload failed",
+  "Image upload failed": "Image upload failed",
   "Navigation": "Navigation",
   "Log in": "Log in",
   "Helping people decide together how to use their resources": "Helping people decide together how to use their resources",

--- a/services/api/src/routers/account/uploadAvatarImage.test.ts
+++ b/services/api/src/routers/account/uploadAvatarImage.test.ts
@@ -10,9 +10,7 @@ describeAccessTierGating('account.uploadImage', {
     const caller = await callers.noJwt();
     await expectFailsAccessTierGate(
       caller.account.uploadImage({
-        file: 'x',
-        fileName: 'x',
-        mimeType: 'image/png',
+        path: 'x',
       }),
       'none',
     );
@@ -24,9 +22,7 @@ describeAccessTierGating('account.uploadImage', {
       const caller = await callers.anonJwt();
       await expectFailsAccessTierGate(
         caller.account.uploadImage({
-          file: 'x',
-          fileName: 'x',
-          mimeType: 'image/png',
+          path: 'x',
         }),
         'anon',
       );
@@ -39,9 +35,7 @@ describeAccessTierGating('account.uploadImage', {
       const caller = await callers.userJwt();
       await expectFailsAccessTierGate(
         caller.account.uploadImage({
-          file: 'x',
-          fileName: 'x',
-          mimeType: 'image/png',
+          path: 'x',
         }),
         'user',
       );
@@ -54,9 +48,7 @@ describeAccessTierGating('account.uploadImage', {
       const caller = await callers.networkJwt();
       await expectPassesAccessTierGate(
         caller.account.uploadImage({
-          file: 'x',
-          fileName: 'x',
-          mimeType: 'image/png',
+          path: 'x',
         }),
       );
     },

--- a/services/api/src/routers/account/uploadAvatarImage.ts
+++ b/services/api/src/routers/account/uploadAvatarImage.ts
@@ -1,15 +1,23 @@
-import { CommonError, ValidationError } from '@op/common';
+import { CommonError } from '@op/common';
 import { eq } from '@op/db/client';
 import { profiles, users } from '@op/db/schema';
-import { createServerClient } from '@op/supabase/lib';
 import { waitUntil } from '@vercel/functions';
-import { Buffer } from 'buffer';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
-import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
+import { sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
+import {
+  STORAGE_BUCKET,
+  createSignedUploadUrl,
+  createStorageAdmin,
+  getUploadedStorageObject,
+  scheduleStorageObjectCleanup,
+  validateMimeAndSize,
+  assertValidStoragePath,
+} from '../../utils/storage';
 
 const ALLOWED_MIME_TYPES = [
   'image/png',
@@ -18,90 +26,71 @@ const ALLOWED_MIME_TYPES = [
   'image/gif',
 ];
 
+const UNSUPPORTED_MESSAGE =
+  'Unsupported file type. Only images (PNG, JPEG, GIF, WebP) are allowed.';
+
 // TODO: This is a duplicate of organization/uploadAvatarImage. Converge these
 export const uploadAvatarImage = router({
+  createImageUploadUrl: networkAuthenticatedProcedure()
+    .input(
+      z.object({
+        fileName: z.string().min(1),
+        mimeType: z.string(),
+        fileSize: z.number().positive(),
+      }),
+    )
+    .output(
+      z.object({
+        signedUrl: z.string(),
+        path: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { fileName, mimeType, fileSize } = input;
+
+      validateMimeAndSize({
+        mimeType,
+        fileSize,
+        allowedMimeTypes: ALLOWED_MIME_TYPES,
+        unsupportedMessage: UNSUPPORTED_MESSAGE,
+      });
+
+      const sanitized = sanitizeS3Filename(fileName);
+      const path = `${ctx.user.id}/avatar/${randomUUID()}_${sanitized}`;
+
+      return createSignedUploadUrl(path);
+    }),
+
   uploadImage: networkAuthenticatedProcedure()
     .use(withDB)
     .input(
       z.object({
-        file: z.string(), // base64 encoded
-        fileName: z.string(),
-        mimeType: z.string(),
+        path: z.string(),
       }),
     )
     .output(
       z.object({
         url: z.string(),
         path: z.string(),
+        id: z.string(),
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const { file, fileName, mimeType } = input;
+      const { path } = input;
       const { db } = ctx.database;
 
-      const sanitizedFileName = sanitizeS3Filename(fileName);
-      if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
-        throw new CommonError(
-          'Unsupported file type. Only images (PNG, JPEG, GIF, WebP) are allowed.',
-        );
-      }
-
-      let buffer: Buffer;
+      assertValidStoragePath({
+        path,
+        expectedPrefix: `${ctx.user.id}/avatar/`,
+      });
 
       try {
-        // Accept data URLs or plain base64
-        let base64 = file;
-
-        if (file.startsWith('data:')) {
-          const commaIndex = file.indexOf(',');
-
-          if (commaIndex === -1) {
-            throw new Error('Invalid data URL');
-          }
-
-          base64 = file.slice(commaIndex + 1);
-        }
-
-        buffer = Buffer.from(base64, 'base64');
-      } catch (_err) {
-        throw new ValidationError('Invalid base64 encoding');
-      }
-
-      // Check file size
-      if (buffer.length > MAX_FILE_SIZE) {
-        throw new CommonError(
-          `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
-        );
-      }
-
-      const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.SUPABASE_SERVICE_ROLE!,
-        {
-          cookieOptions: {},
-          cookies: {
-            getAll: async () => [],
-            setAll: async () => {},
-          },
-        },
-      );
-      const bucket = 'assets';
-      const filePath = `${ctx.user.id}/${Date.now()}_${sanitizedFileName}`;
-
-      const { error: uploadError, data } = await supabase.storage
-        .from(bucket)
-        .upload(filePath, buffer, {
-          contentType: mimeType,
-          upsert: false,
+        const storageObject = await getUploadedStorageObject({
+          path,
+          allowedMimeTypes: ALLOWED_MIME_TYPES,
+          unsupportedMessage: UNSUPPORTED_MESSAGE,
         });
 
-      if (uploadError) {
-        throw new CommonError(uploadError.message);
-      }
-
-      // assign the avatar image
-      if (data) {
-        // Check if user had previous avatar and get their profile ID
         const [existingUser] = await db
           .select({
             avatarImageId: users.avatarImageId,
@@ -112,41 +101,42 @@ export const uploadAvatarImage = router({
 
         const hadPreviousImage = existingUser?.avatarImageId;
 
-        // Update user avatar
         await db
           .update(users)
-          .set({
-            avatarImageId: data.id,
-          })
+          .set({ avatarImageId: storageObject.id })
           .where(eq(users.authUserId, ctx.user.id));
 
-        // Update personal profile avatar if user has a profile
         if (existingUser?.profileId) {
           await db
             .update(profiles)
-            .set({
-              avatarImageId: data.id,
-            })
+            .set({ avatarImageId: storageObject.id })
             .where(eq(profiles.id, existingUser.profileId));
         }
 
-        // Track analytics (non-blocking)
         waitUntil(trackImageUpload(ctx, 'profile', !!hadPreviousImage));
+
+        const supabase = createStorageAdmin();
+        const { data: signedUrlData, error: signedUrlError } =
+          await supabase.storage
+            .from(STORAGE_BUCKET)
+            .createSignedUrl(path, 60 * 60);
+
+        if (signedUrlError || !signedUrlData) {
+          console.error('createSignedUrl failed', {
+            path,
+            error: signedUrlError,
+          });
+          throw new CommonError('Could not get signed url');
+        }
+
+        return {
+          url: signedUrlData.signedUrl,
+          path,
+          id: storageObject.id,
+        };
+      } catch (err) {
+        scheduleStorageObjectCleanup(path);
+        throw err;
       }
-
-      // Get signed URL
-      const { data: signedUrlData, error: signedUrlError } =
-        await supabase.storage.from(bucket).createSignedUrl(filePath, 60 * 60); // 1 hour
-
-      if (signedUrlError || !signedUrlData) {
-        throw new CommonError(
-          signedUrlError?.message || 'Could not get signed url',
-        );
-      }
-
-      return {
-        url: signedUrlData.signedUrl,
-        path: filePath,
-      };
     }),
 });

--- a/services/api/src/routers/account/uploadBannerImage.test.ts
+++ b/services/api/src/routers/account/uploadBannerImage.test.ts
@@ -10,9 +10,7 @@ describeAccessTierGating('account.uploadBannerImage', {
     const caller = await callers.noJwt();
     await expectFailsAccessTierGate(
       caller.account.uploadBannerImage({
-        file: 'x',
-        fileName: 'x',
-        mimeType: 'image/png',
+        path: 'x',
       }),
       'none',
     );
@@ -24,9 +22,7 @@ describeAccessTierGating('account.uploadBannerImage', {
       const caller = await callers.anonJwt();
       await expectFailsAccessTierGate(
         caller.account.uploadBannerImage({
-          file: 'x',
-          fileName: 'x',
-          mimeType: 'image/png',
+          path: 'x',
         }),
         'anon',
       );
@@ -39,9 +35,7 @@ describeAccessTierGating('account.uploadBannerImage', {
       const caller = await callers.userJwt();
       await expectFailsAccessTierGate(
         caller.account.uploadBannerImage({
-          file: 'x',
-          fileName: 'x',
-          mimeType: 'image/png',
+          path: 'x',
         }),
         'user',
       );
@@ -54,9 +48,7 @@ describeAccessTierGating('account.uploadBannerImage', {
       const caller = await callers.networkJwt();
       await expectPassesAccessTierGate(
         caller.account.uploadBannerImage({
-          file: 'x',
-          fileName: 'x',
-          mimeType: 'image/png',
+          path: 'x',
         }),
       );
     },

--- a/services/api/src/routers/account/uploadBannerImage.ts
+++ b/services/api/src/routers/account/uploadBannerImage.ts
@@ -1,15 +1,23 @@
-import { CommonError, NotFoundError, ValidationError } from '@op/common';
+import { CommonError, NotFoundError } from '@op/common';
 import { eq } from '@op/db/client';
 import { profiles, users } from '@op/db/schema';
-import { createServerClient } from '@op/supabase/lib';
 import { waitUntil } from '@vercel/functions';
-import { Buffer } from 'buffer';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
-import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
+import { sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
+import {
+  STORAGE_BUCKET,
+  createSignedUploadUrl,
+  createStorageAdmin,
+  getUploadedStorageObject,
+  scheduleStorageObjectCleanup,
+  validateMimeAndSize,
+  assertValidStoragePath,
+} from '../../utils/storage';
 
 const ALLOWED_MIME_TYPES = [
   'image/png',
@@ -18,14 +26,45 @@ const ALLOWED_MIME_TYPES = [
   'image/gif',
 ];
 
+const UNSUPPORTED_MESSAGE =
+  'Unsupported file type. Only images (PNG, JPEG, GIF, WebP) are allowed.';
+
 export const uploadBannerImage = router({
+  createBannerImageUploadUrl: networkAuthenticatedProcedure()
+    .input(
+      z.object({
+        fileName: z.string().min(1),
+        mimeType: z.string(),
+        fileSize: z.number().positive(),
+      }),
+    )
+    .output(
+      z.object({
+        signedUrl: z.string(),
+        path: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { fileName, mimeType, fileSize } = input;
+
+      validateMimeAndSize({
+        mimeType,
+        fileSize,
+        allowedMimeTypes: ALLOWED_MIME_TYPES,
+        unsupportedMessage: UNSUPPORTED_MESSAGE,
+      });
+
+      const sanitized = sanitizeS3Filename(fileName);
+      const path = `${ctx.user.id}/banner/${randomUUID()}_${sanitized}`;
+
+      return createSignedUploadUrl(path);
+    }),
+
   uploadBannerImage: networkAuthenticatedProcedure()
     .use(withDB)
     .input(
       z.object({
-        file: z.string(), // base64 encoded
-        fileName: z.string(),
-        mimeType: z.string(),
+        path: z.string(),
       }),
     )
     .output(
@@ -36,117 +75,66 @@ export const uploadBannerImage = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const { file, fileName, mimeType } = input;
+      const { path } = input;
       const { db } = ctx.database;
 
-      const sanitizedFileName = sanitizeS3Filename(fileName);
-      if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
-        throw new CommonError(
-          'Unsupported file type. Only images (PNG, JPEG, GIF, WebP) are allowed.',
-        );
-      }
-
-      let buffer: Buffer;
+      assertValidStoragePath({
+        path,
+        expectedPrefix: `${ctx.user.id}/banner/`,
+      });
 
       try {
-        // Accept data URLs or plain base64
-        let base64 = file;
-
-        if (file.startsWith('data:')) {
-          const commaIndex = file.indexOf(',');
-
-          if (commaIndex === -1) {
-            throw new Error('Invalid data URL');
-          }
-
-          base64 = file.slice(commaIndex + 1);
-        }
-
-        buffer = Buffer.from(base64, 'base64');
-      } catch (_err) {
-        throw new ValidationError('Invalid base64 encoding');
-      }
-
-      // Check file size
-      if (buffer.length > MAX_FILE_SIZE) {
-        throw new CommonError(
-          `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
-        );
-      }
-
-      const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.SUPABASE_SERVICE_ROLE!,
-        {
-          cookieOptions: {},
-          cookies: {
-            getAll: async () => [],
-            setAll: async () => {},
-          },
-        },
-      );
-      const bucket = 'assets';
-      const filePath = `${ctx.user.id}/banner/${Date.now()}_${sanitizedFileName}`;
-
-      const { error: uploadError, data } = await supabase.storage
-        .from(bucket)
-        .upload(filePath, buffer, {
-          contentType: mimeType,
-          upsert: false,
+        const storageObject = await getUploadedStorageObject({
+          path,
+          allowedMimeTypes: ALLOWED_MIME_TYPES,
+          unsupportedMessage: UNSUPPORTED_MESSAGE,
         });
 
-      if (uploadError) {
-        throw new CommonError(uploadError.message);
-      }
-
-      // Update user's personal profile banner image
-      if (data) {
-        // Check if user has a profile and get their profile ID
         const [existingUser] = await db
-          .select({
-            profileId: users.profileId,
-          })
+          .select({ profileId: users.profileId })
           .from(users)
           .where(eq(users.authUserId, ctx.user.id));
 
-        if (existingUser?.profileId) {
-          // Check if profile had previous header image
-          const [existingProfile] = await db
-            .select({ headerImageId: profiles.headerImageId })
-            .from(profiles)
-            .where(eq(profiles.id, existingUser.profileId));
-
-          const hadPreviousImage = existingProfile?.headerImageId;
-
-          // Update personal profile banner
-          await db
-            .update(profiles)
-            .set({
-              headerImageId: data.id,
-            })
-            .where(eq(profiles.id, existingUser.profileId));
-
-          // Track analytics (non-blocking)
-          waitUntil(trackImageUpload(ctx, 'banner', !!hadPreviousImage));
-        } else {
+        if (!existingUser?.profileId) {
           throw new NotFoundError('User profile');
         }
+
+        const [existingProfile] = await db
+          .select({ headerImageId: profiles.headerImageId })
+          .from(profiles)
+          .where(eq(profiles.id, existingUser.profileId));
+
+        const hadPreviousImage = existingProfile?.headerImageId;
+
+        await db
+          .update(profiles)
+          .set({ headerImageId: storageObject.id })
+          .where(eq(profiles.id, existingUser.profileId));
+
+        waitUntil(trackImageUpload(ctx, 'banner', !!hadPreviousImage));
+
+        const supabase = createStorageAdmin();
+        const { data: signedUrlData, error: signedUrlError } =
+          await supabase.storage
+            .from(STORAGE_BUCKET)
+            .createSignedUrl(path, 60 * 60);
+
+        if (signedUrlError || !signedUrlData) {
+          console.error('createSignedUrl failed', {
+            path,
+            error: signedUrlError,
+          });
+          throw new CommonError('Could not get signed url');
+        }
+
+        return {
+          url: signedUrlData.signedUrl,
+          path,
+          id: storageObject.id,
+        };
+      } catch (err) {
+        scheduleStorageObjectCleanup(path);
+        throw err;
       }
-
-      // Get signed URL
-      const { data: signedUrlData, error: signedUrlError } =
-        await supabase.storage.from(bucket).createSignedUrl(filePath, 60 * 60); // 1 hour
-
-      if (signedUrlError || !signedUrlData) {
-        throw new CommonError(
-          signedUrlError?.message || 'Could not get signed url',
-        );
-      }
-
-      return {
-        url: signedUrlData.signedUrl,
-        path: filePath,
-        id: data!.id,
-      };
     }),
 });

--- a/services/api/src/routers/organization/uploadAvatarImage.test.ts
+++ b/services/api/src/routers/organization/uploadAvatarImage.test.ts
@@ -10,9 +10,7 @@ describeAccessTierGating('organization.uploadAvatarImage', {
     const caller = await callers.noJwt();
     await expectFailsAccessTierGate(
       caller.organization.uploadAvatarImage({
-        file: 'x',
-        fileName: 'x',
-        mimeType: 'x',
+        path: 'x',
       }),
       'none',
     );
@@ -24,9 +22,7 @@ describeAccessTierGating('organization.uploadAvatarImage', {
       const caller = await callers.anonJwt();
       await expectFailsAccessTierGate(
         caller.organization.uploadAvatarImage({
-          file: 'x',
-          fileName: 'x',
-          mimeType: 'x',
+          path: 'x',
         }),
         'anon',
       );
@@ -39,9 +35,7 @@ describeAccessTierGating('organization.uploadAvatarImage', {
       const caller = await callers.userJwt();
       await expectFailsAccessTierGate(
         caller.organization.uploadAvatarImage({
-          file: 'x',
-          fileName: 'x',
-          mimeType: 'x',
+          path: 'x',
         }),
         'user',
       );
@@ -54,9 +48,7 @@ describeAccessTierGating('organization.uploadAvatarImage', {
       const caller = await callers.networkJwt();
       await expectPassesAccessTierGate(
         caller.organization.uploadAvatarImage({
-          file: 'x',
-          fileName: 'x',
-          mimeType: 'x',
+          path: 'x',
         }),
       );
     },

--- a/services/api/src/routers/organization/uploadAvatarImage.ts
+++ b/services/api/src/routers/organization/uploadAvatarImage.ts
@@ -1,12 +1,20 @@
-import { CommonError, ValidationError } from '@op/common';
-import { createServerClient } from '@op/supabase/lib';
+import { CommonError } from '@op/common';
 import { waitUntil } from '@vercel/functions';
-import { Buffer } from 'buffer';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
-import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
+import { sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
+import {
+  STORAGE_BUCKET,
+  createSignedUploadUrl,
+  createStorageAdmin,
+  getUploadedStorageObject,
+  scheduleStorageObjectCleanup,
+  validateMimeAndSize,
+  assertValidStoragePath,
+} from '../../utils/storage';
 
 const ALLOWED_MIME_TYPES = [
   'image/png',
@@ -16,12 +24,39 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadAvatarImage = router({
+  createAvatarImageUploadUrl: networkAuthenticatedProcedure()
+    .input(
+      z.object({
+        fileName: z.string().min(1),
+        mimeType: z.string(),
+        fileSize: z.number().positive(),
+      }),
+    )
+    .output(
+      z.object({
+        signedUrl: z.string(),
+        path: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { fileName, mimeType, fileSize } = input;
+
+      validateMimeAndSize({
+        mimeType,
+        fileSize,
+        allowedMimeTypes: ALLOWED_MIME_TYPES,
+      });
+
+      const sanitized = sanitizeS3Filename(fileName);
+      const path = `${ctx.user.id}/orgAvatar/${randomUUID()}_${sanitized}`;
+
+      return createSignedUploadUrl(path);
+    }),
+
   uploadAvatarImage: networkAuthenticatedProcedure()
     .input(
       z.object({
-        file: z.string(), // base64 encoded
-        fileName: z.string(),
-        mimeType: z.string(),
+        path: z.string(),
       }),
     )
     .output(
@@ -32,94 +67,126 @@ export const uploadAvatarImage = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const { file, fileName, mimeType } = input;
-      // @ts-ignore
-      const { logger } = ctx;
+      const { path } = input;
 
-      const sanitizedFileName = sanitizeS3Filename(fileName);
-      if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
-        throw new ValidationError('Unsupported file type');
-      }
-
-      let buffer: Buffer;
+      assertValidStoragePath({
+        path,
+        expectedPrefix: `${ctx.user.id}/orgAvatar/`,
+      });
 
       try {
-        // Accept data URLs or plain base64
-        let base64 = file;
-
-        if (file.startsWith('data:')) {
-          const commaIndex = file.indexOf(',');
-
-          if (commaIndex === -1) {
-            throw new Error('Invalid data URL');
-          }
-
-          base64 = file.slice(commaIndex + 1);
-        }
-
-        buffer = Buffer.from(base64, 'base64');
-      } catch (_err) {
-        throw new ValidationError('Invalid base64 encoding');
-      }
-
-      // Check file size
-      if (buffer.length > MAX_FILE_SIZE) {
-        throw new ValidationError(
-          `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
-        );
-      }
-
-      const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.SUPABASE_SERVICE_ROLE!,
-        {
-          cookieOptions: {},
-          cookies: {
-            getAll: async () => [],
-            setAll: async () => {},
-          },
-        },
-      );
-      const bucket = 'assets';
-      const filePath = `${ctx.user.id}/temp/${Date.now()}_${sanitizedFileName}`;
-
-      logger.info('UPLOADING FILE' + filePath);
-
-      const { error: uploadError, data } = await supabase.storage
-        .from(bucket)
-        .upload(filePath, buffer, {
-          contentType: mimeType,
-          upsert: false,
+        const storageObject = await getUploadedStorageObject({
+          path,
+          allowedMimeTypes: ALLOWED_MIME_TYPES,
         });
 
-      if (uploadError) {
-        throw new CommonError(uploadError.message);
+        waitUntil(trackImageUpload(ctx, 'profile', false));
+
+        const supabase = createStorageAdmin();
+        const { data: signedUrlData, error: signedUrlError } =
+          await supabase.storage
+            .from(STORAGE_BUCKET)
+            .createSignedUrl(path, 60 * 60);
+
+        if (signedUrlError || !signedUrlData) {
+          console.error('createSignedUrl failed', {
+            path,
+            error: signedUrlError,
+          });
+          throw new CommonError('Could not get signed url');
+        }
+
+        return {
+          url: signedUrlData.signedUrl,
+          path,
+          id: storageObject.id,
+        };
+      } catch (err) {
+        scheduleStorageObjectCleanup(path);
+        throw err;
       }
+    }),
 
-      // Get signed URL
-      const { data: signedUrlData, error: signedUrlError } =
-        await supabase.storage.from(bucket).createSignedUrl(filePath, 60 * 60); // 1 hour
+  createBannerImageUploadUrl: networkAuthenticatedProcedure()
+    .input(
+      z.object({
+        fileName: z.string().min(1),
+        mimeType: z.string(),
+        fileSize: z.number().positive(),
+      }),
+    )
+    .output(
+      z.object({
+        signedUrl: z.string(),
+        path: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { fileName, mimeType, fileSize } = input;
 
-      logger.info('GOT SIGNED URL' + signedUrlData);
+      validateMimeAndSize({
+        mimeType,
+        fileSize,
+        allowedMimeTypes: ALLOWED_MIME_TYPES,
+      });
 
-      if (signedUrlError || !signedUrlData) {
-        throw new CommonError(
-          signedUrlError?.message || 'Could not get signed url',
-        );
+      const sanitized = sanitizeS3Filename(fileName);
+      const path = `${ctx.user.id}/orgBanner/${randomUUID()}_${sanitized}`;
+
+      return createSignedUploadUrl(path);
+    }),
+
+  uploadBannerImage: networkAuthenticatedProcedure()
+    .input(
+      z.object({
+        path: z.string(),
+      }),
+    )
+    .output(
+      z.object({
+        url: z.string(),
+        path: z.string(),
+        id: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { path } = input;
+
+      assertValidStoragePath({
+        path,
+        expectedPrefix: `${ctx.user.id}/orgBanner/`,
+      });
+
+      try {
+        const storageObject = await getUploadedStorageObject({
+          path,
+          allowedMimeTypes: ALLOWED_MIME_TYPES,
+        });
+
+        waitUntil(trackImageUpload(ctx, 'banner', false));
+
+        const supabase = createStorageAdmin();
+        const { data: signedUrlData, error: signedUrlError } =
+          await supabase.storage
+            .from(STORAGE_BUCKET)
+            .createSignedUrl(path, 60 * 60);
+
+        if (signedUrlError || !signedUrlData) {
+          console.error('createSignedUrl failed', {
+            path,
+            error: signedUrlError,
+          });
+          throw new CommonError('Could not get signed url');
+        }
+
+        return {
+          url: signedUrlData.signedUrl,
+          path,
+          id: storageObject.id,
+        };
+      } catch (err) {
+        scheduleStorageObjectCleanup(path);
+        throw err;
       }
-
-      logger.info(
-        'RETURNING UPLOAD URL' + signedUrlData.signedUrl + ' - ' + filePath,
-      );
-
-      // Track analytics - for organization uploads, we'll track as new uploads since they're temporary (non-blocking)
-      const imageType = filePath.includes('banner') ? 'banner' : 'profile';
-      waitUntil(trackImageUpload(ctx, imageType, false));
-
-      return {
-        url: signedUrlData.signedUrl,
-        path: filePath,
-        id: data.id,
-      };
     }),
 });

--- a/services/api/src/routers/posts/uploadPostAttachment.test.ts
+++ b/services/api/src/routers/posts/uploadPostAttachment.test.ts
@@ -10,9 +10,8 @@ describeAccessTierGating('posts.uploadPostAttachment', {
     const caller = await callers.noJwt();
     await expectFailsAccessTierGate(
       caller.posts.uploadPostAttachment({
-        file: 'x',
+        path: 'x',
         fileName: 'x',
-        mimeType: 'x',
       }),
       'none',
     );
@@ -24,9 +23,8 @@ describeAccessTierGating('posts.uploadPostAttachment', {
       const caller = await callers.anonJwt();
       await expectFailsAccessTierGate(
         caller.posts.uploadPostAttachment({
-          file: 'x',
+          path: 'x',
           fileName: 'x',
-          mimeType: 'x',
         }),
         'anon',
       );
@@ -39,9 +37,8 @@ describeAccessTierGating('posts.uploadPostAttachment', {
       const caller = await callers.userJwt();
       await expectFailsAccessTierGate(
         caller.posts.uploadPostAttachment({
-          file: 'x',
+          path: 'x',
           fileName: 'x',
-          mimeType: 'x',
         }),
         'user',
       );
@@ -54,9 +51,8 @@ describeAccessTierGating('posts.uploadPostAttachment', {
       const caller = await callers.networkJwt();
       await expectPassesAccessTierGate(
         caller.posts.uploadPostAttachment({
-          file: 'x',
+          path: 'x',
           fileName: 'x',
-          mimeType: 'x',
         }),
       );
     },

--- a/services/api/src/routers/posts/uploadPostAttachment.ts
+++ b/services/api/src/routers/posts/uploadPostAttachment.ts
@@ -1,11 +1,19 @@
 import { CommonError, getCurrentProfileId } from '@op/common';
-import { createServerClient } from '@op/supabase/lib';
-import { Buffer } from 'buffer';
+import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
-import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
+import { sanitizeS3Filename } from '../../utils';
+import {
+  STORAGE_BUCKET,
+  createSignedUploadUrl,
+  createStorageAdmin,
+  getUploadedStorageObject,
+  scheduleStorageObjectCleanup,
+  validateMimeAndSize,
+  assertValidStoragePath,
+} from '../../utils/storage';
 
 const ALLOWED_MIME_TYPES = [
   'image/png',
@@ -15,16 +23,53 @@ const ALLOWED_MIME_TYPES = [
   'application/pdf',
 ];
 
+const UNSUPPORTED_MESSAGE =
+  'Unsupported file type. Only images (PNG, JPEG, GIF, WebP) and PDFs are allowed.';
+
 export const uploadPostAttachment = router({
+  createPostAttachmentUploadUrl: networkAuthenticatedProcedure({
+    rateLimit: { windowSize: 10, maxRequests: 20 },
+  })
+    .use(withDB)
+    .input(
+      z.object({
+        fileName: z.string().min(1),
+        mimeType: z.string(),
+        fileSize: z.number().positive(),
+      }),
+    )
+    .output(
+      z.object({
+        signedUrl: z.string(),
+        path: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { fileName, mimeType, fileSize } = input;
+      const { user } = ctx;
+
+      validateMimeAndSize({
+        mimeType,
+        fileSize,
+        allowedMimeTypes: ALLOWED_MIME_TYPES,
+        unsupportedMessage: UNSUPPORTED_MESSAGE,
+      });
+
+      const profileId = await getCurrentProfileId(user.id);
+      const sanitized = sanitizeS3Filename(fileName);
+      const path = `profile/${profileId}/posts/${randomUUID()}_${sanitized}`;
+
+      return createSignedUploadUrl(path);
+    }),
+
   uploadPostAttachment: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .use(withDB)
     .input(
       z.object({
-        file: z.string(), // base64 encoded
-        fileName: z.string(),
-        mimeType: z.string(),
+        path: z.string(),
+        fileName: z.string().min(1),
       }),
     )
     .output(
@@ -38,93 +83,47 @@ export const uploadPostAttachment = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const { file, fileName, mimeType } = input;
+      const { path, fileName } = input;
       const { user } = ctx;
+
       const profileId = await getCurrentProfileId(user.id);
-
-      const sanitizedFileName = sanitizeS3Filename(fileName);
-
-      if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
-        throw new CommonError(
-          'Unsupported file type. Only images (PNG, JPEG, GIF, WebP) and PDFs are allowed.',
-        );
-      }
-
-      let buffer: Buffer;
+      assertValidStoragePath({
+        path,
+        expectedPrefix: `profile/${profileId}/posts/`,
+      });
 
       try {
-        // Accept data URLs or plain base64
-        let base64 = file;
-
-        if (file.startsWith('data:')) {
-          const commaIndex = file.indexOf(',');
-
-          if (commaIndex === -1) {
-            throw new Error('Invalid data URL');
-          }
-
-          base64 = file.slice(commaIndex + 1);
-        }
-
-        buffer = Buffer.from(base64, 'base64');
-      } catch (_err) {
-        throw new CommonError('Invalid base64 encoding');
-      }
-
-      // Check file size
-      if (buffer.length > MAX_FILE_SIZE) {
-        throw new CommonError(
-          `File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB`,
-        );
-      }
-
-      const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.SUPABASE_SERVICE_ROLE!,
-        {
-          cookieOptions: {},
-          cookies: {
-            getAll: async () => [],
-            setAll: async () => {},
-          },
-        },
-      );
-
-      const bucket = 'assets';
-      const filePath = `profile/${profileId}/posts/${Date.now()}_${sanitizedFileName}`;
-
-      const { error: uploadError, data } = await supabase.storage
-        .from(bucket)
-        .upload(filePath, buffer, {
-          contentType: mimeType,
-          upsert: false,
+        const storageObject = await getUploadedStorageObject({
+          path,
+          allowedMimeTypes: ALLOWED_MIME_TYPES,
+          unsupportedMessage: UNSUPPORTED_MESSAGE,
         });
 
-      if (uploadError) {
-        throw new CommonError(uploadError.message);
+        const supabase = createStorageAdmin();
+        const { data: signedUrlData, error: signedUrlError } =
+          await supabase.storage
+            .from(STORAGE_BUCKET)
+            .createSignedUrl(path, 60 * 60 * 24);
+
+        if (signedUrlError || !signedUrlData) {
+          console.error('createSignedUrl failed', {
+            path,
+            error: signedUrlError,
+          });
+          throw new CommonError('Could not get signed url');
+        }
+
+        return {
+          url: signedUrlData.signedUrl,
+          path,
+          id: storageObject.id,
+          fileName: sanitizeS3Filename(fileName),
+          mimeType: storageObject.mimetype,
+          fileSize: storageObject.size,
+        };
+      } catch (err) {
+        scheduleStorageObjectCleanup(path);
+        throw err;
       }
-
-      if (!data) {
-        throw new CommonError('Upload failed - no data returned');
-      }
-
-      // Get signed URL
-      const { data: signedUrlData, error: signedUrlError } =
-        await supabase.storage
-          .from(bucket)
-          .createSignedUrl(filePath, 60 * 60 * 24); // 24 hours
-
-      if (signedUrlError || !signedUrlData) {
-        throw new CommonError('Could not get signed url');
-      }
-
-      return {
-        url: signedUrlData.signedUrl,
-        path: filePath,
-        id: data.id,
-        fileName: sanitizedFileName,
-        mimeType,
-        fileSize: buffer.length,
-      };
     }),
 });

--- a/services/api/src/utils/index.ts
+++ b/services/api/src/utils/index.ts
@@ -64,8 +64,6 @@ export function sanitizeS3Filename(filename: string) {
   return sanitizeForS3(filename, '_');
 }
 
-export { MAX_FILE_SIZE } from './storage';
-
 /** Short, deterministic digest of a search string for cache keys. */
 export function hashSearch(search: string) {
   return crypto.createHash('md5').update(search).digest('hex').substring(0, 16);


### PR DESCRIPTION
Stacked on top of #1184. Extends the proposal-attachment refactor pattern to:

- `posts.uploadPostAttachment`
- `account.uploadAvatarImage` / `uploadBannerImage`
- `organization.uploadAvatarImage` + new `organization.uploadBannerImage` (banners were silently routing through avatar)
- `useFileUpload` hook + 5 image-upload forms

Each follows the same two-step flow with path-prefix scoping, storage-truth metadata, retry on replication lag, and orphan cleanup.