### PR TITLE
fix(decisions): default voting limit to 1 vote when enabling voting on a phase

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -408,11 +408,18 @@ function PhaseDetailForm({
         >
           <ToggleButton
             isSelected={phase.rules?.voting?.submit ?? false}
-            onChange={(val) =>
-              updateRules({
-                voting: { ...phase.rules?.voting, submit: val },
-              })
-            }
+            onChange={(val) => {
+              const nextVoting: PhaseRules['voting'] = {
+                ...phase.rules?.voting,
+                submit: val,
+              };
+              // "1 vote per member" is the standard default — unlimited voting
+              // is the unusual choice and should be picked deliberately.
+              if (val && nextVoting.maxVotesPerMember === undefined) {
+                nextVoting.maxVotesPerMember = 1;
+              }
+              updateRules({ voting: nextVoting });
+            }}
             size="small"
           />
         </ToggleRow>


### PR DESCRIPTION
- When a process author toggled voting on for a phase in `PhaseDetailPage`, `maxVotesPerMember` stayed `undefined` and `VoteLimitSelect` rendered **No limit** as the default. The server-side `validateVoteSelection` treats `undefined` as "no enforcement" (`packages/common/src/services/decision/schemaValidators.ts:154-173`), so the practical default was unlimited voting.
- Now, toggling voting on writes `maxVotesPerMember: 1` whenever no value has been set. Users can still explicitly select **No limit** from the dropdown — that writes back `undefined`, which `schemaValidators.ts` continues to interpret as "no cap". The type comment in `packages/common/src/services/decision/schemas/types.ts:26` documents this sentinel: _"Undefined = no limit (distinct from 0, which would block all voting)."_

We keep the backend logic the same but practically speaking we set the default voting limit to 1

Asana [1214898054846020](https://app.asana.com/0/1213315744811204/1214898054846020): "Voting limit is set as unlimited as a default. Is it wise? The most standard would be one vote".
