### PR TITLE
fix(decisions): sort proposals deterministically with id tie-breaker

### DIFF
--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -426,10 +426,22 @@ export const listProposals = async ({
             sqlOp<number>`${voteCountExpr(table)}`.as('vote_count'),
         },
       }),
-      orderBy: (table, { asc: ascOp, desc: descOp }) =>
-        orderBy === 'votes'
-          ? [descOp(voteCountExpr(table)), descOp(table.createdAt)]
-          : (dir === 'asc' ? ascOp : descOp)(table[orderBy] ?? table.createdAt),
+      orderBy: (table, { asc: ascOp, desc: descOp }) => {
+        // `id` tie-break: without it, rows sharing the primary sort key
+        // return in undefined order and flipping `dir` has no visible effect.
+        const directional = dir === 'asc' ? ascOp : descOp;
+        if (orderBy === 'votes') {
+          return [
+            descOp(voteCountExpr(table)),
+            descOp(table.createdAt),
+            descOp(table.id),
+          ];
+        }
+        return [
+          directional(table[orderBy] ?? table.createdAt),
+          directional(table.id),
+        ];
+      },
     }),
     // Count uses the same builder against the schema table, producing
     // unaliased SQL that matches the FROM clause here.

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -2226,4 +2226,63 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
     });
     expect(reviewResult.proposals.map((p) => p.id)).toContain(draft.id);
   });
+
+  it('orders proposals deterministically when createdAt values tie', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const [p1, p2, p3, caller] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'A', description: 'A' },
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'B', description: 'B' },
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'C', description: 'C' },
+      }),
+      createAuthenticatedCaller(setup.userEmail),
+    ]);
+
+    // Force identical createdAt so the primary sort key alone can't order
+    // them — the query needs a tie-breaker for asc/desc to differ.
+    const sharedTimestamp = '2026-01-01T00:00:00.000Z';
+    await db
+      .update(proposals)
+      .set({ createdAt: sharedTimestamp })
+      .where(eq(proposals.processInstanceId, instance.instance.id));
+
+    const desc = await caller.decision.listProposals({
+      processInstanceId: instance.instance.id,
+      dir: 'desc',
+    });
+    const asc = await caller.decision.listProposals({
+      processInstanceId: instance.instance.id,
+      dir: 'asc',
+    });
+
+    const descIds = desc.proposals.map((p) => p.id);
+    const ascIds = asc.proposals.map((p) => p.id);
+
+    expect([...descIds].sort()).toEqual([p1.id, p2.id, p3.id].sort());
+    expect(ascIds).toEqual([...descIds].reverse());
+  });
 });


### PR DESCRIPTION
## Summary
- Add `id` as a secondary `ORDER BY` key in `listProposals` so rows with identical primary sort values (e.g. matching `createdAt`) return in deterministic order across sessions.
- Without the tie-breaker, Postgres was free to return tied rows in undefined order, and flipping `dir` between `asc`/`desc` had no visible effect — symptom users saw as "proposals don't seem to be sorted consistently".

Asana: https://app.asana.com/0/1209656706357220/1214705378291850

## Test plan
- [x] New integration test: forces three proposals to share `createdAt`, asserts that `asc` and `desc` queries are exact inverses of each other (proves the tie-breaker took effect and is direction-aware).
- [x] Full `services/api/src/routers/decision/proposals/list.test.ts` suite passes (39/39).
- [x] `pnpm typecheck` clean across all workspaces.
- [x] `pnpm format` applied.