### PR TITLE
refactor(decisions): drop redundant authUserId from listProposals input

### DIFF
--- a/packages/common/src/services/decision/getResults.ts
+++ b/packages/common/src/services/decision/getResults.ts
@@ -160,7 +160,6 @@ export const getLatestResultWithProposals = async ({
     listProposals({
       input: {
         processInstanceId,
-        authUserId: user.id,
         proposalIds: paginatedProposalIds,
         limit: paginatedProposalIds.length,
       },

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -54,7 +54,6 @@ export interface ListProposalsInput {
   offset?: number;
   orderBy?: 'createdAt' | 'updatedAt' | 'status' | 'votes';
   dir?: 'asc' | 'desc';
-  authUserId: string;
   skipAccessCheck?: boolean; // For trusted contexts like background jobs
   /**
    * When true, each returned proposal carries a `voteCount` aggregated from
@@ -169,7 +168,7 @@ export const listProposals = async ({
 
   // Resolve the caller's profile once; it's reused for ballot auth, the
   // HIDDEN visibility filter, and owner/editable checks further down.
-  const currentProfileId = await getCurrentProfileId(input.authUserId);
+  const currentProfileId = await getCurrentProfileId(user.id);
 
   // Fetch the instance row up front and resolve the explicit ID scope in
   // parallel. The row is reused for the phase-resolution context (instead of
@@ -227,7 +226,7 @@ export const listProposals = async ({
     const ids = await getPhaseProposalAndDraftIds({
       instance,
       phaseId: input.phaseId,
-      authUserId: input.authUserId,
+      authUserId: user.id,
     });
     return { phaseProposalIds: ids.nonDraftIds, phaseDraftIds: ids.draftIds };
   })();
@@ -380,7 +379,7 @@ export const listProposals = async ({
               db
                 .select({ profileId: profileUsers.profileId })
                 .from(profileUsers)
-                .where(eq(profileUsers.authUserId, input.authUserId)),
+                .where(eq(profileUsers.authUserId, user.id)),
             ),
           )!,
         )!;

--- a/packages/common/src/services/decision/listSelectionCandidates.ts
+++ b/packages/common/src/services/decision/listSelectionCandidates.ts
@@ -99,7 +99,6 @@ export async function listSelectionCandidates({
     input: {
       processInstanceId,
       proposalIds: candidateIds,
-      authUserId: user.id,
       limit: candidateIds.length,
       orderBy: sortOrder === 'votes' ? 'votes' : 'createdAt',
       dir: sortOrder === 'oldest' ? 'asc' : 'desc',

--- a/services/api/src/routers/decision/proposals/list.ts
+++ b/services/api/src/routers/decision/proposals/list.ts
@@ -16,7 +16,7 @@ export const listProposalsRouter = router({
     .query(async ({ ctx, input }) => {
       const { user } = ctx;
       const result = await listProposals({
-        input: { ...input, authUserId: user.id },
+        input,
         user,
       });
 

--- a/services/workflows/src/functions/exports/exportProposals.ts
+++ b/services/workflows/src/functions/exports/exportProposals.ts
@@ -60,7 +60,6 @@ export const exportProposals = inngest.createFunction(
             status: filters.status,
             dir: filters.dir,
             limit: 1000, // High limit for exports
-            authUserId: userId,
             skipAccessCheck: true, // Access already verified when export was created
           },
           user: userRecord as any,


### PR DESCRIPTION
The user param already carries the auth id, so the separate authUserId field forced every caller to spread it and one workflow to synthesize a user just to satisfy the signature.