### PR TITLE
feat(profiles): handle nullable user email across app, api, and workflows

### DIFF
--- a/apps/app/src/app/[locale]/(main)/admin/layout.tsx
+++ b/apps/app/src/app/[locale]/(main)/admin/layout.tsx
@@ -16,7 +16,7 @@ export default async function AdminLayout({
   const client = await createClient();
   const user = await client.account.getMyAccount();
 
-  if (!isUserEmailPlatformAdmin(user.email)) {
+  if (!user.email || !isUserEmailPlatformAdmin(user.email)) {
     notFound();
   }
 

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -223,7 +223,7 @@ function ProfileInviteModalContent({
       allSelectedItems.map((item) => item.email.toLowerCase()),
     );
     const existingUserEmails = new Set(
-      optimisticUsers.map((u) => u.email.toLowerCase()),
+      optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
     );
     const invitedEmails = new Set(
       optimisticInvites.map((i) => i.email.toLowerCase()),
@@ -246,7 +246,7 @@ function ProfileInviteModalContent({
     const lowerQuery = debouncedQuery.toLowerCase();
     const takenEmails = new Set([
       ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.map((u) => u.email.toLowerCase()),
+      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
     return !takenEmails.has(lowerQuery);
@@ -391,7 +391,7 @@ function ProfileInviteModalContent({
 
     const existingEmails = new Set([
       ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.map((u) => u.email.toLowerCase()),
+      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
     const emails = parseEmailPaste(pastedText, existingEmails);
@@ -608,7 +608,7 @@ function ProfileInviteModalContent({
             {currentRoleMembers.map((user) => (
               <PersonRow
                 key={user.id}
-                name={user.name ?? user.email}
+                name={user.name ?? user.email ?? ''}
                 avatarUrl={
                   user.profile?.avatarImage?.name
                     ? getPublicUrl(user.profile.avatarImage.name)

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -3,6 +3,7 @@
 import { getPublicUrl } from '@/utils';
 import { trpc } from '@op/api/client';
 import { EntityType } from '@op/api/encoders';
+import { hasEmail } from '@op/common/client';
 import { useDebounce } from '@op/hooks';
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Avatar } from '@op/ui/Avatar';
@@ -223,7 +224,7 @@ function ProfileInviteModalContent({
       allSelectedItems.map((item) => item.email.toLowerCase()),
     );
     const existingUserEmails = new Set(
-      optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
+      optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
     );
     const invitedEmails = new Set(
       optimisticInvites.map((i) => i.email.toLowerCase()),
@@ -246,7 +247,7 @@ function ProfileInviteModalContent({
     const lowerQuery = debouncedQuery.toLowerCase();
     const takenEmails = new Set([
       ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
+      ...optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
     return !takenEmails.has(lowerQuery);
@@ -391,7 +392,7 @@ function ProfileInviteModalContent({
 
     const existingEmails = new Set([
       ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
+      ...optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
     const emails = parseEmailPaste(pastedText, existingEmails);

--- a/apps/app/src/components/decisions/ShareProposalModal.tsx
+++ b/apps/app/src/components/decisions/ShareProposalModal.tsx
@@ -168,7 +168,7 @@ function ShareProposalModalContent({
     );
     const takenEmails = new Set([
       ...pendingInvites.map((i) => i.email.toLowerCase()),
-      ...optimisticUsers.map((u) => u.email.toLowerCase()),
+      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
 
@@ -189,7 +189,7 @@ function ShareProposalModalContent({
     const lowerQuery = debouncedQuery.toLowerCase();
     const takenEmails = new Set([
       ...pendingInvites.map((i) => i.email.toLowerCase()),
-      ...optimisticUsers.map((u) => u.email.toLowerCase()),
+      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
     return !takenEmails.has(lowerQuery);
@@ -200,7 +200,8 @@ function ShareProposalModalContent({
   const deleteInviteMutation = trpc.profile.deleteProfileInvite.useMutation();
 
   const handleSelectItem = (result: (typeof flattenedResults)[0]) => {
-    if (!result.user?.email) {
+    const userEmail = result.user?.email;
+    if (!userEmail) {
       return;
     }
     setPendingInvites((prev) => [
@@ -209,7 +210,7 @@ function ShareProposalModalContent({
         id: result.id,
         profileId: result.id,
         name: result.name,
-        email: result.user!.email,
+        email: userEmail,
         avatarUrl: result.avatarImage?.name
           ? getPublicUrl(result.avatarImage.name)
           : undefined,
@@ -325,7 +326,7 @@ function ShareProposalModalContent({
 
     const takenEmails = new Set([
       ...pendingInvites.map((i) => i.email.toLowerCase()),
-      ...optimisticUsers.map((u) => u.email.toLowerCase()),
+      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
     const emails = parseEmailPaste(pastedText, takenEmails);
@@ -559,7 +560,7 @@ function ShareProposalModalContent({
                     size="small"
                     avatar={
                       <Avatar
-                        placeholder={user.name ?? user.email}
+                        placeholder={user.name ?? user.email ?? ''}
                         className="size-6 shrink-0"
                       >
                         {user.profile?.avatarImage?.name ? (
@@ -567,14 +568,14 @@ function ShareProposalModalContent({
                             src={
                               getPublicUrl(user.profile.avatarImage.name) ?? ''
                             }
-                            alt={user.name ?? user.email}
+                            alt={user.name ?? user.email ?? ''}
                             fill
                             className="object-cover"
                           />
                         ) : null}
                       </Avatar>
                     }
-                    title={user.name ?? user.email}
+                    title={user.name ?? user.email ?? ''}
                   >
                     {user.name && (
                       <div className="text-sm text-neutral-gray4">
@@ -587,7 +588,7 @@ function ShareProposalModalContent({
                       size="small"
                       onPress={() => handleRemoveExistingUser(user.id)}
                       aria-label={t('Remove {name}', {
-                        name: user.name ?? user.email,
+                        name: user.name ?? user.email ?? '',
                       })}
                     >
                       <LuX className="size-4" />

--- a/apps/app/src/components/decisions/ShareProposalModal.tsx
+++ b/apps/app/src/components/decisions/ShareProposalModal.tsx
@@ -3,6 +3,7 @@
 import { getPublicUrl } from '@/utils';
 import { trpc } from '@op/api/client';
 import { EntityType } from '@op/api/encoders';
+import { hasEmail } from '@op/common/client';
 import { useDebounce } from '@op/hooks';
 import { Avatar } from '@op/ui/Avatar';
 import { Button } from '@op/ui/Button';
@@ -168,7 +169,7 @@ function ShareProposalModalContent({
     );
     const takenEmails = new Set([
       ...pendingInvites.map((i) => i.email.toLowerCase()),
-      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
+      ...optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
 
@@ -189,7 +190,7 @@ function ShareProposalModalContent({
     const lowerQuery = debouncedQuery.toLowerCase();
     const takenEmails = new Set([
       ...pendingInvites.map((i) => i.email.toLowerCase()),
-      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
+      ...optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
     return !takenEmails.has(lowerQuery);
@@ -326,7 +327,7 @@ function ShareProposalModalContent({
 
     const takenEmails = new Set([
       ...pendingInvites.map((i) => i.email.toLowerCase()),
-      ...optimisticUsers.map((u) => (u.email ?? '').toLowerCase()),
+      ...optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
       ...optimisticInvites.map((i) => i.email.toLowerCase()),
     ]);
     const emails = parseEmailPaste(pastedText, takenEmails);

--- a/apps/app/src/components/screens/PlatformAdmin/AddUserToOrgModal.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/AddUserToOrgModal.tsx
@@ -141,7 +141,7 @@ const AddUserToOrgModalContent = ({
               </Avatar>
             }
             title={user.profile?.name ?? user.name ?? t('Unknown user')}
-            description={user.email}
+            description={user.email ?? undefined}
           />
         </div>
 

--- a/apps/app/src/components/screens/PlatformAdmin/UsersTable.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/UsersTable.tsx
@@ -34,13 +34,13 @@ import { UsersRowCells } from './UsersRow';
  * Exports user data to CSV and triggers download
  */
 const exportUsersToCSV = (
-  users: Array<{ name: string | null; email: string }>,
+  users: Array<{ name: string | null; email: string | null }>,
 ) => {
   const header = 'name,email\n';
   const rows = users
     .map((user) => {
       const name = user.name?.replace(/"/g, '""') ?? '';
-      const email = user.email.replace(/"/g, '""');
+      const email = user.email?.replace(/"/g, '""') ?? '';
       return `"${name}","${email}"`;
     })
     .join('\n');

--- a/apps/app/src/utils/UserProvider.tsx
+++ b/apps/app/src/utils/UserProvider.tsx
@@ -66,7 +66,7 @@ export const UserProviderSuspense = ({
   }
 
   // We are only identifying One Project users by email.
-  if (user && user.email.match(/.+@oneproject\.org$|.+@peoplepowered\.org$/)) {
+  if (user?.email?.match(/.+@oneproject\.org$|.+@peoplepowered\.org$/)) {
     posthog.identify(user.authUserId, { email: user.email, name: user.name });
   } else {
     // others are given anonymous IDs

--- a/packages/common/src/client.test.ts
+++ b/packages/common/src/client.test.ts
@@ -7,10 +7,10 @@ describe('hasEmail', () => {
     expect(hasEmail({ email: 'ada@example.com' })).toBe(true);
   });
 
-  it('returns true for an empty string (presence guard, not a validity check)', () => {
-    // hasEmail only narrows away null/undefined; it does not validate format,
-    // so '' is considered present.
-    expect(hasEmail({ email: '' })).toBe(true);
+  it('returns false for an empty string (treated as absent, not format-validated)', () => {
+    // An empty email is unusable everywhere it's consumed, so it counts as
+    // absent — without validating that a non-empty value is a real address.
+    expect(hasEmail({ email: '' })).toBe(false);
   });
 
   it('returns false for a null email', () => {

--- a/packages/common/src/client.test.ts
+++ b/packages/common/src/client.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasEmail } from './client';
+
+describe('hasEmail', () => {
+  it('returns true for a non-empty email', () => {
+    expect(hasEmail({ email: 'ada@example.com' })).toBe(true);
+  });
+
+  it('returns true for an empty string (presence guard, not a validity check)', () => {
+    // hasEmail only narrows away null/undefined; it does not validate format,
+    // so '' is considered present.
+    expect(hasEmail({ email: '' })).toBe(true);
+  });
+
+  it('returns false for a null email', () => {
+    expect(hasEmail({ email: null })).toBe(false);
+  });
+
+  it('returns false for an undefined email', () => {
+    expect(hasEmail({ email: undefined })).toBe(false);
+  });
+
+  it('returns false when the email property is absent', () => {
+    expect(hasEmail({})).toBe(false);
+  });
+
+  it('preserves the rest of the row when used as a filter', () => {
+    const rows = [
+      { id: '1', email: 'ada@example.com' },
+      { id: '2', email: null },
+      { id: '3', email: undefined },
+      { id: '4', email: 'grace@example.com' },
+    ];
+
+    const withEmail = rows.filter(hasEmail);
+
+    // Narrowed to a non-null string, so .toLowerCase() needs no guard.
+    expect(withEmail.map((r) => r.email.toLowerCase())).toEqual([
+      'ada@example.com',
+      'grace@example.com',
+    ]);
+    expect(withEmail.map((r) => r.id)).toEqual(['1', '4']);
+  });
+});

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -73,14 +73,14 @@ export type {
 } from './services/translation/translatedFields';
 
 /**
- * Type guard for rows whose email may be absent (e.g. anonymous users).
- * Narrows `email` to a non-null string so callers can use it directly instead
- * of coalescing to '' or asserting — anonymous users simply aren't email
- * recipients / collision candidates.
+ * Type guard for rows with a usable email. Treats null, undefined, and '' all
+ * as absent (no format validation), so anonymous users are filtered out rather
+ * than collapsed into an empty entry. Narrows `email` to a non-empty string so
+ * callers can use it directly without coalescing or asserting.
  */
 export const hasEmail = <T extends { email?: string | null }>(
   row: T,
-): row is T & { email: string } => row.email != null;
+): row is T & { email: string } => Boolean(row.email);
 
 const LOGIN_PATH_RE = /^\/(?:[a-z]{2}\/)?login(\/|$|\?)/;
 

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -72,15 +72,9 @@ export type {
   TranslatedFields,
 } from './services/translation/translatedFields';
 
-/**
- * Type guard for rows with a usable email. Treats null, undefined, and '' all
- * as absent (no format validation), so anonymous users are filtered out rather
- * than collapsed into an empty entry. Narrows `email` to a non-empty string so
- * callers can use it directly without coalescing or asserting.
- */
-export const hasEmail = <T extends { email?: string | null }>(
-  row: T,
-): row is T & { email: string } => Boolean(row.email);
+// Re-exported from utils so client components can import it without pulling in
+// the server-only utils barrel (which depends on drizzle).
+export { hasEmail } from './utils/email';
 
 const LOGIN_PATH_RE = /^\/(?:[a-z]{2}\/)?login(\/|$|\?)/;
 

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -72,6 +72,16 @@ export type {
   TranslatedFields,
 } from './services/translation/translatedFields';
 
+/**
+ * Type guard for rows whose email may be absent (e.g. anonymous users).
+ * Narrows `email` to a non-null string so callers can use it directly instead
+ * of coalescing to '' or asserting — anonymous users simply aren't email
+ * recipients / collision candidates.
+ */
+export const hasEmail = <T extends { email?: string | null }>(
+  row: T,
+): row is T & { email: string } => row.email != null;
+
 const LOGIN_PATH_RE = /^\/(?:[a-z]{2}\/)?login(\/|$|\?)/;
 
 export function isSafeRedirectPath(path: string | null): path is string {

--- a/packages/common/src/services/access/platformAdmin.ts
+++ b/packages/common/src/services/access/platformAdmin.ts
@@ -3,9 +3,6 @@ import { platformAdminEmails } from '@op/core';
 /**
  * Checks if a user has platform admin privileges based on email allowlist
  */
-export const isUserEmailPlatformAdmin = (
-  userEmail: string | null | undefined,
-): boolean => {
-  if (!userEmail) return false;
+export const isUserEmailPlatformAdmin = (userEmail: string): boolean => {
   return platformAdminEmails.has(userEmail.toLowerCase());
 };

--- a/packages/common/src/services/access/platformAdmin.ts
+++ b/packages/common/src/services/access/platformAdmin.ts
@@ -3,6 +3,9 @@ import { platformAdminEmails } from '@op/core';
 /**
  * Checks if a user has platform admin privileges based on email allowlist
  */
-export const isUserEmailPlatformAdmin = (userEmail: string): boolean => {
+export const isUserEmailPlatformAdmin = (
+  userEmail: string | null | undefined,
+): boolean => {
+  if (!userEmail) return false;
   return platformAdminEmails.has(userEmail.toLowerCase());
 };

--- a/packages/common/src/services/organization/inviteUsers.ts
+++ b/packages/common/src/services/organization/inviteUsers.ts
@@ -127,8 +127,8 @@ export const inviteUsersToOrganization = async (
                 .values({
                   authUserId: existingUser.authUserId,
                   organizationId,
-                  email: existingUser.email,
-                  name: existingUser.name || existingUser.email.split('@')[0],
+                  email,
+                  name: existingUser.name || email.split('@')[0],
                 })
                 .returning();
 

--- a/packages/common/src/services/organization/joinOrganization.ts
+++ b/packages/common/src/services/organization/joinOrganization.ts
@@ -30,7 +30,12 @@ export const joinOrganization = async ({
   roleId?: AccessRole['id'];
   db?: DbClient;
 }): Promise<OrganizationUser> => {
-  const userEmailDomainPart = user.email.split('@')[1];
+  if (!user.email) {
+    throw new CommonError('User email is required to join an organization');
+  }
+  const userEmail = user.email;
+
+  const userEmailDomainPart = userEmail.split('@')[1];
   if (!userEmailDomainPart) {
     throw new CommonError('User email is invalid');
   }
@@ -55,7 +60,7 @@ export const joinOrganization = async ({
       : cache<ReturnType<typeof getAllowListUser>>({
           type: 'allowList',
           params: [userEmailDomain],
-          fetch: () => getAllowListUser({ email: user.email }),
+          fetch: () => getAllowListUser({ email: userEmail }),
           options: {
             skipMemCache: true,
             ttl: 30 * 60 * 1000,
@@ -90,7 +95,7 @@ export const joinOrganization = async ({
       .values({
         organizationId: organization.id,
         authUserId: user.authUserId,
-        email: user.email,
+        email: userEmail,
         name: user.name ?? userEmailDomain,
       })
       .returning();

--- a/packages/common/src/services/profile/inviteUsersToProfile.ts
+++ b/packages/common/src/services/profile/inviteUsersToProfile.ts
@@ -247,7 +247,11 @@ export const inviteUsersToProfile = async ({
   }
 
   const usersByEmail = new Map(
-    existingUsers.map((user) => [user.email.toLowerCase(), user]),
+    existingUsers
+      .filter(
+        (user): user is typeof user & { email: string } => user.email !== null,
+      )
+      .map((user) => [user.email.toLowerCase(), user]),
   );
 
   const existingProfileUserAuthIds = new Set(

--- a/packages/common/src/services/profile/inviteUsersToProfile.ts
+++ b/packages/common/src/services/profile/inviteUsersToProfile.ts
@@ -7,6 +7,7 @@ import { User } from '@op/supabase/lib';
 import { waitUntil } from '@vercel/functions';
 import { assertAccess, permission } from 'access-zones';
 
+import { hasEmail } from '../../utils/email';
 import { CommonError, UnauthorizedError } from '../../utils/error';
 import { getProfileAccessUser } from '../access';
 import { assertProfile } from '../assert';
@@ -248,9 +249,7 @@ export const inviteUsersToProfile = async ({
 
   const usersByEmail = new Map(
     existingUsers
-      .filter(
-        (user): user is typeof user & { email: string } => user.email !== null,
-      )
+      .filter(hasEmail)
       .map((user) => [user.email.toLowerCase(), user]),
   );
 

--- a/packages/common/src/services/profile/listProfileUsers.ts
+++ b/packages/common/src/services/profile/listProfileUsers.ts
@@ -207,13 +207,15 @@ export const listProfileUsers = async ({
     }
 
     if (orderBy === 'email') {
-      return encodeCursor<ProfileUserCursor>({ value: lastResult.email });
+      return encodeCursor<ProfileUserCursor>({
+        value: lastResult.email ?? '',
+      });
     }
 
     if (orderBy === 'name') {
       return encodeCursor<ProfileUserCursor>({
         value: lastResult.name ?? '',
-        tiebreaker: lastResult.email,
+        tiebreaker: lastResult.email ?? '',
       });
     }
 
@@ -233,7 +235,7 @@ export const listProfileUsers = async ({
     const firstRoleName = sortedRoles[0]?.accessRole.name ?? '';
     return encodeCursor<ProfileUserCursor>({
       value: firstRoleName,
-      tiebreaker: lastResult.email,
+      tiebreaker: lastResult.email ?? '',
     });
   };
 

--- a/packages/common/src/services/profile/requests/updateProfileJoinRequest.ts
+++ b/packages/common/src/services/profile/requests/updateProfileJoinRequest.ts
@@ -90,7 +90,8 @@ export const updateProfileJoinRequest = async ({
         eq(table.profileId, existingRequest.requestProfileId),
     });
 
-    if (requestingUser) {
+    if (requestingUser && requestingUser.email) {
+      const requestingUserEmail = requestingUser.email;
       // Check if user is already a member of the target organization.
       // NOTE: We're using organizationUsers instead of profileUsers because we're in between
       // memberships - the profile user membership (new) and the organization user membership (old).
@@ -114,7 +115,7 @@ export const updateProfileJoinRequest = async ({
             .values({
               authUserId: requestingUser.authUserId,
               organizationId: organization.id,
-              email: requestingUser.email,
+              email: requestingUserEmail,
               name: requestingUser.name,
             })
             .returning();

--- a/packages/common/src/utils/email.test.ts
+++ b/packages/common/src/utils/email.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { hasEmail } from './client';
+import { hasEmail } from './email';
 
 describe('hasEmail', () => {
   it('returns true for a non-empty email', () => {

--- a/packages/common/src/utils/email.test.ts
+++ b/packages/common/src/utils/email.test.ts
@@ -25,7 +25,7 @@ describe('hasEmail', () => {
     expect(hasEmail({})).toBe(false);
   });
 
-  it('preserves the rest of the row when used as a filter', () => {
+  it('preserves the rest of the rows when used as a filter', () => {
     const rows = [
       { id: '1', email: 'ada@example.com' },
       { id: '2', email: null },

--- a/packages/common/src/utils/email.ts
+++ b/packages/common/src/utils/email.ts
@@ -1,0 +1,14 @@
+/**
+ * Email-related helpers. Kept pure (no imports) so they stay safe to re-export
+ * from the client surface (see client.ts).
+ */
+
+/**
+ * Type guard for rows with a usable email. Treats null, undefined, and '' all
+ * as absent (no format validation), so anonymous users are filtered out rather
+ * than collapsed into an empty entry. Narrows `email` to a non-empty string so
+ * callers can use it directly without coalescing or asserting.
+ */
+export const hasEmail = <T extends { email?: string | null }>(
+  row: T,
+): row is T & { email: string } => Boolean(row.email);

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './error';
 export * from './db';
 export * from './validation';
+export * from './email';
 
 export const filterNullOrUndefined = (data: Record<string, any>) =>
   Object.fromEntries(

--- a/services/api/src/encoders/profiles.ts
+++ b/services/api/src/encoders/profiles.ts
@@ -68,6 +68,8 @@ export const profileUserEncoder = createSelectSchema(profileUsers).extend({
   createdAt: z.union([z.string(), z.date()]).nullish(),
   updatedAt: z.union([z.string(), z.date()]).nullish(),
   deletedAt: z.union([z.string(), z.date()]).nullish(),
+  // Anonymous users have no email
+  email: z.string().nullable(),
   profile: profileMinimalEncoder.nullable(),
   roles: z.array(accessRoleMinimalEncoder),
 });

--- a/services/api/src/routers/platform/admin/listAllUsers.test.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.test.ts
@@ -275,11 +275,11 @@ describe.concurrent('platform.admin.listAllUsers', () => {
     });
     expect(result.items).toSatisfy((items: typeof result.items) => {
       const satisfies = items.every((user: (typeof result.items)[number]) =>
-        customDomainUserEmails.has(user.email),
+        customDomainUserEmails.has(user.email!),
       );
 
       items.forEach((user: (typeof result.items)[number]) => {
-        customDomainUserEmails.delete(user.email);
+        customDomainUserEmails.delete(user.email!);
       });
 
       return satisfies;
@@ -299,7 +299,7 @@ describe.concurrent('platform.admin.listAllUsers', () => {
     });
     expect(result2.items).toSatisfy((items: typeof result2.items) =>
       items.every((user: (typeof result2.items)[number]) =>
-        customDomainUserEmails.has(user.email),
+        customDomainUserEmails.has(user.email!),
       ),
     );
   });

--- a/services/api/src/routers/profile/users/listUsers.test.ts
+++ b/services/api/src/routers/profile/users/listUsers.test.ts
@@ -437,7 +437,7 @@ describe.concurrent('profile.users.listUsers', () => {
           dir: 'asc',
         });
 
-        allEmails.push(...page.items.map((u) => u.email));
+        allEmails.push(...page.items.map((u) => u.email!));
         cursor = page.next;
         pageCount++;
 
@@ -494,7 +494,7 @@ describe.concurrent('profile.users.listUsers', () => {
           dir: 'asc',
         });
 
-        allEmails.push(...page.items.map((u) => u.email));
+        allEmails.push(...page.items.map((u) => u.email!));
         cursor = page.next;
       } while (cursor);
 
@@ -624,7 +624,7 @@ describe.concurrent('profile.users.listUsers', () => {
           dir: 'asc',
         });
 
-        allEmails.push(...page.items.map((u) => u.email));
+        allEmails.push(...page.items.map((u) => u.email!));
         cursor = page.next;
         pageCount++;
 

--- a/services/api/src/routers/profile/users/removeUser.ts
+++ b/services/api/src/routers/profile/users/removeUser.ts
@@ -11,7 +11,7 @@ export const removeUserRouter = router({
         id: z.string(),
         authUserId: z.string(),
         name: z.string().nullable(),
-        email: z.string(),
+        email: z.string().nullable(),
         about: z.string().nullable(),
         profileId: z.string(),
         createdAt: z.union([z.string(), z.date()]).nullable(),

--- a/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
+++ b/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
@@ -9,7 +9,7 @@ import {
 } from '@op/db/schema';
 import { DecisionUpdateNotificationEmail, OPBatchSend } from '@op/emails';
 import { Events, inngest } from '@op/events';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNotNull } from 'drizzle-orm';
 
 const key = 'event.data.authorProfileId + "-" + event.data.targetProfileId';
 const { decisionUpdatePosted } = Events;
@@ -63,7 +63,12 @@ export const sendDecisionUpdateNotification = inngest.createFunction(
         return db
           .select({ email: profileUsers.email })
           .from(profileUsers)
-          .where(eq(profileUsers.profileId, targetProfileId));
+          .where(
+            and(
+              eq(profileUsers.profileId, targetProfileId),
+              isNotNull(profileUsers.email),
+            ),
+          );
       }),
     ]);
 
@@ -85,7 +90,8 @@ export const sendDecisionUpdateNotification = inngest.createFunction(
     }
 
     const recipients = participants.filter(
-      ({ email }) => email !== post.authorEmail,
+      (p): p is { email: string } =>
+        p.email !== null && p.email !== post.authorEmail,
     );
 
     if (recipients.length === 0) {

--- a/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
+++ b/services/workflows/src/functions/notifications/sendDecisionUpdateNotification.ts
@@ -1,3 +1,4 @@
+import { hasEmail } from '@op/common/client';
 import { OPURLConfig } from '@op/core';
 import { db } from '@op/db/client';
 import {
@@ -89,10 +90,9 @@ export const sendDecisionUpdateNotification = inngest.createFunction(
       return;
     }
 
-    const recipients = participants.filter(
-      (p): p is { email: string } =>
-        p.email !== null && p.email !== post.authorEmail,
-    );
+    const recipients = participants
+      .filter(hasEmail)
+      .filter((p) => p.email !== post.authorEmail);
 
     if (recipients.length === 0) {
       console.warn('No participants to notify for decision update', {

--- a/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
+++ b/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
@@ -7,7 +7,7 @@ import { db } from '@op/db/client';
 import { processInstances, profileUsers, profiles } from '@op/db/schema';
 import { OPBatchSend, PhaseTransitionEmail } from '@op/emails';
 import { Events, inngest } from '@op/events';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNotNull } from 'drizzle-orm';
 
 const { phaseTransitioned, manualSelectionsConfirmed } = Events;
 
@@ -91,12 +91,19 @@ export const sendPhaseTransitionNotification = inngest.createFunction(
     const totalPhases = phases.length;
 
     const participants = await step.run('get-participants', async () => {
-      return db
+      const rows = await db
         .select({
           email: profileUsers.email,
         })
         .from(profileUsers)
-        .where(eq(profileUsers.profileId, processData.profileId!));
+        .where(
+          and(
+            eq(profileUsers.profileId, processData.profileId!),
+            isNotNull(profileUsers.email),
+          ),
+        );
+
+      return rows.filter((p): p is { email: string } => p.email !== null);
     });
 
     if (participants.length === 0) {

--- a/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
+++ b/services/workflows/src/functions/notifications/sendPhaseTransitionNotification.ts
@@ -2,6 +2,7 @@ import {
   type DecisionInstanceData,
   resolveManualSelectionStatus,
 } from '@op/common';
+import { hasEmail } from '@op/common/client';
 import { OPURLConfig } from '@op/core';
 import { db } from '@op/db/client';
 import { processInstances, profileUsers, profiles } from '@op/db/schema';
@@ -103,7 +104,7 @@ export const sendPhaseTransitionNotification = inngest.createFunction(
           ),
         );
 
-      return rows.filter((p): p is { email: string } => p.email !== null);
+      return rows.filter(hasEmail);
     });
 
     if (participants.length === 0) {

--- a/services/workflows/src/functions/notifications/sendProposalSubmittedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendProposalSubmittedNotification.ts
@@ -8,7 +8,7 @@ import {
 } from '@op/db/schema';
 import { OPBatchSend, ProposalSubmittedEmail } from '@op/emails';
 import { Events, inngest } from '@op/events';
-import { eq } from 'drizzle-orm';
+import { and, eq, isNotNull } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 
 const { proposalSubmitted } = Events;
@@ -61,12 +61,19 @@ export const sendProposalSubmittedNotification = inngest.createFunction(
 
     // Step 2: Get all collaborator emails
     const collaborators = await step.run('get-collaborators', async () => {
-      return db
+      const rows = await db
         .select({
           email: profileUsers.email,
         })
         .from(profileUsers)
-        .where(eq(profileUsers.profileId, proposalData.proposalProfileId));
+        .where(
+          and(
+            eq(profileUsers.profileId, proposalData.proposalProfileId),
+            isNotNull(profileUsers.email),
+          ),
+        );
+
+      return rows.filter((p): p is { email: string } => p.email !== null);
     });
 
     if (collaborators.length === 0) {

--- a/services/workflows/src/functions/notifications/sendProposalSubmittedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendProposalSubmittedNotification.ts
@@ -1,3 +1,4 @@
+import { hasEmail } from '@op/common/client';
 import { OPURLConfig } from '@op/core';
 import { db } from '@op/db/client';
 import {
@@ -73,7 +74,7 @@ export const sendProposalSubmittedNotification = inngest.createFunction(
           ),
         );
 
-      return rows.filter((p): p is { email: string } => p.email !== null);
+      return rows.filter(hasEmail);
     });
 
     if (collaborators.length === 0) {

--- a/services/workflows/src/functions/notifications/sendRevisionRequestedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionRequestedNotification.ts
@@ -31,7 +31,9 @@ export const sendRevisionRequestedNotification = inngest.createFunction(
             with: {
               profile: {
                 with: {
-                  profileUsers: true,
+                  profileUsers: {
+                    where: { email: { isNotNull: true } },
+                  },
                 },
               },
             },
@@ -85,7 +87,9 @@ export const sendRevisionRequestedNotification = inngest.createFunction(
     }
 
     const { proposal, processInstance } = assignment;
-    const authorProfileUsers = proposal.profile.profileUsers;
+    const authorProfileUsers = proposal.profile.profileUsers.filter(
+      (p): p is typeof p & { email: string } => p.email !== null,
+    );
 
     if (authorProfileUsers.length === 0) {
       console.warn(

--- a/services/workflows/src/functions/notifications/sendRevisionRequestedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionRequestedNotification.ts
@@ -1,3 +1,4 @@
+import { hasEmail } from '@op/common/client';
 import { OPURLConfig } from '@op/core';
 import { db } from '@op/db/client';
 import {
@@ -87,9 +88,7 @@ export const sendRevisionRequestedNotification = inngest.createFunction(
     }
 
     const { proposal, processInstance } = assignment;
-    const authorProfileUsers = proposal.profile.profileUsers.filter(
-      (p): p is typeof p & { email: string } => p.email !== null,
-    );
+    const authorProfileUsers = proposal.profile.profileUsers.filter(hasEmail);
 
     if (authorProfileUsers.length === 0) {
       console.warn(

--- a/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
@@ -1,3 +1,4 @@
+import { hasEmail } from '@op/common/client';
 import { OPURLConfig } from '@op/core';
 import { db } from '@op/db/client';
 import {
@@ -87,9 +88,7 @@ export const sendRevisionResubmittedNotification = inngest.createFunction(
     }
 
     const { proposal, processInstance, reviewer } = assignment;
-    const reviewerEmails = reviewer.profileUsers.filter(
-      (p): p is typeof p & { email: string } => p.email !== null,
-    );
+    const reviewerEmails = reviewer.profileUsers.filter(hasEmail);
 
     if (reviewerEmails.length === 0) {
       console.warn(

--- a/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionResubmittedNotification.ts
@@ -39,7 +39,9 @@ export const sendRevisionResubmittedNotification = inngest.createFunction(
           },
           reviewer: {
             with: {
-              profileUsers: true,
+              profileUsers: {
+                where: { email: { isNotNull: true } },
+              },
             },
           },
           requests: true,
@@ -85,7 +87,9 @@ export const sendRevisionResubmittedNotification = inngest.createFunction(
     }
 
     const { proposal, processInstance, reviewer } = assignment;
-    const reviewerEmails = reviewer.profileUsers;
+    const reviewerEmails = reviewer.profileUsers.filter(
+      (p): p is typeof p & { email: string } => p.email !== null,
+    );
 
     if (reviewerEmails.length === 0) {
       console.warn(


### PR DESCRIPTION
Defensive null handling for profile/user email plus the encoder contract change (profileUserEncoder.email is now nullable). Self-typechecks against the current non-null schema; the schema flip lands in the stacked follow-up.

---
**Stack** (merge bottom-up):
1. #1232 — app/api/workflows nullable-email handling
2. #1233 — make email columns nullable
3. #1234 — anonymous-user signup support