### PR TITLE
refactor(profile): share profileUserSchema between common and api

### DIFF
--- a/apps/app/src/components/decisions/ProfileUsersAccessTable.tsx
+++ b/apps/app/src/components/decisions/ProfileUsersAccessTable.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import type { ProfileInvite, ProfileUser } from '@op/api/encoders';
+import type { ProfileInvite } from '@op/api/encoders';
+import type { ProfileUser } from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { DialogTrigger } from '@op/ui/Dialog';
 import { EmptyState } from '@op/ui/EmptyState';

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -45,6 +45,7 @@
     "csv-stringify": "^6.6.0",
     "deepl-node": "^1.24.0",
     "drizzle-orm": "catalog:",
+    "drizzle-zod": "catalog:",
     "mitt": "^3.0.1",
     "next": "catalog:",
     "p-map": "^7.0.3",

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -31,6 +31,23 @@ export {
   proposalSelectionSchema,
   type ProposalSelection,
 } from './services/decision/schemas/selection';
+export {
+  profileUserSchema,
+  profileUserWithProfileSchema,
+  profileUserWithRolesSchema,
+  type ProfileUser,
+  type ProfileUserBase,
+} from './services/profile/schemas/profileUser';
+export {
+  profileMinimalSchema,
+  storageItemMinimalSchema,
+  type ProfileMinimal,
+  type StorageItemMinimal,
+} from './services/profile/schemas/profileMinimal';
+export {
+  accessRoleMinimalSchema,
+  type AccessRoleMinimal,
+} from './services/access/schemas/accessRole';
 export * from './services/decision/types';
 export {
   SYSTEM_FIELD_KEYS,

--- a/packages/common/src/services/access/schemas/accessRole.ts
+++ b/packages/common/src/services/access/schemas/accessRole.ts
@@ -1,0 +1,12 @@
+import { accessRoles } from '@op/db/schema';
+import { createSelectSchema } from 'drizzle-zod';
+import { z } from 'zod';
+
+// Minimal access role shape — id, name, description.
+export const accessRoleMinimalSchema = createSelectSchema(accessRoles).pick({
+  id: true,
+  name: true,
+  description: true,
+});
+
+export type AccessRoleMinimal = z.infer<typeof accessRoleMinimalSchema>;

--- a/packages/common/src/services/profile/index.ts
+++ b/packages/common/src/services/profile/index.ts
@@ -15,3 +15,4 @@ export * from './updateProfileUserRole';
 export * from './removeProfileUser';
 export * from './getProfileUserWithRelations';
 export * from './requests';
+export * from './schemas';

--- a/packages/common/src/services/profile/schemas/index.ts
+++ b/packages/common/src/services/profile/schemas/index.ts
@@ -1,0 +1,2 @@
+export * from './profileMinimal';
+export * from './profileUser';

--- a/packages/common/src/services/profile/schemas/profileMinimal.ts
+++ b/packages/common/src/services/profile/schemas/profileMinimal.ts
@@ -1,0 +1,27 @@
+import { profiles } from '@op/db/schema';
+import { createSelectSchema } from 'drizzle-zod';
+import { z } from 'zod';
+
+// Minimal storage item reference (avatar/header) — id + name only.
+export const storageItemMinimalSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+});
+
+export type StorageItemMinimal = z.infer<typeof storageItemMinimalSchema>;
+
+// Minimal profile shape for nested references (profile user, invitee).
+export const profileMinimalSchema = createSelectSchema(profiles)
+  .pick({
+    id: true,
+    name: true,
+    slug: true,
+    bio: true,
+    email: true,
+    type: true,
+  })
+  .extend({
+    avatarImage: storageItemMinimalSchema.nullable(),
+  });
+
+export type ProfileMinimal = z.infer<typeof profileMinimalSchema>;

--- a/packages/common/src/services/profile/schemas/profileUser.ts
+++ b/packages/common/src/services/profile/schemas/profileUser.ts
@@ -1,0 +1,25 @@
+import { profileUsers } from '@op/db/schema';
+import { createSelectSchema } from 'drizzle-zod';
+import { z } from 'zod';
+
+import { accessRoleMinimalSchema } from '../../access/schemas/accessRole';
+import { profileMinimalSchema } from './profileMinimal';
+
+// Base shape — one row of `profile_users`. Anonymous users have no email.
+export const profileUserSchema = createSelectSchema(profileUsers).extend({
+  email: z.string().nullable(),
+});
+
+export type ProfileUserBase = z.infer<typeof profileUserSchema>;
+
+// Base row + linked profile; shared base for the roles and permissions shapes.
+export const profileUserWithProfileSchema = profileUserSchema.extend({
+  profile: profileMinimalSchema.nullable(),
+});
+
+// Member-endpoint shape (listUsers, updateUserRoles): profile + access roles.
+export const profileUserWithRolesSchema = profileUserWithProfileSchema.extend({
+  roles: z.array(accessRoleMinimalSchema),
+});
+
+export type ProfileUser = z.infer<typeof profileUserWithRolesSchema>;

--- a/packages/common/src/services/profile/schemas/profileUser.ts
+++ b/packages/common/src/services/profile/schemas/profileUser.ts
@@ -5,10 +5,22 @@ import { z } from 'zod';
 import { accessRoleMinimalSchema } from '../../access/schemas/accessRole';
 import { profileMinimalSchema } from './profileMinimal';
 
-// Base shape — one row of `profile_users`. Anonymous users have no email.
-export const profileUserSchema = createSelectSchema(profileUsers).extend({
-  email: z.string().nullable(),
-});
+// Member-facing shape of a `profile_users` row. Explicitly picked rather than a
+// full table select so columns aren't leaked at API boundaries by default — new
+// columns must be opted in here. Anonymous users have no email.
+export const profileUserSchema = createSelectSchema(profileUsers)
+  .pick({
+    id: true,
+    name: true,
+    about: true,
+    isOwner: true,
+    profileId: true,
+    createdAt: true,
+    updatedAt: true,
+  })
+  .extend({
+    email: z.string().nullable(),
+  });
 
 export type ProfileUserBase = z.infer<typeof profileUserSchema>;
 

--- a/packages/common/src/services/profile/schemas/profileUser.ts
+++ b/packages/common/src/services/profile/schemas/profileUser.ts
@@ -7,20 +7,18 @@ import { profileMinimalSchema } from './profileMinimal';
 
 // Member-facing shape of a `profile_users` row. Explicitly picked rather than a
 // full table select so columns aren't leaked at API boundaries by default — new
-// columns must be opted in here. Anonymous users have no email.
-export const profileUserSchema = createSelectSchema(profileUsers)
-  .pick({
-    id: true,
-    name: true,
-    about: true,
-    isOwner: true,
-    profileId: true,
-    createdAt: true,
-    updatedAt: true,
-  })
-  .extend({
-    email: z.string().nullable(),
-  });
+// columns must be opted in here. email is nullable (anonymous users have none),
+// derived from the now-nullable column.
+export const profileUserSchema = createSelectSchema(profileUsers).pick({
+  id: true,
+  name: true,
+  email: true,
+  about: true,
+  isOwner: true,
+  profileId: true,
+  createdAt: true,
+  updatedAt: true,
+});
 
 export type ProfileUserBase = z.infer<typeof profileUserSchema>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ catalogs:
     drizzle-orm:
       specifier: 1.0.0-beta.11-05230d9
       version: 1.0.0-beta.11-05230d9
+    drizzle-zod:
+      specifier: 1.0.0-beta.11-05230d9
+      version: 1.0.0-beta.11-05230d9
     next:
       specifier: 16.2.6
       version: 16.2.6
@@ -806,6 +809,9 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 1.0.0-beta.11-05230d9(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9)(@types/pg@8.11.11)(gel@2.0.0)(mssql@11.0.1)(pg@8.16.0)(postgres@3.4.5)
+      drizzle-zod:
+        specifier: 'catalog:'
+        version: 1.0.0-beta.11-05230d9(drizzle-orm@1.0.0-beta.11-05230d9(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9)(@types/pg@8.11.11)(gel@2.0.0)(mssql@11.0.1)(pg@8.16.0)(postgres@3.4.5))(zod@4.1.12)
       mitt:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1276,7 +1282,7 @@ importers:
         specifier: 'catalog:'
         version: 1.0.0-beta.11-05230d9(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9)(@types/pg@8.11.11)(gel@2.0.0)(mssql@11.0.1)(pg@8.16.0)(postgres@3.4.5)
       drizzle-zod:
-        specifier: 1.0.0-beta.11-05230d9
+        specifier: 'catalog:'
         version: 1.0.0-beta.11-05230d9(drizzle-orm@1.0.0-beta.11-05230d9(@opentelemetry/api@1.9.0)(@types/mssql@9.1.9)(@types/pg@8.11.11)(gel@2.0.0)(mssql@11.0.1)(pg@8.16.0)(postgres@3.4.5))(zod@4.1.12)
       fast-xml-parser:
         specifier: ^5.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ catalog:
   zod: ^4.1.12
   access-zones: 1.1.0
   drizzle-orm: 1.0.0-beta.11-05230d9
+  drizzle-zod: 1.0.0-beta.11-05230d9
   '@supabase/ssr': 0.5.2
   '@supabase/supabase-js': 2.49.3
   supabase: 2.95.4

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -51,7 +51,7 @@
     "cookie": "^1.0.2",
     "deepl-node": "^1.24.0",
     "drizzle-orm": "catalog:",
-    "drizzle-zod": "1.0.0-beta.11-05230d9",
+    "drizzle-zod": "catalog:",
     "fast-xml-parser": "^5.2.1",
     "nanoid": "5.1.2",
     "node-geonames-client": "^0.0.2",

--- a/services/api/src/encoders/access.ts
+++ b/services/api/src/encoders/access.ts
@@ -11,15 +11,6 @@ export const permissionsSchema = z.object({
 
 export type Permissions = z.infer<typeof permissionsSchema>;
 
-// Minimal access role encoder for contexts where we only need basic role info
-export const accessRoleMinimalEncoder = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string().nullable(),
-});
-
-export type AccessRoleMinimal = z.infer<typeof accessRoleMinimalEncoder>;
-
 // Decision role permissions schema
 export const decisionRoleEncoder = z.object({
   delete: z.boolean(),

--- a/services/api/src/encoders/organizations.ts
+++ b/services/api/src/encoders/organizations.ts
@@ -1,8 +1,8 @@
+import { accessRoleMinimalSchema } from '@op/common/client';
 import { organizationUsers, organizations, profiles } from '@op/db/schema';
 import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
-import { accessRoleMinimalEncoder } from './access';
 import { baseProfileEncoder } from './baseProfile';
 import { linksEncoder } from './links';
 import { locationEncoder } from './locations';
@@ -38,7 +38,7 @@ export const organizationsWithProfileEncoder = organizationsEncoder.extend({
 });
 
 const adminOrgMemberRoleEncoder = z.object({
-  accessRole: accessRoleMinimalEncoder,
+  accessRole: accessRoleMinimalSchema,
 });
 
 const adminOrgMemberEncoder = z.object({

--- a/services/api/src/encoders/profiles.ts
+++ b/services/api/src/encoders/profiles.ts
@@ -1,14 +1,13 @@
-import { organizations, profileInvites, profileUsers } from '@op/db/schema';
+import { profileMinimalSchema } from '@op/common/client';
+import { organizations, profileInvites } from '@op/db/schema';
 import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
-import { accessRoleMinimalEncoder } from './access';
 import { baseProfileEncoder } from './baseProfile';
 import { linksEncoder } from './links';
 import { locationEncoder } from './locations';
 import { organizationsEncoder } from './organizations';
 import { projectEncoder } from './projects';
-import { storageItemMinimalEncoder } from './shared';
 import { storageItemEncoder } from './storageItem';
 
 export { baseProfileEncoder } from './baseProfile';
@@ -46,33 +45,7 @@ export const profileWithFullOrgEncoder = baseProfileEncoder.extend({
 
 export const profileWithAvatarEncoder = baseProfileEncoder;
 
-// Minimal profile encoder for nested references (e.g., in profileUser, invites)
-export const profileMinimalEncoder = baseProfileEncoder
-  .pick({
-    id: true,
-    name: true,
-    slug: true,
-    bio: true,
-    email: true,
-    type: true,
-  })
-  .extend({
-    avatarImage: storageItemMinimalEncoder.nullable(),
-  });
-
 export type Profile = z.infer<typeof profileEncoder>;
-
-// Profile user encoders - using createSelectSchema for base fields
-export const profileUserEncoder = createSelectSchema(profileUsers).extend({
-  // Override timestamp fields to handle both string and Date, and allow null/undefined
-  createdAt: z.union([z.string(), z.date()]).nullish(),
-  updatedAt: z.union([z.string(), z.date()]).nullish(),
-  deletedAt: z.union([z.string(), z.date()]).nullish(),
-  // Anonymous users have no email
-  email: z.string().nullable(),
-  profile: profileMinimalEncoder.nullable(),
-  roles: z.array(accessRoleMinimalEncoder),
-});
 
 // Profile invite encoder for pending invitations returned by listProfileInvites
 export const profileInviteEncoder = createSelectSchema(profileInvites)
@@ -84,8 +57,7 @@ export const profileInviteEncoder = createSelectSchema(profileInvites)
     notifiedAt: true,
   })
   .extend({
-    inviteeProfile: profileMinimalEncoder.nullable(),
+    inviteeProfile: profileMinimalSchema.nullable(),
   });
 
-export type ProfileUser = z.infer<typeof profileUserEncoder>;
 export type ProfileInvite = z.infer<typeof profileInviteEncoder>;

--- a/services/api/src/encoders/shared.ts
+++ b/services/api/src/encoders/shared.ts
@@ -14,11 +14,3 @@ export const entityTermsEncoder = z.record(
 );
 
 export type EntityTerms = z.infer<typeof entityTermsEncoder>;
-
-// Minimal storage item encoder for avatar/image references where we only need id and name
-export const storageItemMinimalEncoder = z.object({
-  id: z.string(),
-  name: z.string().nullable(),
-});
-
-export type StorageItemMinimal = z.infer<typeof storageItemMinimalEncoder>;

--- a/services/api/src/encoders/users.ts
+++ b/services/api/src/encoders/users.ts
@@ -1,15 +1,19 @@
-import { organizationUsers, profileUsers, users } from '@op/db/schema';
+import {
+  accessRoleMinimalSchema,
+  profileUserWithProfileSchema,
+} from '@op/common/client';
+import { organizationUsers, users } from '@op/db/schema';
 import type { ZonePermissions } from 'access-zones';
 import { authUsers } from 'drizzle-orm/supabase';
 import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
-import { accessRoleMinimalEncoder, permissionsSchema } from './access';
+import { permissionsSchema } from './access';
 import {
   organizationsEncoder,
   organizationsWithProfileEncoder,
 } from './organizations';
-import { baseProfileEncoder, profileMinimalEncoder } from './profiles';
+import { baseProfileEncoder } from './profiles';
 import { storageItemEncoder } from './storageItem';
 
 const zonePermissionsSchema = z.record(
@@ -31,7 +35,7 @@ const zonePermissionSchema = z.object({
 });
 
 // Extend the shared minimal encoder with zone permissions for full role context
-const accessRoleSchema = accessRoleMinimalEncoder.extend({
+const accessRoleSchema = accessRoleMinimalSchema.extend({
   zonePermissions: z.array(zonePermissionSchema).nullish(),
 });
 
@@ -49,13 +53,10 @@ const organizationUserWithPermissionsEncoder = createSelectSchema(
   roles: z.array(roleJunctionSchema).nullish(),
 });
 
-const profileUserWithPermissionsEncoder = createSelectSchema(
-  profileUsers,
-).extend({
-  profile: profileMinimalEncoder.nullish(),
+// Shared base + profile, plus computed permissions. Roles are omitted: they're
+// fetched only to derive `permissions` and no client reads them off the account.
+const profileUserWithPermissionsEncoder = profileUserWithProfileSchema.extend({
   permissions: zonePermissionsSchema.nullish(),
-  roles: z.array(roleJunctionSchema).nullish(),
-  isOwner: z.boolean().default(false),
 });
 
 /**

--- a/services/api/src/routers/profile/updateRolePermission.ts
+++ b/services/api/src/routers/profile/updateRolePermission.ts
@@ -1,10 +1,8 @@
 import { updateRolePermissions } from '@op/common';
+import { accessRoleMinimalSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import {
-  accessRoleMinimalEncoder,
-  permissionsSchema,
-} from '../../encoders/access';
+import { permissionsSchema } from '../../encoders/access';
 import { commonAuthedProcedure, router } from '../../trpcFactory';
 
 const DECISIONS_ZONE_NAME = 'decisions';
@@ -17,7 +15,7 @@ export const updateRolePermissionRouter = router({
         permissions: permissionsSchema,
       }),
     )
-    .output(accessRoleMinimalEncoder)
+    .output(accessRoleMinimalSchema)
     .mutation(async ({ ctx, input }) => {
       return updateRolePermissions({
         roleId: input.roleId,

--- a/services/api/src/routers/profile/users/listUsers.ts
+++ b/services/api/src/routers/profile/users/listUsers.ts
@@ -1,7 +1,7 @@
 import { listProfileUsers } from '@op/common';
+import { profileUserWithRolesSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { profileUserEncoder } from '../../../encoders/profiles';
 import { commonAuthedProcedure, router } from '../../../trpcFactory';
 import { createSortable } from '../../../utils';
 
@@ -21,7 +21,7 @@ export const listUsersRouter = router({
     )
     .output(
       z.object({
-        items: z.array(profileUserEncoder),
+        items: z.array(profileUserWithRolesSchema),
         next: z.string().nullable(),
       }),
     )

--- a/services/api/src/routers/profile/users/removeUser.ts
+++ b/services/api/src/routers/profile/users/removeUser.ts
@@ -1,4 +1,5 @@
 import { removeProfileUser } from '@op/common';
+import { profileUserSchema } from '@op/common/client';
 import { z } from 'zod';
 
 import { commonAuthedProcedure, router } from '../../../trpcFactory';
@@ -6,18 +7,7 @@ import { commonAuthedProcedure, router } from '../../../trpcFactory';
 export const removeUserRouter = router({
   removeUser: commonAuthedProcedure()
     .input(z.object({ profileUserId: z.uuid() }))
-    .output(
-      z.object({
-        id: z.string(),
-        authUserId: z.string(),
-        name: z.string().nullable(),
-        email: z.string().nullable(),
-        about: z.string().nullable(),
-        profileId: z.string(),
-        createdAt: z.union([z.string(), z.date()]).nullable(),
-        updatedAt: z.union([z.string(), z.date()]).nullable(),
-      }),
-    )
+    .output(profileUserSchema)
     .mutation(async ({ ctx, input }) => {
       const { user } = ctx;
       const { profileUserId } = input;

--- a/services/api/src/routers/profile/users/updateUserRole.ts
+++ b/services/api/src/routers/profile/users/updateUserRole.ts
@@ -1,7 +1,7 @@
 import { updateProfileUserRoles } from '@op/common';
+import { profileUserWithRolesSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { profileUserEncoder } from '../../../encoders/profiles';
 import { commonAuthedProcedure, router } from '../../../trpcFactory';
 
 export const updateUserRolesRouter = router({
@@ -14,7 +14,7 @@ export const updateUserRolesRouter = router({
           .min(1, 'At least one role must be specified'),
       }),
     )
-    .output(profileUserEncoder)
+    .output(profileUserWithRolesSchema)
     .mutation(async ({ ctx, input }) => {
       const { user } = ctx;
       const { profileUserId, roleIds } = input;
@@ -25,6 +25,6 @@ export const updateUserRolesRouter = router({
         user,
       });
 
-      return profileUserEncoder.parse(result);
+      return profileUserWithRolesSchema.parse(result);
     }),
 });


### PR DESCRIPTION
Centralizes the profile_users row shape in @op/common so the removeUser router output and the profileUserEncoder both derive from one source of truth instead of restating the column list. The frontend `ProfileUser` type is now defined alongside its schema and imported from `@op/common/client`, rather than re-derived in `@op/api/encoders`.