### PR TITLE
feat(decisions): show allocated vs requested budget on proposal card and detail view

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/page.tsx
@@ -46,6 +46,7 @@ function ProposalViewPageContent({
       proposal={proposal}
       canSeeRevisions={canSeeRevisions}
       backHref={`/decisions/${slug}`}
+      selectionsAreConfirmed={instance.selectionsAreConfirmed ?? false}
     />
   );
 }

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/page.tsx
@@ -3,6 +3,7 @@
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
+import { isLastPhase } from '@op/common/client';
 import { notFound, useParams } from 'next/navigation';
 import { Suspense } from 'react';
 
@@ -27,7 +28,8 @@ function ProposalViewPageContent({
   const instance = decisionProfile.processInstance;
   const { user } = useUser();
 
-  const currentPhase = instance.instanceData?.phases?.find(
+  const phases = instance.instanceData?.phases ?? [];
+  const currentPhase = phases.find(
     (phase) => phase.phaseId === instance.currentStateId,
   );
   const isInReviewPhase = currentPhase?.rules?.proposals?.review === true;
@@ -41,12 +43,20 @@ function ProposalViewPageContent({
       instance.access?.admin === true ||
       instance.access?.review === true);
 
+  // Selections only make sense once we've reached the final/results phase.
+  const inLastPhase = isLastPhase(instance.currentStateId, phases);
+  const { data: selection } =
+    trpc.decision.getLatestSelectionForProposal.useQuery(
+      { proposalId: proposal.id },
+      { enabled: inLastPhase },
+    );
+
   return (
     <ProposalView
       proposal={proposal}
       canSeeRevisions={canSeeRevisions}
       backHref={`/decisions/${slug}`}
-      selectionsAreConfirmed={instance.selectionsAreConfirmed ?? false}
+      selection={selection ?? null}
     />
   );
 }

--- a/apps/app/src/app/[locale]/(no-header)/profile/[slug]/decisions/[id]/proposal/[profileId]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/profile/[slug]/decisions/[id]/proposal/[profileId]/page.tsx
@@ -32,7 +32,7 @@ function ProposalViewPageContent({
       proposal={proposal}
       canSeeRevisions={false}
       backHref={backHref}
-      selectionsAreConfirmed={false}
+      selection={null}
     />
   );
 }

--- a/apps/app/src/app/[locale]/(no-header)/profile/[slug]/decisions/[id]/proposal/[profileId]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/profile/[slug]/decisions/[id]/proposal/[profileId]/page.tsx
@@ -32,6 +32,7 @@ function ProposalViewPageContent({
       proposal={proposal}
       canSeeRevisions={false}
       backHref={backHref}
+      selectionsAreConfirmed={false}
     />
   );
 }

--- a/apps/app/src/components/decisions/BudgetDisplay.tsx
+++ b/apps/app/src/components/decisions/BudgetDisplay.tsx
@@ -1,37 +1,16 @@
 import { formatCurrency } from '@/utils/formatting';
-import { normalizeBudget } from '@op/common/client';
+import { type BudgetInput, normalizeBudget } from '@op/common/client';
 
 export type BudgetDisplayProps = {
-  /**
-   * Raw budget value. Accepts canonical `MoneyAmount` shapes, plain numbers,
-   * numeric strings, or `null`/`undefined`. Anything that doesn't parse renders
-   * as `null`.
-   */
-  value: unknown;
-  /**
-   * Currency to use when the input is a bare number/string with no currency
-   * context (e.g., an allocation amount drawn from a budget known to be in
-   * another currency). Ignored when `value` carries its own currency.
-   */
-  fallbackCurrency?: string;
+  value: BudgetInput;
   className?: string;
 };
 
-/**
- * Renders a single budget value. Today only monetary budgets are supported;
- * if new budget types land (hours, points, etc.) the dispatch lives here.
- */
-export function BudgetDisplay({
-  value,
-  fallbackCurrency = 'USD',
-  className,
-}: BudgetDisplayProps) {
-  const formatted = formatBudget(value, fallbackCurrency);
+export function BudgetDisplay({ value, className }: BudgetDisplayProps) {
+  const formatted = formatBudget(value);
   if (formatted === null) {
     return null;
   }
-  // Pass className through verbatim — `cn`/twMerge collapses our custom
-  // `text-title-*` utilities into adjacent `text-*` color classes.
   return <span className={className}>{formatted}</span>;
 }
 
@@ -39,19 +18,10 @@ export function BudgetDisplay({
  * Format a budget value to a display string. Used when the formatted value
  * needs to be embedded in a translation or otherwise composed inline.
  */
-export function formatBudget(
-  value: unknown,
-  fallbackCurrency = 'USD',
-): string | null {
+export function formatBudget(value: BudgetInput): string | null {
   const budget = normalizeBudget(value);
   if (!budget) {
     return null;
   }
-  // `normalizeBudget` defaults bare numeric inputs to USD; honor the caller's
-  // fallback currency in that case so we don't lose context.
-  const currency =
-    typeof value === 'object' && value !== null
-      ? budget.currency
-      : fallbackCurrency;
-  return formatCurrency(budget.amount, undefined, currency);
+  return formatCurrency(budget.amount, undefined, budget.currency);
 }

--- a/apps/app/src/components/decisions/BudgetDisplay.tsx
+++ b/apps/app/src/components/decisions/BudgetDisplay.tsx
@@ -1,0 +1,56 @@
+import { formatCurrency } from '@/utils/formatting';
+import { normalizeBudget } from '@op/common/client';
+import { cn } from '@op/ui/utils';
+
+export type BudgetDisplayProps = {
+  /**
+   * Raw budget value. Accepts canonical `MoneyAmount` shapes, plain numbers,
+   * numeric strings, or `null`/`undefined`. Anything that doesn't parse renders
+   * as `null`.
+   */
+  value: unknown;
+  /**
+   * Currency to use when the input is a bare number/string with no currency
+   * context (e.g., an allocation amount drawn from a budget known to be in
+   * another currency). Ignored when `value` carries its own currency.
+   */
+  fallbackCurrency?: string;
+  className?: string;
+};
+
+/**
+ * Renders a single budget value. Today only monetary budgets are supported;
+ * if new budget types land (hours, points, etc.) the dispatch lives here.
+ */
+export function BudgetDisplay({
+  value,
+  fallbackCurrency = 'USD',
+  className,
+}: BudgetDisplayProps) {
+  const formatted = formatBudget(value, fallbackCurrency);
+  if (formatted === null) {
+    return null;
+  }
+  return <span className={cn(className)}>{formatted}</span>;
+}
+
+/**
+ * Format a budget value to a display string. Used when the formatted value
+ * needs to be embedded in a translation or otherwise composed inline.
+ */
+export function formatBudget(
+  value: unknown,
+  fallbackCurrency = 'USD',
+): string | null {
+  const budget = normalizeBudget(value);
+  if (!budget) {
+    return null;
+  }
+  // `normalizeBudget` defaults bare numeric inputs to USD; honor the caller's
+  // fallback currency in that case so we don't lose context.
+  const currency =
+    typeof value === 'object' && value !== null
+      ? budget.currency
+      : fallbackCurrency;
+  return formatCurrency(budget.amount, undefined, currency);
+}

--- a/apps/app/src/components/decisions/BudgetDisplay.tsx
+++ b/apps/app/src/components/decisions/BudgetDisplay.tsx
@@ -1,6 +1,5 @@
 import { formatCurrency } from '@/utils/formatting';
 import { normalizeBudget } from '@op/common/client';
-import { cn } from '@op/ui/utils';
 
 export type BudgetDisplayProps = {
   /**
@@ -31,7 +30,9 @@ export function BudgetDisplay({
   if (formatted === null) {
     return null;
   }
-  return <span className={cn(className)}>{formatted}</span>;
+  // Pass className through verbatim — `cn`/twMerge collapses our custom
+  // `text-title-*` utilities into adjacent `text-*` color classes.
+  return <span className={className}>{formatted}</span>;
 }
 
 /**

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -144,7 +144,9 @@ export function ProposalCardTitle({
 }
 
 /**
- * Budget display component
+ * Budget display component. When an allocated amount is present, renders it
+ * as the primary value with the original requested budget as a smaller
+ * secondary label ("$3,500 requested").
  */
 export function ProposalCardBudget({
   proposal,
@@ -154,23 +156,30 @@ export function ProposalCardBudget({
   allocated?: string | number | null;
   className?: string;
 }) {
+  const t = useTranslations();
   const { budget } = resolveProposalSystemFields(proposal);
 
-  // Use allocated amount if provided, otherwise fall back to budget
   if (!isNullish(allocated)) {
+    const allocatedText = formatCurrency(
+      Number(allocated),
+      undefined,
+      budget?.currency ?? 'USD',
+    );
+    const requestedText = budget
+      ? formatCurrency(budget.amount, undefined, budget.currency)
+      : null;
+
     return (
-      <span
-        className={cn(
-          'font-serif text-title-base text-neutral-charcoal',
-          className,
+      <div className={cn('flex flex-wrap items-baseline gap-2', className)}>
+        <span className="font-serif text-title-base text-neutral-charcoal">
+          {allocatedText}
+        </span>
+        {requestedText && (
+          <span className="text-sm text-neutral-gray4">
+            {t('{amount} requested', { amount: requestedText })}
+          </span>
         )}
-      >
-        {formatCurrency(
-          Number(allocated),
-          undefined,
-          budget?.currency ?? 'USD',
-        )}
-      </span>
+      </div>
     );
   }
 

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -163,7 +163,7 @@ export function ProposalCardBudget({
     const requestedText = formatBudget(budget);
 
     return (
-      <div className={cn('flex flex-wrap items-baseline gap-2', className)}>
+      <div className={cn('flex flex-wrap items-end gap-2', className)}>
         <BudgetDisplay
           value={allocated}
           fallbackCurrency={budget?.currency}

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { getPublicUrl } from '@/utils';
-import { formatCurrency } from '@/utils/formatting';
 import { ProposalStatus, Visibility } from '@op/api/encoders';
 import type { Proposal } from '@op/common/client';
 import {
@@ -22,6 +21,7 @@ import { useTranslations } from '@/lib/i18n';
 import { Link } from '@/lib/i18n/routing';
 
 import { Bullet } from '../../Bullet';
+import { BudgetDisplay, formatBudget } from '../BudgetDisplay';
 import { DocumentNotAvailable } from '../DocumentNotAvailable';
 import { useCardTranslation } from '../ProposalTranslationContext';
 import { RevisionRequestChip } from '../RevisionRequestChip';
@@ -160,20 +160,15 @@ export function ProposalCardBudget({
   const { budget } = resolveProposalSystemFields(proposal);
 
   if (!isNullish(allocated)) {
-    const allocatedText = formatCurrency(
-      Number(allocated),
-      undefined,
-      budget?.currency ?? 'USD',
-    );
-    const requestedText = budget
-      ? formatCurrency(budget.amount, undefined, budget.currency)
-      : null;
+    const requestedText = formatBudget(budget);
 
     return (
       <div className={cn('flex flex-wrap items-baseline gap-2', className)}>
-        <span className="font-serif text-title-base text-neutral-charcoal">
-          {allocatedText}
-        </span>
+        <BudgetDisplay
+          value={allocated}
+          fallbackCurrency={budget?.currency}
+          className="font-serif text-title-base text-neutral-charcoal"
+        />
         {requestedText && (
           <span className="text-sm text-neutral-gray4">
             {t('{amount} requested', { amount: requestedText })}
@@ -183,19 +178,14 @@ export function ProposalCardBudget({
     );
   }
 
-  if (!budget) {
-    return null;
-  }
-
   return (
-    <span
+    <BudgetDisplay
+      value={budget}
       className={cn(
         'font-serif text-title-base text-neutral-charcoal',
         className,
       )}
-    >
-      {formatCurrency(budget.amount, undefined, budget.currency)}
-    </span>
+    />
   );
 }
 

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -166,7 +166,6 @@ export function ProposalCardBudget({
       <div className={cn('flex flex-wrap items-end gap-2', className)}>
         <BudgetDisplay
           value={allocated}
-          fallbackCurrency={budget?.currency}
           className="font-serif text-title-base text-neutral-charcoal"
         />
         {requestedText && (

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -105,7 +105,7 @@ export function ProposalPreview({
 
       <div className="space-y-4">
         {selection && (
-          <div className="flex items-center gap-2 text-sm text-neutral-charcoal">
+          <div className="flex items-center gap-1 text-sm text-functional-green">
             <LuCircleCheck className="size-4" />
             <span>{t('Selected')}</span>
           </div>
@@ -132,10 +132,10 @@ export function ProposalPreview({
         )}
 
         <div className="space-y-6">
-          {/* Metadata Row */}
-          <div className="flex flex-wrap gap-4 sm:flex-row sm:items-center">
+          {/* Budget + Categories — stacked, matching the proposal editor layout */}
+          <div className="flex flex-col items-start gap-4">
             {selection?.allocated != null ? (
-              <div className="flex flex-wrap items-baseline gap-2">
+              <div className="flex flex-wrap items-end gap-2">
                 <BudgetDisplay
                   value={selection.allocated}
                   fallbackCurrency={budget?.currency}

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -33,6 +33,8 @@ export type ProposalTranslation = {
 
 export type ProposalPreviewProps = {
   proposal: Proposal;
+  /** Allocated amount from the latest confirmed result, if any. */
+  allocated?: string | null;
   /** When set, overrides proposal content with translated HTML and shows attribution */
   translation?: ProposalTranslation;
   /** Rendered inline after the "Submitted on {date}" line, separated by a bullet. */
@@ -43,6 +45,7 @@ export type ProposalPreviewProps = {
 
 export function ProposalPreview({
   proposal,
+  allocated,
   translation,
   submissionMetaSuffix,
   headerBanner,
@@ -117,10 +120,33 @@ export function ProposalPreview({
         <div className="space-y-6">
           {/* Metadata Row */}
           <div className="flex flex-wrap gap-4 sm:flex-row sm:items-center">
-            {budget && (
-              <span className="font-serif text-title-base text-neutral-black">
-                {formatCurrency(budget.amount, undefined, budget.currency)}
-              </span>
+            {allocated != null ? (
+              <div className="flex flex-wrap items-baseline gap-2">
+                <span className="font-serif text-title-base text-neutral-black">
+                  {formatCurrency(
+                    Number(allocated),
+                    undefined,
+                    budget?.currency ?? 'USD',
+                  )}
+                </span>
+                {budget && (
+                  <span className="text-sm text-neutral-gray4">
+                    {t('{amount} requested', {
+                      amount: formatCurrency(
+                        budget.amount,
+                        undefined,
+                        budget.currency,
+                      ),
+                    })}
+                  </span>
+                )}
+              </div>
+            ) : (
+              budget && (
+                <span className="font-serif text-title-base text-neutral-black">
+                  {formatCurrency(budget.amount, undefined, budget.currency)}
+                </span>
+              )
             )}
             {categories.length > 0 && (
               <TagGroup className="max-w-full">

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { formatCurrency, formatDate } from '@/utils/formatting';
+import { formatDate } from '@/utils/formatting';
 import { ProposalStatus } from '@op/api/encoders';
 import {
   type Proposal,
@@ -25,6 +25,7 @@ import { useTranslations } from '@/lib/i18n';
 import { Link as NavLink } from '@/lib/i18n/routing';
 
 import { ProfileAvatar } from '../ProfileAvatar';
+import { BudgetDisplay, formatBudget } from './BudgetDisplay';
 import { DocumentNotAvailable } from './DocumentNotAvailable';
 import { ProposalAttachmentViewList } from './ProposalAttachmentViewList';
 import { ProposalContentRenderer } from './ProposalContentRenderer';
@@ -135,31 +136,24 @@ export function ProposalPreview({
           <div className="flex flex-wrap gap-4 sm:flex-row sm:items-center">
             {selection?.allocated != null ? (
               <div className="flex flex-wrap items-baseline gap-2">
-                <span className="font-serif text-title-base text-neutral-black">
-                  {formatCurrency(
-                    Number(selection.allocated),
-                    undefined,
-                    budget?.currency ?? 'USD',
-                  )}
-                </span>
+                <BudgetDisplay
+                  value={selection.allocated}
+                  fallbackCurrency={budget?.currency}
+                  className="font-serif text-title-base text-neutral-black"
+                />
                 {budget && (
                   <span className="text-sm text-neutral-gray4">
                     {t('{amount} requested', {
-                      amount: formatCurrency(
-                        budget.amount,
-                        undefined,
-                        budget.currency,
-                      ),
+                      amount: formatBudget(budget) ?? '',
                     })}
                   </span>
                 )}
               </div>
             ) : (
-              budget && (
-                <span className="font-serif text-title-base text-neutral-black">
-                  {formatCurrency(budget.amount, undefined, budget.currency)}
-                </span>
-              )
+              <BudgetDisplay
+                value={budget}
+                className="font-serif text-title-base text-neutral-black"
+              />
             )}
             {categories.length > 0 && (
               <TagGroup className="max-w-full">

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -138,7 +138,6 @@ export function ProposalPreview({
               <div className="flex flex-wrap items-end gap-2">
                 <BudgetDisplay
                   value={selection.allocated}
-                  fallbackCurrency={budget?.currency}
                   className="font-serif text-title-base text-neutral-black"
                 />
                 {budget && (

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -4,6 +4,7 @@ import { formatCurrency, formatDate } from '@/utils/formatting';
 import { ProposalStatus } from '@op/api/encoders';
 import {
   type Proposal,
+  type ProposalSelection,
   type ProposalTemplateSchema,
   normalizeProposalCategories,
   parseTranslatedMeta,
@@ -13,7 +14,12 @@ import { Header1, Header3 } from '@op/ui/Header';
 import { Link } from '@op/ui/Link';
 import { Tag, TagGroup } from '@op/ui/TagGroup';
 import type { ReactNode } from 'react';
-import { LuBookmark, LuHeart, LuMessageCircle } from 'react-icons/lu';
+import {
+  LuBookmark,
+  LuCircleCheck,
+  LuHeart,
+  LuMessageCircle,
+} from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 import { Link as NavLink } from '@/lib/i18n/routing';
@@ -33,8 +39,8 @@ export type ProposalTranslation = {
 
 export type ProposalPreviewProps = {
   proposal: Proposal;
-  /** Allocated amount from the latest confirmed result, if any. */
-  allocated?: string | null;
+  /** Selection record from the latest confirmed result, if any. */
+  selection?: ProposalSelection | null;
   /** When set, overrides proposal content with translated HTML and shows attribution */
   translation?: ProposalTranslation;
   /** Rendered inline after the "Submitted on {date}" line, separated by a bullet. */
@@ -45,7 +51,7 @@ export type ProposalPreviewProps = {
 
 export function ProposalPreview({
   proposal,
-  allocated,
+  selection,
   translation,
   submissionMetaSuffix,
   headerBanner,
@@ -97,6 +103,13 @@ export function ProposalPreview({
       )}
 
       <div className="space-y-4">
+        {selection && (
+          <div className="flex items-center gap-2 text-sm text-neutral-charcoal">
+            <LuCircleCheck className="size-4" />
+            <span>{t('Selected')}</span>
+          </div>
+        )}
+
         <Header1 className="font-serif text-title-lg">
           {title || t('Untitled Proposal')}
         </Header1>
@@ -120,11 +133,11 @@ export function ProposalPreview({
         <div className="space-y-6">
           {/* Metadata Row */}
           <div className="flex flex-wrap gap-4 sm:flex-row sm:items-center">
-            {allocated != null ? (
+            {selection?.allocated != null ? (
               <div className="flex flex-wrap items-baseline gap-2">
                 <span className="font-serif text-title-base text-neutral-black">
                   {formatCurrency(
-                    Number(allocated),
+                    Number(selection.allocated),
                     undefined,
                     budget?.currency ?? 'USD',
                   )}

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -27,10 +27,12 @@ export function ProposalView({
   proposal: initialProposal,
   canSeeRevisions,
   backHref,
+  selectionsAreConfirmed,
 }: {
   proposal: Proposal;
   canSeeRevisions: boolean;
   backHref: string;
+  selectionsAreConfirmed: boolean;
 }) {
   const t = useTranslations();
   const locale = useLocale();
@@ -41,6 +43,15 @@ export function ProposalView({
 
   // Safety check - fallback to initial data if query returns undefined
   const currentProposal = proposal || initialProposal;
+
+  // Only fetch allocation once the instance has confirmed its selections —
+  // before that, the "latest" result row isn't unambiguously canonical.
+  const { data: selection } =
+    trpc.decision.getLatestSelectionForProposal.useQuery(
+      { proposalId: currentProposal.id },
+      { enabled: selectionsAreConfirmed },
+    );
+  const allocated = selection?.allocated ?? null;
 
   // Use relationship mutations hook for like/follow functionality
   const {
@@ -157,6 +168,7 @@ export function ProposalView({
     <>
       <ProposalPreview
         proposal={currentProposal}
+        allocated={allocated}
         translation={
           translatedHtmlContent
             ? {

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -5,6 +5,7 @@ import { trpc } from '@op/api/client';
 import {
   type Proposal,
   ProposalReviewRequestState,
+  type ProposalSelection,
   type ProposalTranslation,
   type SupportedLocale,
 } from '@op/common/client';
@@ -27,12 +28,12 @@ export function ProposalView({
   proposal: initialProposal,
   canSeeRevisions,
   backHref,
-  selectionsAreConfirmed,
+  selection,
 }: {
   proposal: Proposal;
   canSeeRevisions: boolean;
   backHref: string;
-  selectionsAreConfirmed: boolean;
+  selection: ProposalSelection | null;
 }) {
   const t = useTranslations();
   const locale = useLocale();
@@ -43,15 +44,6 @@ export function ProposalView({
 
   // Safety check - fallback to initial data if query returns undefined
   const currentProposal = proposal || initialProposal;
-
-  // Only fetch allocation once the instance has confirmed its selections —
-  // before that, the "latest" result row isn't unambiguously canonical.
-  const { data: selection } =
-    trpc.decision.getLatestSelectionForProposal.useQuery(
-      { proposalId: currentProposal.id },
-      { enabled: selectionsAreConfirmed },
-    );
-  const allocated = selection?.allocated ?? null;
 
   // Use relationship mutations hook for like/follow functionality
   const {
@@ -168,7 +160,7 @@ export function ProposalView({
     <>
       <ProposalPreview
         proposal={currentProposal}
-        allocated={allocated}
+        selection={selection}
         translation={
           translatedHtmlContent
             ? {

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -556,6 +556,7 @@
   "Request": "অনুরোধ",
   "Requested": "অনুরোধ করা হয়েছে",
   "{amount} requested": "{amount} অনুরোধ করা হয়েছে",
+  "Selected": "নির্বাচিত",
   "Request to join this organization as a member": "সদস্য হিসেবে এই সংস্থায় যোগদানের অনুরোধ করুন",
   "Your membership request is pending approval": "আপনার সদস্যপদ অনুরোধ অনুমোদনের অপেক্ষায় রয়েছে",
   "You must be logged in to request membership": "সদস্যপদ অনুরোধ করতে আপনাকে লগইন করতে হবে",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -555,6 +555,7 @@
   "Add emails": "ইমেইল যোগ করুন",
   "Request": "অনুরোধ",
   "Requested": "অনুরোধ করা হয়েছে",
+  "{amount} requested": "{amount} অনুরোধ করা হয়েছে",
   "Request to join this organization as a member": "সদস্য হিসেবে এই সংস্থায় যোগদানের অনুরোধ করুন",
   "Your membership request is pending approval": "আপনার সদস্যপদ অনুরোধ অনুমোদনের অপেক্ষায় রয়েছে",
   "You must be logged in to request membership": "সদস্যপদ অনুরোধ করতে আপনাকে লগইন করতে হবে",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -552,6 +552,7 @@
   "Request": "Request",
   "Requested": "Requested",
   "{amount} requested": "{amount} requested",
+  "Selected": "Selected",
   "Request to join this organization as a member": "Request to join this organization as a member",
   "Your membership request is pending approval": "Your membership request is pending approval",
   "You must be logged in to request membership": "You must be logged in to request membership",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -551,6 +551,7 @@
   "Add emails": "Add emails",
   "Request": "Request",
   "Requested": "Requested",
+  "{amount} requested": "{amount} requested",
   "Request to join this organization as a member": "Request to join this organization as a member",
   "Your membership request is pending approval": "Your membership request is pending approval",
   "You must be logged in to request membership": "You must be logged in to request membership",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -554,6 +554,7 @@
   "Request": "Solicitar",
   "Requested": "Solicitado",
   "{amount} requested": "{amount} solicitado",
+  "Selected": "Seleccionado",
   "Request to join this organization as a member": "Solicitar unirse a esta organización como miembro",
   "Your membership request is pending approval": "Tu solicitud de membresía está pendiente de aprobación",
   "You must be logged in to request membership": "Debes iniciar sesión para solicitar membresía",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -553,6 +553,7 @@
   "Add emails": "Agregar correos",
   "Request": "Solicitar",
   "Requested": "Solicitado",
+  "{amount} requested": "{amount} solicitado",
   "Request to join this organization as a member": "Solicitar unirse a esta organización como miembro",
   "Your membership request is pending approval": "Tu solicitud de membresía está pendiente de aprobación",
   "You must be logged in to request membership": "Debes iniciar sesión para solicitar membresía",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -555,6 +555,7 @@
   "Request": "Demander",
   "Requested": "Demandé",
   "{amount} requested": "{amount} demandé",
+  "Selected": "Sélectionné",
   "Request to join this organization as a member": "Demander à rejoindre cette organisation en tant que membre",
   "Your membership request is pending approval": "Votre demande d'adhésion est en attente d'approbation",
   "You must be logged in to request membership": "Vous devez être connecté pour demander l'adhésion",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -554,6 +554,7 @@
   "Add emails": "Ajouter des courriels",
   "Request": "Demander",
   "Requested": "Demandé",
+  "{amount} requested": "{amount} demandé",
   "Request to join this organization as a member": "Demander à rejoindre cette organisation en tant que membre",
   "Your membership request is pending approval": "Votre demande d'adhésion est en attente d'approbation",
   "You must be logged in to request membership": "Vous devez être connecté pour demander l'adhésion",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -555,6 +555,7 @@
   "Request": "Solicitar",
   "Requested": "Solicitado",
   "{amount} requested": "{amount} solicitado",
+  "Selected": "Selecionado",
   "Request to join this organization as a member": "Solicitar entrada nesta organização como membro",
   "Your membership request is pending approval": "Sua solicitação de adesão está pendente de aprovação",
   "You must be logged in to request membership": "Você precisa estar logado para solicitar adesão",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -554,6 +554,7 @@
   "Add emails": "Adicionar e-mails",
   "Request": "Solicitar",
   "Requested": "Solicitado",
+  "{amount} requested": "{amount} solicitado",
   "Request to join this organization as a member": "Solicitar entrada nesta organização como membro",
   "Your membership request is pending approval": "Sua solicitação de adesão está pendente de aprovação",
   "You must be logged in to request membership": "Você precisa estar logado para solicitar adesão",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -534,6 +534,7 @@
   "Request": "Codsi",
   "Requested": "La codsaday",
   "{amount} requested": "{amount} la codsaday",
+  "Selected": "La doortay",
   "Request to join this organization as a member": "Codso inaad ku biirto ururkan xubin ahaan",
   "Your membership request is pending approval": "Codsigaaga xubinnimada waa la sugayaa ansixinta",
   "You must be logged in to request membership": "Waa inaad soo gashaa si aad u codsato xubinnimo",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -533,6 +533,7 @@
   "Add emails": "Ku dar iimaallad",
   "Request": "Codsi",
   "Requested": "La codsaday",
+  "{amount} requested": "{amount} la codsaday",
   "Request to join this organization as a member": "Codso inaad ku biirto ururkan xubin ahaan",
   "Your membership request is pending approval": "Codsigaaga xubinnimada waa la sugayaa ansixinta",
   "You must be logged in to request membership": "Waa inaad soo gashaa si aad u codsato xubinnimo",

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -21,6 +21,10 @@ export {
   adminDecisionInstanceSchema,
   type AdminDecisionInstance,
 } from './services/decision/schemas/adminDecisionInstance';
+export {
+  proposalSelectionSchema,
+  type ProposalSelection,
+} from './services/decision/schemas/selection';
 export * from './services/decision/types';
 export {
   SYSTEM_FIELD_KEYS,

--- a/packages/common/src/services/decision/getLatestSelectionForProposal.ts
+++ b/packages/common/src/services/decision/getLatestSelectionForProposal.ts
@@ -1,0 +1,74 @@
+import { db } from '@op/db/client';
+import type { User } from '@op/supabase/lib';
+import { permission } from 'access-zones';
+
+import { NotFoundError } from '../../utils';
+import { assertInstanceProfileAccess } from '../access';
+import type { ProposalSelection } from './schemas/selection';
+
+/**
+ * Returns the proposal's selection record (allocation + rank) from the latest
+ * successful result run on the parent process instance, or `null` if no
+ * successful result exists or the proposal isn't in it.
+ *
+ * Callers are responsible for deciding *when* it's meaningful to fetch this —
+ * the "latest" row is only unambiguous once the instance has confirmed
+ * selections (see `selectionsAreConfirmed`).
+ */
+export const getLatestSelectionForProposal = async ({
+  proposalId,
+  user,
+}: {
+  proposalId: string;
+  user: User;
+}): Promise<ProposalSelection | null> => {
+  const proposal = await db.query.proposals.findFirst({
+    where: { id: proposalId },
+    columns: { id: true, processInstanceId: true },
+    with: {
+      processInstance: true,
+    },
+  });
+
+  if (!proposal) {
+    throw new NotFoundError('Proposal', proposalId);
+  }
+
+  await assertInstanceProfileAccess({
+    user: { id: user.id },
+    instance: proposal.processInstance,
+    profilePermissions: { decisions: permission.READ },
+    orgFallbackPermissions: [
+      { decisions: permission.READ },
+      { decisions: permission.ADMIN },
+    ],
+  });
+
+  const latestResult = await db.query.decisionProcessResults.findFirst({
+    where: { processInstanceId: proposal.processInstanceId },
+    orderBy: (table, { desc }) => [desc(table.executedAt)],
+    columns: { id: true, success: true },
+  });
+
+  if (!latestResult?.success) {
+    return null;
+  }
+
+  const selection = await db.query.decisionProcessResultSelections.findFirst({
+    where: {
+      processResultId: latestResult.id,
+      proposalId,
+    },
+    columns: { allocated: true, selectionRank: true },
+  });
+
+  if (!selection) {
+    return null;
+  }
+
+  return {
+    proposalId,
+    allocated: selection.allocated,
+    selectionRank: selection.selectionRank,
+  };
+};

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -52,6 +52,7 @@ export * from './createProposal';
 export * from './submitProposal';
 export * from './updateProposal';
 export * from './getProposal';
+export * from './getLatestSelectionForProposal';
 export * from './listProposalVersions';
 export * from './listProposals';
 export * from './generateReviewAssignments';

--- a/packages/common/src/services/decision/proposalDataSchema.ts
+++ b/packages/common/src/services/decision/proposalDataSchema.ts
@@ -33,6 +33,9 @@ export const budgetValueSchema = z
  */
 export type BudgetData = MoneyAmount;
 
+/** Raw budget input accepted by `budgetValueSchema` (canonical or legacy). */
+export type BudgetInput = z.input<typeof budgetValueSchema>;
+
 /**
  * Zod schema for proposal data with known fields.
  * Uses looseObject to allow additional fields from custom proposal templates.

--- a/packages/common/src/services/decision/schemas/index.ts
+++ b/packages/common/src/services/decision/schemas/index.ts
@@ -4,5 +4,6 @@ export * from './instance';
 export * from './instanceData';
 export * from './reviews';
 export * from './proposal';
+export * from './selection';
 export * from './adminDecisionInstance';
 export * from './transitionData';

--- a/packages/common/src/services/decision/schemas/selection.ts
+++ b/packages/common/src/services/decision/schemas/selection.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+/**
+ * A proposal's selection record from the latest successful result run on its
+ * process instance. `allocated` is stored as numeric (string) in the DB to
+ * preserve precision.
+ */
+export const proposalSelectionSchema = z.object({
+  proposalId: z.uuid(),
+  allocated: z.string().nullable(),
+  selectionRank: z.number().nullable(),
+});
+
+export type ProposalSelection = z.infer<typeof proposalSelectionSchema>;

--- a/services/api/src/routers/decision/proposals/getLatestSelection.ts
+++ b/services/api/src/routers/decision/proposals/getLatestSelection.ts
@@ -1,0 +1,24 @@
+import { getLatestSelectionForProposal } from '@op/common';
+import { proposalSelectionSchema } from '@op/common/client';
+import { z } from 'zod';
+
+import { commonAuthedProcedure, router } from '../../../trpcFactory';
+
+export const getLatestSelectionForProposalRouter = router({
+  getLatestSelectionForProposal: commonAuthedProcedure()
+    .input(
+      z.object({
+        proposalId: z.uuid(),
+      }),
+    )
+    .output(proposalSelectionSchema.nullable())
+    .query(async ({ ctx, input }) => {
+      const { user } = ctx;
+      const { proposalId } = input;
+
+      return getLatestSelectionForProposal({
+        proposalId,
+        user,
+      });
+    }),
+});

--- a/services/api/src/routers/decision/proposals/index.ts
+++ b/services/api/src/routers/decision/proposals/index.ts
@@ -5,6 +5,7 @@ import { deleteProposalRouter } from './delete';
 import { exportProposalsRouter } from './export';
 import { getProposalRouter } from './get';
 import { getExportStatusRouter } from './getExportStatus';
+import { getLatestSelectionForProposalRouter } from './getLatestSelection';
 import { getProposalWithReviewAggregatesRouter } from './getProposalWithReviewAggregates';
 import { listProposalsRouter } from './list';
 import { listProposalVersionsRouter } from './listVersions';
@@ -16,6 +17,7 @@ export const proposalsRouter = mergeRouters(
   acceptProposalInviteRouter,
   createProposalRouter,
   getProposalRouter,
+  getLatestSelectionForProposalRouter,
   getProposalWithReviewAggregatesRouter,
   listProposalsRouter,
   listProposalVersionsRouter,


### PR DESCRIPTION
Surfaces the allocated amount alongside the original requested budget once a decision's selections are confirmed, so viewers can see the gap between ask and award.

## Demo

<img width="2464" height="606" alt="CleanShot 2026-05-22 at 12 17 04@2x" src="https://github.com/user-attachments/assets/61780456-ad14-40ca-912c-c515b4bd9146" />
<img width="1540" height="1302" alt="CleanShot 2026-05-22 at 12 18 08@2x" src="https://github.com/user-attachments/assets/91c7dd8f-a8a1-45d6-854c-ce520dafae9d" />
