### PR TITLE
fix(a11y): allow user zoom to satisfy WCAG 1.4.4

### DIFF
--- a/apps/app/src/app/[locale]/start/layout.tsx
+++ b/apps/app/src/app/[locale]/start/layout.tsx
@@ -1,9 +1,9 @@
-import { Link, useTranslations } from '@/lib/i18n/routing';
+import { Link } from '@/lib/i18n/routing';
 
 import { CommonLogo } from '@/components/CommonLogo';
+import { TranslatedText } from '@/components/TranslatedText';
 
 const StartLayout = ({ children }: { children: React.ReactNode }) => {
-  const t = useTranslations();
   return (
     <div className="relative flex h-svh w-full flex-col items-center justify-center font-sans">
       <div id="top-slot" className="absolute top-0 w-full" />
@@ -13,8 +13,10 @@ const StartLayout = ({ children }: { children: React.ReactNode }) => {
             <Link
               href="/"
               className="flex items-center gap-2 hover:no-underline"
-              aria-label={t('Home')}
             >
+              <span className="sr-only">
+                <TranslatedText text="Home" />
+              </span>
               <CommonLogo />
             </Link>
           </div>

--- a/apps/app/src/app/[locale]/start/layout.tsx
+++ b/apps/app/src/app/[locale]/start/layout.tsx
@@ -1,8 +1,9 @@
-import { Link } from '@/lib/i18n/routing';
+import { Link, useTranslations } from '@/lib/i18n/routing';
 
 import { CommonLogo } from '@/components/CommonLogo';
 
 const StartLayout = ({ children }: { children: React.ReactNode }) => {
+  const t = useTranslations();
   return (
     <div className="relative flex h-svh w-full flex-col items-center justify-center font-sans">
       <div id="top-slot" className="absolute top-0 w-full" />
@@ -12,6 +13,7 @@ const StartLayout = ({ children }: { children: React.ReactNode }) => {
             <Link
               href="/"
               className="flex items-center gap-2 hover:no-underline"
+              aria-label={t('Home')}
             >
               <CommonLogo />
             </Link>

--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -63,11 +63,7 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   width: 'device-width',
-  height: 'device-height',
   initialScale: 1,
-  minimumScale: 1,
-  maximumScale: 1,
-  userScalable: false,
 };
 
 const RootLayout = async ({ children }: { children: React.ReactNode }) => {

--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -508,7 +508,7 @@ export const SiteHeader = () => {
               className="p-1"
               size="small"
             />
-            <Link href="/" className="flex gap-1">
+            <Link href="/" className="flex gap-1" aria-label={t('Home')}>
               <CommonLogo />
             </Link>
           </div>

--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -469,7 +469,7 @@ export const SiteHeader = () => {
       <header className="gridCentered hidden h-auto w-full items-center justify-between border-b border-offWhite px-4 py-3 sm:grid">
         <div className="flex items-center gap-3">
           <SidebarTrigger aria-label={t('Open menu')} />
-          <Link href="/" className="flex gap-1">
+          <Link href="/" className="flex gap-1" aria-label={t('Home')}>
             <CommonLogo />
           </Link>
         </div>

--- a/apps/app/src/components/layout/split/FullScreenSplitMain.tsx
+++ b/apps/app/src/components/layout/split/FullScreenSplitMain.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@/lib/i18n/routing';
+import { Link, useTranslations } from '@/lib/i18n/routing';
 
 import { CommonLogo } from '@/components/CommonLogo';
 
@@ -9,6 +9,7 @@ export const FullScreenSplitMain = ({
   logo?: boolean;
   children: React.ReactNode;
 }) => {
+  const t = useTranslations();
   return (
     <main className="relative col-span-3 flex size-full flex-col overflow-y-scroll p-4 md:p-8 lg:col-span-2 lg:max-w-[calc(100vw-24rem)]">
       <section className="sticky top-0 hidden lg:block">
@@ -17,6 +18,7 @@ export const FullScreenSplitMain = ({
             <Link
               href="/"
               className="flex items-center gap-2 hover:no-underline"
+              aria-label={t('Home')}
             >
               <CommonLogo />
             </Link>

--- a/apps/app/src/components/layout/split/FullScreenSplitMain.tsx
+++ b/apps/app/src/components/layout/split/FullScreenSplitMain.tsx
@@ -1,6 +1,7 @@
-import { Link, useTranslations } from '@/lib/i18n/routing';
+import { Link } from '@/lib/i18n/routing';
 
 import { CommonLogo } from '@/components/CommonLogo';
+import { TranslatedText } from '@/components/TranslatedText';
 
 export const FullScreenSplitMain = ({
   logo = true,
@@ -9,7 +10,6 @@ export const FullScreenSplitMain = ({
   logo?: boolean;
   children: React.ReactNode;
 }) => {
-  const t = useTranslations();
   return (
     <main className="relative col-span-3 flex size-full flex-col overflow-y-scroll p-4 md:p-8 lg:col-span-2 lg:max-w-[calc(100vw-24rem)]">
       <section className="sticky top-0 hidden lg:block">
@@ -18,8 +18,10 @@ export const FullScreenSplitMain = ({
             <Link
               href="/"
               className="flex items-center gap-2 hover:no-underline"
-              aria-label={t('Home')}
             >
+              <span className="sr-only">
+                <TranslatedText text="Home" />
+              </span>
               <CommonLogo />
             </Link>
           ) : null}

--- a/tests/e2e/a11y-baseline/summary.json
+++ b/tests/e2e/a11y-baseline/summary.json
@@ -8,11 +8,11 @@
   ],
   "totals": {
     "critical": 3,
-    "serious": 12,
-    "moderate": 16,
+    "serious": 1,
+    "moderate": 0,
     "minor": 0
   },
-  "totalViolations": 31,
+  "totalViolations": 4,
   "routesScanned": 16,
   "ruleTotals": [
     {
@@ -25,16 +25,6 @@
       ]
     },
     {
-      "id": "link-name",
-      "impact": "serious",
-      "occurrences": 11,
-      "routes": 11,
-      "wcagCriteria": [
-        "2.4.4",
-        "4.1.2"
-      ]
-    },
-    {
       "id": "scrollable-region-focusable",
       "impact": "serious",
       "occurrences": 1,
@@ -42,15 +32,6 @@
       "wcagCriteria": [
         "2.1.1",
         "2.1.3"
-      ]
-    },
-    {
-      "id": "meta-viewport",
-      "impact": "moderate",
-      "occurrences": 16,
-      "routes": 16,
-      "wcagCriteria": [
-        "1.4.4"
       ]
     }
   ],
@@ -63,7 +44,7 @@
       "counts": {
         "critical": 0,
         "serious": 0,
-        "moderate": 1,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -74,8 +55,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 2,
-        "moderate": 1,
+        "serious": 1,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -86,8 +67,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -98,8 +79,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -110,8 +91,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -122,8 +103,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -134,8 +115,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -146,8 +127,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -158,8 +139,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -170,8 +151,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -182,8 +163,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -194,8 +175,8 @@
       "status": "ok",
       "counts": {
         "critical": 0,
-        "serious": 1,
-        "moderate": 1,
+        "serious": 0,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -207,7 +188,7 @@
       "counts": {
         "critical": 0,
         "serious": 0,
-        "moderate": 1,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -219,7 +200,7 @@
       "counts": {
         "critical": 3,
         "serious": 0,
-        "moderate": 1,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -231,7 +212,7 @@
       "counts": {
         "critical": 0,
         "serious": 0,
-        "moderate": 1,
+        "moderate": 0,
         "minor": 0
       }
     },
@@ -243,11 +224,11 @@
       "counts": {
         "critical": 0,
         "serious": 0,
-        "moderate": 1,
+        "moderate": 0,
         "minor": 0
       }
     }
   ],
-  "screenshotsAttempted": 31,
-  "screenshotsCaptured": 15
+  "screenshotsAttempted": 4,
+  "screenshotsCaptured": 4
 }


### PR DESCRIPTION
## Summary
- Drop `maximumScale`, `minimumScale`, `userScalable`, and non-standard `height` from the root `viewport` export.
- Resolves axe `meta-viewport` violation (WCAG 1.4.4 Resize Text) across all 16 routes in the a11y baseline.
- Low-vision users can now pinch- and browser-zoom; `initialScale: 1` still prevents iOS input auto-zoom (inputs already render at ≥16px).
- Also adds a name to the link wrapping the Common logo in the site header.