### PR TITLE
feat(ui): Add ButtonGroup Component

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,7 @@
     "./GrowingFacePile": "./src/components/GrowingFacePile/index.tsx",
     "./BannerUploader": "./src/components/BannerUploader.tsx",
     "./Button": "./src/components/Button.tsx",
+    "./ButtonGroup": "./src/components/ButtonGroup.tsx",
     "./CategoryList": "./src/components/CategoryList.tsx",
     "./ComboBox": "./src/components/ComboBox.tsx",
     "./CheckIcon": "./src/components/icons/CheckIcon.tsx",

--- a/packages/ui/src/components/ButtonGroup.tsx
+++ b/packages/ui/src/components/ButtonGroup.tsx
@@ -1,0 +1,49 @@
+import { twMerge } from 'tailwind-merge';
+import { tv } from 'tailwind-variants';
+import type { VariantProps } from 'tailwind-variants';
+
+const buttonGroupStyles = tv({
+  base: "flex w-fit items-stretch *:focus-visible:relative *:focus-visible:z-10 has-[>[data-slot=button-group]]:gap-2 [&>*]:shadow-none [&>[aria-pressed=false]]:bg-neutral-offWhite [&>[aria-pressed=false]]:text-neutral-charcoal [&>[aria-pressed=false]_svg]:text-neutral-gray4 [&>[aria-pressed=false]:hover]:bg-neutral-offWhite [&>[aria-pressed=true]]:bg-primary-tealWhite [&>[aria-pressed=true]]:text-primary-teal [&>[aria-pressed=true]:hover]:bg-primary-tealWhite has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-e-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  variants: {
+    orientation: {
+      horizontal:
+        '[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none',
+      vertical:
+        'flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none',
+    },
+  },
+  defaultVariants: {
+    orientation: 'horizontal',
+  },
+});
+
+export function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof buttonGroupStyles>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={buttonGroupStyles({ orientation, className })}
+      {...props}
+    />
+  );
+}
+
+export function ButtonGroupText({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      className={twMerge(
+        "flex items-center gap-2 rounded-md border bg-muted px-4 text-sm font-medium shadow-xs *:data-[slot=icon]:pointer-events-none [&_[data-slot=icon]:not([class*='size-'])]:size-5 sm:[&_[data-slot=icon]:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/stories/ButtonGroup.stories.tsx
+++ b/packages/ui/stories/ButtonGroup.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta } from '@storybook/react-vite';
+import { useState } from 'react';
+import { LuFile, LuLink } from 'react-icons/lu';
+
+import { Button } from '../src/components/Button';
+import { ButtonGroup } from '../src/components/ButtonGroup';
+
+const meta: Meta = {
+  title: 'ButtonGroup',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+export const Basic = () => {
+  const [value, setValue] = useState<'one' | 'two' | 'three'>('one');
+  return (
+    <ButtonGroup>
+      <Button
+        color="secondary"
+        size="small"
+        aria-pressed={value === 'one'}
+        onPress={() => setValue('one')}
+      >
+        One
+      </Button>
+      <Button
+        color="secondary"
+        size="small"
+        aria-pressed={value === 'two'}
+        onPress={() => setValue('two')}
+      >
+        Two
+      </Button>
+      <Button
+        color="secondary"
+        size="small"
+        aria-pressed={value === 'three'}
+        onPress={() => setValue('three')}
+      >
+        Three
+      </Button>
+    </ButtonGroup>
+  );
+};
+
+export const ToggleTwoOptions = () => {
+  const [value, setValue] = useState<'link' | 'document'>('link');
+  return (
+    <div className="w-80">
+      <ButtonGroup className="w-full">
+        <Button
+          color="secondary"
+          size="small"
+          aria-pressed={value === 'link'}
+          onPress={() => setValue('link')}
+          className="flex-1"
+        >
+          <LuLink className="size-4" />
+          Link
+        </Button>
+        <Button
+          color="secondary"
+          size="small"
+          aria-pressed={value === 'document'}
+          onPress={() => setValue('document')}
+          className="flex-1"
+        >
+          <LuFile className="size-4" />
+          Document
+        </Button>
+      </ButtonGroup>
+    </div>
+  );
+};
+
+export const Vertical = () => {
+  const [value, setValue] = useState<'top' | 'middle' | 'bottom'>('top');
+  return (
+    <ButtonGroup orientation="vertical">
+      <Button
+        color="secondary"
+        size="small"
+        aria-pressed={value === 'top'}
+        onPress={() => setValue('top')}
+      >
+        Top
+      </Button>
+      <Button
+        color="secondary"
+        size="small"
+        aria-pressed={value === 'middle'}
+        onPress={() => setValue('middle')}
+      >
+        Middle
+      </Button>
+      <Button
+        color="secondary"
+        size="small"
+        aria-pressed={value === 'bottom'}
+        onPress={() => setValue('bottom')}
+      >
+        Bottom
+      </Button>
+    </ButtonGroup>
+  );
+};


### PR DESCRIPTION
## Summary

- Adds `ButtonGroup` into `@op/ui` (`packages/ui/src/components/ui/button-group.tsx`) from intent-ui with some custom styling
- Adds `./ButtonGroup` to the `@op/ui` package exports.
- Adds a Storybook story with three examples: basic three-button group, two-option toggle (selected state styled with brand teal tokens), and a vertical orientation.

The component is a thin wrapper around its children: it sets `role="group"` and strips the rounded edges + border between adjacent items so a row (or column) of `<Button>`s reads as a single grouped control. Used in the resources panel for the Link/Document tabs but also to be used in filter toggles so needs to be agnostic to tabs vs radiogroups vs toggles.

Storybook: https://apps-workshop-qpz30ksyt-oneproject.vercel.app/?path=/docs/buttongroup--docs

<img width="376" height="86" alt="Screenshot 2026-05-25 at 17 39 20" src="https://github.com/user-attachments/assets/41e39960-0510-4921-bb0a-92753c919fcd" />
<img width="220" height="78" alt="Screenshot 2026-05-25 at 17 39 21" src="https://github.com/user-attachments/assets/d217a3ac-67ab-4f67-848c-8d8134e128f2" />

