### PR TITLE
perf(access): request-scoped cache for access-control fetches

### DIFF
--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -331,48 +331,43 @@ export const getUserSession = memoize(
   async ({ authUserId }: { authUserId: string }) => {
     const validatedAuthUserId = validateAuthUserId(authUserId);
 
-    try {
-      const dbUser = await db._query.users.findFirst({
-        where: (table, { eq }) => eq(table.authUserId, validatedAuthUserId),
-        with: {
-          organizationUsers: true,
-        },
-      });
+    const dbUser = await db._query.users.findFirst({
+      where: (table, { eq }) => eq(table.authUserId, validatedAuthUserId),
+      with: {
+        organizationUsers: true,
+      },
+    });
 
-      if (!dbUser) {
-        return null;
-      }
-
-      // Backwards compatibility: migrate lastOrgId to currentProfileId if needed
-      if (dbUser.lastOrgId && !dbUser.currentProfileId) {
-        try {
-          const [org] = await db
-            .select({ profileId: organizations.profileId })
-            .from(organizations)
-            .where(eq(organizations.id, dbUser.lastOrgId))
-            .limit(1);
-
-          if (org) {
-            // Update the user with the profile ID
-            await db
-              .update(users)
-              .set({ currentProfileId: org.profileId })
-              .where(eq(users.authUserId, validatedAuthUserId));
-
-            // Return the updated user object
-            return { user: { ...dbUser, currentProfileId: org.profileId } };
-          }
-        } catch (migrationError) {
-          console.error('Migration error:', migrationError);
-          // Continue with the original user object if migration fails
-        }
-      }
-
-      return { user: dbUser };
-    } catch (error) {
-      console.error('ERROR');
+    if (!dbUser) {
       return null;
     }
+
+    // Backwards compatibility: migrate lastOrgId to currentProfileId if needed
+    if (dbUser.lastOrgId && !dbUser.currentProfileId) {
+      try {
+        const [org] = await db
+          .select({ profileId: organizations.profileId })
+          .from(organizations)
+          .where(eq(organizations.id, dbUser.lastOrgId))
+          .limit(1);
+
+        if (org) {
+          // Update the user with the profile ID
+          await db
+            .update(users)
+            .set({ currentProfileId: org.profileId })
+            .where(eq(users.authUserId, validatedAuthUserId));
+
+          // Return the updated user object
+          return { user: { ...dbUser, currentProfileId: org.profileId } };
+        }
+      } catch (migrationError) {
+        console.error('Migration error:', migrationError);
+        // Continue with the original user object if migration fails
+      }
+    }
+
+    return { user: dbUser };
   },
   ({ authUserId }) => authUserId,
 );

--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -8,7 +8,7 @@ import { checkPermission } from 'access-zones';
 import { z } from 'zod';
 
 import { UnauthorizedError } from '../../utils/error';
-import { memoRequest } from './requestCache';
+import { memoize } from './requestCache';
 import { type RoleJunction, getNormalizedRoles } from './utils';
 
 type OrgUserWithNormalizedRoles = {
@@ -30,14 +30,14 @@ type ProfileUserWithNormalizedRoles = ProfileUser & {
 };
 
 // gets a user assuming that the user is authenticated
-export const getOrgAccessUser = async ({
-  user,
-  organizationId,
-}: {
-  user: { id: string };
-  organizationId: string;
-}): Promise<OrgUserWithNormalizedRoles | undefined> =>
-  memoRequest(`orgUser:${organizationId}:${user.id}`, async () => {
+export const getOrgAccessUser = memoize(
+  async ({
+    user,
+    organizationId,
+  }: {
+    user: { id: string };
+    organizationId: string;
+  }): Promise<OrgUserWithNormalizedRoles | undefined> => {
     const getOrgUser = async () => {
       const orgUser = await db._query.organizationUsers.findFirst({
         where: (table, { eq }) =>
@@ -89,17 +89,19 @@ export const getOrgAccessUser = async ({
         skipMemCache: true,
       },
     });
-  });
+  },
+  ({ user, organizationId }) => `${user.id}:${organizationId}`,
+);
 
 // gets a user's access for a specific profile
-export const getProfileAccessUser = async ({
-  user,
-  profileId,
-}: {
-  user: { id: string };
-  profileId: string;
-}): Promise<ProfileUserWithNormalizedRoles | undefined> =>
-  memoRequest(`profileUser:${profileId}:${user.id}`, async () => {
+export const getProfileAccessUser = memoize(
+  async ({
+    user,
+    profileId,
+  }: {
+    user: { id: string };
+    profileId: string;
+  }): Promise<ProfileUserWithNormalizedRoles | undefined> => {
     const profileUser = await db._query.profileUsers.findFirst({
       where: (table, { eq }) =>
         and(eq(table.profileId, profileId), eq(table.authUserId, user.id)),
@@ -137,7 +139,9 @@ export const getProfileAccessUser = async ({
       profile: profileUser.profile as Profile,
       roles: normalizedRoles,
     };
-  });
+  },
+  ({ user, profileId }) => `${user.id}:${profileId}`,
+);
 
 /**
  * Asserts profile-level access, falling back to org-level access if the user
@@ -323,14 +327,10 @@ export const validateAuthUserId = (authUserId: string | undefined) => {
  * Gets user session data by authUserId (database-only, no Supabase auth)
  * Used internally
  */
-export const getUserSession = async ({
-  authUserId,
-}: {
-  authUserId: string;
-}) => {
-  const validatedAuthUserId = validateAuthUserId(authUserId);
+export const getUserSession = memoize(
+  async ({ authUserId }: { authUserId: string }) => {
+    const validatedAuthUserId = validateAuthUserId(authUserId);
 
-  return memoRequest(`userSession:${validatedAuthUserId}`, async () => {
     try {
       const dbUser = await db._query.users.findFirst({
         where: (table, { eq }) => eq(table.authUserId, validatedAuthUserId),
@@ -373,8 +373,9 @@ export const getUserSession = async ({
       console.error('ERROR');
       return null;
     }
-  });
-};
+  },
+  ({ authUserId }) => authUserId,
+);
 
 export * from './assertProfileTypeAccess';
 export * from './getRoles';

--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -8,6 +8,7 @@ import { checkPermission } from 'access-zones';
 import { z } from 'zod';
 
 import { UnauthorizedError } from '../../utils/error';
+import { memoRequest } from './requestCache';
 import { type RoleJunction, getNormalizedRoles } from './utils';
 
 type OrgUserWithNormalizedRoles = {
@@ -35,15 +36,75 @@ export const getOrgAccessUser = async ({
 }: {
   user: { id: string };
   organizationId: string;
-}): Promise<OrgUserWithNormalizedRoles | undefined> => {
-  const getOrgUser = async () => {
-    const orgUser = await db._query.organizationUsers.findFirst({
+}): Promise<OrgUserWithNormalizedRoles | undefined> =>
+  memoRequest(`orgUser:${organizationId}:${user.id}`, async () => {
+    const getOrgUser = async () => {
+      const orgUser = await db._query.organizationUsers.findFirst({
+        where: (table, { eq }) =>
+          and(
+            eq(table.organizationId, organizationId),
+            eq(table.authUserId, user.id),
+          ),
+        with: {
+          roles: {
+            with: {
+              accessRole: {
+                with: {
+                  zonePermissions: {
+                    with: {
+                      accessZone: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!orgUser) {
+        return;
+      }
+
+      // Transform the relational data into normalized format for access-zones library
+      // Type assertion needed because Drizzle query result type is complex but we know it has the right structure
+      const normalizedRoles = getNormalizedRoles(
+        orgUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
+      );
+
+      const { roles: _, ...orgUserWithoutRoles } = orgUser;
+
+      // Replace roles with normalized format
+      return {
+        ...orgUserWithoutRoles,
+        roles: normalizedRoles,
+      };
+    };
+
+    return cache({
+      type: 'orgUser',
+      params: [organizationId, user.id],
+      fetch: getOrgUser,
+      options: {
+        skipMemCache: true,
+      },
+    });
+  });
+
+// gets a user's access for a specific profile
+export const getProfileAccessUser = async ({
+  user,
+  profileId,
+}: {
+  user: { id: string };
+  profileId: string;
+}): Promise<ProfileUserWithNormalizedRoles | undefined> =>
+  memoRequest(`profileUser:${profileId}:${user.id}`, async () => {
+    const profileUser = await db._query.profileUsers.findFirst({
       where: (table, { eq }) =>
-        and(
-          eq(table.organizationId, organizationId),
-          eq(table.authUserId, user.id),
-        ),
+        and(eq(table.profileId, profileId), eq(table.authUserId, user.id)),
       with: {
+        profile: true,
         roles: {
           with: {
             accessRole: {
@@ -60,81 +121,23 @@ export const getOrgAccessUser = async ({
       },
     });
 
-    if (!orgUser) {
-      return;
+    if (!profileUser) {
+      return undefined;
     }
 
     // Transform the relational data into normalized format for access-zones library
     // Type assertion needed because Drizzle query result type is complex but we know it has the right structure
     const normalizedRoles = getNormalizedRoles(
-      orgUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
+      profileUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
     );
 
-    const { roles: _, ...orgUserWithoutRoles } = orgUser;
-
-    // Replace roles with normalized format
+    const { roles: _, ...profileUserWithoutRoles } = profileUser;
     return {
-      ...orgUserWithoutRoles,
+      ...profileUserWithoutRoles,
+      profile: profileUser.profile as Profile,
       roles: normalizedRoles,
     };
-  };
-
-  return cache({
-    type: 'orgUser',
-    params: [organizationId, user.id],
-    fetch: getOrgUser,
-    options: {
-      skipMemCache: true,
-    },
   });
-};
-
-// gets a user's access for a specific profile
-export const getProfileAccessUser = async ({
-  user,
-  profileId,
-}: {
-  user: { id: string };
-  profileId: string;
-}): Promise<ProfileUserWithNormalizedRoles | undefined> => {
-  const profileUser = await db._query.profileUsers.findFirst({
-    where: (table, { eq }) =>
-      and(eq(table.profileId, profileId), eq(table.authUserId, user.id)),
-    with: {
-      profile: true,
-      roles: {
-        with: {
-          accessRole: {
-            with: {
-              zonePermissions: {
-                with: {
-                  accessZone: true,
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  });
-
-  if (!profileUser) {
-    return undefined;
-  }
-
-  // Transform the relational data into normalized format for access-zones library
-  // Type assertion needed because Drizzle query result type is complex but we know it has the right structure
-  const normalizedRoles = getNormalizedRoles(
-    profileUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
-  );
-
-  const { roles: _, ...profileUserWithoutRoles } = profileUser;
-  return {
-    ...profileUserWithoutRoles,
-    profile: profileUser.profile as Profile,
-    roles: normalizedRoles,
-  };
-};
 
 /**
  * Asserts profile-level access, falling back to org-level access if the user
@@ -327,52 +330,55 @@ export const getUserSession = async ({
 }) => {
   const validatedAuthUserId = validateAuthUserId(authUserId);
 
-  try {
-    const dbUser = await db._query.users.findFirst({
-      where: (table, { eq }) => eq(table.authUserId, validatedAuthUserId),
-      with: {
-        organizationUsers: true,
-      },
-    });
+  return memoRequest(`userSession:${validatedAuthUserId}`, async () => {
+    try {
+      const dbUser = await db._query.users.findFirst({
+        where: (table, { eq }) => eq(table.authUserId, validatedAuthUserId),
+        with: {
+          organizationUsers: true,
+        },
+      });
 
-    if (!dbUser) {
+      if (!dbUser) {
+        return null;
+      }
+
+      // Backwards compatibility: migrate lastOrgId to currentProfileId if needed
+      if (dbUser.lastOrgId && !dbUser.currentProfileId) {
+        try {
+          const [org] = await db
+            .select({ profileId: organizations.profileId })
+            .from(organizations)
+            .where(eq(organizations.id, dbUser.lastOrgId))
+            .limit(1);
+
+          if (org) {
+            // Update the user with the profile ID
+            await db
+              .update(users)
+              .set({ currentProfileId: org.profileId })
+              .where(eq(users.authUserId, validatedAuthUserId));
+
+            // Return the updated user object
+            return { user: { ...dbUser, currentProfileId: org.profileId } };
+          }
+        } catch (migrationError) {
+          console.error('Migration error:', migrationError);
+          // Continue with the original user object if migration fails
+        }
+      }
+
+      return { user: dbUser };
+    } catch (error) {
+      console.error('ERROR');
       return null;
     }
-
-    // Backwards compatibility: migrate lastOrgId to currentProfileId if needed
-    if (dbUser.lastOrgId && !dbUser.currentProfileId) {
-      try {
-        const [org] = await db
-          .select({ profileId: organizations.profileId })
-          .from(organizations)
-          .where(eq(organizations.id, dbUser.lastOrgId))
-          .limit(1);
-
-        if (org) {
-          // Update the user with the profile ID
-          await db
-            .update(users)
-            .set({ currentProfileId: org.profileId })
-            .where(eq(users.authUserId, validatedAuthUserId));
-
-          // Return the updated user object
-          return { user: { ...dbUser, currentProfileId: org.profileId } };
-        }
-      } catch (migrationError) {
-        console.error('Migration error:', migrationError);
-        // Continue with the original user object if migration fails
-      }
-    }
-
-    return { user: dbUser };
-  } catch (error) {
-    console.error('ERROR');
-    return null;
-  }
+  });
 };
 
 export * from './assertProfileTypeAccess';
 export * from './getRoles';
 export * from './permissions';
+export * from './requestCache';
 export * from './utils';
 export * from './platformAdmin';

--- a/packages/common/src/services/access/requestCache.test.ts
+++ b/packages/common/src/services/access/requestCache.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  invalidateRequest,
+  memoRequest,
+  runWithRequestCache,
+} from './requestCache';
+
+describe('requestCache', () => {
+  describe('isolation between requests', () => {
+    it('does not leak entries across separate runWithRequestCache scopes', async () => {
+      const fetcher = vi.fn(async () => 'value');
+
+      await runWithRequestCache(async () => {
+        await memoRequest('k', fetcher);
+        await memoRequest('k', fetcher);
+      });
+
+      await runWithRequestCache(async () => {
+        await memoRequest('k', fetcher);
+      });
+
+      // first scope: 1 call (dedup); second scope: fresh fetch → 2 total
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('isolates concurrent requests', async () => {
+      const seen: string[] = [];
+      const fetcherA = vi.fn(async () => {
+        seen.push('A');
+        return 'A';
+      });
+      const fetcherB = vi.fn(async () => {
+        seen.push('B');
+        return 'B';
+      });
+
+      await Promise.all([
+        runWithRequestCache(async () => {
+          const v1 = await memoRequest('shared-key', fetcherA);
+          const v2 = await memoRequest('shared-key', fetcherA);
+          expect(v1).toBe('A');
+          expect(v2).toBe('A');
+        }),
+        runWithRequestCache(async () => {
+          const v1 = await memoRequest('shared-key', fetcherB);
+          const v2 = await memoRequest('shared-key', fetcherB);
+          expect(v1).toBe('B');
+          expect(v2).toBe('B');
+        }),
+      ]);
+
+      // Each scope dedups internally — should be 1 call each, NOT cross-contaminated
+      expect(fetcherA).toHaveBeenCalledTimes(1);
+      expect(fetcherB).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('rejection handling (no poisoning)', () => {
+    it('drops the entry when the fetcher rejects so the next caller retries', async () => {
+      let attempt = 0;
+      const fetcher = vi.fn(async () => {
+        attempt += 1;
+        if (attempt === 1) {
+          throw new Error('transient');
+        }
+        return 'ok';
+      });
+
+      await runWithRequestCache(async () => {
+        await expect(memoRequest('k', fetcher)).rejects.toThrow('transient');
+        const value = await memoRequest('k', fetcher);
+        expect(value).toBe('ok');
+      });
+
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not allow a poisoned rejected promise to be returned to other keys', async () => {
+      const fetcher = vi.fn(async (key: string) => {
+        if (key === 'bad') {
+          throw new Error('bad key');
+        }
+        return `value-${key}`;
+      });
+
+      await runWithRequestCache(async () => {
+        await expect(memoRequest('bad', () => fetcher('bad'))).rejects.toThrow(
+          'bad key',
+        );
+        const good = await memoRequest('good', () => fetcher('good'));
+        expect(good).toBe('value-good');
+      });
+    });
+
+    it('shares the same in-flight rejection among concurrent callers but lets later ones retry', async () => {
+      const fetcher = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce('recovered');
+
+      await runWithRequestCache(async () => {
+        const [r1, r2] = await Promise.allSettled([
+          memoRequest('k', fetcher),
+          memoRequest('k', fetcher),
+        ]);
+        expect(r1.status).toBe('rejected');
+        expect(r2.status).toBe('rejected');
+        // Both concurrent callers should have received the same in-flight rejection
+        expect(fetcher).toHaveBeenCalledTimes(1);
+
+        const retry = await memoRequest('k', fetcher);
+        expect(retry).toBe('recovered');
+        expect(fetcher).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('key separation', () => {
+    it('does not return one key’s value for another key', async () => {
+      await runWithRequestCache(async () => {
+        const a = await memoRequest('a', async () => 'value-a');
+        const b = await memoRequest('b', async () => 'value-b');
+        expect(a).toBe('value-a');
+        expect(b).toBe('value-b');
+      });
+    });
+  });
+
+  describe('invalidation', () => {
+    it('refetches after invalidateRequest by exact key', async () => {
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce('v1')
+        .mockResolvedValueOnce('v2');
+
+      await runWithRequestCache(async () => {
+        expect(await memoRequest('profileUser:p1:u1', fetcher)).toBe('v1');
+        invalidateRequest('profileUser:p1:u1');
+        expect(await memoRequest('profileUser:p1:u1', fetcher)).toBe('v2');
+      });
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('only invalidates keys matching the prefix', async () => {
+      const fetcher = vi.fn(async (k: string) => `v-${k}`);
+
+      await runWithRequestCache(async () => {
+        await memoRequest('profileUser:p1:u1', () =>
+          fetcher('profileUser:p1:u1'),
+        );
+        await memoRequest('profileUser:p1:u2', () =>
+          fetcher('profileUser:p1:u2'),
+        );
+        await memoRequest('orgUser:o1:u1', () => fetcher('orgUser:o1:u1'));
+
+        invalidateRequest('profileUser:p1:u1');
+
+        // Re-call all three: only p1:u1 should refetch
+        await memoRequest('profileUser:p1:u1', () =>
+          fetcher('profileUser:p1:u1'),
+        );
+        await memoRequest('profileUser:p1:u2', () =>
+          fetcher('profileUser:p1:u2'),
+        );
+        await memoRequest('orgUser:o1:u1', () => fetcher('orgUser:o1:u1'));
+      });
+
+      // 3 initial + 1 refetch for p1:u1 = 4
+      expect(fetcher).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe('out-of-scope behavior', () => {
+    it('runs the fetcher every call when not inside runWithRequestCache', async () => {
+      const fetcher = vi.fn(async () => 'x');
+      await memoRequest('k', fetcher);
+      await memoRequest('k', fetcher);
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidateRequest is a no-op outside a scope', () => {
+      expect(() => invalidateRequest('anything')).not.toThrow();
+    });
+  });
+});

--- a/packages/common/src/services/access/requestCache.test.ts
+++ b/packages/common/src/services/access/requestCache.test.ts
@@ -23,6 +23,39 @@ describe('memoize / requestCache', () => {
       expect(fetcher).toHaveBeenCalledTimes(2);
     });
 
+    it('shares the in-flight promise between concurrent same-key callers', async () => {
+      const fetcher = vi.fn(async (k: string) => `value-${k}`);
+      const memoFetcher = memoize(fetcher, byArg);
+
+      await runWithRequestCache(async () => {
+        const [v1, v2] = await Promise.all([
+          memoFetcher('k'),
+          memoFetcher('k'),
+        ]);
+        expect(v1).toBe('value-k');
+        expect(v2).toBe('value-k');
+        expect(fetcher).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('nested runWithRequestCache creates an isolated inner scope', async () => {
+      const fetcher = vi.fn(async (k: string) => `value-${k}`);
+      const memoFetcher = memoize(fetcher, byArg);
+
+      await runWithRequestCache(async () => {
+        await memoFetcher('k'); // outer fetch #1
+
+        await runWithRequestCache(async () => {
+          await memoFetcher('k'); // inner fetch #2 (separate scope)
+          await memoFetcher('k'); // inner cache hit
+        });
+
+        await memoFetcher('k'); // outer cache hit (still cached from #1)
+      });
+
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
     it('isolates concurrent requests with the same key', async () => {
       const fetcherA = vi.fn(async (_k: string) => 'A');
       const fetcherB = vi.fn(async (_k: string) => 'B');
@@ -196,6 +229,34 @@ describe('memoize / requestCache', () => {
       });
 
       expect(fetcher).toHaveBeenCalledTimes(4);
+    });
+
+    it('invalidate during an in-flight fetch does not evict a later entry', async () => {
+      let rejectFirst: (e: Error) => void = () => {};
+      const firstPromise = new Promise<string>((_res, rej) => {
+        rejectFirst = rej;
+      });
+
+      const fetcher = vi
+        .fn<(k: string) => Promise<string>>()
+        .mockReturnValueOnce(firstPromise)
+        .mockResolvedValueOnce('second')
+        .mockResolvedValueOnce('third');
+      const memoFetcher = memoize(fetcher, byArg);
+
+      await runWithRequestCache(async () => {
+        const p1 = memoFetcher('k'); // in-flight, pending
+        memoFetcher.invalidate('k');
+
+        expect(await memoFetcher('k')).toBe('second');
+
+        rejectFirst(new Error('late'));
+        await expect(p1).rejects.toThrow('late');
+
+        // p1's late rejection must NOT delete the 'second' entry.
+        expect(await memoFetcher('k')).toBe('second');
+        expect(fetcher).toHaveBeenCalledTimes(2);
+      });
     });
 
     it('invalidate and invalidateAll are no-ops outside a scope', () => {

--- a/packages/common/src/services/access/requestCache.test.ts
+++ b/packages/common/src/services/access/requestCache.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { memoize, runWithRequestCache } from './requestCache';
 
+const byArg = (s: string) => s;
+const constant = () => '';
+
 describe('memoize / requestCache', () => {
   describe('isolation between requests', () => {
     it('does not leak entries across separate runWithRequestCache scopes', async () => {
       const fetcher = vi.fn(async (_id: string) => 'value');
-      const memoFetcher = memoize(fetcher);
+      const memoFetcher = memoize(fetcher, byArg);
 
       await runWithRequestCache(async () => {
         await memoFetcher('k');
@@ -21,10 +24,10 @@ describe('memoize / requestCache', () => {
     });
 
     it('isolates concurrent requests with the same key', async () => {
-      const fetcherA = vi.fn(async () => 'A');
-      const fetcherB = vi.fn(async () => 'B');
-      const memoA = memoize(fetcherA);
-      const memoB = memoize(fetcherB);
+      const fetcherA = vi.fn(async (_k: string) => 'A');
+      const fetcherB = vi.fn(async (_k: string) => 'B');
+      const memoA = memoize(fetcherA, byArg);
+      const memoB = memoize(fetcherB, byArg);
 
       await Promise.all([
         runWithRequestCache(async () => {
@@ -45,14 +48,14 @@ describe('memoize / requestCache', () => {
   describe('rejection handling (no poisoning)', () => {
     it('drops the entry when the fetcher rejects so the next caller retries', async () => {
       let attempt = 0;
-      const fetcher = vi.fn(async () => {
+      const fetcher = vi.fn(async (_k: string) => {
         attempt += 1;
         if (attempt === 1) {
           throw new Error('transient');
         }
         return 'ok';
       });
-      const memoFetcher = memoize(fetcher);
+      const memoFetcher = memoize(fetcher, byArg);
 
       await runWithRequestCache(async () => {
         await expect(memoFetcher('k')).rejects.toThrow('transient');
@@ -69,7 +72,7 @@ describe('memoize / requestCache', () => {
         }
         return `value-${key}`;
       });
-      const memoFetcher = memoize(fetcher);
+      const memoFetcher = memoize(fetcher, byArg);
 
       await runWithRequestCache(async () => {
         await expect(memoFetcher('bad')).rejects.toThrow('bad key');
@@ -79,10 +82,10 @@ describe('memoize / requestCache', () => {
 
     it('shares the in-flight rejection but allows later retries', async () => {
       const fetcher = vi
-        .fn()
+        .fn<(k: string) => Promise<string>>()
         .mockRejectedValueOnce(new Error('boom'))
         .mockResolvedValueOnce('recovered');
-      const memoFetcher = memoize(fetcher);
+      const memoFetcher = memoize(fetcher, byArg);
 
       await runWithRequestCache(async () => {
         const [r1, r2] = await Promise.allSettled([
@@ -124,22 +127,9 @@ describe('memoize / requestCache', () => {
       expect(fetcher).toHaveBeenCalledTimes(1);
     });
 
-    it('default keyFn stable-stringifies args (order-insensitive for object keys)', async () => {
-      const fetcher = vi.fn(async (_args: Record<string, string>) => 'v');
-      const memoFetcher = memoize(fetcher);
-
-      await runWithRequestCache(async () => {
-        await memoFetcher({ a: '1', b: '2' });
-        // Different key order, same values
-        await memoFetcher({ b: '2', a: '1' });
-      });
-
-      expect(fetcher).toHaveBeenCalledTimes(1);
-    });
-
     it('distinct keys do not collide', async () => {
       const fetcher = vi.fn(async (id: string) => `value-${id}`);
-      const memoFetcher = memoize(fetcher);
+      const memoFetcher = memoize(fetcher, byArg);
 
       await runWithRequestCache(async () => {
         expect(await memoFetcher('a')).toBe('value-a');
@@ -166,10 +156,10 @@ describe('memoize / requestCache', () => {
   describe('invalidate', () => {
     it('invalidate(args) drops the entry for that key and refetches next time', async () => {
       const fetcher = vi
-        .fn()
+        .fn<(k: string) => Promise<string>>()
         .mockResolvedValueOnce('v1')
         .mockResolvedValueOnce('v2');
-      const memoFetcher = memoize(fetcher);
+      const memoFetcher = memoize(fetcher, byArg);
 
       await runWithRequestCache(async () => {
         expect(await memoFetcher('k')).toBe('v1');
@@ -180,7 +170,7 @@ describe('memoize / requestCache', () => {
 
     it('invalidate only drops matching keys', async () => {
       const fetcher = vi.fn(async (id: string) => `v-${id}`);
-      const memoFetcher = memoize(fetcher);
+      const memoFetcher = memoize(fetcher, byArg);
 
       await runWithRequestCache(async () => {
         await memoFetcher('a');
@@ -195,7 +185,7 @@ describe('memoize / requestCache', () => {
 
     it('invalidateAll clears every entry for the memoized fn', async () => {
       const fetcher = vi.fn(async (id: string) => `v-${id}`);
-      const memoFetcher = memoize(fetcher);
+      const memoFetcher = memoize(fetcher, byArg);
 
       await runWithRequestCache(async () => {
         await memoFetcher('a');
@@ -209,7 +199,7 @@ describe('memoize / requestCache', () => {
     });
 
     it('invalidate and invalidateAll are no-ops outside a scope', () => {
-      const memoFetcher = memoize(async () => 'x');
+      const memoFetcher = memoize(async () => 'x', constant);
       expect(() => memoFetcher.invalidate()).not.toThrow();
       expect(() => memoFetcher.invalidateAll()).not.toThrow();
     });
@@ -218,7 +208,7 @@ describe('memoize / requestCache', () => {
   describe('out-of-scope behavior', () => {
     it('runs the fetcher every call when not inside runWithRequestCache', async () => {
       const fetcher = vi.fn(async () => 'x');
-      const memoFetcher = memoize(fetcher);
+      const memoFetcher = memoize(fetcher, constant);
 
       await memoFetcher();
       await memoFetcher();

--- a/packages/common/src/services/access/requestCache.test.ts
+++ b/packages/common/src/services/access/requestCache.test.ts
@@ -1,56 +1,42 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  invalidateRequest,
-  memoRequest,
-  runWithRequestCache,
-} from './requestCache';
+import { memoize, runWithRequestCache } from './requestCache';
 
-describe('requestCache', () => {
+describe('memoize / requestCache', () => {
   describe('isolation between requests', () => {
     it('does not leak entries across separate runWithRequestCache scopes', async () => {
-      const fetcher = vi.fn(async () => 'value');
+      const fetcher = vi.fn(async (_id: string) => 'value');
+      const memoFetcher = memoize(fetcher);
 
       await runWithRequestCache(async () => {
-        await memoRequest('k', fetcher);
-        await memoRequest('k', fetcher);
+        await memoFetcher('k');
+        await memoFetcher('k');
       });
 
       await runWithRequestCache(async () => {
-        await memoRequest('k', fetcher);
+        await memoFetcher('k');
       });
 
-      // first scope: 1 call (dedup); second scope: fresh fetch → 2 total
       expect(fetcher).toHaveBeenCalledTimes(2);
     });
 
-    it('isolates concurrent requests', async () => {
-      const seen: string[] = [];
-      const fetcherA = vi.fn(async () => {
-        seen.push('A');
-        return 'A';
-      });
-      const fetcherB = vi.fn(async () => {
-        seen.push('B');
-        return 'B';
-      });
+    it('isolates concurrent requests with the same key', async () => {
+      const fetcherA = vi.fn(async () => 'A');
+      const fetcherB = vi.fn(async () => 'B');
+      const memoA = memoize(fetcherA);
+      const memoB = memoize(fetcherB);
 
       await Promise.all([
         runWithRequestCache(async () => {
-          const v1 = await memoRequest('shared-key', fetcherA);
-          const v2 = await memoRequest('shared-key', fetcherA);
-          expect(v1).toBe('A');
-          expect(v2).toBe('A');
+          expect(await memoA('shared')).toBe('A');
+          expect(await memoA('shared')).toBe('A');
         }),
         runWithRequestCache(async () => {
-          const v1 = await memoRequest('shared-key', fetcherB);
-          const v2 = await memoRequest('shared-key', fetcherB);
-          expect(v1).toBe('B');
-          expect(v2).toBe('B');
+          expect(await memoB('shared')).toBe('B');
+          expect(await memoB('shared')).toBe('B');
         }),
       ]);
 
-      // Each scope dedups internally — should be 1 call each, NOT cross-contaminated
       expect(fetcherA).toHaveBeenCalledTimes(1);
       expect(fetcherB).toHaveBeenCalledTimes(1);
     });
@@ -66,121 +52,177 @@ describe('requestCache', () => {
         }
         return 'ok';
       });
+      const memoFetcher = memoize(fetcher);
 
       await runWithRequestCache(async () => {
-        await expect(memoRequest('k', fetcher)).rejects.toThrow('transient');
-        const value = await memoRequest('k', fetcher);
-        expect(value).toBe('ok');
+        await expect(memoFetcher('k')).rejects.toThrow('transient');
+        expect(await memoFetcher('k')).toBe('ok');
       });
 
       expect(fetcher).toHaveBeenCalledTimes(2);
     });
 
-    it('does not allow a poisoned rejected promise to be returned to other keys', async () => {
+    it('does not let a poisoned rejected promise leak to other keys', async () => {
       const fetcher = vi.fn(async (key: string) => {
         if (key === 'bad') {
           throw new Error('bad key');
         }
         return `value-${key}`;
       });
+      const memoFetcher = memoize(fetcher);
 
       await runWithRequestCache(async () => {
-        await expect(memoRequest('bad', () => fetcher('bad'))).rejects.toThrow(
-          'bad key',
-        );
-        const good = await memoRequest('good', () => fetcher('good'));
-        expect(good).toBe('value-good');
+        await expect(memoFetcher('bad')).rejects.toThrow('bad key');
+        expect(await memoFetcher('good')).toBe('value-good');
       });
     });
 
-    it('shares the same in-flight rejection among concurrent callers but lets later ones retry', async () => {
+    it('shares the in-flight rejection but allows later retries', async () => {
       const fetcher = vi
         .fn()
         .mockRejectedValueOnce(new Error('boom'))
         .mockResolvedValueOnce('recovered');
+      const memoFetcher = memoize(fetcher);
 
       await runWithRequestCache(async () => {
         const [r1, r2] = await Promise.allSettled([
-          memoRequest('k', fetcher),
-          memoRequest('k', fetcher),
+          memoFetcher('k'),
+          memoFetcher('k'),
         ]);
         expect(r1.status).toBe('rejected');
         expect(r2.status).toBe('rejected');
-        // Both concurrent callers should have received the same in-flight rejection
         expect(fetcher).toHaveBeenCalledTimes(1);
 
-        const retry = await memoRequest('k', fetcher);
-        expect(retry).toBe('recovered');
+        expect(await memoFetcher('k')).toBe('recovered');
         expect(fetcher).toHaveBeenCalledTimes(2);
       });
     });
   });
 
-  describe('key separation', () => {
-    it('does not return one key’s value for another key', async () => {
+  describe('key derivation', () => {
+    it('uses the keyFn to dedupe across differently-shaped args with the same identity', async () => {
+      const fetcher = vi.fn(
+        async (_args: {
+          user: { id: string; extra?: string };
+          profileId: string;
+        }) => 'v',
+      );
+      const memoFetcher = memoize(
+        fetcher,
+        ({ user, profileId }) => `${user.id}:${profileId}`,
+      );
+
       await runWithRequestCache(async () => {
-        const a = await memoRequest('a', async () => 'value-a');
-        const b = await memoRequest('b', async () => 'value-b');
-        expect(a).toBe('value-a');
-        expect(b).toBe('value-b');
+        await memoFetcher({ user: { id: 'u1' }, profileId: 'p1' });
+        // Different shape (extra field), same identity → should be a cache hit
+        await memoFetcher({
+          user: { id: 'u1', extra: 'unrelated' },
+          profileId: 'p1',
+        });
       });
+
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('default keyFn stable-stringifies args (order-insensitive for object keys)', async () => {
+      const fetcher = vi.fn(async (_args: Record<string, string>) => 'v');
+      const memoFetcher = memoize(fetcher);
+
+      await runWithRequestCache(async () => {
+        await memoFetcher({ a: '1', b: '2' });
+        // Different key order, same values
+        await memoFetcher({ b: '2', a: '1' });
+      });
+
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('distinct keys do not collide', async () => {
+      const fetcher = vi.fn(async (id: string) => `value-${id}`);
+      const memoFetcher = memoize(fetcher);
+
+      await runWithRequestCache(async () => {
+        expect(await memoFetcher('a')).toBe('value-a');
+        expect(await memoFetcher('b')).toBe('value-b');
+      });
+    });
+
+    it('different memoize instances are isolated even with identical keyFns', async () => {
+      const fA = vi.fn(async () => 'A');
+      const fB = vi.fn(async () => 'B');
+      const memoA = memoize(fA, () => 'k');
+      const memoB = memoize(fB, () => 'k');
+
+      await runWithRequestCache(async () => {
+        expect(await memoA()).toBe('A');
+        expect(await memoB()).toBe('B');
+      });
+
+      expect(fA).toHaveBeenCalledTimes(1);
+      expect(fB).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('invalidation', () => {
-    it('refetches after invalidateRequest by exact key', async () => {
+  describe('invalidate', () => {
+    it('invalidate(args) drops the entry for that key and refetches next time', async () => {
       const fetcher = vi
         .fn()
         .mockResolvedValueOnce('v1')
         .mockResolvedValueOnce('v2');
+      const memoFetcher = memoize(fetcher);
 
       await runWithRequestCache(async () => {
-        expect(await memoRequest('profileUser:p1:u1', fetcher)).toBe('v1');
-        invalidateRequest('profileUser:p1:u1');
-        expect(await memoRequest('profileUser:p1:u1', fetcher)).toBe('v2');
+        expect(await memoFetcher('k')).toBe('v1');
+        memoFetcher.invalidate('k');
+        expect(await memoFetcher('k')).toBe('v2');
       });
-      expect(fetcher).toHaveBeenCalledTimes(2);
     });
 
-    it('only invalidates keys matching the prefix', async () => {
-      const fetcher = vi.fn(async (k: string) => `v-${k}`);
+    it('invalidate only drops matching keys', async () => {
+      const fetcher = vi.fn(async (id: string) => `v-${id}`);
+      const memoFetcher = memoize(fetcher);
 
       await runWithRequestCache(async () => {
-        await memoRequest('profileUser:p1:u1', () =>
-          fetcher('profileUser:p1:u1'),
-        );
-        await memoRequest('profileUser:p1:u2', () =>
-          fetcher('profileUser:p1:u2'),
-        );
-        await memoRequest('orgUser:o1:u1', () => fetcher('orgUser:o1:u1'));
-
-        invalidateRequest('profileUser:p1:u1');
-
-        // Re-call all three: only p1:u1 should refetch
-        await memoRequest('profileUser:p1:u1', () =>
-          fetcher('profileUser:p1:u1'),
-        );
-        await memoRequest('profileUser:p1:u2', () =>
-          fetcher('profileUser:p1:u2'),
-        );
-        await memoRequest('orgUser:o1:u1', () => fetcher('orgUser:o1:u1'));
+        await memoFetcher('a');
+        await memoFetcher('b');
+        memoFetcher.invalidate('a');
+        await memoFetcher('a'); // refetch
+        await memoFetcher('b'); // cached
       });
 
-      // 3 initial + 1 refetch for p1:u1 = 4
+      expect(fetcher).toHaveBeenCalledTimes(3);
+    });
+
+    it('invalidateAll clears every entry for the memoized fn', async () => {
+      const fetcher = vi.fn(async (id: string) => `v-${id}`);
+      const memoFetcher = memoize(fetcher);
+
+      await runWithRequestCache(async () => {
+        await memoFetcher('a');
+        await memoFetcher('b');
+        memoFetcher.invalidateAll();
+        await memoFetcher('a');
+        await memoFetcher('b');
+      });
+
       expect(fetcher).toHaveBeenCalledTimes(4);
+    });
+
+    it('invalidate and invalidateAll are no-ops outside a scope', () => {
+      const memoFetcher = memoize(async () => 'x');
+      expect(() => memoFetcher.invalidate()).not.toThrow();
+      expect(() => memoFetcher.invalidateAll()).not.toThrow();
     });
   });
 
   describe('out-of-scope behavior', () => {
     it('runs the fetcher every call when not inside runWithRequestCache', async () => {
       const fetcher = vi.fn(async () => 'x');
-      await memoRequest('k', fetcher);
-      await memoRequest('k', fetcher);
-      expect(fetcher).toHaveBeenCalledTimes(2);
-    });
+      const memoFetcher = memoize(fetcher);
 
-    it('invalidateRequest is a no-op outside a scope', () => {
-      expect(() => invalidateRequest('anything')).not.toThrow();
+      await memoFetcher();
+      await memoFetcher();
+      expect(fetcher).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/common/src/services/access/requestCache.ts
+++ b/packages/common/src/services/access/requestCache.ts
@@ -1,40 +1,76 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-type Store = Map<string, Promise<unknown>>;
+type Sub = Map<string, Promise<unknown>>;
+type Store = WeakMap<object, Sub>;
 
 const als = new AsyncLocalStorage<Store>();
 
 export const runWithRequestCache = <T>(fn: () => T): T =>
-  als.run(new Map(), fn);
+  als.run(new WeakMap(), fn);
 
-const getStore = (): Store | undefined => als.getStore();
-
-export async function memoRequest<T>(
-  key: string,
-  fetcher: () => Promise<T>,
-): Promise<T> {
-  const store = getStore();
-  if (!store) {
-    return fetcher();
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'undefined';
   }
-  const hit = store.get(key);
-  if (hit) {
-    return hit as Promise<T>;
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
   }
-  const p = fetcher();
-  store.set(key, p);
-  p.catch(() => store.delete(key));
-  return p as Promise<T>;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(',')}}`;
 }
 
-export function invalidateRequest(prefix: string) {
-  const store = getStore();
-  if (!store) {
-    return;
-  }
-  for (const k of Array.from(store.keys())) {
-    if (k.startsWith(prefix)) {
-      store.delete(k);
+export interface MemoizedFn<TArgs extends unknown[], TReturn> {
+  (...args: TArgs): Promise<TReturn>;
+  invalidate(...args: TArgs): void;
+  invalidateAll(): void;
+}
+
+export function memoize<TArgs extends unknown[], TReturn>(
+  fn: (...args: TArgs) => Promise<TReturn>,
+  keyFn: (...args: TArgs) => string = (...args) => stableStringify(args),
+): MemoizedFn<TArgs, TReturn> {
+  const getSub = (): Sub | undefined => {
+    const store = als.getStore();
+    if (!store) {
+      return undefined;
     }
-  }
+    let sub = store.get(wrapped);
+    if (!sub) {
+      sub = new Map();
+      store.set(wrapped, sub);
+    }
+    return sub;
+  };
+
+  const wrapped = ((...args: TArgs) => {
+    const sub = getSub();
+    if (!sub) {
+      return fn(...args);
+    }
+    const key = keyFn(...args);
+    const hit = sub.get(key);
+    if (hit) {
+      return hit as Promise<TReturn>;
+    }
+    const p = fn(...args);
+    sub.set(key, p);
+    p.catch(() => sub.delete(key));
+    return p;
+  }) as MemoizedFn<TArgs, TReturn>;
+
+  wrapped.invalidate = (...args: TArgs) => {
+    const store = als.getStore();
+    const sub = store?.get(wrapped);
+    sub?.delete(keyFn(...args));
+  };
+
+  wrapped.invalidateAll = () => {
+    const store = als.getStore();
+    store?.get(wrapped)?.clear();
+  };
+
+  return wrapped;
 }

--- a/packages/common/src/services/access/requestCache.ts
+++ b/packages/common/src/services/access/requestCache.ts
@@ -38,7 +38,11 @@ export function memoize<TArgs extends unknown[], TReturn>(
 
     const promise = fn(...args);
     cache.set(key, promise);
-    promise.catch(() => cache.delete(key));
+    promise.catch(() => {
+      if (cache.get(key) === promise) {
+        cache.delete(key);
+      }
+    });
     return promise;
   };
 

--- a/packages/common/src/services/access/requestCache.ts
+++ b/packages/common/src/services/access/requestCache.ts
@@ -1,26 +1,10 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-type Sub = Map<string, Promise<unknown>>;
-type Store = WeakMap<object, Sub>;
-
-const als = new AsyncLocalStorage<Store>();
+type Cache = Map<string, Promise<unknown>>;
+const als = new AsyncLocalStorage<Map<symbol, Cache>>();
 
 export const runWithRequestCache = <T>(fn: () => T): T =>
-  als.run(new WeakMap(), fn);
-
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value) ?? 'undefined';
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(',')}]`;
-  }
-  const obj = value as Record<string, unknown>;
-  const keys = Object.keys(obj).sort();
-  return `{${keys
-    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
-    .join(',')}}`;
-}
+  als.run(new Map(), fn);
 
 export interface MemoizedFn<TArgs extends unknown[], TReturn> {
   (...args: TArgs): Promise<TReturn>;
@@ -30,47 +14,40 @@ export interface MemoizedFn<TArgs extends unknown[], TReturn> {
 
 export function memoize<TArgs extends unknown[], TReturn>(
   fn: (...args: TArgs) => Promise<TReturn>,
-  keyFn: (...args: TArgs) => string = (...args) => stableStringify(args),
+  keyFn: (...args: TArgs) => string,
 ): MemoizedFn<TArgs, TReturn> {
-  const getSub = (): Sub | undefined => {
+  const id = Symbol();
+
+  const call = (...args: TArgs): Promise<TReturn> => {
     const store = als.getStore();
     if (!store) {
-      return undefined;
-    }
-    let sub = store.get(wrapped);
-    if (!sub) {
-      sub = new Map();
-      store.set(wrapped, sub);
-    }
-    return sub;
-  };
-
-  const wrapped = ((...args: TArgs) => {
-    const sub = getSub();
-    if (!sub) {
       return fn(...args);
     }
-    const key = keyFn(...args);
-    const hit = sub.get(key);
-    if (hit) {
-      return hit as Promise<TReturn>;
+
+    let cache = store.get(id);
+    if (!cache) {
+      cache = new Map();
+      store.set(id, cache);
     }
-    const p = fn(...args);
-    sub.set(key, p);
-    p.catch(() => sub.delete(key));
-    return p;
-  }) as MemoizedFn<TArgs, TReturn>;
 
-  wrapped.invalidate = (...args: TArgs) => {
-    const store = als.getStore();
-    const sub = store?.get(wrapped);
-    sub?.delete(keyFn(...args));
+    const key = keyFn(...args);
+    const hit = cache.get(key) as Promise<TReturn> | undefined;
+    if (hit) {
+      return hit;
+    }
+
+    const promise = fn(...args);
+    cache.set(key, promise);
+    promise.catch(() => cache.delete(key));
+    return promise;
   };
 
-  wrapped.invalidateAll = () => {
-    const store = als.getStore();
-    store?.get(wrapped)?.clear();
-  };
-
-  return wrapped;
+  return Object.assign(call, {
+    invalidate: (...args: TArgs) =>
+      als
+        .getStore()
+        ?.get(id)
+        ?.delete(keyFn(...args)),
+    invalidateAll: () => als.getStore()?.get(id)?.clear(),
+  });
 }

--- a/packages/common/src/services/access/requestCache.ts
+++ b/packages/common/src/services/access/requestCache.ts
@@ -1,0 +1,40 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+type Store = Map<string, Promise<unknown>>;
+
+const als = new AsyncLocalStorage<Store>();
+
+export const runWithRequestCache = <T>(fn: () => T): T =>
+  als.run(new Map(), fn);
+
+const getStore = (): Store | undefined => als.getStore();
+
+export async function memoRequest<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+): Promise<T> {
+  const store = getStore();
+  if (!store) {
+    return fetcher();
+  }
+  const hit = store.get(key);
+  if (hit) {
+    return hit as Promise<T>;
+  }
+  const p = fetcher();
+  store.set(key, p);
+  p.catch(() => store.delete(key));
+  return p as Promise<T>;
+}
+
+export function invalidateRequest(prefix: string) {
+  const store = getStore();
+  if (!store) {
+    return;
+  }
+  for (const k of Array.from(store.keys())) {
+    if (k.startsWith(prefix)) {
+      store.delete(k);
+    }
+  }
+}

--- a/packages/common/src/services/organization/deleteOrganization.ts
+++ b/packages/common/src/services/organization/deleteOrganization.ts
@@ -5,7 +5,7 @@ import type { User } from '@supabase/supabase-js';
 import { assertAccess, permission } from 'access-zones';
 
 import { NotFoundError, UnauthorizedError } from '../../utils';
-import { getOrgAccessUser } from '../access';
+import { getOrgAccessUser, invalidateRequest } from '../access';
 
 export async function deleteOrganization({
   organizationProfileId,
@@ -50,6 +50,7 @@ export async function deleteOrganization({
   invalidate({ type: 'organization', params: [organizationProfileId] });
   invalidate({ type: 'organization', params: [deletedOrganization.slug] });
   invalidate({ type: 'orgUser', params: [organization.id, user.id] });
+  invalidateRequest(`orgUser:${organization.id}:${user.id}`);
 
   return { deletedId: organizationProfileId };
 }

--- a/packages/common/src/services/organization/deleteOrganization.ts
+++ b/packages/common/src/services/organization/deleteOrganization.ts
@@ -5,7 +5,7 @@ import type { User } from '@supabase/supabase-js';
 import { assertAccess, permission } from 'access-zones';
 
 import { NotFoundError, UnauthorizedError } from '../../utils';
-import { getOrgAccessUser, invalidateRequest } from '../access';
+import { getOrgAccessUser } from '../access';
 
 export async function deleteOrganization({
   organizationProfileId,
@@ -50,7 +50,7 @@ export async function deleteOrganization({
   invalidate({ type: 'organization', params: [organizationProfileId] });
   invalidate({ type: 'organization', params: [deletedOrganization.slug] });
   invalidate({ type: 'orgUser', params: [organization.id, user.id] });
-  invalidateRequest(`orgUser:${organization.id}:${user.id}`);
+  getOrgAccessUser.invalidate({ user, organizationId: organization.id });
 
   return { deletedId: organizationProfileId };
 }

--- a/packages/common/src/services/organization/deleteOrganizationUser.ts
+++ b/packages/common/src/services/organization/deleteOrganizationUser.ts
@@ -63,6 +63,7 @@ export async function deleteOrganizationUser({
     type: 'orgUser',
     params: [organizationId, user.id],
   });
+  getOrgAccessUser.invalidate({ user, organizationId });
 
   if (!deletedUser) {
     throw new NotFoundError('Organization user', organizationUserId);

--- a/packages/common/src/services/organization/updateOrganizationUser.ts
+++ b/packages/common/src/services/organization/updateOrganizationUser.ts
@@ -9,7 +9,7 @@ import type { User } from '@supabase/supabase-js';
 import { assertAccess, permission } from 'access-zones';
 
 import { NotFoundError, UnauthorizedError } from '../../utils';
-import { getOrgAccessUser } from '../access';
+import { getOrgAccessUser, invalidateRequest } from '../access';
 
 export interface UpdateOrganizationUserData {
   name?: string;
@@ -131,6 +131,7 @@ export async function updateOrganizationUser({
     type: 'orgUser',
     params: [organizationId, user.id],
   });
+  invalidateRequest(`orgUser:${organizationId}:${user.id}`);
 
   return {
     ...updatedUserWithRoles,

--- a/packages/common/src/services/organization/updateOrganizationUser.ts
+++ b/packages/common/src/services/organization/updateOrganizationUser.ts
@@ -9,7 +9,7 @@ import type { User } from '@supabase/supabase-js';
 import { assertAccess, permission } from 'access-zones';
 
 import { NotFoundError, UnauthorizedError } from '../../utils';
-import { getOrgAccessUser, invalidateRequest } from '../access';
+import { getOrgAccessUser } from '../access';
 
 export interface UpdateOrganizationUserData {
   name?: string;
@@ -131,7 +131,7 @@ export async function updateOrganizationUser({
     type: 'orgUser',
     params: [organizationId, user.id],
   });
-  invalidateRequest(`orgUser:${organizationId}:${user.id}`);
+  getOrgAccessUser.invalidate({ user, organizationId });
 
   return {
     ...updatedUserWithRoles,

--- a/packages/common/src/services/profile/removeProfileUser.ts
+++ b/packages/common/src/services/profile/removeProfileUser.ts
@@ -9,7 +9,7 @@ import {
   UnauthorizedError,
   ValidationError,
 } from '../../utils/error';
-import { getProfileAccessUser } from '../access';
+import { getProfileAccessUser, invalidateRequest } from '../access';
 import { assertProfileUser } from '../assert';
 
 /**
@@ -60,6 +60,10 @@ export const removeProfileUser = async ({
       params: [deletedUser.authUserId],
     }),
   ]);
+  invalidateRequest(
+    `profileUser:${deletedUser.profileId}:${deletedUser.authUserId}`,
+  );
+  invalidateRequest(`userSession:${deletedUser.authUserId}`);
 
   return deletedUser;
 };

--- a/packages/common/src/services/profile/removeProfileUser.ts
+++ b/packages/common/src/services/profile/removeProfileUser.ts
@@ -9,7 +9,7 @@ import {
   UnauthorizedError,
   ValidationError,
 } from '../../utils/error';
-import { getProfileAccessUser, invalidateRequest } from '../access';
+import { getProfileAccessUser, getUserSession } from '../access';
 import { assertProfileUser } from '../assert';
 
 /**
@@ -60,10 +60,11 @@ export const removeProfileUser = async ({
       params: [deletedUser.authUserId],
     }),
   ]);
-  invalidateRequest(
-    `profileUser:${deletedUser.profileId}:${deletedUser.authUserId}`,
-  );
-  invalidateRequest(`userSession:${deletedUser.authUserId}`);
+  getProfileAccessUser.invalidate({
+    user: { id: deletedUser.authUserId },
+    profileId: deletedUser.profileId,
+  });
+  getUserSession.invalidate({ authUserId: deletedUser.authUserId });
 
   return deletedUser;
 };

--- a/packages/common/src/services/profile/updateProfileUserRole.ts
+++ b/packages/common/src/services/profile/updateProfileUserRole.ts
@@ -10,7 +10,11 @@ import {
   UnauthorizedError,
   ValidationError,
 } from '../../utils/error';
-import { getNormalizedRoles, getProfileAccessUser } from '../access';
+import {
+  getNormalizedRoles,
+  getProfileAccessUser,
+  invalidateRequest,
+} from '../access';
 import { getProfileUserWithRelations } from './getProfileUserWithRelations';
 
 /**
@@ -139,6 +143,10 @@ export const updateProfileUserRoles = async ({
       params: [targetProfileUser.authUserId],
     }),
   ]);
+  invalidateRequest(
+    `profileUser:${targetProfileId}:${targetProfileUser.authUserId}`,
+  );
+  invalidateRequest(`userSession:${targetProfileUser.authUserId}`);
 
   // Fetch and return the updated profile user with full relations
   const updatedProfileUser = await getProfileUserWithRelations(profileUserId);

--- a/packages/common/src/services/profile/updateProfileUserRole.ts
+++ b/packages/common/src/services/profile/updateProfileUserRole.ts
@@ -13,7 +13,7 @@ import {
 import {
   getNormalizedRoles,
   getProfileAccessUser,
-  invalidateRequest,
+  getUserSession,
 } from '../access';
 import { getProfileUserWithRelations } from './getProfileUserWithRelations';
 
@@ -143,10 +143,11 @@ export const updateProfileUserRoles = async ({
       params: [targetProfileUser.authUserId],
     }),
   ]);
-  invalidateRequest(
-    `profileUser:${targetProfileId}:${targetProfileUser.authUserId}`,
-  );
-  invalidateRequest(`userSession:${targetProfileUser.authUserId}`);
+  getProfileAccessUser.invalidate({
+    user: { id: targetProfileUser.authUserId },
+    profileId: targetProfileId,
+  });
+  getUserSession.invalidate({ authUserId: targetProfileUser.authUserId });
 
   // Fetch and return the updated profile user with full relations
   const updatedProfileUser = await getProfileUserWithRelations(profileUserId);

--- a/services/api/src/middlewares/withRequestCache.ts
+++ b/services/api/src/middlewares/withRequestCache.ts
@@ -1,0 +1,8 @@
+import { runWithRequestCache } from '@op/common/src/services/access';
+
+import type { MiddlewareBuilderBase } from '../types';
+
+const withRequestCache: MiddlewareBuilderBase = ({ ctx, next }) =>
+  runWithRequestCache(() => next({ ctx }));
+
+export default withRequestCache;

--- a/services/api/src/routers/platform/admin/addUsersToOrganization.ts
+++ b/services/api/src/routers/platform/admin/addUsersToOrganization.ts
@@ -1,5 +1,10 @@
 import { invalidate } from '@op/cache';
-import { CommonError, NotFoundError, joinOrganization } from '@op/common';
+import {
+  CommonError,
+  NotFoundError,
+  getOrgAccessUser,
+  joinOrganization,
+} from '@op/common';
 import { db } from '@op/db/client';
 import { z } from 'zod';
 
@@ -116,6 +121,12 @@ export const addUsersToOrganizationRouter = router({
           }),
         ),
       ]);
+      for (const addedUser of joinResults) {
+        getOrgAccessUser.invalidate({
+          user: { id: addedUser.authUserId },
+          organizationId,
+        });
+      }
 
       return joinResults;
     }),

--- a/services/api/src/routers/platform/admin/addUsersToOrganization.ts
+++ b/services/api/src/routers/platform/admin/addUsersToOrganization.ts
@@ -88,7 +88,8 @@ export const addUsersToOrganizationRouter = router({
         throw new NotFoundError('Role', invalidRoleIds[0]);
       }
 
-      // Join each user to the organization
+      // Join each user to the organization and invalidate caches per-user
+      // immediately so any same-request reads after the join see fresh data.
       const joinResults = await Promise.all(
         users.map(async (user) => {
           const userToAdd = usersToAdd.find(
@@ -98,11 +99,19 @@ export const addUsersToOrganizationRouter = router({
             throw new CommonError('User to add not found');
           }
 
-          // Join the organization
           const orgUser = await joinOrganization({
             user,
             organization,
             roleId: userToAdd.roleId,
+          });
+
+          await invalidate({
+            type: 'orgUser',
+            params: [organizationId, user.authUserId],
+          });
+          getOrgAccessUser.invalidate({
+            user: { id: user.authUserId },
+            organizationId,
           });
 
           return {
@@ -111,22 +120,6 @@ export const addUsersToOrganizationRouter = router({
           };
         }),
       );
-
-      // Invalidate relevant caches for each added user
-      await Promise.all([
-        ...joinResults.map((addedUser) =>
-          invalidate({
-            type: 'orgUser',
-            params: [organizationId, addedUser.authUserId],
-          }),
-        ),
-      ]);
-      for (const addedUser of joinResults) {
-        getOrgAccessUser.invalidate({
-          user: { id: addedUser.authUserId },
-          organizationId,
-        });
-      }
 
       return joinResults;
     }),

--- a/services/api/src/trpcFactory.ts
+++ b/services/api/src/trpcFactory.ts
@@ -14,6 +14,7 @@ import withAuthenticated from './middlewares/withAuthenticated';
 import withChannelMeta from './middlewares/withChannelMeta';
 import withLogger from './middlewares/withLogger';
 import withRateLimited from './middlewares/withRateLimited';
+import withRequestCache from './middlewares/withRequestCache';
 import type { TContext } from './types';
 
 export const createContext = async ({
@@ -60,7 +61,10 @@ export const { router } = t;
 export const { middleware } = t;
 export const { mergeRouters } = t;
 export const createCallerFactory = t.createCallerFactory;
-export const commonProcedure = t.procedure.use(withChannelMeta).use(withLogger);
+export const commonProcedure = t.procedure
+  .use(withRequestCache)
+  .use(withChannelMeta)
+  .use(withLogger);
 
 const DEFAULT_RATE_LIMIT = { windowSize: 10, maxRequests: 10 };
 


### PR DESCRIPTION
## Summary
- Wraps `getProfileAccessUser`, `getOrgAccessUser`, and `getUserSession` (`packages/common/src/services/access/index.ts`) in an `AsyncLocalStorage`-backed memo. The same `(profileId, authUserId)` / `(orgId, authUserId)` / `authUserId` lookups in a single tRPC request now hit the DB once instead of N times.
- `assertAccess` itself stays in the `access-zones` library — it is already a synchronous bitfield check. Only the roles fetch that precedes it is cached.
- The cache scope is entered by a new `withRequestCache` middleware on `commonProcedure` in `services/api/src/trpcFactory.ts`, so every tRPC procedure runs inside its own store. Outside a scope (scripts, tests), `memoRequest` calls the fetcher every time — no behavior change.
- Existing `@op/cache` invalidations (`updateProfileUserRole`, `removeProfileUser`, `deleteOrganization`, `updateOrganizationUser`) now also call `invalidateRequest(...)` so within-request reads after a role change see fresh data.

## Cache-poisoning safety
`packages/common/src/services/access/requestCache.test.ts` covers:
- isolation between separate `runWithRequestCache` scopes (no cross-request leak)
- isolation between concurrent requests using the same key (each scope dedupes independently)
- rejected fetchers drop the cache entry so the next caller retries (no poisoned rejection cached)
- a rejection on one key never leaks to other keys
- prefix-based `invalidateRequest` only evicts matching keys
- out-of-scope behavior: `memoRequest` always calls the fetcher; `invalidateRequest` is a no-op