### PR TITLE
feat(decisions): rename "Funded" status to "Selected"

### DIFF
--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -357,7 +357,7 @@ export function ProposalCardStatus({
       <>
         <Bullet />
         <span className={cn('text-sm text-green-700', className)}>
-          {t('Funded')}
+          {t('Selected')}
         </span>
       </>
     ),

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -354,7 +354,7 @@
   "Your drafts": "আপনার খসড়াসমূহ",
   "Not shortlisted": "শর্টলিস্ট করা হয়নি",
   "Shortlisted": "শর্টলিস্ট করা হয়েছে",
-  "Funded": "অর্থায়িত",
+  "Selected": "নির্বাচিত",
   "Reject from shortlist": "শর্টলিস্ট থেকে প্রত্যাখ্যান করুন",
   "Shortlist for voting": "ভোটের জন্য শর্টলিস্ট",
   "Shortlisted proposals": "শর্টলিস্ট করা প্রস্তাব",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -353,7 +353,7 @@
   "Your drafts": "Your drafts",
   "Not shortlisted": "Not shortlisted",
   "Shortlisted": "Shortlisted",
-  "Funded": "Funded",
+  "Selected": "Selected",
   "Reject from shortlist": "Reject from shortlist",
   "Shortlist for voting": "Shortlist for voting",
   "Shortlisted proposals": "Shortlisted proposals",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -354,7 +354,7 @@
   "Your drafts": "Tus borradores",
   "Not shortlisted": "No preseleccionada",
   "Shortlisted": "Preseleccionada",
-  "Funded": "Financiada",
+  "Selected": "Seleccionada",
   "Reject from shortlist": "Rechazar de la preselección",
   "Shortlist for voting": "Preseleccionar para votación",
   "Shortlisted proposals": "Propuestas preseleccionadas",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -355,7 +355,7 @@
   "Your drafts": "Vos brouillons",
   "Not shortlisted": "Non présélectionné",
   "Shortlisted": "Présélectionné",
-  "Funded": "Financé",
+  "Selected": "Sélectionnée",
   "Reject from shortlist": "Rejeter de la présélection",
   "Shortlist for voting": "Présélectionner pour le vote",
   "Shortlisted proposals": "Propositions présélectionnées",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -355,7 +355,7 @@
   "Your drafts": "Seus rascunhos",
   "Not shortlisted": "Não pré-selecionada",
   "Shortlisted": "Pré-selecionada",
-  "Funded": "Financiada",
+  "Selected": "Selecionada",
   "Reject from shortlist": "Rejeitar da pré-seleção",
   "Shortlist for voting": "Pré-selecionar para votação",
   "Shortlisted proposals": "Propostas pré-selecionadas",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -338,7 +338,7 @@
   "Your drafts": "Qoraallada qoraaleedkaaga",
   "Not shortlisted": "Lama soo gaabin",
   "Shortlisted": "La soo gaabiyay",
-  "Funded": "La maalgeliyay",
+  "Selected": "La doortay",
   "Reject from shortlist": "Ka diid liiska gaaban",
   "Shortlist for voting": "U soo gaabi codaynta",
   "Shortlisted proposals": "Soo jeedimaha la soo gaabiyay",


### PR DESCRIPTION
## Summary

- Renames the proposal status indicator label from **Funded** to **Selected** on the results screen / proposal cards (rendered when `ProposalStatus.SELECTED`).
- Updates the `i18n` key `Funded` → `Selected` across all six locale dictionaries (en, bn, es, fr, pt, so) with translated values.

## Why

Product wants the public-facing label to read "Selected" instead of "Funded" in the results UI.

## Notes for reviewers

- Single call-site (`apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx:360`) — verified by grep, no other usages of `t('Funded')`.
- Non-English translations are my best inference matching the feminine form used by adjacent `Shortlisted` / `Not shortlisted` keys. A native-speaker pass would be welcome:
  - es: `Seleccionada`
  - pt: `Selecionada`
  - fr: `Sélectionnée`
  - bn: `নির্বাচিত`
  - so: `La doortay`

## Test plan

- [ ] Open the results screen for a process with at least one selected proposal — confirm the status chip reads "Selected" (green) instead of "Funded".
- [ ] Switch locale to es / pt / fr / bn / so and confirm the translated label renders.