### PR TITLE
experiment: scroll process builder via nuqs scroll option

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
@@ -380,7 +380,7 @@ export function TemplateEditorContent({
 
   return (
     <SidebarProvider isOpen={sidebarOpen} onOpenChange={setMobileSidebarOpen}>
-      <div className="flex h-full flex-col md:flex-row">
+      <div className="flex h-full flex-col overflow-hidden md:flex-row">
         <div className="flex items-center justify-between gap-2 p-4 md:hidden">
           <Header2 className="font-serif text-title-sm">
             {t('Proposal template')}

--- a/apps/app/src/components/decisions/ProcessBuilder/useProcessNavigation.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/useProcessNavigation.ts
@@ -27,6 +27,7 @@ export function useProcessNavigation(
 ) {
   const [sectionParam, setSectionParam] = useQueryState('section', {
     history: 'push',
+    scroll: true,
   });
 
   // Legacy params for backward compatibility


### PR DESCRIPTION
## Summary
- Tries `scroll: true` on nuqs `useQueryState('section', ...)` instead of a manual scroll-reset effect
- Compare against #1154

## Expected outcome
- `scroll: true` delegates to Next.js router which calls `window.scrollTo(0, 0)`
- Process builder scroll container is `<main>` inside `overflow-y-hidden` parent — `window` isn't the scroller
- Likely no observable scroll reset, but worth confirming locally