### PR TITLE
fix(profile): prevent removing admin access from a profile owner

### DIFF
--- a/apps/app/src/components/decisions/ProfileUsersAccessTable.tsx
+++ b/apps/app/src/components/decisions/ProfileUsersAccessTable.tsx
@@ -182,7 +182,7 @@ const ProfileUserRoleSelect = ({
             handleRoleChange(keyStr);
           }
         }}
-        isDisabled={isPending}
+        isDisabled={isPending || isOwner}
         size="small"
         className={className}
       >

--- a/packages/common/src/services/profile/updateProfileUserRole.ts
+++ b/packages/common/src/services/profile/updateProfileUserRole.ts
@@ -2,14 +2,15 @@ import { invalidate } from '@op/cache';
 import { and, db, eq, inArray } from '@op/db/client';
 import { profileUserToAccessRoles } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
-import { assertAccess, permission } from 'access-zones';
+import { assertAccess, checkPermission, permission } from 'access-zones';
 
 import {
   CommonError,
   NotFoundError,
   UnauthorizedError,
+  ValidationError,
 } from '../../utils/error';
-import { getProfileAccessUser } from '../access';
+import { getNormalizedRoles, getProfileAccessUser } from '../access';
 import { getProfileUserWithRelations } from './getProfileUserWithRelations';
 
 /**
@@ -67,6 +68,31 @@ export const updateProfileUserRoles = async ({
   }
 
   assertAccess({ profile: permission.ADMIN }, currentProfileUser.roles ?? []);
+
+  if (targetProfileUser.isOwner) {
+    // Profile owners must always retain admin access on their own profile —
+    // the UI lets an owner switch themselves to a non-admin role and locks
+    // them out, so we enforce it server-side. Load the desired roles with
+    // their zone permissions and verify the union still grants profile ADMIN.
+    const desiredRolesWithPermissions = await db.query.accessRoles.findMany({
+      where: { id: { in: roleIdsDeduped } },
+      with: {
+        zonePermissions: {
+          with: { accessZone: true },
+        },
+      },
+    });
+
+    const normalizedDesired = getNormalizedRoles(
+      desiredRolesWithPermissions.map((accessRole) => ({ accessRole })),
+    );
+
+    if (!checkPermission({ profile: permission.ADMIN }, normalizedDesired)) {
+      throw new ValidationError(
+        'Cannot remove admin access from the owner of a profile',
+      );
+    }
+  }
 
   const existingRoleIds = new Set(
     targetProfileUser.roles.map((r) => r.accessRoleId),

--- a/packages/common/src/services/profile/updateProfileUserRole.ts
+++ b/packages/common/src/services/profile/updateProfileUserRole.ts
@@ -74,7 +74,7 @@ export const updateProfileUserRoles = async ({
     // the UI lets an owner switch themselves to a non-admin role and locks
     // them out, so we enforce it server-side. Load the desired roles with
     // their zone permissions and verify the union still grants profile ADMIN.
-    const desiredRolesWithPermissions = await db.query.accessRoles.findMany({
+    const requestedRolesWithPermissions = await db.query.accessRoles.findMany({
       where: { id: { in: roleIdsDeduped } },
       with: {
         zonePermissions: {
@@ -84,7 +84,7 @@ export const updateProfileUserRoles = async ({
     });
 
     const normalizedDesired = getNormalizedRoles(
-      desiredRolesWithPermissions.map((accessRole) => ({ accessRole })),
+      requestedRolesWithPermissions.map((accessRole) => ({ accessRole })),
     );
 
     if (!checkPermission({ profile: permission.ADMIN }, normalizedDesired)) {

--- a/services/api/src/routers/profile/users/updateUserRoles.test.ts
+++ b/services/api/src/routers/profile/users/updateUserRoles.test.ts
@@ -1,4 +1,5 @@
-import { db } from '@op/db/client';
+import { db, eq } from '@op/db/client';
+import { profileUsers } from '@op/db/schema';
 import { ROLES } from '@op/db/seedData/accessControl';
 import { describe, expect, it } from 'vitest';
 
@@ -126,6 +127,44 @@ describe.concurrent('profile.users.updateUserRoles', () => {
 
     expect(userWithAdminOnly?.roles).toHaveLength(1);
     expect(userWithAdminOnly?.roles[0]?.accessRole.id).toBe(ROLES.ADMIN.id);
+  });
+
+  it('should reject demoting the profile owner from admin', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+    const { adminUser } = await testData.createProfile({
+      users: { admin: 1 },
+    });
+
+    // Promote the admin to owner of the profile. The test data manager seeds
+    // the admin role but not isOwner; this models the production case where a
+    // process owner is also its admin.
+    await db
+      .update(profileUsers)
+      .set({ isOwner: true })
+      .where(eq(profileUsers.id, adminUser.profileUserId));
+
+    const { session } = await createIsolatedSession(adminUser.email);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    await expect(
+      caller.updateUserRoles({
+        profileUserId: adminUser.profileUserId,
+        roleIds: [ROLES.MEMBER.id],
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'ValidationError' },
+    });
+
+    // Confirm the role was not changed — the admin role should still be there.
+    const unchanged = await db.query.profileUsers.findFirst({
+      where: { id: adminUser.profileUserId },
+      with: { roles: true },
+    });
+    expect(unchanged?.roles).toHaveLength(1);
+    expect(unchanged?.roles[0]?.accessRoleId).toBe(ROLES.ADMIN.id);
   });
 
   it('should fail when non-admin tries to update roles', async ({


### PR DESCRIPTION
## Summary
- Server: `updateProfileUserRoles` now rejects role updates that would strip `profile.ADMIN` from a profileUser flagged `isOwner=true`, with a `ValidationError("Cannot remove admin access from the owner of a profile")`.
- UI: the role-select dropdown on `ProfileUsersAccessTable` is disabled for owners, matching the server contract.
- Test: `updateUserRoles.test.ts` now covers the owner-demotion case (existing tests still pass).

## Asana
https://app.asana.com/0/1213315744811204/1214897805510041

