### PR TITLE
fix(decisions): remove AI questions from process survey

### DIFF
--- a/apps/app/src/components/decisions/ProcessSurveyModal.tsx
+++ b/apps/app/src/components/decisions/ProcessSurveyModal.tsx
@@ -29,7 +29,6 @@ const PROMOTER_OPTION_IDS = [
   'values',
   'support',
   'designed-for-us',
-  'ai',
 ] as const;
 
 const DETRACTOR_OPTION_IDS = [
@@ -42,7 +41,6 @@ const DETRACTOR_OPTION_IDS = [
   'alternatives',
   'no-help',
   'different-org',
-  'dislike-ai',
 ] as const;
 
 function shuffle<T>(items: readonly T[]): T[] {
@@ -110,7 +108,6 @@ export const ProcessSurveyModal = ({
     values: t("It aligns with our community's values"),
     support: t('The support and documentation are helpful'),
     'designed-for-us': t("It's designed for organizations like ours"),
-    ai: t('The AI features are really helpful'),
   };
 
   const detractorLabels: Record<string, string> = {
@@ -131,7 +128,6 @@ export const ProcessSurveyModal = ({
     'different-org': t(
       "It feels like it's built for a different type of organization than mine",
     ),
-    'dislike-ai': t("I don't like the AI features"),
   };
 
   const promoterOrder = useMemo(() => shuffle(PROMOTER_OPTION_IDS), []);

--- a/apps/app/src/components/decisions/ProcessSurveyModal.tsx
+++ b/apps/app/src/components/decisions/ProcessSurveyModal.tsx
@@ -59,7 +59,7 @@ const NPS_SCORES = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
 const SKIP_COOKIE_PREFIX = 'survey-skipped-';
 const SKIP_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
 
-export const getSurveySkipCookieName = (instanceId: string) =>
+const getSurveySkipCookieName = (instanceId: string) =>
   `${SKIP_COOKIE_PREFIX}${instanceId}`;
 
 export const hasSurveySkipCookie = (instanceId: string): boolean => {

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1255,7 +1255,6 @@
   "It aligns with our community's values": "এটি আমাদের সম্প্রদায়ের মূল্যবোধের সাথে সঙ্গতিপূর্ণ",
   "The support and documentation are helpful": "সহায়তা ও ডকুমেন্টেশন সহায়ক",
   "It's designed for organizations like ours": "এটি আমাদের মতো সংস্থার জন্য ডিজাইন করা",
-  "The AI features are really helpful": "AI বৈশিষ্ট্যগুলো সত্যিই সহায়ক",
   "Tell us more": "আরও বলুন",
   "Please select at least one option": "অনুগ্রহ করে অন্তত একটি বিকল্প নির্বাচন করুন",
   "Please describe your answer": "অনুগ্রহ করে আপনার উত্তর বর্ণনা করুন",
@@ -1269,7 +1268,6 @@
   "There are better alternatives that do what I need": "আমার প্রয়োজন পূরণ করে এমন আরও ভালো বিকল্প রয়েছে",
   "I could not find help when I had issues": "সমস্যা হলে আমি সাহায্য খুঁজে পাইনি",
   "It feels like it's built for a different type of organization than mine": "মনে হয় এটি আমার সংস্থার চেয়ে ভিন্ন ধরনের সংস্থার জন্য তৈরি",
-  "I don't like the AI features": "আমি AI বৈশিষ্ট্যগুলো পছন্দ করি না",
   "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!": "আমাদের কোন বৈশিষ্ট্য ঠিক করা, উন্নত করা বা রাখা উচিত? কোন বৈশিষ্ট্য যোগ করা উচিত? আমরা সত্যিই এগুলো পড়ি!",
   "Go to the platform": "প্ল্যাটফর্মে যান"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1296,7 +1296,6 @@
   "It aligns with our community's values": "It aligns with our community's values",
   "The support and documentation are helpful": "The support and documentation are helpful",
   "It's designed for organizations like ours": "It's designed for organizations like ours",
-  "The AI features are really helpful": "The AI features are really helpful",
   "Tell us more": "Tell us more",
   "Please select at least one option": "Please select at least one option",
   "Please describe your answer": "Please describe your answer",
@@ -1310,7 +1309,6 @@
   "There are better alternatives that do what I need": "There are better alternatives that do what I need",
   "I could not find help when I had issues": "I could not find help when I had issues",
   "It feels like it's built for a different type of organization than mine": "It feels like it's built for a different type of organization than mine",
-  "I don't like the AI features": "I don't like the AI features",
   "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!": "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!",
   "Go to the platform": "Go to the platform"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1254,7 +1254,6 @@
   "It aligns with our community's values": "Está alineado con los valores de nuestra comunidad",
   "The support and documentation are helpful": "El soporte y la documentación son útiles",
   "It's designed for organizations like ours": "Está diseñado para organizaciones como la nuestra",
-  "The AI features are really helpful": "Las funciones de IA son realmente útiles",
   "Tell us more": "Cuéntanos más",
   "Please select at least one option": "Por favor, selecciona al menos una opción",
   "Please describe your answer": "Por favor, describe tu respuesta",
@@ -1268,7 +1267,6 @@
   "There are better alternatives that do what I need": "Hay mejores alternativas que hacen lo que necesito",
   "I could not find help when I had issues": "No pude encontrar ayuda cuando tuve problemas",
   "It feels like it's built for a different type of organization than mine": "Parece que está hecho para un tipo de organización diferente a la mía",
-  "I don't like the AI features": "No me gustan las funciones de IA",
   "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!": "¿Hay funciones específicas que deberíamos arreglar, mejorar o mantener? ¿Funciones que deberíamos añadir? ¡De verdad leemos esto!",
   "Go to the platform": "Ir a la plataforma"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1254,7 +1254,6 @@
   "It aligns with our community's values": "Il est en accord avec les valeurs de notre communauté",
   "The support and documentation are helpful": "Le support et la documentation sont utiles",
   "It's designed for organizations like ours": "Il est conçu pour des organisations comme la nôtre",
-  "The AI features are really helpful": "Les fonctionnalités d'IA sont vraiment utiles",
   "Tell us more": "Dites-nous en plus",
   "Please select at least one option": "Veuillez sélectionner au moins une option",
   "Please describe your answer": "Veuillez décrire votre réponse",
@@ -1268,7 +1267,6 @@
   "There are better alternatives that do what I need": "Il existe de meilleures alternatives qui répondent à mes besoins",
   "I could not find help when I had issues": "Je n'ai pas pu trouver d'aide en cas de problème",
   "It feels like it's built for a different type of organization than mine": "On dirait qu'il est conçu pour un autre type d'organisation que la mienne",
-  "I don't like the AI features": "Je n'aime pas les fonctionnalités d'IA",
   "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!": "Y a-t-il des fonctionnalités à corriger, améliorer ou conserver ? Des fonctionnalités à ajouter ? Nous lisons vraiment vos réponses !",
   "Go to the platform": "Aller à la plateforme"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1254,7 +1254,6 @@
   "It aligns with our community's values": "Está alinhada com os valores da nossa comunidade",
   "The support and documentation are helpful": "O suporte e a documentação são úteis",
   "It's designed for organizations like ours": "Foi projetada para organizações como a nossa",
-  "The AI features are really helpful": "As funcionalidades de IA são realmente úteis",
   "Tell us more": "Conte-nos mais",
   "Please select at least one option": "Por favor, selecione pelo menos uma opção",
   "Please describe your answer": "Por favor, descreva sua resposta",
@@ -1268,7 +1267,6 @@
   "There are better alternatives that do what I need": "Existem alternativas melhores que fazem o que preciso",
   "I could not find help when I had issues": "Não consegui encontrar ajuda quando tive problemas",
   "It feels like it's built for a different type of organization than mine": "Parece que foi feita para um tipo diferente de organização que a minha",
-  "I don't like the AI features": "Não gosto das funcionalidades de IA",
   "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!": "Alguma funcionalidade específica que devemos corrigir, melhorar ou manter? Alguma para adicionar? Nós realmente lemos isso!",
   "Go to the platform": "Ir para a plataforma"
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1198,7 +1198,6 @@
   "It aligns with our community's values": "Waxay la jaanqaadaysaa qiyamka bulshadayada",
   "The support and documentation are helpful": "Taageerada iyo dukumentigu way caawiyaan",
   "It's designed for organizations like ours": "Waxaa loogu talagalay ururo annaga oo kale",
-  "The AI features are really helpful": "Astaamaha AI runtii way caawiyaan",
   "Tell us more": "Wax dheeraad ah noo sheeg",
   "Please select at least one option": "Fadlan dooro ugu yaraan hal ikhtiyaar",
   "Please describe your answer": "Fadlan sharax jawaabtaada",
@@ -1212,7 +1211,6 @@
   "There are better alternatives that do what I need": "Waxaa jira beddel ka fiican kuwaas oo qaba waxa aan u baahanahay",
   "I could not find help when I had issues": "Ma helin caawimaad markaan dhibaato qabay",
   "It feels like it's built for a different type of organization than mine": "Waxay u muuqataa in loo dhisay nooc ururro ah oo ka duwan kayga",
-  "I don't like the AI features": "Ma jecli astaamaha AI",
   "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!": "Astaamo gaar ah oo aan hagaajinno, kor u qaadno ama hayno? Astaamo aan ku darno? Runtii waan akhrinaynaa kuwaan!",
   "Go to the platform": "Tag goobta"
 }


### PR DESCRIPTION
## Summary
- Removes the two AI-related NPS survey options ("The AI features are really helpful" promoter, "I don't like the AI features" detractor) from the Process Survey modal, since we don't currently ship AI features.
- Drops the corresponding entries from all 6 locale dictionaries (en, bn, es, fr, pt, so).
- Unexports `getSurveySkipCookieName` (only used internally by the modal's cookie helpers).

Asana: https://app.asana.com/0/1213315744811204/task/1215005400601510

