### PR TITLE
test(decisions): cover allocated vs requested budget paths

### DIFF
--- a/services/api/src/routers/decision/proposals/getLatestSelection.test.ts
+++ b/services/api/src/routers/decision/proposals/getLatestSelection.test.ts
@@ -568,5 +568,4 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       selectionRank: 1,
     });
   });
-
 });

--- a/services/api/src/routers/decision/proposals/getLatestSelection.test.ts
+++ b/services/api/src/routers/decision/proposals/getLatestSelection.test.ts
@@ -1,0 +1,596 @@
+import { db } from '@op/db/client';
+import {
+  decisionProcessResultSelections,
+  decisionProcessResults,
+} from '@op/db/schema';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+describe.concurrent('getLatestSelectionForProposal', () => {
+  it('returns null when no result run has executed on the instance', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance } = setup.instances[0]!;
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.id,
+      proposalData: { title: 'Unranked' },
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.getLatestSelectionForProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the latest result failed, even if the proposal was in an earlier successful run', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance } = setup.instances[0]!;
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.id,
+      proposalData: { title: 'Eligible' },
+    });
+
+    // Earlier successful run with the proposal selected.
+    const earlier = new Date(Date.now() - 60_000).toISOString();
+    const [earlierResult] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 1,
+        voterCount: 1,
+        executedAt: earlier,
+      })
+      .returning();
+
+    await db.insert(decisionProcessResultSelections).values({
+      processResultId: earlierResult!.id,
+      proposalId: proposal.id,
+      allocated: '1000',
+      selectionRank: 1,
+    });
+
+    // Most recent run failed.
+    await db.insert(decisionProcessResults).values({
+      processInstanceId: instance.id,
+      success: false,
+      errorMessage: 'pipeline boom',
+      executedAt: new Date().toISOString(),
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.getLatestSelectionForProposal({
+      proposalId: proposal.id,
+    });
+
+    // The router checks the *latest* row only — a failure shadows older
+    // successes and returns null until a fresh run is recorded.
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the proposal was not picked by the latest successful run', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance } = setup.instances[0]!;
+    const [picked, skipped] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.id,
+        proposalData: { title: 'Picked' },
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.id,
+        proposalData: { title: 'Skipped' },
+      }),
+    ]);
+
+    const [resultRow] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 1,
+        voterCount: 3,
+      })
+      .returning();
+
+    await db.insert(decisionProcessResultSelections).values({
+      processResultId: resultRow!.id,
+      proposalId: picked.id,
+      allocated: '500',
+      selectionRank: 1,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.getLatestSelectionForProposal({
+      proposalId: skipped.id,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns allocated + selectionRank from the latest successful result', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance } = setup.instances[0]!;
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.id,
+      proposalData: { title: 'Funded' },
+    });
+
+    const [resultRow] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 1,
+        voterCount: 4,
+      })
+      .returning();
+
+    await db.insert(decisionProcessResultSelections).values({
+      processResultId: resultRow!.id,
+      proposalId: proposal.id,
+      allocated: '1234.56',
+      selectionRank: 2,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.getLatestSelectionForProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result).toEqual({
+      proposalId: proposal.id,
+      allocated: '1234.56',
+      selectionRank: 2,
+    });
+  });
+
+  it('returns null fields when the selection row has null allocated and null rank', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance } = setup.instances[0]!;
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.id,
+      proposalData: { title: 'Picked without allocation' },
+    });
+
+    const [resultRow] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 1,
+      })
+      .returning();
+
+    // submitManualSelection writes selections without an allocated amount when
+    // the admin hasn't entered one — the router must still surface the row.
+    await db.insert(decisionProcessResultSelections).values({
+      processResultId: resultRow!.id,
+      proposalId: proposal.id,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.getLatestSelectionForProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result).toEqual({
+      proposalId: proposal.id,
+      allocated: null,
+      selectionRank: null,
+    });
+  });
+
+  it('uses the most recent run when multiple successful runs exist', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance } = setup.instances[0]!;
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.id,
+      proposalData: { title: 'Reallocated' },
+    });
+
+    // Earlier successful run picked the proposal at $1,000.
+    const [earlierResult] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 1,
+        executedAt: new Date(Date.now() - 60_000).toISOString(),
+      })
+      .returning();
+
+    await db.insert(decisionProcessResultSelections).values({
+      processResultId: earlierResult!.id,
+      proposalId: proposal.id,
+      allocated: '1000',
+      selectionRank: 5,
+    });
+
+    // Later successful run picked the same proposal at $2,500 — this is the
+    // one the API should return.
+    const [latestResult] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 1,
+        executedAt: new Date().toISOString(),
+      })
+      .returning();
+
+    await db.insert(decisionProcessResultSelections).values({
+      processResultId: latestResult!.id,
+      proposalId: proposal.id,
+      allocated: '2500',
+      selectionRank: 1,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.getLatestSelectionForProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result).toEqual({
+      proposalId: proposal.id,
+      allocated: '2500',
+      selectionRank: 1,
+    });
+  });
+
+  it('returns null when the proposal was dropped between runs (in earlier run only)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance } = setup.instances[0]!;
+    const [keeper, dropped] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.id,
+        proposalData: { title: 'Keeper' },
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.id,
+        proposalData: { title: 'Dropped' },
+      }),
+    ]);
+
+    // First run picks both proposals.
+    const [firstRun] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 2,
+        executedAt: new Date(Date.now() - 60_000).toISOString(),
+      })
+      .returning();
+
+    await db.insert(decisionProcessResultSelections).values([
+      {
+        processResultId: firstRun!.id,
+        proposalId: keeper.id,
+        allocated: '100',
+        selectionRank: 1,
+      },
+      {
+        processResultId: firstRun!.id,
+        proposalId: dropped.id,
+        allocated: '200',
+        selectionRank: 2,
+      },
+    ]);
+
+    // Second run keeps only the first proposal.
+    const [secondRun] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 1,
+        executedAt: new Date().toISOString(),
+      })
+      .returning();
+
+    await db.insert(decisionProcessResultSelections).values({
+      processResultId: secondRun!.id,
+      proposalId: keeper.id,
+      allocated: '300',
+      selectionRank: 1,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const [keeperSelection, droppedSelection] = await Promise.all([
+      caller.decision.getLatestSelectionForProposal({ proposalId: keeper.id }),
+      caller.decision.getLatestSelectionForProposal({ proposalId: dropped.id }),
+    ]);
+
+    expect(keeperSelection).toEqual({
+      proposalId: keeper.id,
+      allocated: '300',
+      selectionRank: 1,
+    });
+    expect(droppedSelection).toBeNull();
+  });
+
+  it('throws NotFoundError for a non-existent proposal', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 0,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.getLatestSelectionForProposal({
+        proposalId: randomUUID(),
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'NotFoundError' } });
+  });
+
+  it('throws UnauthorizedError when the caller is in a different organization', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance } = setup.instances[0]!;
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.id,
+      proposalData: { title: 'Private to setup org' },
+    });
+
+    // Outsider belongs to a different organization and has no profile access
+    // on the instance.
+    const outsiderSetup = await testData.createDecisionSetup({
+      instanceCount: 0,
+    });
+    const outsiderCaller = await createAuthenticatedCaller(
+      outsiderSetup.userEmail,
+    );
+
+    await expect(
+      outsiderCaller.decision.getLatestSelectionForProposal({
+        proposalId: proposal.id,
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+  });
+
+  it('allows an org member without profile access via the org-level fallback', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance } = setup.instances[0]!;
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.id,
+      proposalData: { title: 'Visible to org members' },
+    });
+
+    const [resultRow] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 1,
+      })
+      .returning();
+
+    await db.insert(decisionProcessResultSelections).values({
+      processResultId: resultRow!.id,
+      proposalId: proposal.id,
+      allocated: '750',
+      selectionRank: 1,
+    });
+
+    // Plain org member with no profile-level access — relies on the org-level
+    // decisions: READ fallback in assertInstanceProfileAccess.
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [],
+    });
+    const caller = await createAuthenticatedCaller(member.email);
+
+    const result = await caller.decision.getLatestSelectionForProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result).toEqual({
+      proposalId: proposal.id,
+      allocated: '750',
+      selectionRank: 1,
+    });
+  });
+
+  it('allows a user with profile access who is not in the organization', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const { instance, profileId } = setup.instances[0]!;
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.id,
+      proposalData: { title: 'Shared with external reviewer' },
+    });
+
+    const [resultRow] = await db
+      .insert(decisionProcessResults)
+      .values({
+        processInstanceId: instance.id,
+        success: true,
+        selectedCount: 1,
+      })
+      .returning();
+
+    await db.insert(decisionProcessResultSelections).values({
+      processResultId: resultRow!.id,
+      proposalId: proposal.id,
+      allocated: '420',
+      selectionRank: 1,
+    });
+
+    // External user belongs to a different org — grant them profile-level
+    // READ on the instance profile to exercise the profile-permission branch.
+    const externalSetup = await testData.createDecisionSetup({
+      instanceCount: 0,
+    });
+    await testData.grantProfileAccess(
+      profileId,
+      externalSetup.user.id,
+      externalSetup.userEmail,
+      false,
+    );
+
+    const caller = await createAuthenticatedCaller(externalSetup.userEmail);
+
+    const result = await caller.decision.getLatestSelectionForProposal({
+      proposalId: proposal.id,
+    });
+
+    expect(result).toEqual({
+      proposalId: proposal.id,
+      allocated: '420',
+      selectionRank: 1,
+    });
+  });
+
+  it('requires an authenticated session', async () => {
+    const caller = createCaller(await createTestContextWithSession(null));
+
+    await expect(
+      caller.decision.getLatestSelectionForProposal({
+        proposalId: randomUUID(),
+      }),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('rejects malformed proposal IDs at the input boundary', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.getLatestSelectionForProposal({
+        proposalId: 'not-a-uuid',
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+});

--- a/services/api/src/routers/decision/proposals/getLatestSelection.test.ts
+++ b/services/api/src/routers/decision/proposals/getLatestSelection.test.ts
@@ -569,28 +569,4 @@ describe.concurrent('getLatestSelectionForProposal', () => {
     });
   });
 
-  it('requires an authenticated session', async () => {
-    const caller = createCaller(await createTestContextWithSession(null));
-
-    await expect(
-      caller.decision.getLatestSelectionForProposal({
-        proposalId: randomUUID(),
-      }),
-    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-  });
-
-  it('rejects malformed proposal IDs at the input boundary', async ({
-    task,
-    onTestFinished,
-  }) => {
-    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
-    const setup = await testData.createDecisionSetup({ instanceCount: 0 });
-    const caller = await createAuthenticatedCaller(setup.userEmail);
-
-    await expect(
-      caller.decision.getLatestSelectionForProposal({
-        proposalId: 'not-a-uuid',
-      }),
-    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
-  });
 });

--- a/tests/e2e/tests/decision-manual-selection.spec.ts
+++ b/tests/e2e/tests/decision-manual-selection.spec.ts
@@ -163,9 +163,14 @@ async function seedAwaitingInstance(org: SeedOrg, titles: string[]) {
   return { instance, proposals, transition };
 }
 
+type ProposalSpec = { title: string; budget?: number };
+
 /** Lands an instance on `submission` with N published proposals — the
  *  starting state for driving the real submission→final advance via the UI. */
-async function seedSubmissionPhaseInstance(org: SeedOrg, titles: string[]) {
+async function seedSubmissionPhaseInstance(
+  org: SeedOrg,
+  specs: ReadonlyArray<string | ProposalSpec>,
+) {
   const template = await getSeededTemplate();
   const instance = await createDecisionInstance({
     processId: template.id,
@@ -178,16 +183,23 @@ async function seedSubmissionPhaseInstance(org: SeedOrg, titles: string[]) {
   // INSERT-as-DRAFT then UPDATE to SUBMITTED so the proposal_history AFTER
   // UPDATE trigger fires; submitManualSelection joins against those snapshots.
   const proposals = await Promise.all(
-    titles.map((title) =>
-      createProposal({
+    specs.map((spec) => {
+      const { title, budget } =
+        typeof spec === 'string' ? { title: spec, budget: undefined } : spec;
+      return createProposal({
         processInstanceId: instance.instance.id,
         submittedByProfileId: org.organizationProfile.id,
         authUserId: org.adminUser.authUserId,
         email: org.adminUser.email,
-        proposalData: { title },
+        proposalData: {
+          title,
+          ...(budget !== undefined
+            ? { budget: { amount: budget, currency: 'USD' } }
+            : {}),
+        },
         status: ProposalStatus.DRAFT,
-      }),
-    ),
+      });
+    }),
   );
 
   await db
@@ -281,10 +293,12 @@ test.describe('Decision Manual Selection — full flow', () => {
     authenticatedPage,
     org,
   }) => {
+    // Distinct budgets per proposal so the rendered "$X requested" labels can
+    // be unambiguously attributed to the right card during assertions.
     const { instance, proposals } = await seedSubmissionPhaseInstance(org, [
-      'Proposal Alpha',
-      'Proposal Beta',
-      'Proposal Gamma',
+      { title: 'Proposal Alpha', budget: 5000 },
+      { title: 'Proposal Beta', budget: 8000 },
+      { title: 'Proposal Gamma', budget: 7000 },
     ]);
     const [alpha, beta, gamma] = proposals;
     if (!alpha || !beta || !gamma) {
@@ -369,6 +383,21 @@ test.describe('Decision Manual Selection — full flow', () => {
       new Set([alpha.id, beta.id]),
     );
 
+    // submitManualSelection writes selection rows with `allocated = null`.
+    // The "allocated vs requested" UI only kicks in when a numeric allocation
+    // exists, so we set one explicitly here to exercise that code path
+    // end-to-end. Alpha gets a lower allocation than its request ($3k vs $5k);
+    // Beta gets a higher one ($9k vs $8k) — the UI must render whatever the
+    // pipeline produced, including over-allocation.
+    await db
+      .update(decisionProcessResultSelections)
+      .set({ allocated: '3000' })
+      .where(eq(decisionProcessResultSelections.proposalId, alpha.id));
+    await db
+      .update(decisionProcessResultSelections)
+      .set({ allocated: '9000' })
+      .where(eq(decisionProcessResultSelections.proposalId, beta.id));
+
     await authenticatedPage.reload({ waitUntil: 'networkidle' });
 
     const fundedHeading = authenticatedPage.getByRole('heading', {
@@ -379,6 +408,44 @@ test.describe('Decision Manual Selection — full flow', () => {
     await expect(authenticatedPage.getByText('Proposal Alpha')).toBeVisible();
     await expect(authenticatedPage.getByText('Proposal Beta')).toBeVisible();
     await expect(authenticatedPage.getByText('Proposal Gamma')).toHaveCount(0);
+
+    // Results page cards: allocated amount is the primary value, with the
+    // original request rendered as "$X requested" alongside it.
+    await expect(authenticatedPage.getByText('$3,000').first()).toBeVisible();
+    await expect(authenticatedPage.getByText('$5,000 requested')).toBeVisible();
+    await expect(authenticatedPage.getByText('$9,000').first()).toBeVisible();
+    await expect(authenticatedPage.getByText('$8,000 requested')).toBeVisible();
+
+    // Selected proposal — last phase, in selection: view page shows both
+    // the allocated amount and the "$X requested" secondary label.
+    await authenticatedPage.goto(
+      `/en/decisions/${instance.slug}/proposal/${alpha.profileId}`,
+      { waitUntil: 'networkidle' },
+    );
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Proposal Alpha' }),
+    ).toBeVisible({ timeout: 15_000 });
+    // The "Selected" badge is only rendered when a selection exists for this
+    // proposal — proves the page consumed getLatestSelectionForProposal.
+    await expect(authenticatedPage.getByText('Selected').first()).toBeVisible();
+    await expect(authenticatedPage.getByText('$3,000').first()).toBeVisible();
+    await expect(authenticatedPage.getByText('$5,000 requested')).toBeVisible();
+
+    // Non-selected proposal — last phase, no selection record: view page
+    // falls back to rendering only the proposal's requested budget. The
+    // "$X requested" secondary label must NOT appear (nothing to compare).
+    await authenticatedPage.goto(
+      `/en/decisions/${instance.slug}/proposal/${gamma.profileId}`,
+      { waitUntil: 'networkidle' },
+    );
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Proposal Gamma' }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(authenticatedPage.getByText('$7,000').first()).toBeVisible();
+    await expect(authenticatedPage.getByText(/requested/i)).toHaveCount(0);
+    await expect(authenticatedPage.getByText('Selected').first()).toHaveCount(
+      0,
+    );
   });
 
   test('non-admin does not see the admin manual-selection UI', async ({

--- a/tests/e2e/tests/proposal-view.spec.ts
+++ b/tests/e2e/tests/proposal-view.spec.ts
@@ -168,6 +168,11 @@ test.describe('Proposal View', () => {
       authenticatedPage.getByText('Renewable Energy').first(),
     ).toBeVisible();
 
+    // Non-last phase + no selection: the page must not surface the
+    // "{amount} requested" secondary label, since there is no allocated value
+    // to compare against.
+    await expect(authenticatedPage.getByText(/requested/i)).toHaveCount(0);
+
     // Dynamic dropdown fields render with their label via ProposalContentRenderer.
     // The field labels should be visible as section headings.
     await expect(


### PR DESCRIPTION
Adds API + e2e coverage for the latest-selection endpoint and the allocated/requested budget UI added in #1208.