### PR TITLE
feat(decisions): notify participants when an update is posted

### DIFF
--- a/packages/common/src/services/posts/createPost.ts
+++ b/packages/common/src/services/posts/createPost.ts
@@ -399,7 +399,6 @@ export const createPost = async (input: CreatePostServiceInput) => {
     return newPost;
   });
 
-  // TODO: Use the message queue for this and remove @vercel/functions as a dependency in @op/common
   waitUntil(
     (async () => {
       try {

--- a/packages/common/src/services/posts/createPost.ts
+++ b/packages/common/src/services/posts/createPost.ts
@@ -1,5 +1,5 @@
 import { invalidate } from '@op/cache';
-import { OPURLConfig } from '@op/core';
+import { OPURLConfig, match } from '@op/core';
 import { db } from '@op/db/client';
 import {
   EntityType,
@@ -123,28 +123,6 @@ const sendPostCommentNotification = async (
     console.error(
       'Failed to send post comment notification email:',
       emailError,
-    );
-  }
-};
-
-const dispatchDecisionUpdatePostedEvent = async ({
-  postId,
-  targetProfileId,
-  authorProfileId,
-}: {
-  postId: string;
-  targetProfileId: string;
-  authorProfileId: string;
-}) => {
-  try {
-    await event.send({
-      name: Events.decisionUpdatePosted.name,
-      data: { postId, targetProfileId, authorProfileId },
-    });
-  } catch (error) {
-    console.error(
-      '[createPost] Failed to emit decisionUpdatePosted event',
-      error,
     );
   }
 };
@@ -376,20 +354,33 @@ export const createPost = async (input: CreatePostServiceInput) => {
     return newPost;
   });
 
+  const postKind = parentPostId
+    ? 'comment'
+    : proposalId && targetProfileId
+      ? 'proposalComment'
+      : targetProfileId
+        ? 'decisionUpdate'
+        : 'none';
+
   waitUntil(
     (async () => {
       try {
-        if (parentPostId) {
-          await sendPostCommentNotification(parentPostId, content, profileId);
-        } else if (targetProfileId && proposalId) {
-          await sendProposalCommentNotification(proposalId, content, profileId);
-        } else if (targetProfileId) {
-          await dispatchDecisionUpdatePostedEvent({
-            postId: newPost.id,
-            targetProfileId,
-            authorProfileId: profileId,
-          });
-        }
+        await match<Promise<unknown>>(postKind, {
+          comment: () =>
+            sendPostCommentNotification(parentPostId!, content, profileId),
+          proposalComment: () =>
+            sendProposalCommentNotification(proposalId!, content, profileId),
+          decisionUpdate: () =>
+            event.send({
+              name: Events.decisionUpdatePosted.name,
+              data: {
+                postId: newPost.id,
+                targetProfileId: targetProfileId!,
+                authorProfileId: profileId,
+              },
+            }),
+          none: () => Promise.resolve(),
+        });
       } catch (error) {
         console.error('Failed to send notification email:', error);
       }

--- a/packages/common/src/services/posts/createPost.ts
+++ b/packages/common/src/services/posts/createPost.ts
@@ -365,20 +365,21 @@ export const createPost = async (input: CreatePostServiceInput) => {
   waitUntil(
     (async () => {
       try {
-        await match<Promise<unknown>>(postKind, {
+        await match<Promise<void>>(postKind, {
           comment: () =>
             sendPostCommentNotification(parentPostId!, content, profileId),
           proposalComment: () =>
             sendProposalCommentNotification(proposalId!, content, profileId),
-          decisionUpdate: () =>
-            event.send({
+          decisionUpdate: async () => {
+            await event.send({
               name: Events.decisionUpdatePosted.name,
               data: {
                 postId: newPost.id,
                 targetProfileId: targetProfileId!,
                 authorProfileId: profileId,
               },
-            }),
+            });
+          },
           none: () => Promise.resolve(),
         });
       } catch (error) {

--- a/packages/common/src/services/posts/createPost.ts
+++ b/packages/common/src/services/posts/createPost.ts
@@ -8,7 +8,6 @@ import {
   posts,
   postsToOrganizations,
   postsToProfiles,
-  processInstances,
   profiles,
 } from '@op/db/schema';
 import { Events, event } from '@op/events';
@@ -138,31 +137,9 @@ const dispatchDecisionUpdatePostedEvent = async ({
   authorProfileId: string;
 }) => {
   try {
-    const [target] = await db
-      .select({
-        profileType: profiles.type,
-        processInstanceId: processInstances.id,
-      })
-      .from(profiles)
-      .leftJoin(processInstances, eq(processInstances.profileId, profiles.id))
-      .where(eq(profiles.id, targetProfileId))
-      .limit(1);
-
-    if (
-      !target ||
-      target.profileType !== EntityType.DECISION ||
-      !target.processInstanceId
-    ) {
-      return;
-    }
-
     await event.send({
       name: Events.decisionUpdatePosted.name,
-      data: {
-        postId,
-        processInstanceId: target.processInstanceId,
-        authorProfileId,
-      },
+      data: { postId, targetProfileId, authorProfileId },
     });
   } catch (error) {
     console.error(

--- a/packages/common/src/services/posts/createPost.ts
+++ b/packages/common/src/services/posts/createPost.ts
@@ -1,5 +1,5 @@
 import { invalidate } from '@op/cache';
-import { OPURLConfig, match } from '@op/core';
+import { OPURLConfig } from '@op/core';
 import { db } from '@op/db/client';
 import {
   EntityType,
@@ -365,12 +365,22 @@ export const createPost = async (input: CreatePostServiceInput) => {
   waitUntil(
     (async () => {
       try {
-        await match<Promise<void>>(postKind, {
-          comment: () =>
-            sendPostCommentNotification(parentPostId!, content, profileId),
-          proposalComment: () =>
-            sendProposalCommentNotification(proposalId!, content, profileId),
-          decisionUpdate: async () => {
+        switch (postKind) {
+          case 'comment':
+            await sendPostCommentNotification(
+              parentPostId!,
+              content,
+              profileId,
+            );
+            break;
+          case 'proposalComment':
+            await sendProposalCommentNotification(
+              proposalId!,
+              content,
+              profileId,
+            );
+            break;
+          case 'decisionUpdate':
             await event.send({
               name: Events.decisionUpdatePosted.name,
               data: {
@@ -379,9 +389,10 @@ export const createPost = async (input: CreatePostServiceInput) => {
                 authorProfileId: profileId,
               },
             });
-          },
-          none: () => Promise.resolve(),
-        });
+            break;
+          case 'none':
+            break;
+        }
       } catch (error) {
         console.error('Failed to send notification email:', error);
       }

--- a/packages/common/src/services/posts/createPost.ts
+++ b/packages/common/src/services/posts/createPost.ts
@@ -8,8 +8,10 @@ import {
   posts,
   postsToOrganizations,
   postsToProfiles,
+  processInstances,
   profiles,
 } from '@op/db/schema';
+import { Events, event } from '@op/events';
 import { CreatePostInput } from '@op/types';
 import { waitUntil } from '@vercel/functions';
 import { permission } from 'access-zones';
@@ -122,6 +124,50 @@ const sendPostCommentNotification = async (
     console.error(
       'Failed to send post comment notification email:',
       emailError,
+    );
+  }
+};
+
+const dispatchDecisionUpdatePostedEvent = async ({
+  postId,
+  targetProfileId,
+  authorProfileId,
+}: {
+  postId: string;
+  targetProfileId: string;
+  authorProfileId: string;
+}) => {
+  try {
+    const [target] = await db
+      .select({
+        profileType: profiles.type,
+        processInstanceId: processInstances.id,
+      })
+      .from(profiles)
+      .leftJoin(processInstances, eq(processInstances.profileId, profiles.id))
+      .where(eq(profiles.id, targetProfileId))
+      .limit(1);
+
+    if (
+      !target ||
+      target.profileType !== EntityType.DECISION ||
+      !target.processInstanceId
+    ) {
+      return;
+    }
+
+    await event.send({
+      name: Events.decisionUpdatePosted.name,
+      data: {
+        postId,
+        processInstanceId: target.processInstanceId,
+        authorProfileId,
+      },
+    });
+  } catch (error) {
+    console.error(
+      '[createPost] Failed to emit decisionUpdatePosted event',
+      error,
     );
   }
 };
@@ -361,6 +407,12 @@ export const createPost = async (input: CreatePostServiceInput) => {
           await sendPostCommentNotification(parentPostId, content, profileId);
         } else if (targetProfileId && proposalId) {
           await sendProposalCommentNotification(proposalId, content, profileId);
+        } else if (targetProfileId) {
+          await dispatchDecisionUpdatePostedEvent({
+            postId: newPost.id,
+            targetProfileId,
+            authorProfileId: profileId,
+          });
         }
       } catch (error) {
         console.error('Failed to send notification email:', error);

--- a/packages/common/src/services/posts/createPost.ts
+++ b/packages/common/src/services/posts/createPost.ts
@@ -354,13 +354,14 @@ export const createPost = async (input: CreatePostServiceInput) => {
     return newPost;
   });
 
-  const postKind = parentPostId
-    ? 'comment'
-    : proposalId && targetProfileId
-      ? 'proposalComment'
-      : targetProfileId
-        ? 'decisionUpdate'
-        : 'none';
+  let postKind: 'comment' | 'proposalComment' | 'decisionUpdate' | undefined;
+  if (parentPostId) {
+    postKind = 'comment';
+  } else if (proposalId && targetProfileId) {
+    postKind = 'proposalComment';
+  } else if (targetProfileId) {
+    postKind = 'decisionUpdate';
+  }
 
   waitUntil(
     (async () => {
@@ -389,8 +390,6 @@ export const createPost = async (input: CreatePostServiceInput) => {
                 authorProfileId: profileId,
               },
             });
-            break;
-          case 'none':
             break;
         }
       } catch (error) {

--- a/packages/common/src/services/posts/decisionUpdateNotification.test.ts
+++ b/packages/common/src/services/posts/decisionUpdateNotification.test.ts
@@ -1,0 +1,16 @@
+import { DecisionUpdateNotificationEmail } from '@op/emails';
+import { describe, expect, it } from 'vitest';
+
+describe('DecisionUpdateNotificationEmail.subject', () => {
+  it('formats author + process title', () => {
+    expect(
+      DecisionUpdateNotificationEmail.subject('Ada', 'Budget 2026'),
+    ).toBe('Ada posted an update in Budget 2026');
+  });
+
+  it('preserves special characters in the process title', () => {
+    expect(
+      DecisionUpdateNotificationEmail.subject('Ada', 'Q&A "Open Floor"'),
+    ).toBe('Ada posted an update in Q&A "Open Floor"');
+  });
+});

--- a/packages/common/src/services/posts/decisionUpdateNotification.test.ts
+++ b/packages/common/src/services/posts/decisionUpdateNotification.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest';
 
 describe('DecisionUpdateNotificationEmail.subject', () => {
   it('formats author + process title', () => {
-    expect(
-      DecisionUpdateNotificationEmail.subject('Ada', 'Budget 2026'),
-    ).toBe('Ada posted an update in Budget 2026');
+    expect(DecisionUpdateNotificationEmail.subject('Ada', 'Budget 2026')).toBe(
+      'Ada posted an update in Budget 2026',
+    );
   });
 
   it('preserves special characters in the process title', () => {

--- a/services/emails/emails/DecisionUpdateNotificationEmail.tsx
+++ b/services/emails/emails/DecisionUpdateNotificationEmail.tsx
@@ -1,0 +1,62 @@
+import { Button, Section, Text } from '@react-email/components';
+
+import EmailTemplate from '../components/EmailTemplate';
+
+export const DecisionUpdateNotificationEmail = ({
+  authorName = 'A Common user',
+  processTitle,
+  updateContent,
+  updateUrl = 'https://common.oneproject.org/',
+}: {
+  authorName: string;
+  processTitle: string;
+  updateContent: string;
+  updateUrl: string;
+}) => {
+  const previewSnippet =
+    updateContent.length > 50
+      ? `${updateContent.slice(0, 50)}...`
+      : updateContent;
+
+  return (
+    <EmailTemplate
+      previewText={`${authorName} posted an update in ${processTitle}: "${previewSnippet}"`}
+    >
+      <Text className="my-8 text-lg">
+        <strong>{authorName}</strong> posted an update in{' '}
+        <strong>{processTitle}</strong>.
+      </Text>
+
+      <Section className="my-6">
+        <Text className="my-0 text-lg text-neutral-charcoal">
+          "{updateContent}"
+        </Text>
+      </Section>
+
+      <Section className="pb-0">
+        <Button
+          href={updateUrl}
+          className="rounded-lg bg-primary-teal px-4 py-3 text-white no-underline hover:bg-primary-teal/90"
+          style={{
+            fontSize: '0.875rem',
+            textAlign: 'center',
+            textDecoration: 'none',
+          }}
+        >
+          View update
+        </Button>
+      </Section>
+
+      <Text className="mt-8 mb-0 text-xs text-neutral-gray4">
+        You're receiving this because you're a participant in {processTitle}.
+      </Text>
+    </EmailTemplate>
+  );
+};
+
+DecisionUpdateNotificationEmail.subject = (
+  authorName: string,
+  processTitle: string,
+) => `${authorName} posted an update in ${processTitle}`;
+
+export default DecisionUpdateNotificationEmail;

--- a/services/emails/index.tsx
+++ b/services/emails/index.tsx
@@ -130,3 +130,4 @@ export * from './emails/PhaseTransitionEmail';
 export * from './emails/VoteSubmittedEmail';
 export * from './emails/RevisionResubmittedEmail';
 export * from './emails/RevisionRequestedEmail';
+export * from './emails/DecisionUpdateNotificationEmail';

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -82,7 +82,7 @@ export const Events = {
     name: 'decision/update-posted' as const,
     schema: z.object({
       postId: z.string().uuid(),
-      processInstanceId: z.string().uuid(),
+      targetProfileId: z.string().uuid(),
       authorProfileId: z.string().uuid(),
     }),
   },

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -78,4 +78,12 @@ export const Events = {
       revisionRequestId: z.string().uuid(),
     }),
   },
+  decisionUpdatePosted: {
+    name: 'decision/update-posted' as const,
+    schema: z.object({
+      postId: z.string().uuid(),
+      processInstanceId: z.string().uuid(),
+      authorProfileId: z.string().uuid(),
+    }),
+  },
 } as const;

--- a/services/workflows/src/functions/notifications/decisionUpdateUrl.ts
+++ b/services/workflows/src/functions/notifications/decisionUpdateUrl.ts
@@ -1,4 +1,0 @@
-import { OPURLConfig } from '@op/core';
-
-export const buildDecisionUpdateUrl = (processProfileSlug: string) =>
-  `${OPURLConfig('APP').ENV_URL}/decisions/${processProfileSlug}?panel=updates`;

--- a/services/workflows/src/functions/notifications/decisionUpdateUrl.ts
+++ b/services/workflows/src/functions/notifications/decisionUpdateUrl.ts
@@ -1,0 +1,4 @@
+import { OPURLConfig } from '@op/core';
+
+export const buildDecisionUpdateUrl = (processProfileSlug: string) =>
+  `${OPURLConfig('APP').ENV_URL}/decisions/${processProfileSlug}?panel=updates`;

--- a/services/workflows/src/functions/notifications/index.ts
+++ b/services/workflows/src/functions/notifications/index.ts
@@ -5,3 +5,4 @@ export * from './sendPhaseTransitionNotification';
 export * from './sendVoteSubmittedNotification';
 export * from './sendRevisionResubmittedNotification';
 export * from './sendRevisionRequestedNotification';
+export * from './sendDecisionUpdateNotification';

--- a/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
+++ b/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
@@ -1,16 +1,9 @@
+import { OPURLConfig } from '@op/core';
 import { db } from '@op/db/client';
-import {
-  posts,
-  processInstances,
-  profileUsers,
-  profiles,
-} from '@op/db/schema';
+import { posts, processInstances, profileUsers, profiles } from '@op/db/schema';
 import { DecisionUpdateNotificationEmail, OPBatchSend } from '@op/emails';
 import { Events, inngest } from '@op/events';
-import { and, eq, ne } from 'drizzle-orm';
-import { alias } from 'drizzle-orm/pg-core';
-
-import { buildDecisionUpdateUrl } from './decisionUpdateUrl';
+import { eq } from 'drizzle-orm';
 
 const { decisionUpdatePosted } = Events;
 
@@ -24,64 +17,69 @@ export const sendDecisionUpdateNotification = inngest.createFunction(
       event.data,
     );
 
-    const updateData = await step.run('get-update-data', async () => {
-      const authorProfile = alias(profiles, 'author_profile');
-      const processProfile = alias(profiles, 'process_profile');
+    const [post, processWithParticipants] = await Promise.all([
+      step.run('get-post', async () => {
+        const [row] = await db
+          .select({
+            authorName: profiles.name,
+            authorEmail: profiles.email,
+            postContent: posts.content,
+          })
+          .from(posts)
+          .innerJoin(profiles, eq(profiles.id, posts.profileId))
+          .where(eq(posts.id, postId))
+          .limit(1);
+        return row ?? null;
+      }),
+      step.run('get-process-participants', async () => {
+        const [instance] = await db
+          .select({
+            processTitle: processInstances.name,
+            processProfileId: processInstances.profileId,
+            processProfileSlug: profiles.slug,
+          })
+          .from(processInstances)
+          .leftJoin(profiles, eq(profiles.id, processInstances.profileId))
+          .where(eq(processInstances.id, processInstanceId))
+          .limit(1);
 
-      const [row] = await db
-        .select({
-          processTitle: processInstances.name,
-          processProfileId: processInstances.profileId,
-          processProfileSlug: processProfile.slug,
-          authorName: authorProfile.name,
-          authorEmail: authorProfile.email,
-          postContent: posts.content,
-        })
-        .from(posts)
-        .innerJoin(authorProfile, eq(authorProfile.id, posts.profileId))
-        .innerJoin(
-          processInstances,
-          eq(processInstances.id, processInstanceId),
-        )
-        .leftJoin(
-          processProfile,
-          eq(processProfile.id, processInstances.profileId),
-        )
-        .where(eq(posts.id, postId))
-        .limit(1);
+        if (!instance?.processProfileId || !instance.processProfileSlug) {
+          return null;
+        }
 
-      return row;
-    });
+        const participants = await db
+          .select({ email: profileUsers.email })
+          .from(profileUsers)
+          .where(eq(profileUsers.profileId, instance.processProfileId));
 
-    if (!updateData) {
-      console.error('No post or process found for update notification', {
+        return {
+          processTitle: instance.processTitle,
+          processProfileSlug: instance.processProfileSlug,
+          participants,
+        };
+      }),
+    ]);
+
+    if (!post) {
+      console.error('No post found for update notification', {
         postId,
         processInstanceId,
       });
       return;
     }
 
-    if (!updateData.processProfileId || !updateData.processProfileSlug) {
+    if (!processWithParticipants) {
       console.error('Process instance has no associated profile/slug', {
         processInstanceId,
       });
       return;
     }
 
-    const participants = await step.run('get-participants', async () => {
-      const whereClauses = [
-        eq(profileUsers.profileId, updateData.processProfileId!),
-      ];
-      if (updateData.authorEmail) {
-        whereClauses.push(ne(profileUsers.email, updateData.authorEmail));
-      }
-      return db
-        .select({ email: profileUsers.email })
-        .from(profileUsers)
-        .where(and(...whereClauses));
-    });
+    const recipients = processWithParticipants.participants.filter(
+      ({ email }) => email !== post.authorEmail,
+    );
 
-    if (participants.length === 0) {
+    if (recipients.length === 0) {
       console.warn('No participants to notify for decision update', {
         postId,
         processInstanceId,
@@ -89,21 +87,21 @@ export const sendDecisionUpdateNotification = inngest.createFunction(
       return;
     }
 
-    const updateUrl = buildDecisionUpdateUrl(updateData.processProfileSlug);
-    const authorName = updateData.authorName ?? 'A Common user';
+    const updateUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processWithParticipants.processProfileSlug}?panel=updates`;
+    const authorName = post.authorName ?? 'A Common user';
 
     const result = await step.run('send-emails', async () => {
-      const emails = participants.map(({ email }) => ({
+      const emails = recipients.map(({ email }) => ({
         to: email,
         subject: DecisionUpdateNotificationEmail.subject(
           authorName,
-          updateData.processTitle,
+          processWithParticipants.processTitle,
         ),
         component: () =>
           DecisionUpdateNotificationEmail({
             authorName,
-            processTitle: updateData.processTitle,
-            updateContent: updateData.postContent,
+            processTitle: processWithParticipants.processTitle,
+            updateContent: post.postContent,
             updateUrl,
           }),
       }));

--- a/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
+++ b/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
@@ -11,11 +11,18 @@ import { DecisionUpdateNotificationEmail, OPBatchSend } from '@op/emails';
 import { Events, inngest } from '@op/events';
 import { eq } from 'drizzle-orm';
 
+const key =
+  'event.data.authorProfileId + "-" + event.data.targetProfileId';
 const { decisionUpdatePosted } = Events;
 
 export const sendDecisionUpdateNotification = inngest.createFunction(
   {
     id: 'sendDecisionUpdateNotification',
+    debounce: {
+      key,
+      period: '1m',
+      timeout: '5m',
+    },
   },
   { event: decisionUpdatePosted.name },
   async ({ event, step }) => {

--- a/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
+++ b/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
@@ -1,6 +1,12 @@
 import { OPURLConfig } from '@op/core';
 import { db } from '@op/db/client';
-import { posts, processInstances, profileUsers, profiles } from '@op/db/schema';
+import {
+  EntityType,
+  posts,
+  processInstances,
+  profileUsers,
+  profiles,
+} from '@op/db/schema';
 import { DecisionUpdateNotificationEmail, OPBatchSend } from '@op/emails';
 import { Events, inngest } from '@op/events';
 import { eq } from 'drizzle-orm';
@@ -13,11 +19,11 @@ export const sendDecisionUpdateNotification = inngest.createFunction(
   },
   { event: decisionUpdatePosted.name },
   async ({ event, step }) => {
-    const { postId, processInstanceId } = decisionUpdatePosted.schema.parse(
+    const { postId, targetProfileId } = decisionUpdatePosted.schema.parse(
       event.data,
     );
 
-    const [post, processWithParticipants] = await Promise.all([
+    const [post, target, participants] = await Promise.all([
       step.run('get-post', async () => {
         const [row] = await db
           .select({
@@ -31,63 +37,60 @@ export const sendDecisionUpdateNotification = inngest.createFunction(
           .limit(1);
         return row ?? null;
       }),
-      step.run('get-process-participants', async () => {
-        const [instance] = await db
+      step.run('get-target', async () => {
+        const [row] = await db
           .select({
-            processTitle: processInstances.name,
-            processProfileId: processInstances.profileId,
+            profileType: profiles.type,
             processProfileSlug: profiles.slug,
+            processTitle: processInstances.name,
           })
-          .from(processInstances)
-          .leftJoin(profiles, eq(profiles.id, processInstances.profileId))
-          .where(eq(processInstances.id, processInstanceId))
+          .from(profiles)
+          .leftJoin(
+            processInstances,
+            eq(processInstances.profileId, profiles.id),
+          )
+          .where(eq(profiles.id, targetProfileId))
           .limit(1);
-
-        if (!instance?.processProfileId || !instance.processProfileSlug) {
-          return null;
-        }
-
-        const participants = await db
+        return row ?? null;
+      }),
+      step.run('get-participants', async () => {
+        return db
           .select({ email: profileUsers.email })
           .from(profileUsers)
-          .where(eq(profileUsers.profileId, instance.processProfileId));
-
-        return {
-          processTitle: instance.processTitle,
-          processProfileSlug: instance.processProfileSlug,
-          participants,
-        };
+          .where(eq(profileUsers.profileId, targetProfileId));
       }),
     ]);
+
+    if (target?.profileType !== EntityType.DECISION) {
+      return;
+    }
+
+    const { processProfileSlug, processTitle } = target;
+    if (!processProfileSlug || !processTitle) {
+      return;
+    }
 
     if (!post) {
       console.error('No post found for update notification', {
         postId,
-        processInstanceId,
+        targetProfileId,
       });
       return;
     }
 
-    if (!processWithParticipants) {
-      console.error('Process instance has no associated profile/slug', {
-        processInstanceId,
-      });
-      return;
-    }
-
-    const recipients = processWithParticipants.participants.filter(
+    const recipients = participants.filter(
       ({ email }) => email !== post.authorEmail,
     );
 
     if (recipients.length === 0) {
       console.warn('No participants to notify for decision update', {
         postId,
-        processInstanceId,
+        targetProfileId,
       });
       return;
     }
 
-    const updateUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processWithParticipants.processProfileSlug}?panel=updates`;
+    const updateUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processProfileSlug}?panel=updates`;
     const authorName = post.authorName ?? 'A Common user';
 
     const result = await step.run('send-emails', async () => {
@@ -95,12 +98,12 @@ export const sendDecisionUpdateNotification = inngest.createFunction(
         to: email,
         subject: DecisionUpdateNotificationEmail.subject(
           authorName,
-          processWithParticipants.processTitle,
+          processTitle,
         ),
         component: () =>
           DecisionUpdateNotificationEmail({
             authorName,
-            processTitle: processWithParticipants.processTitle,
+            processTitle,
             updateContent: post.postContent,
             updateUrl,
           }),

--- a/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
+++ b/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
@@ -11,8 +11,7 @@ import { DecisionUpdateNotificationEmail, OPBatchSend } from '@op/emails';
 import { Events, inngest } from '@op/events';
 import { eq } from 'drizzle-orm';
 
-const key =
-  'event.data.authorProfileId + "-" + event.data.targetProfileId';
+const key = 'event.data.authorProfileId + "-" + event.data.targetProfileId';
 const { decisionUpdatePosted } = Events;
 
 export const sendDecisionUpdateNotification = inngest.createFunction(

--- a/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
+++ b/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
@@ -1,0 +1,124 @@
+import { db } from '@op/db/client';
+import {
+  posts,
+  processInstances,
+  profileUsers,
+  profiles,
+} from '@op/db/schema';
+import { DecisionUpdateNotificationEmail, OPBatchSend } from '@op/emails';
+import { Events, inngest } from '@op/events';
+import { and, eq, ne } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+
+import { buildDecisionUpdateUrl } from './decisionUpdateUrl';
+
+const { decisionUpdatePosted } = Events;
+
+export const sendDecisionUpdateNotification = inngest.createFunction(
+  {
+    id: 'sendDecisionUpdateNotification',
+  },
+  { event: decisionUpdatePosted.name },
+  async ({ event, step }) => {
+    const { postId, processInstanceId } = decisionUpdatePosted.schema.parse(
+      event.data,
+    );
+
+    const updateData = await step.run('get-update-data', async () => {
+      const authorProfile = alias(profiles, 'author_profile');
+      const processProfile = alias(profiles, 'process_profile');
+
+      const [row] = await db
+        .select({
+          processTitle: processInstances.name,
+          processProfileId: processInstances.profileId,
+          processProfileSlug: processProfile.slug,
+          authorName: authorProfile.name,
+          authorEmail: authorProfile.email,
+          postContent: posts.content,
+        })
+        .from(posts)
+        .innerJoin(authorProfile, eq(authorProfile.id, posts.profileId))
+        .innerJoin(
+          processInstances,
+          eq(processInstances.id, processInstanceId),
+        )
+        .leftJoin(
+          processProfile,
+          eq(processProfile.id, processInstances.profileId),
+        )
+        .where(eq(posts.id, postId))
+        .limit(1);
+
+      return row;
+    });
+
+    if (!updateData) {
+      console.error('No post or process found for update notification', {
+        postId,
+        processInstanceId,
+      });
+      return;
+    }
+
+    if (!updateData.processProfileId || !updateData.processProfileSlug) {
+      console.error('Process instance has no associated profile/slug', {
+        processInstanceId,
+      });
+      return;
+    }
+
+    const participants = await step.run('get-participants', async () => {
+      const whereClauses = [
+        eq(profileUsers.profileId, updateData.processProfileId!),
+      ];
+      if (updateData.authorEmail) {
+        whereClauses.push(ne(profileUsers.email, updateData.authorEmail));
+      }
+      return db
+        .select({ email: profileUsers.email })
+        .from(profileUsers)
+        .where(and(...whereClauses));
+    });
+
+    if (participants.length === 0) {
+      console.warn('No participants to notify for decision update', {
+        postId,
+        processInstanceId,
+      });
+      return;
+    }
+
+    const updateUrl = buildDecisionUpdateUrl(updateData.processProfileSlug);
+    const authorName = updateData.authorName ?? 'A Common user';
+
+    const result = await step.run('send-emails', async () => {
+      const emails = participants.map(({ email }) => ({
+        to: email,
+        subject: DecisionUpdateNotificationEmail.subject(
+          authorName,
+          updateData.processTitle,
+        ),
+        component: () =>
+          DecisionUpdateNotificationEmail({
+            authorName,
+            processTitle: updateData.processTitle,
+            updateContent: updateData.postContent,
+            updateUrl,
+          }),
+      }));
+
+      const { data, errors } = await OPBatchSend(emails);
+
+      if (errors.length > 0) {
+        throw new Error(`Email batch failed: ${JSON.stringify(errors)}`);
+      }
+
+      return { sent: data.length };
+    });
+
+    return {
+      message: `${result.sent} decision update notification(s) sent`,
+    };
+  },
+);


### PR DESCRIPTION
## Summary
- New Inngest event `decision/update-posted` fired from `createPost` when a top-level post is created against a decision profile.
- New `DecisionUpdateNotificationEmail` template (mirrors `CommentNotificationEmail` styling) linking back to `/decisions/{slug}?panel=updates`.
- New workflow `sendDecisionUpdateNotification` fans out via `OPBatchSend` to all `profileUsers` of the decision profile, excluding the author by email.

## Asana
https://app.asana.com/0/1209754323385077/1214930301855221