### PR TITLE
fix(api): scope profile search results to the fields the UI needs

### DIFF
--- a/services/api/src/encoders/organizations.ts
+++ b/services/api/src/encoders/organizations.ts
@@ -1,5 +1,5 @@
 import { accessRoleMinimalSchema } from '@op/common/client';
-import { organizationUsers, organizations, profiles } from '@op/db/schema';
+import { organizations, profiles } from '@op/db/schema';
 import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
@@ -106,5 +106,3 @@ export type OrganizationSearchResult = z.infer<
 >;
 export type Organization = z.infer<typeof organizationsWithProfileEncoder>;
 export type AdminOrg = z.infer<typeof adminOrgEncoder>;
-
-export const orgUserEncoder = createSelectSchema(organizationUsers);

--- a/services/api/src/encoders/searchResults.ts
+++ b/services/api/src/encoders/searchResults.ts
@@ -5,12 +5,10 @@ import { z } from 'zod';
 
 import { baseProfileEncoder } from './baseProfile';
 
-// The search service over-selects every column; these encoders are the output
-// boundary that picks back down to what the UI reads. Never bare
-// createSelectSchema here — that would forward PII and internal FKs.
+// The search service over-selects every column; these encoders pick it back
+// down to what the UI reads, so PII and internal FKs aren't forwarded.
 
-// On the raw table, not organizationsEncoder: this validates raw left-join rows,
-// before that encoder's output transforms (e.g. acceptingApplications default).
+// Raw table, not organizationsEncoder, which transforms its output.
 const searchOrganizationEncoder = createSelectSchema(organizations)
   .pick({
     id: true,
@@ -32,7 +30,6 @@ const searchOrganizationEncoder = createSelectSchema(organizations)
   })
   .nullable();
 
-// Only email is read (member/invite dedupe).
 const searchUserEncoder = createSelectSchema(users)
   .pick({
     id: true,
@@ -41,8 +38,7 @@ const searchUserEncoder = createSelectSchema(users)
   })
   .nullable();
 
-// Picked from baseProfileEncoder so search can't expose more than the public
-// profile does (notably not email/phone/address).
+// Picked from baseProfileEncoder so search can't expose more than the profile.
 export const profileSearchResultEncoder = baseProfileEncoder
   .pick({
     id: true,
@@ -56,10 +52,9 @@ export const profileSearchResultEncoder = baseProfileEncoder
     avatarImage: storageItemMinimalSchema.nullable(),
     organization: searchOrganizationEncoder,
     user: searchUserEncoder,
-    rank: z.coerce.number(), // raw SQL result is unknown
+    rank: z.coerce.number(),
   });
 
-// Results grouped by entity type
 export const searchProfilesResultEncoder = z.array(
   z.object({
     type: z.enum(EntityType),

--- a/services/api/src/encoders/searchResults.ts
+++ b/services/api/src/encoders/searchResults.ts
@@ -9,10 +9,9 @@ import { z } from 'zod';
 
 import { baseProfileEncoder } from './baseProfile';
 
-// The search service over-selects every column via `getTableColumns`; these
-// output encoders are the boundary that strips it back down. Keep them picked
-// to the fields the search UI actually reads — never bare createSelectSchema,
-// which would forward PII and internal FKs.
+// The search service over-selects every column; these encoders are the output
+// boundary that picks back down to what the UI reads. Never bare
+// createSelectSchema here — that would forward PII and internal FKs.
 
 const searchStorageObjectEncoder = createSelectSchema(objectsInStorage)
   .pick({
@@ -21,10 +20,8 @@ const searchStorageObjectEncoder = createSelectSchema(objectsInStorage)
   })
   .nullable();
 
-// Mirrors the config columns organizationsEncoder exposes; only whereWeWork is
-// read. Kept on the raw table schema (not organizationsEncoder) because this is
-// the boundary for raw left-join rows, before organizationsEncoder's output
-// transforms (e.g. acceptingApplications default) are applied.
+// On the raw table, not organizationsEncoder: this validates raw left-join rows,
+// before that encoder's output transforms (e.g. acceptingApplications default).
 const searchOrganizationEncoder = createSelectSchema(organizations)
   .pick({
     id: true,
@@ -46,7 +43,7 @@ const searchOrganizationEncoder = createSelectSchema(organizations)
   })
   .nullable();
 
-// Only email is read (member/invite dedupe); drops the user table's internal FKs.
+// Only email is read (member/invite dedupe).
 const searchUserEncoder = createSelectSchema(users)
   .pick({
     id: true,
@@ -55,8 +52,8 @@ const searchUserEncoder = createSelectSchema(users)
   })
   .nullable();
 
-// Pick from baseProfileEncoder so search structurally can't leak more than the
-// public profile does (no phone/address/postalCode — and notably not email).
+// Picked from baseProfileEncoder so search can't expose more than the public
+// profile does (notably not email/phone/address).
 export const profileSearchResultEncoder = baseProfileEncoder
   .pick({
     id: true,
@@ -70,10 +67,10 @@ export const profileSearchResultEncoder = baseProfileEncoder
     avatarImage: searchStorageObjectEncoder,
     organization: searchOrganizationEncoder,
     user: searchUserEncoder,
-    rank: z.coerce.number(), // Coerce from unknown (raw SQL result) to number
+    rank: z.coerce.number(), // raw SQL result is unknown
   });
 
-// Discriminated union for search results grouped by entity type
+// Results grouped by entity type
 export const searchProfilesResultEncoder = z.array(
   z.object({
     type: z.enum(EntityType),

--- a/services/api/src/encoders/searchResults.ts
+++ b/services/api/src/encoders/searchResults.ts
@@ -1,9 +1,5 @@
-import {
-  EntityType,
-  objectsInStorage,
-  organizations,
-  users,
-} from '@op/db/schema';
+import { storageItemMinimalSchema } from '@op/common/client';
+import { EntityType, organizations, users } from '@op/db/schema';
 import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
@@ -12,13 +8,6 @@ import { baseProfileEncoder } from './baseProfile';
 // The search service over-selects every column; these encoders are the output
 // boundary that picks back down to what the UI reads. Never bare
 // createSelectSchema here — that would forward PII and internal FKs.
-
-const searchStorageObjectEncoder = createSelectSchema(objectsInStorage)
-  .pick({
-    id: true,
-    name: true,
-  })
-  .nullable();
 
 // On the raw table, not organizationsEncoder: this validates raw left-join rows,
 // before that encoder's output transforms (e.g. acceptingApplications default).
@@ -64,7 +53,7 @@ export const profileSearchResultEncoder = baseProfileEncoder
     city: true,
   })
   .extend({
-    avatarImage: searchStorageObjectEncoder,
+    avatarImage: storageItemMinimalSchema.nullable(),
     organization: searchOrganizationEncoder,
     user: searchUserEncoder,
     rank: z.coerce.number(), // raw SQL result is unknown

--- a/services/api/src/encoders/searchResults.ts
+++ b/services/api/src/encoders/searchResults.ts
@@ -8,15 +8,29 @@ import {
 import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
-// Storage encoder for search results that accepts raw database format from LEFT JOIN
-// Uses createSelectSchema to handle all objectsInStorage fields and make them nullable
-const searchStorageObjectEncoder =
-  createSelectSchema(objectsInStorage).nullable();
+// The search service over-selects every column via `getTableColumns`; these
+// output encoders are the boundary that strips it back down. Keep them picked
+// to the fields the search UI actually reads — never bare createSelectSchema,
+// which would forward PII and internal FKs.
 
-// Search-specific organization encoder (nullable fields from left join)
-// Include whereWeWork array which is used by ProfileSummaryList
-// Make links, receivingFundsTerms, and strategies optional since they're not in the base table
+const searchStorageObjectEncoder = createSelectSchema(objectsInStorage)
+  .pick({
+    id: true,
+    name: true,
+  })
+  .nullable();
+
+// Mirrors the config columns organizationsEncoder exposes; only whereWeWork is read.
 const searchOrganizationEncoder = createSelectSchema(organizations)
+  .pick({
+    id: true,
+    isOfferingFunds: true,
+    isReceivingFunds: true,
+    acceptingApplications: true,
+    networkOrganization: true,
+    orgType: true,
+    domain: true,
+  })
   .extend({
     whereWeWork: z
       .array(
@@ -25,24 +39,34 @@ const searchOrganizationEncoder = createSelectSchema(organizations)
         }),
       )
       .optional(),
-    links: z.array(z.any()).optional(),
-    receivingFundsTerms: z.array(z.any()).optional(),
-    strategies: z.array(z.any()).optional(),
   })
   .nullable();
 
-// Search-specific user encoder (nullable fields from left join)
+// Only email is read (member/invite dedupe); drops the user table's internal FKs.
 const searchUserEncoder = createSelectSchema(users)
-  .omit({ onboardedAt: true })
+  .pick({
+    id: true,
+    name: true,
+    email: true,
+  })
   .nullable();
 
-// Profile search result encoder
-export const profileSearchResultEncoder = createSelectSchema(profiles).extend({
-  avatarImage: searchStorageObjectEncoder,
-  organization: searchOrganizationEncoder,
-  user: searchUserEncoder,
-  rank: z.coerce.number(), // Coerce from unknown (raw SQL result) to number
-});
+// Stays within what baseProfileEncoder exposes — must not leak phone/address/postalCode.
+export const profileSearchResultEncoder = createSelectSchema(profiles)
+  .pick({
+    id: true,
+    name: true,
+    slug: true,
+    type: true,
+    bio: true,
+    city: true,
+  })
+  .extend({
+    avatarImage: searchStorageObjectEncoder,
+    organization: searchOrganizationEncoder,
+    user: searchUserEncoder,
+    rank: z.coerce.number(), // Coerce from unknown (raw SQL result) to number
+  });
 
 // Discriminated union for search results grouped by entity type
 export const searchProfilesResultEncoder = z.array(

--- a/services/api/src/encoders/searchResults.ts
+++ b/services/api/src/encoders/searchResults.ts
@@ -2,11 +2,12 @@ import {
   EntityType,
   objectsInStorage,
   organizations,
-  profiles,
   users,
 } from '@op/db/schema';
 import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
+
+import { baseProfileEncoder } from './baseProfile';
 
 // The search service over-selects every column via `getTableColumns`; these
 // output encoders are the boundary that strips it back down. Keep them picked
@@ -20,7 +21,10 @@ const searchStorageObjectEncoder = createSelectSchema(objectsInStorage)
   })
   .nullable();
 
-// Mirrors the config columns organizationsEncoder exposes; only whereWeWork is read.
+// Mirrors the config columns organizationsEncoder exposes; only whereWeWork is
+// read. Kept on the raw table schema (not organizationsEncoder) because this is
+// the boundary for raw left-join rows, before organizationsEncoder's output
+// transforms (e.g. acceptingApplications default) are applied.
 const searchOrganizationEncoder = createSelectSchema(organizations)
   .pick({
     id: true,
@@ -51,8 +55,9 @@ const searchUserEncoder = createSelectSchema(users)
   })
   .nullable();
 
-// Stays within what baseProfileEncoder exposes — must not leak phone/address/postalCode.
-export const profileSearchResultEncoder = createSelectSchema(profiles)
+// Pick from baseProfileEncoder so search structurally can't leak more than the
+// public profile does (no phone/address/postalCode — and notably not email).
+export const profileSearchResultEncoder = baseProfileEncoder
   .pick({
     id: true,
     name: true,


### PR DESCRIPTION
Picks the profile search encoders down to the fields the search UI actually reads, so the endpoint doesn't accidentally expose more data than needed. Derives the profile encoder from baseProfileEncoder so it stays in sync with the public profile shape.