### PR TITLE
test(decisions): add regression test for budget cap enforcement on submit

### DIFF
--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -518,6 +518,71 @@ describe.concurrent('submitProposal', () => {
     });
   });
 
+  // Repro for Asana 1214710291141659 ("budget limit not enforced"):
+  // the CreateDecisionProcessModal form generates a proposal template with
+  // `budget: { type: 'number', maximum: budgetCapAmount }` (legacy number
+  // shape), not the object shape used by the test above. Make sure
+  // submission rejection still works in that shape.
+  it('should reject submission when budget exceeds the legacy number-shape template maximum', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+      proposalTemplate: {
+        type: 'object',
+        required: ['title', 'budget'],
+        'x-field-order': ['title', 'budget'],
+        properties: {
+          title: { type: 'string', 'x-format': 'short-text' },
+          budget: { type: 'number', maximum: 100000, 'x-format': 'money' },
+        },
+      },
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Over Cap' },
+    });
+
+    const collaborationDocId = `proposal-${proposal.id}`;
+
+    await db
+      .update(proposals)
+      .set({
+        proposalData: {
+          title: 'Over Cap',
+          collaborationDocId,
+          budget: { amount: 1000000, currency: 'USD' },
+        },
+      })
+      .where(eq(proposals.id, proposal.id));
+
+    mockCollab.setDocFragments(collaborationDocId, {
+      title: 'Over Cap',
+      budget: JSON.stringify({ amount: 1000000, currency: 'USD' }),
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.submitProposal({
+        proposalId: proposal.id,
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'ValidationError' },
+    });
+  });
+
   it('should reject submission when a required text field is empty in the collaboration document', async ({
     task,
     onTestFinished,


### PR DESCRIPTION
## Summary
- Asana 1214710291141659 reported "in a process with a max budget 100,000 I put in one million and it went through".
- Adds a regression test that walks through the exact path that should reject this: a proposal template with `budget: { type: 'number', maximum: 100000 }` (the legacy number shape the `CreateDecisionProcessModal` form actually generates — `apps/app/src/components/Profile/CreateDecisionProcessModal/schemas/{simple,horizon,cowop}.ts`), a draft proposal with `budget.amount = 1_000_000`, and a TipTap fragment seeded to the same over-cap value.
- The submission **does** reject with `ValidationError`. We could not reproduce the original report from this layer.
- Per task instructions: "If the test does pass, then we know that this was a strange scenario and that our test will make sure that it continues to work." So we lock in the behavior as a regression test and leave production logic untouched.

### Possible non-reproductions to investigate if it recurs
- User entered an amount in **Total Budget Available** (`totalBudget`) rather than **Budget cap amount** (`budgetCapAmount`); only the latter caps individual proposals.
- Process was created against an instance whose `resolveProposalTemplate` returned `null` (no `proposalTemplate` on `instanceData` and no `processSchema.proposalTemplate`), causing `submitProposal` to skip the validator entirely (`packages/common/src/services/decision/submitProposal.ts:98`).
- Proposal was created and read back as a draft (drafts never run the template validator) and the original report conflated "saved" with "submitted".

Asana: https://app.asana.com/0/1209656706357220/1214710291141659

## Test plan
- [x] New test passes: `pnpm --filter @op/api test submit.test.ts -t "budget exceeds the legacy number-shape template maximum"`.
- [x] Full `submit.test.ts` suite passes (19/19).
- [x] `pnpm typecheck` clean.
- [x] `pnpm format` applied.
