### PR TITLE
exp(decisions): public participation procedure + roleless anon participants

### DIFF
--- a/packages/common/src/services/decision/createProposal.ts
+++ b/packages/common/src/services/decision/createProposal.ts
@@ -42,9 +42,18 @@ export interface CreateProposalInput {
 export const createProposal = async ({
   data,
   user,
+  skipAccessCheck = false,
 }: {
   data: CreateProposalInput;
   user: User;
+  /**
+   * When `true`, skip the per-actor profile-access role check. The procedure
+   * layer is expected to have already determined the caller is allowed
+   * (e.g. public-mode anonymous participants on a Columbus instance). See
+   * COLUMBUS_TECH_DECISIONS.md §1 — anonymous users get owner-bounded
+   * capabilities without holding a role on the instance profile.
+   */
+  skipAccessCheck?: boolean;
 }) => {
   const authUserId = user.id;
 
@@ -62,22 +71,24 @@ export const createProposal = async ({
       throw new ValidationError('Process instance has no profile');
     }
 
-    const profileAccessUser = await getProfileAccessUser({
-      user: { id: authUserId },
-      profileId: instance.profileId,
-    });
+    if (!skipAccessCheck) {
+      const profileAccessUser = await getProfileAccessUser({
+        user: { id: authUserId },
+        profileId: instance.profileId,
+      });
 
-    if (!profileAccessUser) {
-      throw new UnauthorizedError('Not authorized');
+      if (!profileAccessUser) {
+        throw new UnauthorizedError('Not authorized');
+      }
+
+      assertAccess(
+        [
+          { profile: permission.ADMIN },
+          { decisions: decisionPermission.SUBMIT_PROPOSALS },
+        ],
+        profileAccessUser.roles,
+      );
     }
-
-    assertAccess(
-      [
-        { profile: permission.ADMIN },
-        { decisions: decisionPermission.SUBMIT_PROPOSALS },
-      ],
-      profileAccessUser.roles,
-    );
 
     const instanceData = instance.instanceData as DecisionInstanceData;
     const currentPhaseId = instance.currentStateId;

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -114,6 +114,7 @@ export { schemaValidator } from './schemaValidator';
 export * from './types';
 export type {
   DecisionInstanceData,
+  ParticipationMode,
   PhaseInstanceData,
   PhaseOverride,
 } from './schemas/instanceData';

--- a/packages/common/src/services/decision/schemas/instanceData.ts
+++ b/packages/common/src/services/decision/schemas/instanceData.ts
@@ -47,6 +47,13 @@ export interface PhaseInstanceData {
  * Instance data stored in processInstances table for new DecisionSchemaDefinition-based instances.
  * This structure must match instanceDataNewEncoder in the API encoders.
  */
+/**
+ * Participation mode. `public` opens the instance to anonymous + no-JWT
+ * traffic per COLUMBUS_TECH_DECISIONS.md §6; absent or any other value falls
+ * back to the closed-network gate.
+ */
+export type ParticipationMode = 'public';
+
 export interface DecisionInstanceData {
   config?: ProcessConfig;
   fieldValues?: Record<string, unknown>;
@@ -59,6 +66,8 @@ export interface DecisionInstanceData {
   proposalTemplate?: ProposalTemplateSchema;
   /** Rubric template (JSON Schema defining evaluation criteria) */
   rubricTemplate?: RubricTemplateSchema;
+  /** Participation mode for the instance; see {@link ParticipationMode}. */
+  mode?: ParticipationMode;
 }
 
 export interface PhaseOverride {

--- a/services/api/src/middlewares/withProcessInstanceAuth.ts
+++ b/services/api/src/middlewares/withProcessInstanceAuth.ts
@@ -1,0 +1,174 @@
+import { cache } from '@op/cache';
+import { UnauthorizedError, getAllowListUser } from '@op/common';
+import type { ParticipationMode } from '@op/common';
+import { db } from '@op/db/client';
+import { processInstances, proposals } from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+import { eq } from 'drizzle-orm';
+
+import { getCachedAuthUser } from '../supabase/server';
+import type { MiddlewareBuilderBase, TContext } from '../types';
+
+export interface ProcessInstanceAuthCtxRequired {
+  user: User;
+  /** Resolved instance participation mode; null when not a public instance. */
+  instanceMode: ParticipationMode | null;
+  /**
+   * `true` when the caller cleared the gate via the public-mode path and the
+   * service layer should bypass its per-actor access check. Handlers forward
+   * this to the service rather than re-deriving from `instanceMode`.
+   */
+  skipAccessCheck: boolean;
+}
+
+export interface ProcessInstanceAuthCtxOptional {
+  user: User | null;
+  instanceMode: ParticipationMode | null;
+  skipAccessCheck: boolean;
+}
+
+/**
+ * Resolves the participation mode for the instance referenced by the call's
+ * raw input. Accepts either a direct `processInstanceId` (e.g. listProposals)
+ * or a `proposalId` that the middleware joins through to its instance (e.g.
+ * submitProposal). Returns `null` when neither key is present or the row is
+ * missing — the gate treats `null` as non-public.
+ */
+async function resolveInstanceMode(
+  rawInput: unknown,
+): Promise<ParticipationMode | null> {
+  if (!rawInput || typeof rawInput !== 'object') return null;
+  const input = rawInput as Record<string, unknown>;
+
+  if (typeof input.processInstanceId === 'string') {
+    const rows = await db
+      .select({ instanceData: processInstances.instanceData })
+      .from(processInstances)
+      .where(eq(processInstances.id, input.processInstanceId))
+      .limit(1);
+    const data = rows[0]?.instanceData as { mode?: ParticipationMode } | null;
+    return data?.mode ?? null;
+  }
+
+  if (typeof input.proposalId === 'string') {
+    const rows = await db
+      .select({ instanceData: processInstances.instanceData })
+      .from(proposals)
+      .innerJoin(
+        processInstances,
+        eq(processInstances.id, proposals.processInstanceId),
+      )
+      .where(eq(proposals.id, input.proposalId))
+      .limit(1);
+    const data = rows[0]?.instanceData as { mode?: ParticipationMode } | null;
+    return data?.mode ?? null;
+  }
+
+  return null;
+}
+
+async function resolveUser(ctx: TContext): Promise<User | null> {
+  const data = await getCachedAuthUser(ctx);
+  if (data && !data.error && data.data?.user) {
+    return data.data.user;
+  }
+  return null;
+}
+
+/**
+ * Closed-network gate: mirrors `withAuthenticated`'s rules (no anonymous, no
+ * unconfirmed email, allowList enforced for non-oneproject domains). Used
+ * when the instance is NOT tagged `mode: 'public'`.
+ */
+async function enforceClosedNetwork(user: User | null): Promise<User> {
+  if (!user) {
+    throw new UnauthorizedError(
+      'This action requires an authenticated session',
+    );
+  }
+  if (user.is_anonymous) {
+    throw new UnauthorizedError(
+      'Anonymous users are not allowed on this instance',
+    );
+  }
+  if (user.confirmed_at === null) {
+    throw new UnauthorizedError('User has not confirmed their email address');
+  }
+
+  if (user.email?.toLowerCase().split('@')[1] !== 'oneproject.org') {
+    const allowedUserEmail = await cache<ReturnType<typeof getAllowListUser>>({
+      type: 'allowList',
+      params: [user.email?.toLowerCase()],
+      fetch: () => getAllowListUser({ email: user.email?.toLowerCase() }),
+      options: { ttl: 30 * 60 * 1000 },
+    });
+    if (!allowedUserEmail) {
+      throw new UnauthorizedError();
+    }
+  }
+
+  return user;
+}
+
+/**
+ * Mode-aware auth for instance-scoped endpoints — see
+ * COLUMBUS_TECH_DECISIONS.md §5–6.
+ *
+ * On `mode: 'public'` instances anonymous and (when `requireUser:false`)
+ * no-JWT requests are accepted. On any other instance the closed-network
+ * gate runs unchanged: only authed, allowList-verified users get through.
+ */
+export const withProcessInstanceAuthRequired: MiddlewareBuilderBase<
+  ProcessInstanceAuthCtxRequired
+> = async ({ ctx, next, getRawInput }) => {
+  const [user, mode] = await Promise.all([
+    resolveUser(ctx),
+    resolveInstanceMode(await getRawInput()),
+  ]);
+
+  if (mode === 'public') {
+    if (!user) {
+      throw new UnauthorizedError(
+        'This action requires an authenticated session',
+      );
+    }
+    return next({
+      ctx: { ...ctx, user, instanceMode: mode, skipAccessCheck: true },
+    });
+  }
+
+  const verifiedUser = await enforceClosedNetwork(user);
+  return next({
+    ctx: {
+      ...ctx,
+      user: verifiedUser,
+      instanceMode: mode,
+      skipAccessCheck: false,
+    },
+  });
+};
+
+export const withProcessInstanceAuthOptional: MiddlewareBuilderBase<
+  ProcessInstanceAuthCtxOptional
+> = async ({ ctx, next, getRawInput }) => {
+  const [user, mode] = await Promise.all([
+    resolveUser(ctx),
+    resolveInstanceMode(await getRawInput()),
+  ]);
+
+  if (mode === 'public') {
+    return next({
+      ctx: { ...ctx, user, instanceMode: mode, skipAccessCheck: true },
+    });
+  }
+
+  const verifiedUser = await enforceClosedNetwork(user);
+  return next({
+    ctx: {
+      ...ctx,
+      user: verifiedUser,
+      instanceMode: mode,
+      skipAccessCheck: false,
+    },
+  });
+};

--- a/services/api/src/routers/decision/proposals/create.test.ts
+++ b/services/api/src/routers/decision/proposals/create.test.ts
@@ -1,0 +1,155 @@
+import { ProposalStatus } from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createIsolatedTestClient,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+async function createAnonymousCaller() {
+  const client = createIsolatedTestClient();
+  const { data, error } = await client.auth.signInAnonymously();
+  if (error || !data.session) {
+    throw new Error(`Failed to sign in anonymously: ${error?.message}`);
+  }
+  return createCaller(await createTestContextWithSession(data.session));
+}
+
+async function createUnauthenticatedCaller() {
+  return createCaller(await createTestContextWithSession(null));
+}
+
+describe.concurrent('createProposal', () => {
+  it('creates a draft proposal for an authenticated user', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.decision.createProposal({
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Authenticated baseline' },
+    });
+
+    expect(result.status).toBe(ProposalStatus.DRAFT);
+    if (result.profileId) {
+      testData.trackProfileForCleanup(result.profileId);
+    }
+  });
+
+  // Gating tests for processInstanceProcedure({ requireUser: true }) on
+  // createProposal. Creation is the real start of the anonymous participant
+  // flow — submit presupposes a draft already exists.
+  describe('processInstanceProcedure gating', () => {
+    it('creates a draft proposal as an anonymous participant on a public instance', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const instance = setup.instances[0];
+      if (!instance) {
+        throw new Error('No instance created');
+      }
+      await testData.setInstancePublic(instance.instance.id);
+
+      const anon = await testData.createAnonymousParticipant({ instance });
+
+      const anonCaller = createCaller(
+        await createTestContextWithSession(anon.session),
+      );
+
+      const result = await anonCaller.decision.createProposal({
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Created by anon owner' },
+      });
+
+      expect(result.status).toBe(ProposalStatus.DRAFT);
+      if (result.profileId) {
+        testData.trackProfileForCleanup(result.profileId);
+      }
+    });
+
+    it('rejects a no-JWT request on a public instance (requireUser:true)', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const instance = setup.instances[0];
+      if (!instance) {
+        throw new Error('No instance created');
+      }
+      await testData.setInstancePublic(instance.instance.id);
+
+      const caller = await createUnauthenticatedCaller();
+
+      await expect(
+        caller.decision.createProposal({
+          processInstanceId: instance.instance.id,
+          proposalData: { title: 'Should reject no-JWT create' },
+        }),
+      ).rejects.toMatchObject({
+        cause: { name: 'UnauthorizedError' },
+      });
+    });
+
+    it('rejects an anonymous JWT on a non-public instance', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const instance = setup.instances[0];
+      if (!instance) {
+        throw new Error('No instance created');
+      }
+      // Non-public by default — closed-network gate.
+
+      const anonCaller = await createAnonymousCaller();
+
+      await expect(
+        anonCaller.decision.createProposal({
+          processInstanceId: instance.instance.id,
+          proposalData: { title: 'Non-public; anon should bounce' },
+        }),
+      ).rejects.toMatchObject({
+        cause: { name: 'UnauthorizedError' },
+      });
+    });
+  });
+});

--- a/services/api/src/routers/decision/proposals/create.ts
+++ b/services/api/src/routers/decision/proposals/create.ts
@@ -2,19 +2,23 @@ import { Channels, createProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 
 import { createProposalInputSchema } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { processInstanceProcedure, router } from '../../../trpcFactory';
 
 export const createProposalRouter = router({
   /** Creates a new proposal in draft status. Use submitProposal to transition to submitted. */
-  createProposal: commonAuthedProcedure()
+  createProposal: processInstanceProcedure({ requireUser: true })
     .input(createProposalInputSchema)
     .output(proposalSchema)
-    .mutation(async ({ ctx, input }) => {
-      const { user } = ctx;
+    .mutation(async ({ ctx: rawCtx, input }) => {
+      const ctx = rawCtx as typeof rawCtx & {
+        user: NonNullable<typeof rawCtx.user>;
+      };
+      const { user, skipAccessCheck } = ctx;
 
       const proposal = await createProposal({
         data: input,
         user,
+        skipAccessCheck,
       });
 
       ctx.registerMutationChannels([

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../test/helpers/pipelineSchemas';
 import {
   createIsolatedSession,
+  createIsolatedTestClient,
   createTestContextWithSession,
 } from '../../../test/supabase-utils';
 import { createCallerFactory } from '../../../trpcFactory';
@@ -34,6 +35,15 @@ const createCaller = createCallerFactory(appRouter);
 async function createAuthenticatedCaller(email: string) {
   const { session } = await createIsolatedSession(email);
   return createCaller(await createTestContextWithSession(session));
+}
+
+async function createAnonymousCaller() {
+  const client = createIsolatedTestClient();
+  const { data, error } = await client.auth.signInAnonymously();
+  if (error || !data.session) {
+    throw new Error(`Failed to sign in anonymously: ${error?.message}`);
+  }
+  return createCaller(await createTestContextWithSession(data.session));
 }
 
 describe.concurrent('listProposals', () => {
@@ -1689,6 +1699,97 @@ describe.concurrent('listProposals', () => {
       textFragment('{"amount":500,"currency":"EUR"}'),
     );
     expect(fragments.category).toEqual(textFragment('Pinned Category'));
+  });
+
+  // Gating tests for processInstanceProcedure({ requireUser: false }) — see
+  // COLUMBUS_TECH_DECISIONS.md §5–6. Public instances accept anonymous and
+  // no-JWT reads; non-public instances reject both at the closed-network
+  // gate.
+  describe('processInstanceProcedure gating', () => {
+    it('allows an anonymous JWT to list proposals on a public instance', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const instance = setup.instances[0];
+      if (!instance) {
+        throw new Error('No instance created');
+      }
+      await testData.setInstancePublic(instance.instance.id);
+
+      await testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Visible to anon' },
+      });
+
+      const anonCaller = await createAnonymousCaller();
+
+      const result = await anonCaller.decision.listProposals({
+        processInstanceId: instance.instance.id,
+      });
+
+      expect(result.proposals).toBeDefined();
+    });
+
+    it('rejects an unauthenticated request on a non-public instance', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const instance = setup.instances[0];
+      if (!instance) {
+        throw new Error('No instance created');
+      }
+      // Non-public by default — closed-network gate.
+
+      const caller = createCaller(await createTestContextWithSession(null));
+
+      await expect(
+        caller.decision.listProposals({
+          processInstanceId: instance.instance.id,
+        }),
+      ).rejects.toMatchObject({
+        cause: { name: 'UnauthorizedError' },
+      });
+    });
+
+    it('rejects an anonymous JWT on a non-public instance', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const instance = setup.instances[0];
+      if (!instance) {
+        throw new Error('No instance created');
+      }
+      // Non-public by default — closed-network gate.
+
+      const anonCaller = await createAnonymousCaller();
+
+      await expect(
+        anonCaller.decision.listProposals({
+          processInstanceId: instance.instance.id,
+        }),
+      ).rejects.toMatchObject({
+        cause: { name: 'UnauthorizedError' },
+      });
+    });
   });
 });
 

--- a/services/api/src/routers/decision/proposals/list.ts
+++ b/services/api/src/routers/decision/proposals/list.ts
@@ -6,18 +6,30 @@ import {
 } from '@op/common/client';
 
 import { proposalFilterSchema } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import {
+  commonAuthedProcedure,
+  processInstanceProcedure,
+  router,
+} from '../../../trpcFactory';
 
 export const listProposalsRouter = router({
   /** Lists proposals for a given process instanc in the curent phase. */
-  listProposals: commonAuthedProcedure()
+  listProposals: processInstanceProcedure({ requireUser: false })
     .input(proposalFilterSchema)
     .output(proposalListSchema)
     .query(async ({ ctx, input }) => {
-      const { user } = ctx;
+      const { user, skipAccessCheck } = ctx;
+      // The procedure resolves whether access checks should be skipped
+      // (public-mode anonymous / no-JWT path). Handler just forwards the
+      // decision to the service. See COLUMBUS_TECH_DEBT.md §2 for why
+      // `skipAccessCheck` is the reused mechanism.
       const result = await listProposals({
-        input: { ...input, authUserId: user.id },
-        user,
+        input: {
+          ...input,
+          authUserId: user?.id ?? '',
+          skipAccessCheck,
+        },
+        user: (user ?? { id: '' }) as never,
       });
 
       ctx.registerQueryChannels([

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -13,6 +13,7 @@ import { appRouter } from '../..';
 import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
 import {
   createIsolatedSession,
+  createIsolatedTestClient,
   createTestContextWithSession,
 } from '../../../test/supabase-utils';
 import { createCallerFactory } from '../../../trpcFactory';
@@ -22,6 +23,19 @@ const createCaller = createCallerFactory(appRouter);
 async function createAuthenticatedCaller(email: string) {
   const { session } = await createIsolatedSession(email);
   return createCaller(await createTestContextWithSession(session));
+}
+
+async function createAnonymousCaller() {
+  const client = createIsolatedTestClient();
+  const { data, error } = await client.auth.signInAnonymously();
+  if (error || !data.session) {
+    throw new Error(`Failed to sign in anonymously: ${error?.message}`);
+  }
+  return createCaller(await createTestContextWithSession(data.session));
+}
+
+async function createUnauthenticatedCaller() {
+  return createCaller(await createTestContextWithSession(null));
 }
 
 describe.concurrent('submitProposal', () => {
@@ -1072,5 +1086,73 @@ describe.concurrent('submitProposal', () => {
     await expect(
       caller.decision.submitProposal({ proposalId: proposal.id }),
     ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
+  });
+
+  // Gating tests for processInstanceProcedure({ requireUser: true }) — see
+  // COLUMBUS_TECH_DECISIONS.md §5–6. The anon-success path lives on
+  // createProposal (see create.test.ts) since submit presupposes an existing
+  // draft; here we only pin the gate-level rejects for submit.
+  describe('processInstanceProcedure gating', () => {
+    it('rejects a no-JWT request on a public instance (requireUser:true)', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const instance = setup.instances[0];
+      if (!instance) {
+        throw new Error('No instance created');
+      }
+      await testData.setInstancePublic(instance.instance.id);
+
+      const proposal = await testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Should reject no-JWT submit' },
+      });
+
+      const caller = await createUnauthenticatedCaller();
+
+      await expect(
+        caller.decision.submitProposal({ proposalId: proposal.id }),
+      ).rejects.toMatchObject({
+        cause: { name: 'UnauthorizedError' },
+      });
+    });
+
+    it('rejects an anonymous JWT on a non-public instance', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const instance = setup.instances[0];
+      if (!instance) {
+        throw new Error('No instance created');
+      }
+      // Deliberately NOT calling setInstancePublic — closed-network gate.
+
+      const proposal = await testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Non-public; anon should bounce' },
+      });
+
+      const anonCaller = await createAnonymousCaller();
+
+      await expect(
+        anonCaller.decision.submitProposal({ proposalId: proposal.id }),
+      ).rejects.toMatchObject({
+        cause: { name: 'UnauthorizedError' },
+      });
+    });
   });
 });

--- a/services/api/src/routers/decision/proposals/submit.ts
+++ b/services/api/src/routers/decision/proposals/submit.ts
@@ -4,7 +4,7 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { processInstanceProcedure, router } from '../../../trpcFactory';
 import { trackProposalSubmitted } from '../../../utils/analytics';
 
 const submitProposalInputSchema = z.object({
@@ -12,10 +12,15 @@ const submitProposalInputSchema = z.object({
 });
 
 export const submitProposalRouter = router({
-  submitProposal: commonAuthedProcedure()
+  submitProposal: processInstanceProcedure({ requireUser: true })
     .input(submitProposalInputSchema)
     .output(proposalSchema)
-    .mutation(async ({ ctx, input }) => {
+    .mutation(async ({ ctx: rawCtx, input }) => {
+      // requireUser:true guarantees ctx.user is non-null at runtime; the
+      // current factory return type doesn't narrow that, hence the assertion.
+      const ctx = rawCtx as typeof rawCtx & {
+        user: NonNullable<typeof rawCtx.user>;
+      };
       const { user } = ctx;
 
       const proposal = await submitProposal({

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -32,7 +32,11 @@ import type {
   processInstanceWithSchemaEncoder,
 } from '../../encoders/decision';
 import { processInstanceWithSchemaEncoder as processInstanceEncoder } from '../../encoders/decision';
-import { createTestUser, supabaseTestAdminClient } from '../supabase-utils';
+import {
+  createIsolatedTestClient,
+  createTestUser,
+  supabaseTestAdminClient,
+} from '../supabase-utils';
 
 type DecisionSchemaDefinition = z.infer<typeof decisionSchemaDefinitionEncoder>;
 
@@ -428,6 +432,73 @@ export class TestDecisionsDataManager {
       email,
       isAdmin,
     });
+  }
+
+  /**
+   * Marks an instance as public-participation for COLUMBUS_TECH_DECISIONS §6.
+   * Merges `mode: 'public'` into the row's `instanceData` JSONB.
+   */
+  async setInstancePublic(instanceId: string): Promise<void> {
+    const row = await db.query.processInstances.findFirst({
+      where: { id: instanceId },
+    });
+    if (!row) {
+      throw new Error(`Instance ${instanceId} not found`);
+    }
+    const next: DecisionInstanceData = {
+      ...((row.instanceData as DecisionInstanceData) ?? { phases: [] }),
+      mode: 'public',
+    };
+    await db
+      .update(processInstances)
+      .set({ instanceData: next })
+      .where(eq(processInstances.id, instanceId));
+  }
+
+  /**
+   * Creates an anonymous Supabase participant. Returns the session for
+   * building an authenticated tRPC caller, plus the Supabase user and the
+   * participant profileId provisioned by the auth trigger.
+   *
+   * Anonymous participants are NOT granted any instance-profile role here —
+   * per COLUMBUS_TECH_DECISIONS.md §1, public-mode instances accept anon
+   * participants without per-actor access roles, and the procedure layer
+   * propagates `skipAccessCheck` to the service.
+   */
+  async createAnonymousParticipant(_opts?: { instance?: CreatedInstance }) {
+    this.ensureCleanupRegistered();
+
+    const client = createIsolatedTestClient();
+    const { data, error } = await client.auth.signInAnonymously();
+    if (error || !data.session || !data.user) {
+      throw new Error(
+        `Failed to create anonymous session: ${error?.message ?? 'no session'}`,
+      );
+    }
+
+    const authUserId = data.user.id;
+    this.createdAuthUserIds.push(authUserId);
+
+    // The auth trigger provisions public.users + profile + profile_users
+    // rows for anonymous sign-ins. Fetch the resulting profileId for cleanup
+    // tracking.
+    const userRecord = await db.query.users.findFirst({
+      where: { authUserId },
+    });
+    if (!userRecord?.profileId) {
+      throw new Error(
+        `Anonymous user ${authUserId} missing profile after sign-in trigger`,
+      );
+    }
+    this.createdProfileIds.push(userRecord.profileId);
+
+    return {
+      authUserId,
+      session: data.session,
+      user: data.user,
+      profileId: userRecord.profileId,
+      client,
+    };
   }
 
   /**

--- a/services/api/src/trpcFactory.ts
+++ b/services/api/src/trpcFactory.ts
@@ -13,6 +13,10 @@ import withAnalytics from './middlewares/withAnalytics';
 import withAuthenticated from './middlewares/withAuthenticated';
 import withChannelMeta from './middlewares/withChannelMeta';
 import withLogger from './middlewares/withLogger';
+import {
+  withProcessInstanceAuthOptional,
+  withProcessInstanceAuthRequired,
+} from './middlewares/withProcessInstanceAuth';
 import withRateLimited from './middlewares/withRateLimited';
 import type { TContext } from './types';
 
@@ -88,5 +92,39 @@ export function commonAuthedProcedure(opts?: CommonAuthedProcedureOptions) {
   return commonProcedure
     .use(withRateLimited(rateLimit))
     .use(withAuthenticated)
+    .use(withAnalytics);
+}
+
+interface ProcessInstanceProcedureOptions {
+  /**
+   * If `true`, the request must carry a Supabase JWT (anonymous or full); a
+   * missing session throws `UnauthorizedError`. If `false`, `ctx.user` is
+   * `User | null` and the handler is responsible for the null case.
+   */
+  requireUser: boolean;
+  rateLimit?: {
+    windowSize: number;
+    maxRequests: number;
+  };
+}
+
+/**
+ * Procedure builder for endpoints scoped to a specific process instance.
+ *
+ * Experimental stub for COLUMBUS_TECH_DECISIONS.md §5–6: mode is hardcoded to
+ * `public`, so anonymous and authed JWTs are both accepted, and no-JWT is
+ * allowed when `requireUser` is `false`. Instance-mode lookup and the
+ * invite-mode allowList gate are deferred to the real implementation.
+ */
+export function processInstanceProcedure(
+  opts: ProcessInstanceProcedureOptions,
+) {
+  const rateLimit = opts.rateLimit ?? DEFAULT_RATE_LIMIT;
+  const middleware = opts.requireUser
+    ? withProcessInstanceAuthRequired
+    : withProcessInstanceAuthOptional;
+  return commonProcedure
+    .use(withRateLimited(rateLimit))
+    .use(middleware)
     .use(withAnalytics);
 }

--- a/supabase/supabase-dev.toml
+++ b/supabase/supabase-dev.toml
@@ -59,7 +59,7 @@ jwt_expiry = 3600
 enable_refresh_token_rotation = true
 refresh_token_reuse_interval = 10
 enable_signup = true
-enable_anonymous_sign_ins = false
+enable_anonymous_sign_ins = true
 enable_manual_linking = false
 
 [auth.email]

--- a/supabase/supabase-test.toml
+++ b/supabase/supabase-test.toml
@@ -45,7 +45,7 @@ jwt_expiry = 3600
 enable_refresh_token_rotation = true
 refresh_token_reuse_interval = 10
 enable_signup = true
-enable_anonymous_sign_ins = false
+enable_anonymous_sign_ins = true
 enable_manual_linking = false
 
 [auth.email]


### PR DESCRIPTION
Experimental prototype of the Columbus public-participation architecture. Not for merge — exploring the mode-aware procedure shape and the roleless anonymous-participant flow before committing to the design. See ../columbus/COLUMBUS_TECH_DECISIONS.md (§5–6, §1) and ../columbus/COLUMBUS_TECH_DEBT.md for the workarounds and follow-ups.