### PR TITLE
fix(decisions): Fix Budget Max Test and Schema Validation for money type

### DIFF
--- a/packages/common/src/services/decision/schemaValidator.test.ts
+++ b/packages/common/src/services/decision/schemaValidator.test.ts
@@ -1,0 +1,103 @@
+import type { JSONSchema7 } from 'json-schema';
+import { describe, expect, it } from 'vitest';
+
+import { schemaValidator } from './schemaValidator';
+
+describe('schemaValidator money constraints', () => {
+  // Mirrors the schema produced by the template builder (BudgetFieldConfig):
+  // the budget is an object-typed money field and the cap lives on the OBJECT.
+  const moneyTemplate: JSONSchema7 = {
+    type: 'object',
+    required: ['budget'],
+    properties: {
+      budget: {
+        type: 'object',
+        title: 'Budget',
+        // @ts-expect-error vendor extension keyword
+        'x-format': 'money',
+        maximum: 10,
+        properties: {
+          amount: { type: 'number' },
+          currency: { type: 'string', default: 'USD' },
+        },
+      },
+    },
+  };
+
+  it('rejects a budget amount above the object-level maximum', () => {
+    const result = schemaValidator.validate(moneyTemplate, {
+      budget: { amount: 20, currency: 'USD' },
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('accepts a budget amount within the maximum', () => {
+    const result = schemaValidator.validate(moneyTemplate, {
+      budget: { amount: 5, currency: 'USD' },
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts a budget amount equal to the maximum', () => {
+    const result = schemaValidator.validate(moneyTemplate, {
+      budget: { amount: 10, currency: 'USD' },
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('enforces an object-level minimum against the amount', () => {
+    const minTemplate: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        budget: {
+          type: 'object',
+          title: 'Budget',
+          // @ts-expect-error vendor extension keyword
+          'x-format': 'money',
+          minimum: 100,
+          properties: {
+            amount: { type: 'number' },
+            currency: { type: 'string', default: 'USD' },
+          },
+        },
+      },
+    };
+
+    expect(
+      schemaValidator.validate(minTemplate, {
+        budget: { amount: 50, currency: 'USD' },
+      }).valid,
+    ).toBe(false);
+    expect(
+      schemaValidator.validate(minTemplate, {
+        budget: { amount: 150, currency: 'USD' },
+      }).valid,
+    ).toBe(true);
+  });
+
+  it('still enforces a maximum declared directly on the amount', () => {
+    const amountCapTemplate: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        budget: {
+          type: 'object',
+          // @ts-expect-error vendor extension keyword
+          'x-format': 'money',
+          properties: {
+            amount: { type: 'number', maximum: 10 },
+            currency: { type: 'string', default: 'USD' },
+          },
+        },
+      },
+    };
+
+    expect(
+      schemaValidator.validate(amountCapTemplate, {
+        budget: { amount: 20, currency: 'USD' },
+      }).valid,
+    ).toBe(false);
+  });
+});

--- a/packages/common/src/services/decision/schemaValidator.ts
+++ b/packages/common/src/services/decision/schemaValidator.ts
@@ -148,18 +148,17 @@ export class SchemaValidator {
     const nextProperties: Record<string, JSONSchema7Definition> = {};
 
     for (const [key, propSchema] of Object.entries(properties)) {
-      const xFormat =
-        typeof propSchema === 'object'
-          ? (propSchema as XFormatPropertySchema)['x-format']
-          : undefined;
+      if (typeof propSchema !== 'object') {
+        nextProperties[key] = propSchema;
+        continue;
+      }
 
-      if (
-        typeof propSchema !== 'object' ||
-        xFormat !== 'money' ||
-        !propSchema.properties ||
-        (typeof propSchema.minimum !== 'number' &&
-          typeof propSchema.maximum !== 'number')
-      ) {
+      const xFormat = (propSchema as XFormatPropertySchema)['x-format'];
+      const hasNumericBound =
+        typeof propSchema.minimum === 'number' ||
+        typeof propSchema.maximum === 'number';
+
+      if (xFormat !== 'money' || !propSchema.properties || !hasNumericBound) {
         nextProperties[key] = propSchema;
         continue;
       }

--- a/packages/common/src/services/decision/schemaValidator.ts
+++ b/packages/common/src/services/decision/schemaValidator.ts
@@ -1,8 +1,9 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
-import type { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 import { ValidationError } from '../../utils';
+import type { XFormatPropertySchema } from './types';
 
 export interface SchemaValidationResult {
   valid: boolean;
@@ -54,7 +55,7 @@ export class SchemaValidator {
    * Validate data against a JSON Schema
    */
   validate(schema: JSONSchema7, data: unknown): SchemaValidationResult {
-    const validate = this.ajv.compile(schema);
+    const validate = this.ajv.compile(this.normalizeMoneyConstraints(schema));
     const valid = validate(data);
 
     if (valid) {
@@ -124,6 +125,70 @@ export class SchemaValidator {
    */
   assertRubricData(rubricTemplate: JSONSchema7, rubricData: unknown): void {
     this.validateDataOrThrow(rubricTemplate, rubricData, 'Rubric');
+  }
+
+  /**
+   * Push money-field `minimum`/`maximum` constraints down onto the nested
+   * `amount` sub-property so Ajv actually enforces them.
+   *
+   * Money fields (`x-format: 'money'`) are stored as objects
+   * (`{ amount, currency }`), but the template builder and form renderer keep
+   * the budget cap on the *object* (`schema.maximum`). Ajv's `minimum`/`maximum`
+   * keywords only apply to numeric instances, so a cap left on the object is
+   * silently ignored — letting over-budget proposals pass validation. Moving
+   * the constraint onto the numeric `amount` makes Ajv enforce it.
+   */
+  private normalizeMoneyConstraints(schema: JSONSchema7): JSONSchema7 {
+    const properties = schema.properties;
+    if (!properties) {
+      return schema;
+    }
+
+    let changed = false;
+    const nextProperties: Record<string, JSONSchema7Definition> = {};
+
+    for (const [key, propSchema] of Object.entries(properties)) {
+      const xFormat =
+        typeof propSchema === 'object'
+          ? (propSchema as XFormatPropertySchema)['x-format']
+          : undefined;
+
+      if (
+        typeof propSchema !== 'object' ||
+        xFormat !== 'money' ||
+        !propSchema.properties ||
+        (typeof propSchema.minimum !== 'number' &&
+          typeof propSchema.maximum !== 'number')
+      ) {
+        nextProperties[key] = propSchema;
+        continue;
+      }
+
+      const { minimum, maximum, ...rest } = propSchema;
+      const amountSchema =
+        typeof propSchema.properties.amount === 'object'
+          ? propSchema.properties.amount
+          : { type: 'number' as const };
+
+      nextProperties[key] = {
+        ...rest,
+        properties: {
+          ...propSchema.properties,
+          amount: {
+            ...amountSchema,
+            ...(typeof minimum === 'number' ? { minimum } : {}),
+            ...(typeof maximum === 'number' ? { maximum } : {}),
+          },
+        },
+      };
+      changed = true;
+    }
+
+    if (!changed) {
+      return schema;
+    }
+
+    return { ...schema, properties: nextProperties };
   }
 
   /**

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -460,11 +460,16 @@ describe.concurrent('submitProposal', () => {
         'x-field-order': ['title', 'budget'],
         properties: {
           title: { type: 'string', 'x-format': 'short-text' },
+          // Mirror the schema the template builder (BudgetFieldConfig) actually
+          // produces: the `maximum` constraint lives on the money OBJECT, not on
+          // the nested `amount`. AJV only enforces `maximum` on numbers, so the
+          // validator must push the constraint down onto `amount`.
           budget: {
             type: 'object',
             'x-format': 'money',
+            maximum: 10000,
             properties: {
-              amount: { type: 'number', maximum: 10000 },
+              amount: { type: 'number' },
               currency: { type: 'string', default: 'USD' },
             },
           },


### PR DESCRIPTION
We use a custom type of money in the Proposal Editor so the standard validator was not catching the maximum value. This adds in some custom validation so budget fields in proposals are properly limited to their maximum.

Asana task: https://app.asana.com/1/1108348036672214/project/1213315744811204/task/1214710291141659?focus=true