### PR TITLE
fix(post-update): clear comment textarea on submit

### DIFF
--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -140,7 +140,6 @@ const PostUpdateWithUser = ({
       const tempId = `optimistic-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
       optimisticCommentRef.current = tempId;
 
-      const previousContent = content;
       setContent('');
       setDetectedUrls([]);
       setLastFailedPost(null);
@@ -188,7 +187,6 @@ const PostUpdateWithUser = ({
           previousComments,
           tempId,
           isComment: true,
-          previousContent,
         };
       }
 
@@ -238,19 +236,16 @@ const PostUpdateWithUser = ({
           previousPosts,
           tempId,
           isComment: false,
-          previousContent,
         };
       }
 
-      return { previousContent };
+      return {};
     },
     onError: (err, variables, context) => {
       const errorInfo = analyzeError(err);
 
-      if (context) {
-        setContent(context.previousContent);
-        setDetectedUrls(detectLinks(context.previousContent).urls);
-      }
+      setContent(variables.content);
+      setDetectedUrls(detectLinks(variables.content).urls);
 
       // Rollback optimistic updates on error
       if (context?.tempId && optimisticCommentRef.current === context.tempId) {
@@ -290,7 +285,7 @@ const PostUpdateWithUser = ({
       if (errorInfo.isConnectionError) {
         // Store failed post data for retry
         setLastFailedPost({
-          content: (context?.previousContent ?? '').trim(),
+          content: variables.content,
           attachmentIds: fileUpload.getUploadedAttachmentIds(),
         });
 

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -305,7 +305,6 @@ const PostUpdateWithUser = ({
     },
     onSuccess: (data, variables, context) => {
       fileUpload.clearFiles();
-      setLastFailedPost(null);
 
       if (data && context?.tempId) {
         // Clear the optimistic comment ID since we have real data

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -140,6 +140,11 @@ const PostUpdateWithUser = ({
       const tempId = `optimistic-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
       optimisticCommentRef.current = tempId;
 
+      const previousContent = content;
+      setContent('');
+      setDetectedUrls([]);
+      setLastFailedPost(null);
+
       // For comments (posts with parentPostId)
       if (variables.parentPostId) {
         // Cancel any outgoing refetches
@@ -179,7 +184,12 @@ const PostUpdateWithUser = ({
           return [optimisticComment, ...old];
         });
 
-        return { previousComments, tempId, isComment: true };
+        return {
+          previousComments,
+          tempId,
+          isComment: true,
+          previousContent,
+        };
       }
 
       // For top-level posts (profile posts like proposal comments)
@@ -224,13 +234,23 @@ const PostUpdateWithUser = ({
           return [optimisticPost, ...old];
         });
 
-        return { previousPosts, tempId, isComment: false };
+        return {
+          previousPosts,
+          tempId,
+          isComment: false,
+          previousContent,
+        };
       }
 
-      return {};
+      return { previousContent };
     },
     onError: (err, variables, context) => {
       const errorInfo = analyzeError(err);
+
+      if (context) {
+        setContent(context.previousContent);
+        setDetectedUrls(detectLinks(context.previousContent).urls);
+      }
 
       // Rollback optimistic updates on error
       if (context?.tempId && optimisticCommentRef.current === context.tempId) {
@@ -270,7 +290,7 @@ const PostUpdateWithUser = ({
       if (errorInfo.isConnectionError) {
         // Store failed post data for retry
         setLastFailedPost({
-          content: content.trim(),
+          content: (context?.previousContent ?? '').trim(),
           attachmentIds: fileUpload.getUploadedAttachmentIds(),
         });
 
@@ -284,9 +304,6 @@ const PostUpdateWithUser = ({
       console.log('ERROR', err);
     },
     onSuccess: (data, variables, context) => {
-      // Clear form and failed post on success
-      setContent('');
-      setDetectedUrls([]);
       fileUpload.clearFiles();
       setLastFailedPost(null);
 


### PR DESCRIPTION
 Clearing the input in onMutate matches the optimistic feed update; onError restores the snapshot so retry still works.