### PR TITLE
refactor(api): split network/authenticated/open tRPC procedures

### DIFF
--- a/services/api/src/middlewares/withAuthenticatedUser.ts
+++ b/services/api/src/middlewares/withAuthenticatedUser.ts
@@ -7,11 +7,11 @@ import type {
 } from '../types';
 
 /**
- * Requires *a* user (any session, including anonymous sign-ins), rejecting only
- * no-JWT callers. No network/allow-list gating — authorization is left to the
- * service layer. Must run after {@link withResolvedUser}.
+ * Requires an authenticated user (any session, including anonymous sign-ins),
+ * rejecting only no-JWT callers. No network/allow-list gating — authorization
+ * is left to the service layer. Must run after {@link withResolvedUser}.
  */
-const withRequireUser: MiddlewareBuilderBeforeAfter<
+const withAuthenticatedUser: MiddlewareBuilderBeforeAfter<
   TContextWithMaybeUser,
   TContextWithUser
 > = async ({ ctx, next }) => {
@@ -24,4 +24,4 @@ const withRequireUser: MiddlewareBuilderBeforeAfter<
   });
 };
 
-export default withRequireUser;
+export default withAuthenticatedUser;

--- a/services/api/src/middlewares/withConfirmedUser.ts
+++ b/services/api/src/middlewares/withConfirmedUser.ts
@@ -1,0 +1,29 @@
+import { getCachedAuthUser } from '../supabase/server';
+import type { MiddlewareBuilderBase, TContextWithUser } from '../types';
+import { verifyAuthentication } from '../utils/verifyAuthentication';
+
+/**
+ * Confirmed-user authentication gate. Requires a confirmed, non-anonymous user
+ * — a real account whose email/phone has been confirmed (`confirmed_at` is set)
+ * — but applies no closed-network/allow-list gating; authorization is left to
+ * the service layer. Sits one tier below {@link withNetworkAuthenticatedUser},
+ * which additionally enforces the `@oneproject.org` / invite allow list.
+ *
+ * Note: a real but as-yet-unconfirmed signup (`confirmed_at === null`) is
+ * rejected here as `anon`, alongside anonymous sessions — see
+ * {@link verifyAuthentication}.
+ */
+const withConfirmedUser: MiddlewareBuilderBase<TContextWithUser> = async ({
+  ctx,
+  next,
+}) => {
+  const data = await getCachedAuthUser(ctx);
+
+  const user = verifyAuthentication(data);
+
+  return next({
+    ctx: { ...ctx, user },
+  });
+};
+
+export default withConfirmedUser;

--- a/services/api/src/middlewares/withNetworkAuthenticatedUser.ts
+++ b/services/api/src/middlewares/withNetworkAuthenticatedUser.ts
@@ -6,11 +6,13 @@ import type { MiddlewareBuilderBase, TContextWithUser } from '../types';
 import { verifyAuthentication } from '../utils/verifyAuthentication';
 
 /**
- * Closed-network authentication gate (formerly `withAuthenticated`). Requires a
- * confirmed, non-anonymous user that is either an `@oneproject.org` account or
- * on the invite allow list; everyone else is rejected before input parsing.
+ * Closed-network authentication gate. Requires a confirmed, non-anonymous user
+ * that is either an `@oneproject.org` account or on the invite allow list;
+ * everyone else is rejected before input parsing. This is the strongest user
+ * gate — a network-authenticated user is also an authenticated user (see
+ * {@link withAuthenticatedUser}).
  */
-const withNetworkAuthentication: MiddlewareBuilderBase<
+const withNetworkAuthenticatedUser: MiddlewareBuilderBase<
   TContextWithUser
 > = async ({ ctx, next }) => {
   const data = await getCachedAuthUser(ctx);
@@ -39,4 +41,4 @@ const withNetworkAuthentication: MiddlewareBuilderBase<
   });
 };
 
-export default withNetworkAuthentication;
+export default withNetworkAuthenticatedUser;

--- a/services/api/src/middlewares/withNetworkAuthentication.ts
+++ b/services/api/src/middlewares/withNetworkAuthentication.ts
@@ -6,12 +6,9 @@ import type { MiddlewareBuilderBase, TContextWithUser } from '../types';
 import { verifyAuthentication } from '../utils/verifyAuthentication';
 
 /**
- * Closed-network authentication gate (formerly `withAuthenticated`).
- *
- * Requires a confirmed, non-anonymous Supabase user that is either an
- * `@oneproject.org` account or present on the invite allow list. Anonymous and
- * unauthenticated callers are rejected here, before any input parsing — this is
- * the gate that enforces today's closed-network behavior.
+ * Closed-network authentication gate (formerly `withAuthenticated`). Requires a
+ * confirmed, non-anonymous user that is either an `@oneproject.org` account or
+ * on the invite allow list; everyone else is rejected before input parsing.
  */
 const withNetworkAuthentication: MiddlewareBuilderBase<
   TContextWithUser
@@ -36,21 +33,6 @@ const withNetworkAuthentication: MiddlewareBuilderBase<
       throw new AccessTierError('user');
     }
   }
-
-  return next({
-    ctx: { ...ctx, user },
-  });
-};
-
-/**
- * @deprecated Use withAuthenticatedPlatformAdmin
- */
-export const withAuthenticatedAdmin: MiddlewareBuilderBase<
-  TContextWithUser
-> = async ({ ctx, next }) => {
-  const data = await getCachedAuthUser(ctx);
-
-  const user = verifyAuthentication(data, true);
 
   return next({
     ctx: { ...ctx, user },

--- a/services/api/src/middlewares/withNetworkAuthentication.ts
+++ b/services/api/src/middlewares/withNetworkAuthentication.ts
@@ -5,10 +5,17 @@ import { getCachedAuthUser } from '../supabase/server';
 import type { MiddlewareBuilderBase, TContextWithUser } from '../types';
 import { verifyAuthentication } from '../utils/verifyAuthentication';
 
-const withAuthenticated: MiddlewareBuilderBase<TContextWithUser> = async ({
-  ctx,
-  next,
-}) => {
+/**
+ * Closed-network authentication gate (formerly `withAuthenticated`).
+ *
+ * Requires a confirmed, non-anonymous Supabase user that is either an
+ * `@oneproject.org` account or present on the invite allow list. Anonymous and
+ * unauthenticated callers are rejected here, before any input parsing — this is
+ * the gate that enforces today's closed-network behavior.
+ */
+const withNetworkAuthentication: MiddlewareBuilderBase<
+  TContextWithUser
+> = async ({ ctx, next }) => {
   const data = await getCachedAuthUser(ctx);
 
   const user = verifyAuthentication(data);
@@ -50,4 +57,4 @@ export const withAuthenticatedAdmin: MiddlewareBuilderBase<
   });
 };
 
-export default withAuthenticated;
+export default withNetworkAuthentication;

--- a/services/api/src/middlewares/withRequireUser.ts
+++ b/services/api/src/middlewares/withRequireUser.ts
@@ -1,0 +1,34 @@
+import { AccessTierError } from '@op/common';
+
+import type {
+  MiddlewareBuilderBeforeAfter,
+  TContextWithMaybeUser,
+  TContextWithUser,
+} from '../types';
+
+/**
+ * Narrows an optionally-resolved user (see {@link withResolvedUser}) to a
+ * required one: any real Supabase user — **including anonymous sign-ins** — is
+ * admitted, and `ctx.user` is guaranteed defined downstream. Only fully
+ * unauthenticated (no-JWT) callers are rejected here.
+ *
+ * Unlike {@link withNetworkAuthentication}, this gate does not enforce
+ * closed-network membership, email confirmation, or the allow list. Whether an
+ * authenticated caller may perform the operation is left to the service layer.
+ *
+ * Must run after `withResolvedUser`.
+ */
+const withRequireUser: MiddlewareBuilderBeforeAfter<
+  TContextWithMaybeUser,
+  TContextWithUser
+> = async ({ ctx, next }) => {
+  if (!ctx.user) {
+    throw new AccessTierError('none');
+  }
+
+  return next({
+    ctx: { ...ctx, user: ctx.user },
+  });
+};
+
+export default withRequireUser;

--- a/services/api/src/middlewares/withRequireUser.ts
+++ b/services/api/src/middlewares/withRequireUser.ts
@@ -7,16 +7,9 @@ import type {
 } from '../types';
 
 /**
- * Narrows an optionally-resolved user (see {@link withResolvedUser}) to a
- * required one: any real Supabase user — **including anonymous sign-ins** — is
- * admitted, and `ctx.user` is guaranteed defined downstream. Only fully
- * unauthenticated (no-JWT) callers are rejected here.
- *
- * Unlike {@link withNetworkAuthentication}, this gate does not enforce
- * closed-network membership, email confirmation, or the allow list. Whether an
- * authenticated caller may perform the operation is left to the service layer.
- *
- * Must run after `withResolvedUser`.
+ * Requires *a* user (any session, including anonymous sign-ins), rejecting only
+ * no-JWT callers. No network/allow-list gating — authorization is left to the
+ * service layer. Must run after {@link withResolvedUser}.
  */
 const withRequireUser: MiddlewareBuilderBeforeAfter<
   TContextWithMaybeUser,

--- a/services/api/src/middlewares/withResolvedUser.ts
+++ b/services/api/src/middlewares/withResolvedUser.ts
@@ -1,0 +1,27 @@
+import { getCachedAuthUser } from '../supabase/server';
+import type { MiddlewareBuilderBase, TContextWithMaybeUser } from '../types';
+
+/**
+ * Resolves the caller's Supabase identity onto `ctx.user` without rejecting
+ * anyone. If the request carries a valid session — including an anonymous
+ * sign-in — `ctx.user` is the resolved user; otherwise it is `undefined`.
+ *
+ * This middleware performs **no authorization**: it neither rejects anonymous
+ * users nor enforces the closed-network allow list. Procedures built on it
+ * (`openProcedure`, and `authenticatedProcedure` together with
+ * `withRequireUser`) leave admission decisions to the service layer.
+ */
+const withResolvedUser: MiddlewareBuilderBase<TContextWithMaybeUser> = async ({
+  ctx,
+  next,
+}) => {
+  const data = await getCachedAuthUser(ctx);
+
+  const user = data && !data.error ? data.data.user : undefined;
+
+  return next({
+    ctx: { ...ctx, user },
+  });
+};
+
+export default withResolvedUser;

--- a/services/api/src/middlewares/withResolvedUser.ts
+++ b/services/api/src/middlewares/withResolvedUser.ts
@@ -2,14 +2,9 @@ import { getCachedAuthUser } from '../supabase/server';
 import type { MiddlewareBuilderBase, TContextWithMaybeUser } from '../types';
 
 /**
- * Resolves the caller's Supabase identity onto `ctx.user` without rejecting
- * anyone. If the request carries a valid session — including an anonymous
- * sign-in — `ctx.user` is the resolved user; otherwise it is `undefined`.
- *
- * This middleware performs **no authorization**: it neither rejects anonymous
- * users nor enforces the closed-network allow list. Procedures built on it
- * (`openProcedure`, and `authenticatedProcedure` together with
- * `withRequireUser`) leave admission decisions to the service layer.
+ * Resolves the caller's Supabase identity onto `ctx.user` (including anonymous
+ * sign-ins) without rejecting anyone; `ctx.user` is `undefined` when there is
+ * no valid session. Performs no authorization.
  */
 const withResolvedUser: MiddlewareBuilderBase<TContextWithMaybeUser> = async ({
   ctx,

--- a/services/api/src/routers/account/completeOnboarding.ts
+++ b/services/api/src/routers/account/completeOnboarding.ts
@@ -2,10 +2,10 @@ import { invalidate } from '@op/cache';
 import { completeOnboarding as completeOnboardingService } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const completeOnboarding = router({
-  completeOnboarding: commonNetworkProcedure()
+  completeOnboarding: networkAuthenticatedProcedure()
     .input(
       z.object({
         tos: z.boolean(),

--- a/services/api/src/routers/account/completeOnboarding.ts
+++ b/services/api/src/routers/account/completeOnboarding.ts
@@ -2,10 +2,10 @@ import { invalidate } from '@op/cache';
 import { completeOnboarding as completeOnboardingService } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const completeOnboarding = router({
-  completeOnboarding: commonAuthedProcedure()
+  completeOnboarding: commonNetworkProcedure()
     .input(
       z.object({
         tos: z.boolean(),

--- a/services/api/src/routers/account/getMyAccount.ts
+++ b/services/api/src/routers/account/getMyAccount.ts
@@ -8,10 +8,10 @@ import {
 import { z } from 'zod';
 
 import { userEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const getMyAccount = router({
-  getMyAccount: commonNetworkProcedure()
+  getMyAccount: networkAuthenticatedProcedure()
     .input(z.undefined())
     .output(userEncoder)
     .query(async ({ ctx }) => {

--- a/services/api/src/routers/account/getMyAccount.ts
+++ b/services/api/src/routers/account/getMyAccount.ts
@@ -8,10 +8,10 @@ import {
 import { z } from 'zod';
 
 import { userEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const getMyAccount = router({
-  getMyAccount: commonAuthedProcedure()
+  getMyAccount: commonNetworkProcedure()
     .input(z.undefined())
     .output(userEncoder)
     .query(async ({ ctx }) => {

--- a/services/api/src/routers/account/getUserProfiles.ts
+++ b/services/api/src/routers/account/getUserProfiles.ts
@@ -2,7 +2,7 @@ import { UnauthorizedError, getUserWithProfiles } from '@op/common';
 import { EntityType, ObjectsInStorage, Profile } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const userProfileSchema = z.object({
   id: z.string(),
@@ -19,7 +19,7 @@ export const userProfileSchema = z.object({
 });
 
 export const getUserProfiles = router({
-  getUserProfiles: commonNetworkProcedure()
+  getUserProfiles: networkAuthenticatedProcedure()
     .input(z.undefined())
     .output(
       z.array(

--- a/services/api/src/routers/account/getUserProfiles.ts
+++ b/services/api/src/routers/account/getUserProfiles.ts
@@ -2,7 +2,7 @@ import { UnauthorizedError, getUserWithProfiles } from '@op/common';
 import { EntityType, ObjectsInStorage, Profile } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const userProfileSchema = z.object({
   id: z.string(),
@@ -19,7 +19,7 @@ export const userProfileSchema = z.object({
 });
 
 export const getUserProfiles = router({
-  getUserProfiles: commonAuthedProcedure()
+  getUserProfiles: commonNetworkProcedure()
     .input(z.undefined())
     .output(
       z.array(

--- a/services/api/src/routers/account/listUserInvites.ts
+++ b/services/api/src/routers/account/listUserInvites.ts
@@ -2,10 +2,10 @@ import { listUserInvites } from '@op/common';
 import { EntityType } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const listUserInvitesRouter = router({
-  listUserInvites: commonNetworkProcedure()
+  listUserInvites: networkAuthenticatedProcedure()
     .input(
       z.object({
         entityType: z.nativeEnum(EntityType).optional(),

--- a/services/api/src/routers/account/listUserInvites.ts
+++ b/services/api/src/routers/account/listUserInvites.ts
@@ -2,10 +2,10 @@ import { listUserInvites } from '@op/common';
 import { EntityType } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const listUserInvitesRouter = router({
-  listUserInvites: commonAuthedProcedure()
+  listUserInvites: commonNetworkProcedure()
     .input(
       z.object({
         entityType: z.nativeEnum(EntityType).optional(),

--- a/services/api/src/routers/account/matchingDomainOrganizations.ts
+++ b/services/api/src/routers/account/matchingDomainOrganizations.ts
@@ -2,10 +2,10 @@ import { matchingDomainOrganizations as getMatchingDomainOrganizations } from '@
 import { z } from 'zod';
 
 import { searchedOrganizationEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const matchingDomainOrganizations = router({
-  listMatchingDomainOrganizations: commonNetworkProcedure({
+  listMatchingDomainOrganizations: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(z.undefined())

--- a/services/api/src/routers/account/matchingDomainOrganizations.ts
+++ b/services/api/src/routers/account/matchingDomainOrganizations.ts
@@ -2,10 +2,10 @@ import { matchingDomainOrganizations as getMatchingDomainOrganizations } from '@
 import { z } from 'zod';
 
 import { searchedOrganizationEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const matchingDomainOrganizations = router({
-  listMatchingDomainOrganizations: commonAuthedProcedure({
+  listMatchingDomainOrganizations: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(z.undefined())

--- a/services/api/src/routers/account/switchProfile.ts
+++ b/services/api/src/routers/account/switchProfile.ts
@@ -11,10 +11,10 @@ import { assertAccess, permission } from 'access-zones';
 import { z } from 'zod';
 
 import { userEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const switchProfile = router({
-  switchProfile: commonNetworkProcedure()
+  switchProfile: networkAuthenticatedProcedure()
     .input(z.object({ profileId: z.uuid() }))
     .output(userEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/account/switchProfile.ts
+++ b/services/api/src/routers/account/switchProfile.ts
@@ -11,10 +11,10 @@ import { assertAccess, permission } from 'access-zones';
 import { z } from 'zod';
 
 import { userEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const switchProfile = router({
-  switchProfile: commonAuthedProcedure()
+  switchProfile: commonNetworkProcedure()
     .input(z.object({ profileId: z.uuid() }))
     .output(userEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/account/updateLastOrgId.ts
+++ b/services/api/src/routers/account/updateLastOrgId.ts
@@ -2,10 +2,10 @@ import { switchUserOrganization } from '@op/common';
 import { z } from 'zod';
 
 import { userEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const switchOrganization = router({
-  switchOrganization: commonNetworkProcedure({
+  switchOrganization: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(z.object({ organizationId: z.string().min(1) }))

--- a/services/api/src/routers/account/updateLastOrgId.ts
+++ b/services/api/src/routers/account/updateLastOrgId.ts
@@ -2,10 +2,10 @@ import { switchUserOrganization } from '@op/common';
 import { z } from 'zod';
 
 import { userEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const switchOrganization = router({
-  switchOrganization: commonAuthedProcedure({
+  switchOrganization: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(z.object({ organizationId: z.string().min(1) }))

--- a/services/api/src/routers/account/updateUserProfile.ts
+++ b/services/api/src/routers/account/updateUserProfile.ts
@@ -1,11 +1,11 @@
 import { updateUserProfile as updateUserProfileService } from '@op/common';
 
 import { userEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { updateUserProfileDataSchema } from '../shared/profile';
 
 const updateUserProfile = router({
-  updateUserProfile: commonAuthedProcedure({
+  updateUserProfile: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 3 },
   })
     .input(updateUserProfileDataSchema)

--- a/services/api/src/routers/account/updateUserProfile.ts
+++ b/services/api/src/routers/account/updateUserProfile.ts
@@ -1,11 +1,11 @@
 import { updateUserProfile as updateUserProfileService } from '@op/common';
 
 import { userEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { updateUserProfileDataSchema } from '../shared/profile';
 
 const updateUserProfile = router({
-  updateUserProfile: commonNetworkProcedure({
+  updateUserProfile: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 3 },
   })
     .input(updateUserProfileDataSchema)

--- a/services/api/src/routers/account/uploadAvatarImage.ts
+++ b/services/api/src/routers/account/uploadAvatarImage.ts
@@ -7,7 +7,7 @@ import { Buffer } from 'buffer';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
 
@@ -20,7 +20,7 @@ const ALLOWED_MIME_TYPES = [
 
 // TODO: This is a duplicate of organization/uploadAvatarImage. Converge these
 export const uploadAvatarImage = router({
-  uploadImage: commonNetworkProcedure()
+  uploadImage: networkAuthenticatedProcedure()
     .use(withDB)
     .input(
       z.object({

--- a/services/api/src/routers/account/uploadAvatarImage.ts
+++ b/services/api/src/routers/account/uploadAvatarImage.ts
@@ -7,7 +7,7 @@ import { Buffer } from 'buffer';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
 
@@ -20,7 +20,7 @@ const ALLOWED_MIME_TYPES = [
 
 // TODO: This is a duplicate of organization/uploadAvatarImage. Converge these
 export const uploadAvatarImage = router({
-  uploadImage: commonAuthedProcedure()
+  uploadImage: commonNetworkProcedure()
     .use(withDB)
     .input(
       z.object({

--- a/services/api/src/routers/account/uploadBannerImage.ts
+++ b/services/api/src/routers/account/uploadBannerImage.ts
@@ -7,7 +7,7 @@ import { Buffer } from 'buffer';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
 
@@ -19,7 +19,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadBannerImage = router({
-  uploadBannerImage: commonAuthedProcedure()
+  uploadBannerImage: commonNetworkProcedure()
     .use(withDB)
     .input(
       z.object({

--- a/services/api/src/routers/account/uploadBannerImage.ts
+++ b/services/api/src/routers/account/uploadBannerImage.ts
@@ -7,7 +7,7 @@ import { Buffer } from 'buffer';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
 
@@ -19,7 +19,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadBannerImage = router({
-  uploadBannerImage: commonNetworkProcedure()
+  uploadBannerImage: networkAuthenticatedProcedure()
     .use(withDB)
     .input(
       z.object({

--- a/services/api/src/routers/content/linkPreview.ts
+++ b/services/api/src/routers/content/linkPreview.ts
@@ -1,7 +1,7 @@
 import { getLinkPreview, httpUrlSchema } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const linkPreviewResponseSchema = z.object({
   url: z.string(),
@@ -23,7 +23,7 @@ const linkPreviewResponseSchema = z.object({
 });
 
 export const linkPreview = router({
-  linkPreview: commonNetworkProcedure()
+  linkPreview: networkAuthenticatedProcedure()
     .input(z.object({ url: httpUrlSchema }))
     .output(linkPreviewResponseSchema)
     .query(async ({ input }) => {

--- a/services/api/src/routers/content/linkPreview.ts
+++ b/services/api/src/routers/content/linkPreview.ts
@@ -1,7 +1,7 @@
 import { getLinkPreview, httpUrlSchema } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const linkPreviewResponseSchema = z.object({
   url: z.string(),
@@ -23,7 +23,7 @@ const linkPreviewResponseSchema = z.object({
 });
 
 export const linkPreview = router({
-  linkPreview: commonAuthedProcedure()
+  linkPreview: commonNetworkProcedure()
     .input(z.object({ url: httpUrlSchema }))
     .output(linkPreviewResponseSchema)
     .query(async ({ input }) => {

--- a/services/api/src/routers/decision/deleteProposalAttachment.ts
+++ b/services/api/src/routers/decision/deleteProposalAttachment.ts
@@ -1,10 +1,10 @@
 import { deleteProposalAttachment as deleteProposalAttachmentService } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const deleteProposalAttachment = router({
-  deleteProposalAttachment: commonNetworkProcedure({
+  deleteProposalAttachment: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(

--- a/services/api/src/routers/decision/deleteProposalAttachment.ts
+++ b/services/api/src/routers/decision/deleteProposalAttachment.ts
@@ -1,10 +1,10 @@
 import { deleteProposalAttachment as deleteProposalAttachmentService } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const deleteProposalAttachment = router({
-  deleteProposalAttachment: commonAuthedProcedure({
+  deleteProposalAttachment: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(

--- a/services/api/src/routers/decision/instances/createInstanceFromTemplate.ts
+++ b/services/api/src/routers/decision/instances/createInstanceFromTemplate.ts
@@ -5,10 +5,10 @@ import {
   createInstanceFromTemplateInputSchema,
   decisionProfileWithSchemaEncoder,
 } from '../../../encoders/decision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const createInstanceFromTemplateRouter = router({
-  createInstanceFromTemplate: commonNetworkProcedure()
+  createInstanceFromTemplate: networkAuthenticatedProcedure()
     .input(createInstanceFromTemplateInputSchema)
     .output(decisionProfileWithSchemaEncoder)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/createInstanceFromTemplate.ts
+++ b/services/api/src/routers/decision/instances/createInstanceFromTemplate.ts
@@ -5,10 +5,10 @@ import {
   createInstanceFromTemplateInputSchema,
   decisionProfileWithSchemaEncoder,
 } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const createInstanceFromTemplateRouter = router({
-  createInstanceFromTemplate: commonAuthedProcedure()
+  createInstanceFromTemplate: commonNetworkProcedure()
     .input(createInstanceFromTemplateInputSchema)
     .output(decisionProfileWithSchemaEncoder)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/deleteDecision.ts
+++ b/services/api/src/routers/decision/instances/deleteDecision.ts
@@ -1,10 +1,10 @@
 import { Channels, deleteDecision } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const deleteDecisionRouter = router({
-  deleteDecision: commonAuthedProcedure({
+  deleteDecision: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(

--- a/services/api/src/routers/decision/instances/deleteDecision.ts
+++ b/services/api/src/routers/decision/instances/deleteDecision.ts
@@ -1,10 +1,10 @@
 import { Channels, deleteDecision } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const deleteDecisionRouter = router({
-  deleteDecision: commonNetworkProcedure({
+  deleteDecision: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(

--- a/services/api/src/routers/decision/instances/duplicateInstance.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.ts
@@ -2,7 +2,7 @@ import { duplicateInstance } from '@op/common';
 import { z } from 'zod';
 
 import { decisionProfileWithSchemaEncoder } from '../../../encoders/decision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const duplicateInstanceInputSchema = z.object({
   instanceId: z.string().uuid(),
@@ -20,7 +20,7 @@ const duplicateInstanceInputSchema = z.object({
 });
 
 export const duplicateInstanceRouter = router({
-  duplicateInstance: commonNetworkProcedure({
+  duplicateInstance: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(duplicateInstanceInputSchema)

--- a/services/api/src/routers/decision/instances/duplicateInstance.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.ts
@@ -2,7 +2,7 @@ import { duplicateInstance } from '@op/common';
 import { z } from 'zod';
 
 import { decisionProfileWithSchemaEncoder } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const duplicateInstanceInputSchema = z.object({
   instanceId: z.string().uuid(),
@@ -20,7 +20,7 @@ const duplicateInstanceInputSchema = z.object({
 });
 
 export const duplicateInstanceRouter = router({
-  duplicateInstance: commonAuthedProcedure({
+  duplicateInstance: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(duplicateInstanceInputSchema)

--- a/services/api/src/routers/decision/instances/getCategories.ts
+++ b/services/api/src/routers/decision/instances/getCategories.ts
@@ -1,7 +1,7 @@
 import { getProcessCategories } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const getCategoriesInputSchema = z.object({
   processInstanceId: z.uuid(),
@@ -18,7 +18,7 @@ const getCategoriesOutputSchema = z.object({
 });
 
 export const getCategoriesRouter = router({
-  getCategories: commonNetworkProcedure()
+  getCategories: networkAuthenticatedProcedure()
     .input(getCategoriesInputSchema)
     .output(getCategoriesOutputSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/getCategories.ts
+++ b/services/api/src/routers/decision/instances/getCategories.ts
@@ -1,7 +1,7 @@
 import { getProcessCategories } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const getCategoriesInputSchema = z.object({
   processInstanceId: z.uuid(),
@@ -18,7 +18,7 @@ const getCategoriesOutputSchema = z.object({
 });
 
 export const getCategoriesRouter = router({
-  getCategories: commonAuthedProcedure()
+  getCategories: commonNetworkProcedure()
     .input(getCategoriesInputSchema)
     .output(getCategoriesOutputSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/getDecisionBySlug.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlug.ts
@@ -8,14 +8,14 @@ import { collapseRoles } from 'access-zones';
 import { z } from 'zod';
 
 import { decisionProfileWithSchemaEncoder } from '../../../encoders/decision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   slug: z.string().min(1, 'Slug cannot be empty'),
 });
 
 export const getDecisionBySlugRouter = router({
-  getDecisionBySlug: commonNetworkProcedure({
+  getDecisionBySlug: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/decision/instances/getDecisionBySlug.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlug.ts
@@ -8,14 +8,14 @@ import { collapseRoles } from 'access-zones';
 import { z } from 'zod';
 
 import { decisionProfileWithSchemaEncoder } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   slug: z.string().min(1, 'Slug cannot be empty'),
 });
 
 export const getDecisionBySlugRouter = router({
-  getDecisionBySlug: commonAuthedProcedure({
+  getDecisionBySlug: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/decision/instances/getInstance.ts
+++ b/services/api/src/routers/decision/instances/getInstance.ts
@@ -9,7 +9,7 @@ import {
   legacyGetInstanceInputSchema,
   legacyProcessInstanceEncoder,
 } from '../../../encoders/legacyDecision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 import { trackProcessViewed } from '../../../utils/analytics';
 
 /**
@@ -19,7 +19,7 @@ import { trackProcessViewed } from '../../../utils/analytics';
  */
 
 export const getLegacyInstanceRouter = router({
-  getLegacyInstance: commonNetworkProcedure({
+  getLegacyInstance: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 30 },
   })
     .input(legacyGetInstanceInputSchema)
@@ -63,7 +63,7 @@ export const getLegacyInstanceRouter = router({
  * Only supports new decision-making schemas.
  */
 export const getInstanceRouter = router({
-  getInstance: commonNetworkProcedure({
+  getInstance: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 30 },
   })
     .input(getInstanceInputSchema)

--- a/services/api/src/routers/decision/instances/getInstance.ts
+++ b/services/api/src/routers/decision/instances/getInstance.ts
@@ -9,7 +9,7 @@ import {
   legacyGetInstanceInputSchema,
   legacyProcessInstanceEncoder,
 } from '../../../encoders/legacyDecision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 import { trackProcessViewed } from '../../../utils/analytics';
 
 /**
@@ -19,7 +19,7 @@ import { trackProcessViewed } from '../../../utils/analytics';
  */
 
 export const getLegacyInstanceRouter = router({
-  getLegacyInstance: commonAuthedProcedure({
+  getLegacyInstance: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 30 },
   })
     .input(legacyGetInstanceInputSchema)
@@ -63,7 +63,7 @@ export const getLegacyInstanceRouter = router({
  * Only supports new decision-making schemas.
  */
 export const getInstanceRouter = router({
-  getInstance: commonAuthedProcedure({
+  getInstance: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 30 },
   })
     .input(getInstanceInputSchema)

--- a/services/api/src/routers/decision/instances/getPhaseReviewProgress.ts
+++ b/services/api/src/routers/decision/instances/getPhaseReviewProgress.ts
@@ -5,10 +5,10 @@ import {
   phaseReviewProgressSchema,
 } from '@op/common';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const getPhaseReviewProgressRouter = router({
-  getPhaseReviewProgress: commonNetworkProcedure()
+  getPhaseReviewProgress: networkAuthenticatedProcedure()
     .input(instancePhaseRefSchema)
     .output(phaseReviewProgressSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/getPhaseReviewProgress.ts
+++ b/services/api/src/routers/decision/instances/getPhaseReviewProgress.ts
@@ -5,10 +5,10 @@ import {
   phaseReviewProgressSchema,
 } from '@op/common';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const getPhaseReviewProgressRouter = router({
-  getPhaseReviewProgress: commonAuthedProcedure()
+  getPhaseReviewProgress: commonNetworkProcedure()
     .input(instancePhaseRefSchema)
     .output(phaseReviewProgressSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/listDecisionProfiles.ts
+++ b/services/api/src/routers/decision/instances/listDecisionProfiles.ts
@@ -4,10 +4,10 @@ import {
   decisionProfileWithSchemaFilterSchema,
   decisionProfileWithSchemaListEncoder,
 } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const listDecisionProfilesRouter = router({
-  listDecisionProfiles: commonAuthedProcedure()
+  listDecisionProfiles: commonNetworkProcedure()
     .input(decisionProfileWithSchemaFilterSchema)
     .output(decisionProfileWithSchemaListEncoder)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/decision/instances/listDecisionProfiles.ts
+++ b/services/api/src/routers/decision/instances/listDecisionProfiles.ts
@@ -4,10 +4,10 @@ import {
   decisionProfileWithSchemaFilterSchema,
   decisionProfileWithSchemaListEncoder,
 } from '../../../encoders/decision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listDecisionProfilesRouter = router({
-  listDecisionProfiles: commonNetworkProcedure()
+  listDecisionProfiles: networkAuthenticatedProcedure()
     .input(decisionProfileWithSchemaFilterSchema)
     .output(decisionProfileWithSchemaListEncoder)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/decision/instances/listLegacyInstances.ts
+++ b/services/api/src/routers/decision/instances/listLegacyInstances.ts
@@ -5,10 +5,10 @@ import {
   legacyOnlyInstanceFilterSchema,
   legacyProcessInstanceEncoder,
 } from '../../../encoders/legacyDecision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listLegacyInstancesRouter = router({
-  listLegacyInstances: commonNetworkProcedure()
+  listLegacyInstances: networkAuthenticatedProcedure()
     .input(legacyOnlyInstanceFilterSchema)
     .output(legacyInstanceListEncoder)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/decision/instances/listLegacyInstances.ts
+++ b/services/api/src/routers/decision/instances/listLegacyInstances.ts
@@ -5,10 +5,10 @@ import {
   legacyOnlyInstanceFilterSchema,
   legacyProcessInstanceEncoder,
 } from '../../../encoders/legacyDecision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const listLegacyInstancesRouter = router({
-  listLegacyInstances: commonAuthedProcedure()
+  listLegacyInstances: commonNetworkProcedure()
     .input(legacyOnlyInstanceFilterSchema)
     .output(legacyInstanceListEncoder)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/decision/instances/listProposalSubmitters.ts
+++ b/services/api/src/routers/decision/instances/listProposalSubmitters.ts
@@ -5,14 +5,14 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const listProposalSubmittersInputSchema = z.object({
   processInstanceId: z.uuid(),
 });
 
 export const listProposalSubmittersRouter = router({
-  listProposalSubmitters: commonAuthedProcedure()
+  listProposalSubmitters: commonNetworkProcedure()
     .input(listProposalSubmittersInputSchema)
     .output(proposalSubmittersListSchema)
     .query(({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/listProposalSubmitters.ts
+++ b/services/api/src/routers/decision/instances/listProposalSubmitters.ts
@@ -5,14 +5,14 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const listProposalSubmittersInputSchema = z.object({
   processInstanceId: z.uuid(),
 });
 
 export const listProposalSubmittersRouter = router({
-  listProposalSubmitters: commonNetworkProcedure()
+  listProposalSubmitters: networkAuthenticatedProcedure()
     .input(listProposalSubmittersInputSchema)
     .output(proposalSubmittersListSchema)
     .query(({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/listSelectionCandidates.ts
+++ b/services/api/src/routers/decision/instances/listSelectionCandidates.ts
@@ -2,7 +2,7 @@ import { Channels, listSelectionCandidates } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const listSelectionCandidatesInputSchema = z.object({
   processInstanceId: z.uuid(),
@@ -15,7 +15,7 @@ const listSelectionCandidatesOutputSchema = z.object({
 });
 
 export const listSelectionCandidatesRouter = router({
-  listSelectionCandidates: commonAuthedProcedure()
+  listSelectionCandidates: commonNetworkProcedure()
     .input(listSelectionCandidatesInputSchema)
     .output(listSelectionCandidatesOutputSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/listSelectionCandidates.ts
+++ b/services/api/src/routers/decision/instances/listSelectionCandidates.ts
@@ -2,7 +2,7 @@ import { Channels, listSelectionCandidates } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const listSelectionCandidatesInputSchema = z.object({
   processInstanceId: z.uuid(),
@@ -15,7 +15,7 @@ const listSelectionCandidatesOutputSchema = z.object({
 });
 
 export const listSelectionCandidatesRouter = router({
-  listSelectionCandidates: commonNetworkProcedure()
+  listSelectionCandidates: networkAuthenticatedProcedure()
     .input(listSelectionCandidatesInputSchema)
     .output(listSelectionCandidatesOutputSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/submitManualSelection.ts
+++ b/services/api/src/routers/decision/instances/submitManualSelection.ts
@@ -2,7 +2,7 @@ import { Channels, submitManualSelection } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 import { trackManualSelectionSubmitted } from '../../../utils/analytics';
 
 const submitManualSelectionInputSchema = z.object({
@@ -11,7 +11,7 @@ const submitManualSelectionInputSchema = z.object({
 });
 
 export const submitManualSelectionRouter = router({
-  submitManualSelection: commonNetworkProcedure()
+  submitManualSelection: networkAuthenticatedProcedure()
     .input(submitManualSelectionInputSchema)
     .mutation(async ({ ctx, input }) => {
       await submitManualSelection({

--- a/services/api/src/routers/decision/instances/submitManualSelection.ts
+++ b/services/api/src/routers/decision/instances/submitManualSelection.ts
@@ -2,7 +2,7 @@ import { Channels, submitManualSelection } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 import { trackManualSelectionSubmitted } from '../../../utils/analytics';
 
 const submitManualSelectionInputSchema = z.object({
@@ -11,7 +11,7 @@ const submitManualSelectionInputSchema = z.object({
 });
 
 export const submitManualSelectionRouter = router({
-  submitManualSelection: commonAuthedProcedure()
+  submitManualSelection: commonNetworkProcedure()
     .input(submitManualSelectionInputSchema)
     .mutation(async ({ ctx, input }) => {
       await submitManualSelection({

--- a/services/api/src/routers/decision/instances/transitionFromPhase.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.ts
@@ -2,11 +2,11 @@ import { Channels, triggerPhaseAdvancement } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 import { trackManualTransitionConfirmed } from '../../../utils/analytics';
 
 export const transitionFromPhaseRouter = router({
-  transitionFromPhase: commonAuthedProcedure()
+  transitionFromPhase: commonNetworkProcedure()
     .input(
       z.object({
         instanceId: z.uuid(),

--- a/services/api/src/routers/decision/instances/transitionFromPhase.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.ts
@@ -2,11 +2,11 @@ import { Channels, triggerPhaseAdvancement } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 import { trackManualTransitionConfirmed } from '../../../utils/analytics';
 
 export const transitionFromPhaseRouter = router({
-  transitionFromPhase: commonNetworkProcedure()
+  transitionFromPhase: networkAuthenticatedProcedure()
     .input(
       z.object({
         instanceId: z.uuid(),

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.ts
@@ -6,10 +6,10 @@ import {
   decisionProfileWithSchemaEncoder,
   updateDecisionInstanceInputSchema,
 } from '../../../encoders/decision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const updateDecisionInstanceRouter = router({
-  updateDecisionInstance: commonNetworkProcedure()
+  updateDecisionInstance: networkAuthenticatedProcedure()
     .input(updateDecisionInstanceInputSchema)
     .output(decisionProfileWithSchemaEncoder)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.ts
@@ -6,10 +6,10 @@ import {
   decisionProfileWithSchemaEncoder,
   updateDecisionInstanceInputSchema,
 } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const updateDecisionInstanceRouter = router({
-  updateDecisionInstance: commonAuthedProcedure()
+  updateDecisionInstance: commonNetworkProcedure()
     .input(updateDecisionInstanceInputSchema)
     .output(decisionProfileWithSchemaEncoder)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/processes/listProcesses.ts
+++ b/services/api/src/routers/decision/processes/listProcesses.ts
@@ -4,10 +4,10 @@ import {
   decisionProcessWithSchemaListEncoder,
   processFilterSchema,
 } from '../../../encoders/decision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listProcessesRouter = router({
-  listProcesses: commonNetworkProcedure()
+  listProcesses: networkAuthenticatedProcedure()
     .input(processFilterSchema)
     .output(decisionProcessWithSchemaListEncoder)
     .query(async ({ input }) => {

--- a/services/api/src/routers/decision/processes/listProcesses.ts
+++ b/services/api/src/routers/decision/processes/listProcesses.ts
@@ -4,10 +4,10 @@ import {
   decisionProcessWithSchemaListEncoder,
   processFilterSchema,
 } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const listProcessesRouter = router({
-  listProcesses: commonAuthedProcedure()
+  listProcesses: commonNetworkProcedure()
     .input(processFilterSchema)
     .output(decisionProcessWithSchemaListEncoder)
     .query(async ({ input }) => {

--- a/services/api/src/routers/decision/proposals/acceptProposalInvite.ts
+++ b/services/api/src/routers/decision/proposals/acceptProposalInvite.ts
@@ -3,10 +3,10 @@ import { acceptProposalInvite } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const acceptProposalInviteRouter = router({
-  acceptProposalInvite: commonNetworkProcedure()
+  acceptProposalInvite: networkAuthenticatedProcedure()
     .input(z.object({ profileId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       await acceptProposalInvite({

--- a/services/api/src/routers/decision/proposals/acceptProposalInvite.ts
+++ b/services/api/src/routers/decision/proposals/acceptProposalInvite.ts
@@ -3,10 +3,10 @@ import { acceptProposalInvite } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const acceptProposalInviteRouter = router({
-  acceptProposalInvite: commonAuthedProcedure()
+  acceptProposalInvite: commonNetworkProcedure()
     .input(z.object({ profileId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
       await acceptProposalInvite({

--- a/services/api/src/routers/decision/proposals/create.ts
+++ b/services/api/src/routers/decision/proposals/create.ts
@@ -2,11 +2,11 @@ import { Channels, createProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 
 import { createProposalInputSchema } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const createProposalRouter = router({
   /** Creates a new proposal in draft status. Use submitProposal to transition to submitted. */
-  createProposal: commonAuthedProcedure()
+  createProposal: commonNetworkProcedure()
     .input(createProposalInputSchema)
     .output(proposalSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/create.ts
+++ b/services/api/src/routers/decision/proposals/create.ts
@@ -2,11 +2,11 @@ import { Channels, createProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 
 import { createProposalInputSchema } from '../../../encoders/decision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const createProposalRouter = router({
   /** Creates a new proposal in draft status. Use submitProposal to transition to submitted. */
-  createProposal: commonNetworkProcedure()
+  createProposal: networkAuthenticatedProcedure()
     .input(createProposalInputSchema)
     .output(proposalSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/delete.ts
+++ b/services/api/src/routers/decision/proposals/delete.ts
@@ -1,10 +1,10 @@
 import { Channels, deleteProposal as deleteProposalService } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const deleteProposalRouter = router({
-  deleteProposal: commonAuthedProcedure({
+  deleteProposal: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(

--- a/services/api/src/routers/decision/proposals/delete.ts
+++ b/services/api/src/routers/decision/proposals/delete.ts
@@ -1,10 +1,10 @@
 import { Channels, deleteProposal as deleteProposalService } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const deleteProposalRouter = router({
-  deleteProposal: commonNetworkProcedure({
+  deleteProposal: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(

--- a/services/api/src/routers/decision/proposals/export.ts
+++ b/services/api/src/routers/decision/proposals/export.ts
@@ -3,7 +3,7 @@ import { ProposalFilter } from '@op/core';
 import { ProposalStatus } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const exportInputSchema = z.object({
   processInstanceId: z.string().uuid(),
@@ -20,7 +20,7 @@ const exportOutputSchema = z.object({
 });
 
 export const exportProposalsRouter = router({
-  export: commonAuthedProcedure()
+  export: commonNetworkProcedure()
     .input(exportInputSchema)
     .output(exportOutputSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/export.ts
+++ b/services/api/src/routers/decision/proposals/export.ts
@@ -3,7 +3,7 @@ import { ProposalFilter } from '@op/core';
 import { ProposalStatus } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const exportInputSchema = z.object({
   processInstanceId: z.string().uuid(),
@@ -20,7 +20,7 @@ const exportOutputSchema = z.object({
 });
 
 export const exportProposalsRouter = router({
-  export: commonNetworkProcedure()
+  export: networkAuthenticatedProcedure()
     .input(exportInputSchema)
     .output(exportOutputSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/get.ts
+++ b/services/api/src/routers/decision/proposals/get.ts
@@ -6,11 +6,11 @@ import { logger } from '@op/logging';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 import { trackProposalViewed } from '../../../utils/analytics';
 
 export const getProposalRouter = router({
-  getProposal: commonNetworkProcedure()
+  getProposal: networkAuthenticatedProcedure()
     .input(
       z.object({
         profileId: z.uuid(),

--- a/services/api/src/routers/decision/proposals/get.ts
+++ b/services/api/src/routers/decision/proposals/get.ts
@@ -6,11 +6,11 @@ import { logger } from '@op/logging';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 import { trackProposalViewed } from '../../../utils/analytics';
 
 export const getProposalRouter = router({
-  getProposal: commonAuthedProcedure()
+  getProposal: commonNetworkProcedure()
     .input(
       z.object({
         profileId: z.uuid(),

--- a/services/api/src/routers/decision/proposals/getExportStatus.ts
+++ b/services/api/src/routers/decision/proposals/getExportStatus.ts
@@ -1,7 +1,7 @@
 import { getExportStatus } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const exportStatusInputSchema = z.object({
   exportId: z.string().uuid(),
@@ -28,7 +28,7 @@ const exportStatusOutputSchema = z.union([
 ]);
 
 export const getExportStatusRouter = router({
-  getExportStatus: commonAuthedProcedure()
+  getExportStatus: commonNetworkProcedure()
     .input(exportStatusInputSchema)
     .output(exportStatusOutputSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/getExportStatus.ts
+++ b/services/api/src/routers/decision/proposals/getExportStatus.ts
@@ -1,7 +1,7 @@
 import { getExportStatus } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const exportStatusInputSchema = z.object({
   exportId: z.string().uuid(),
@@ -28,7 +28,7 @@ const exportStatusOutputSchema = z.union([
 ]);
 
 export const getExportStatusRouter = router({
-  getExportStatus: commonNetworkProcedure()
+  getExportStatus: networkAuthenticatedProcedure()
     .input(exportStatusInputSchema)
     .output(exportStatusOutputSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/getLatestSelection.ts
+++ b/services/api/src/routers/decision/proposals/getLatestSelection.ts
@@ -2,10 +2,10 @@ import { getLatestSelectionForProposal } from '@op/common';
 import { proposalSelectionSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const getLatestSelectionForProposalRouter = router({
-  getLatestSelectionForProposal: commonAuthedProcedure()
+  getLatestSelectionForProposal: commonNetworkProcedure()
     .input(
       z.object({
         proposalId: z.uuid(),

--- a/services/api/src/routers/decision/proposals/getLatestSelection.ts
+++ b/services/api/src/routers/decision/proposals/getLatestSelection.ts
@@ -2,10 +2,10 @@ import { getLatestSelectionForProposal } from '@op/common';
 import { proposalSelectionSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const getLatestSelectionForProposalRouter = router({
-  getLatestSelectionForProposal: commonNetworkProcedure()
+  getLatestSelectionForProposal: networkAuthenticatedProcedure()
     .input(
       z.object({
         proposalId: z.uuid(),

--- a/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.ts
+++ b/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.ts
@@ -4,10 +4,10 @@ import {
   proposalWithSubmittedReviewsSchema,
 } from '@op/common';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const getProposalWithReviewAggregatesRouter = router({
-  getProposalWithReviewAggregates: commonAuthedProcedure()
+  getProposalWithReviewAggregates: commonNetworkProcedure()
     .input(getProposalWithReviewAggregatesInputSchema)
     .output(proposalWithSubmittedReviewsSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.ts
+++ b/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.ts
@@ -4,10 +4,10 @@ import {
   proposalWithSubmittedReviewsSchema,
 } from '@op/common';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const getProposalWithReviewAggregatesRouter = router({
-  getProposalWithReviewAggregates: commonNetworkProcedure()
+  getProposalWithReviewAggregates: networkAuthenticatedProcedure()
     .input(getProposalWithReviewAggregatesInputSchema)
     .output(proposalWithSubmittedReviewsSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/list.ts
+++ b/services/api/src/routers/decision/proposals/list.ts
@@ -6,11 +6,11 @@ import {
 } from '@op/common/client';
 
 import { proposalFilterSchema } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const listProposalsRouter = router({
   /** Lists proposals for a given process instanc in the curent phase. */
-  listProposals: commonAuthedProcedure()
+  listProposals: commonNetworkProcedure()
     .input(proposalFilterSchema)
     .output(proposalListSchema)
     .query(async ({ ctx, input }) => {
@@ -27,7 +27,7 @@ export const listProposalsRouter = router({
       return proposalListSchema.parse(result);
     }),
   /** Lists all proposals for a given process instance, no phase filter. */
-  listAllProposals: commonAuthedProcedure()
+  listAllProposals: commonNetworkProcedure()
     .input(allProposalsFilterSchema)
     .output(allProposalsListSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/list.ts
+++ b/services/api/src/routers/decision/proposals/list.ts
@@ -6,11 +6,11 @@ import {
 } from '@op/common/client';
 
 import { proposalFilterSchema } from '../../../encoders/decision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listProposalsRouter = router({
   /** Lists proposals for a given process instanc in the curent phase. */
-  listProposals: commonNetworkProcedure()
+  listProposals: networkAuthenticatedProcedure()
     .input(proposalFilterSchema)
     .output(proposalListSchema)
     .query(async ({ ctx, input }) => {
@@ -27,7 +27,7 @@ export const listProposalsRouter = router({
       return proposalListSchema.parse(result);
     }),
   /** Lists all proposals for a given process instance, no phase filter. */
-  listAllProposals: commonNetworkProcedure()
+  listAllProposals: networkAuthenticatedProcedure()
     .input(allProposalsFilterSchema)
     .output(allProposalsListSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/listWithReviewAggregates.ts
+++ b/services/api/src/routers/decision/proposals/listWithReviewAggregates.ts
@@ -4,10 +4,10 @@ import {
   proposalsWithReviewAggregatesListSchema,
 } from '@op/common';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listWithReviewAggregatesRouter = router({
-  listWithReviewAggregates: commonNetworkProcedure()
+  listWithReviewAggregates: networkAuthenticatedProcedure()
     .input(listProposalsWithReviewAggregatesInputSchema)
     .output(proposalsWithReviewAggregatesListSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/listWithReviewAggregates.ts
+++ b/services/api/src/routers/decision/proposals/listWithReviewAggregates.ts
@@ -4,10 +4,10 @@ import {
   proposalsWithReviewAggregatesListSchema,
 } from '@op/common';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const listWithReviewAggregatesRouter = router({
-  listWithReviewAggregates: commonAuthedProcedure()
+  listWithReviewAggregates: commonNetworkProcedure()
     .input(listProposalsWithReviewAggregatesInputSchema)
     .output(proposalsWithReviewAggregatesListSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/submit.ts
+++ b/services/api/src/routers/decision/proposals/submit.ts
@@ -4,7 +4,7 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 import { trackProposalSubmitted } from '../../../utils/analytics';
 
 const submitProposalInputSchema = z.object({
@@ -12,7 +12,7 @@ const submitProposalInputSchema = z.object({
 });
 
 export const submitProposalRouter = router({
-  submitProposal: commonAuthedProcedure()
+  submitProposal: commonNetworkProcedure()
     .input(submitProposalInputSchema)
     .output(proposalSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/submit.ts
+++ b/services/api/src/routers/decision/proposals/submit.ts
@@ -4,7 +4,7 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 import { trackProposalSubmitted } from '../../../utils/analytics';
 
 const submitProposalInputSchema = z.object({
@@ -12,7 +12,7 @@ const submitProposalInputSchema = z.object({
 });
 
 export const submitProposalRouter = router({
-  submitProposal: commonNetworkProcedure()
+  submitProposal: networkAuthenticatedProcedure()
     .input(submitProposalInputSchema)
     .output(proposalSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/update.ts
+++ b/services/api/src/routers/decision/proposals/update.ts
@@ -4,10 +4,10 @@ import { proposalSchema } from '@op/common/client';
 import { z } from 'zod';
 
 import { updateProposalInputSchema } from '../../../encoders/decision';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const updateProposalRouter = router({
-  updateProposal: commonAuthedProcedure({
+  updateProposal: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(

--- a/services/api/src/routers/decision/proposals/update.ts
+++ b/services/api/src/routers/decision/proposals/update.ts
@@ -4,10 +4,10 @@ import { proposalSchema } from '@op/common/client';
 import { z } from 'zod';
 
 import { updateProposalInputSchema } from '../../../encoders/decision';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const updateProposalRouter = router({
-  updateProposal: commonNetworkProcedure({
+  updateProposal: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(

--- a/services/api/src/routers/decision/results/getInstanceResults.ts
+++ b/services/api/src/routers/decision/results/getInstanceResults.ts
@@ -2,10 +2,10 @@ import { NotFoundError, getLatestResultWithProposals } from '@op/common';
 
 import { legacyInstanceResultsEncoder } from '../../../encoders/legacyDecision';
 import { getInstanceResultsInputSchema } from '../../../encoders/results';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const getInstanceResultsRouter = router({
-  getInstanceResults: commonAuthedProcedure({
+  getInstanceResults: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 30 },
   })
     .input(getInstanceResultsInputSchema)

--- a/services/api/src/routers/decision/results/getInstanceResults.ts
+++ b/services/api/src/routers/decision/results/getInstanceResults.ts
@@ -2,10 +2,10 @@ import { NotFoundError, getLatestResultWithProposals } from '@op/common';
 
 import { legacyInstanceResultsEncoder } from '../../../encoders/legacyDecision';
 import { getInstanceResultsInputSchema } from '../../../encoders/results';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const getInstanceResultsRouter = router({
-  getInstanceResults: commonNetworkProcedure({
+  getInstanceResults: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 30 },
   })
     .input(getInstanceResultsInputSchema)

--- a/services/api/src/routers/decision/results/getResultsStats.ts
+++ b/services/api/src/routers/decision/results/getResultsStats.ts
@@ -5,10 +5,10 @@ import {
   getResultsStatsInputSchema,
   resultsStatsEncoder,
 } from '../../../encoders/results';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const getResultsStatsRouter = router({
-  getResultsStats: commonNetworkProcedure({
+  getResultsStats: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 30 },
   })
     .input(getResultsStatsInputSchema)

--- a/services/api/src/routers/decision/results/getResultsStats.ts
+++ b/services/api/src/routers/decision/results/getResultsStats.ts
@@ -5,10 +5,10 @@ import {
   getResultsStatsInputSchema,
   resultsStatsEncoder,
 } from '../../../encoders/results';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const getResultsStatsRouter = router({
-  getResultsStats: commonAuthedProcedure({
+  getResultsStats: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 30 },
   })
     .input(getResultsStatsInputSchema)

--- a/services/api/src/routers/decision/reviews/cancelRevisionRequest.ts
+++ b/services/api/src/routers/decision/reviews/cancelRevisionRequest.ts
@@ -2,10 +2,10 @@ import { Channels, cancelRevisionRequest } from '@op/common';
 import { proposalReviewRequestSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const cancelRevisionRequestRouter = router({
-  cancelRevisionRequest: commonAuthedProcedure()
+  cancelRevisionRequest: commonNetworkProcedure()
     .input(
       z.object({
         assignmentId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/cancelRevisionRequest.ts
+++ b/services/api/src/routers/decision/reviews/cancelRevisionRequest.ts
@@ -2,10 +2,10 @@ import { Channels, cancelRevisionRequest } from '@op/common';
 import { proposalReviewRequestSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const cancelRevisionRequestRouter = router({
-  cancelRevisionRequest: commonNetworkProcedure()
+  cancelRevisionRequest: networkAuthenticatedProcedure()
     .input(
       z.object({
         assignmentId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/getReviewAssignment.ts
+++ b/services/api/src/routers/decision/reviews/getReviewAssignment.ts
@@ -5,10 +5,10 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const getReviewAssignmentRouter = router({
-  getReviewAssignment: commonAuthedProcedure()
+  getReviewAssignment: commonNetworkProcedure()
     .input(
       z.object({
         assignmentId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/getReviewAssignment.ts
+++ b/services/api/src/routers/decision/reviews/getReviewAssignment.ts
@@ -5,10 +5,10 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const getReviewAssignmentRouter = router({
-  getReviewAssignment: commonNetworkProcedure()
+  getReviewAssignment: networkAuthenticatedProcedure()
     .input(
       z.object({
         assignmentId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/listProposalRevisionRequests.ts
+++ b/services/api/src/routers/decision/reviews/listProposalRevisionRequests.ts
@@ -6,10 +6,10 @@ import {
 import { ProposalReviewRequestState } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listProposalRevisionRequestsRouter = router({
-  listProposalRevisionRequests: commonNetworkProcedure()
+  listProposalRevisionRequests: networkAuthenticatedProcedure()
     .input(
       z.object({
         proposalId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/listProposalRevisionRequests.ts
+++ b/services/api/src/routers/decision/reviews/listProposalRevisionRequests.ts
@@ -6,10 +6,10 @@ import {
 import { ProposalReviewRequestState } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const listProposalRevisionRequestsRouter = router({
-  listProposalRevisionRequests: commonAuthedProcedure()
+  listProposalRevisionRequests: commonNetworkProcedure()
     .input(
       z.object({
         proposalId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
+++ b/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
@@ -6,10 +6,10 @@ import {
 import { ProposalReviewRequestState } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const listProposalsRevisionRequestsRouter = router({
-  listProposalsRevisionRequests: commonAuthedProcedure()
+  listProposalsRevisionRequests: commonNetworkProcedure()
     .input(
       z.object({
         states: z.array(z.enum(ProposalReviewRequestState)).optional(),

--- a/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
+++ b/services/api/src/routers/decision/reviews/listProposalsRevisionRequests.ts
@@ -6,10 +6,10 @@ import {
 import { ProposalReviewRequestState } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listProposalsRevisionRequestsRouter = router({
-  listProposalsRevisionRequests: commonNetworkProcedure()
+  listProposalsRevisionRequests: networkAuthenticatedProcedure()
     .input(
       z.object({
         states: z.array(z.enum(ProposalReviewRequestState)).optional(),

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.ts
@@ -6,10 +6,10 @@ import {
 import { ProposalReviewAssignmentStatus } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listReviewAssignmentsRouter = router({
-  listReviewAssignments: commonNetworkProcedure()
+  listReviewAssignments: networkAuthenticatedProcedure()
     .input(
       z.object({
         processInstanceId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.ts
@@ -6,10 +6,10 @@ import {
 import { ProposalReviewAssignmentStatus } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const listReviewAssignmentsRouter = router({
-  listReviewAssignments: commonAuthedProcedure()
+  listReviewAssignments: commonNetworkProcedure()
     .input(
       z.object({
         processInstanceId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/requestRevision.ts
+++ b/services/api/src/routers/decision/reviews/requestRevision.ts
@@ -4,10 +4,10 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const requestRevisionRouter = router({
-  requestRevision: commonNetworkProcedure()
+  requestRevision: networkAuthenticatedProcedure()
     .input(
       z.object({
         assignmentId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/requestRevision.ts
+++ b/services/api/src/routers/decision/reviews/requestRevision.ts
@@ -4,10 +4,10 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const requestRevisionRouter = router({
-  requestRevision: commonAuthedProcedure()
+  requestRevision: commonNetworkProcedure()
     .input(
       z.object({
         assignmentId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.ts
@@ -5,7 +5,7 @@ import {
 } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const saveReviewDraftInputSchema = z.object({
   assignmentId: z.uuid(),
@@ -14,7 +14,7 @@ const saveReviewDraftInputSchema = z.object({
 });
 
 export const saveReviewDraftRouter = router({
-  saveReviewDraft: commonNetworkProcedure()
+  saveReviewDraft: networkAuthenticatedProcedure()
     .input(saveReviewDraftInputSchema)
     .output(proposalReviewSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.ts
@@ -5,7 +5,7 @@ import {
 } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const saveReviewDraftInputSchema = z.object({
   assignmentId: z.uuid(),
@@ -14,7 +14,7 @@ const saveReviewDraftInputSchema = z.object({
 });
 
 export const saveReviewDraftRouter = router({
-  saveReviewDraft: commonAuthedProcedure()
+  saveReviewDraft: commonNetworkProcedure()
     .input(saveReviewDraftInputSchema)
     .output(proposalReviewSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/reviews/submitReview.ts
+++ b/services/api/src/routers/decision/reviews/submitReview.ts
@@ -5,7 +5,7 @@ import {
 } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const reviewInputSchema = z.object({
   assignmentId: z.uuid(),
@@ -14,7 +14,7 @@ const reviewInputSchema = z.object({
 });
 
 export const submitReviewRouter = router({
-  submitReview: commonNetworkProcedure()
+  submitReview: networkAuthenticatedProcedure()
     .input(reviewInputSchema)
     .output(proposalReviewSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/reviews/submitReview.ts
+++ b/services/api/src/routers/decision/reviews/submitReview.ts
@@ -5,7 +5,7 @@ import {
 } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const reviewInputSchema = z.object({
   assignmentId: z.uuid(),
@@ -14,7 +14,7 @@ const reviewInputSchema = z.object({
 });
 
 export const submitReviewRouter = router({
-  submitReview: commonAuthedProcedure()
+  submitReview: commonNetworkProcedure()
     .input(reviewInputSchema)
     .output(proposalReviewSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/reviews/submitRevisionResponse.ts
+++ b/services/api/src/routers/decision/reviews/submitRevisionResponse.ts
@@ -4,10 +4,10 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const submitRevisionResponseRouter = router({
-  submitRevisionResponse: commonAuthedProcedure()
+  submitRevisionResponse: commonNetworkProcedure()
     .input(
       z.object({
         revisionRequestId: z.uuid(),

--- a/services/api/src/routers/decision/reviews/submitRevisionResponse.ts
+++ b/services/api/src/routers/decision/reviews/submitRevisionResponse.ts
@@ -4,10 +4,10 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const submitRevisionResponseRouter = router({
-  submitRevisionResponse: commonNetworkProcedure()
+  submitRevisionResponse: networkAuthenticatedProcedure()
     .input(
       z.object({
         revisionRequestId: z.uuid(),

--- a/services/api/src/routers/decision/survey.ts
+++ b/services/api/src/routers/decision/survey.ts
@@ -4,7 +4,7 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const FREE_TEXT_MAX = 5000;
 const OPTION_ID_MAX = 50;
@@ -42,7 +42,7 @@ const processSurveyQueryInput = z.object({
 });
 
 export const surveyRouter = router({
-  submitProcessSurveyResponse: commonNetworkProcedure({
+  submitProcessSurveyResponse: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(submitProcessSurveyResponseInput)
@@ -57,7 +57,7 @@ export const surveyRouter = router({
       });
     }),
 
-  getProcessSurveyResponse: commonNetworkProcedure()
+  getProcessSurveyResponse: networkAuthenticatedProcedure()
     .input(processSurveyQueryInput)
     .query(async ({ input, ctx }) => {
       return await getProcessSurveyResponse({

--- a/services/api/src/routers/decision/survey.ts
+++ b/services/api/src/routers/decision/survey.ts
@@ -4,7 +4,7 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const FREE_TEXT_MAX = 5000;
 const OPTION_ID_MAX = 50;
@@ -42,7 +42,7 @@ const processSurveyQueryInput = z.object({
 });
 
 export const surveyRouter = router({
-  submitProcessSurveyResponse: commonAuthedProcedure({
+  submitProcessSurveyResponse: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(submitProcessSurveyResponseInput)
@@ -57,7 +57,7 @@ export const surveyRouter = router({
       });
     }),
 
-  getProcessSurveyResponse: commonAuthedProcedure()
+  getProcessSurveyResponse: commonNetworkProcedure()
     .input(processSurveyQueryInput)
     .query(async ({ input, ctx }) => {
       return await getProcessSurveyResponse({

--- a/services/api/src/routers/decision/uploadProposalAttachment.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.ts
@@ -7,7 +7,7 @@ import { createServerClient } from '@op/supabase/lib';
 import { Buffer } from 'node:buffer';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 
 const ALLOWED_MIME_TYPES = [
@@ -22,7 +22,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadProposalAttachment = router({
-  uploadProposalAttachment: commonNetworkProcedure({
+  uploadProposalAttachment: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(

--- a/services/api/src/routers/decision/uploadProposalAttachment.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.ts
@@ -7,7 +7,7 @@ import { createServerClient } from '@op/supabase/lib';
 import { Buffer } from 'node:buffer';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 
 const ALLOWED_MIME_TYPES = [
@@ -22,7 +22,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadProposalAttachment = router({
-  uploadProposalAttachment: commonAuthedProcedure({
+  uploadProposalAttachment: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(

--- a/services/api/src/routers/decision/voting.ts
+++ b/services/api/src/routers/decision/voting.ts
@@ -3,7 +3,7 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 // Input Schemas based on our contracts
 const customDataSchema = z.record(z.string(), z.unknown()).optional();
@@ -17,7 +17,7 @@ const submitVoteInput = z.object({
 
 export const votingRouter = router({
   // Submit user's vote (validates against current schema)
-  submitVote: commonNetworkProcedure({
+  submitVote: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(submitVoteInput)
@@ -48,7 +48,7 @@ export const votingRouter = router({
     }),
 
   // Get user's vote status with schema context
-  getVotingStatus: commonNetworkProcedure()
+  getVotingStatus: networkAuthenticatedProcedure()
     .input(
       z.object({
         processInstanceId: z.uuid(),

--- a/services/api/src/routers/decision/voting.ts
+++ b/services/api/src/routers/decision/voting.ts
@@ -3,7 +3,7 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 // Input Schemas based on our contracts
 const customDataSchema = z.record(z.string(), z.unknown()).optional();
@@ -17,7 +17,7 @@ const submitVoteInput = z.object({
 
 export const votingRouter = router({
   // Submit user's vote (validates against current schema)
-  submitVote: commonAuthedProcedure({
+  submitVote: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(submitVoteInput)
@@ -48,7 +48,7 @@ export const votingRouter = router({
     }),
 
   // Get user's vote status with schema context
-  getVotingStatus: commonAuthedProcedure()
+  getVotingStatus: commonNetworkProcedure()
     .input(
       z.object({
         processInstanceId: z.uuid(),

--- a/services/api/src/routers/individual/getIndividual.ts
+++ b/services/api/src/routers/individual/getIndividual.ts
@@ -2,10 +2,10 @@ import { getIndividualTermsByProfile } from '@op/common';
 import { z } from 'zod';
 
 import { individualsTermsEncoder } from '../../encoders/individuals';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const getIndividualRouter = router({
-  getTermsByProfile: commonAuthedProcedure()
+  getTermsByProfile: commonNetworkProcedure()
     .input(z.object({ profileId: z.string(), termUri: z.string().optional() }))
     .output(individualsTermsEncoder)
     .query(async ({ input }) => {

--- a/services/api/src/routers/individual/getIndividual.ts
+++ b/services/api/src/routers/individual/getIndividual.ts
@@ -2,10 +2,10 @@ import { getIndividualTermsByProfile } from '@op/common';
 import { z } from 'zod';
 
 import { individualsTermsEncoder } from '../../encoders/individuals';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const getIndividualRouter = router({
-  getTermsByProfile: commonNetworkProcedure()
+  getTermsByProfile: networkAuthenticatedProcedure()
     .input(z.object({ profileId: z.string(), termUri: z.string().optional() }))
     .output(individualsTermsEncoder)
     .query(async ({ input }) => {

--- a/services/api/src/routers/organization/addRelationship.ts
+++ b/services/api/src/routers/organization/addRelationship.ts
@@ -7,7 +7,7 @@ import { getCurrentOrgId } from '@op/common/src/services/access';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { trackRelationshipAdded } from '../../utils/analytics';
 
 const inputSchema = z.object({
@@ -19,7 +19,7 @@ const inputSchema = z.object({
 });
 
 export const addRelationshipRouter = router({
-  addRelationship: commonNetworkProcedure()
+  addRelationship: networkAuthenticatedProcedure()
     .input(inputSchema)
     .mutation(async ({ ctx, input }) => {
       const { user } = ctx;

--- a/services/api/src/routers/organization/addRelationship.ts
+++ b/services/api/src/routers/organization/addRelationship.ts
@@ -7,7 +7,7 @@ import { getCurrentOrgId } from '@op/common/src/services/access';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { trackRelationshipAdded } from '../../utils/analytics';
 
 const inputSchema = z.object({
@@ -19,7 +19,7 @@ const inputSchema = z.object({
 });
 
 export const addRelationshipRouter = router({
-  addRelationship: commonAuthedProcedure()
+  addRelationship: commonNetworkProcedure()
     .input(inputSchema)
     .mutation(async ({ ctx, input }) => {
       const { user } = ctx;

--- a/services/api/src/routers/organization/approveRelationship.ts
+++ b/services/api/src/routers/organization/approveRelationship.ts
@@ -2,7 +2,7 @@ import { approveRelationship } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { trackRelationshipAccepted } from '../../utils/analytics';
 
 const inputSchema = z.object({
@@ -15,7 +15,7 @@ const inputSchema = z.object({
 });
 
 export const approveRelationshipRouter = router({
-  approveRelationship: commonNetworkProcedure()
+  approveRelationship: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(z.boolean())
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/organization/approveRelationship.ts
+++ b/services/api/src/routers/organization/approveRelationship.ts
@@ -2,7 +2,7 @@ import { approveRelationship } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { trackRelationshipAccepted } from '../../utils/analytics';
 
 const inputSchema = z.object({
@@ -15,7 +15,7 @@ const inputSchema = z.object({
 });
 
 export const approveRelationshipRouter = router({
-  approveRelationship: commonAuthedProcedure()
+  approveRelationship: commonNetworkProcedure()
     .input(inputSchema)
     .output(z.boolean())
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/organization/checkMembership.ts
+++ b/services/api/src/routers/organization/checkMembership.ts
@@ -3,7 +3,7 @@ import { db } from '@op/db/client';
 import { assertAccess, permission } from 'access-zones';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   email: z.email(),
@@ -15,7 +15,7 @@ const outputSchema = z.object({
 });
 
 export const checkMembershipRouter = router({
-  checkMembership: commonNetworkProcedure({
+  checkMembership: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 20 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/checkMembership.ts
+++ b/services/api/src/routers/organization/checkMembership.ts
@@ -3,7 +3,7 @@ import { db } from '@op/db/client';
 import { assertAccess, permission } from 'access-zones';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   email: z.email(),
@@ -15,7 +15,7 @@ const outputSchema = z.object({
 });
 
 export const checkMembershipRouter = router({
-  checkMembership: commonAuthedProcedure({
+  checkMembership: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 20 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/createOrganization.ts
+++ b/services/api/src/routers/organization/createOrganization.ts
@@ -2,11 +2,11 @@ import { invalidate } from '@op/cache';
 import { createOrganization } from '@op/common';
 
 import { organizationsEncoder } from '../../encoders/organizations';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { createOrganizationInputSchema } from './validators';
 
 export const createOrganizationRouter = router({
-  create: commonAuthedProcedure()
+  create: commonNetworkProcedure()
     .input(createOrganizationInputSchema)
     .output(organizationsEncoder)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/organization/createOrganization.ts
+++ b/services/api/src/routers/organization/createOrganization.ts
@@ -2,11 +2,11 @@ import { invalidate } from '@op/cache';
 import { createOrganization } from '@op/common';
 
 import { organizationsEncoder } from '../../encoders/organizations';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { createOrganizationInputSchema } from './validators';
 
 export const createOrganizationRouter = router({
-  create: commonNetworkProcedure()
+  create: networkAuthenticatedProcedure()
     .input(createOrganizationInputSchema)
     .output(organizationsEncoder)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/organization/createPostInOrganization.ts
+++ b/services/api/src/routers/organization/createPostInOrganization.ts
@@ -3,13 +3,13 @@ import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
 import { postsEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { trackUserPost } from '../../utils/analytics';
 
 const outputSchema = postsEncoder;
 
 export const createPostInOrganizationRouter = router({
-  createPost: commonAuthedProcedure({
+  createPost: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 3 },
   })
     .input(

--- a/services/api/src/routers/organization/createPostInOrganization.ts
+++ b/services/api/src/routers/organization/createPostInOrganization.ts
@@ -3,13 +3,13 @@ import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
 import { postsEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { trackUserPost } from '../../utils/analytics';
 
 const outputSchema = postsEncoder;
 
 export const createPostInOrganizationRouter = router({
-  createPost: commonNetworkProcedure({
+  createPost: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 3 },
   })
     .input(

--- a/services/api/src/routers/organization/declineRelationship.ts
+++ b/services/api/src/routers/organization/declineRelationship.ts
@@ -1,7 +1,7 @@
 import { declineRelationship } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   targetOrganizationId: z.uuid({
@@ -11,7 +11,7 @@ const inputSchema = z.object({
 });
 
 export const declineRelationshipRouter = router({
-  declineRelationship: commonAuthedProcedure()
+  declineRelationship: commonNetworkProcedure()
     .input(inputSchema)
     .output(z.boolean())
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/organization/declineRelationship.ts
+++ b/services/api/src/routers/organization/declineRelationship.ts
@@ -1,7 +1,7 @@
 import { declineRelationship } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   targetOrganizationId: z.uuid({
@@ -11,7 +11,7 @@ const inputSchema = z.object({
 });
 
 export const declineRelationshipRouter = router({
-  declineRelationship: commonNetworkProcedure()
+  declineRelationship: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(z.boolean())
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/organization/deleteOrganization.ts
+++ b/services/api/src/routers/organization/deleteOrganization.ts
@@ -1,7 +1,7 @@
 import { deleteOrganization } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const outputSchema = z.object({
   deletedId: z.string().uuid(),
@@ -12,7 +12,7 @@ const inputSchema = z.object({
 });
 
 export const deleteOrganizationRouter = router({
-  deleteOrganization: commonNetworkProcedure({
+  deleteOrganization: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 5 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/deleteOrganization.ts
+++ b/services/api/src/routers/organization/deleteOrganization.ts
@@ -1,7 +1,7 @@
 import { deleteOrganization } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const outputSchema = z.object({
   deletedId: z.string().uuid(),
@@ -12,7 +12,7 @@ const inputSchema = z.object({
 });
 
 export const deleteOrganizationRouter = router({
-  deleteOrganization: commonAuthedProcedure({
+  deleteOrganization: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 5 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/deleteOrganizationUser.ts
+++ b/services/api/src/routers/organization/deleteOrganizationUser.ts
@@ -1,7 +1,7 @@
 import { deleteOrganizationUser } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   organizationId: z.uuid(),
@@ -20,7 +20,7 @@ const outputSchema = z.object({
 });
 
 export const deleteOrganizationUserRouter = router({
-  deleteOrganizationUser: commonNetworkProcedure({
+  deleteOrganizationUser: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 5 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/deleteOrganizationUser.ts
+++ b/services/api/src/routers/organization/deleteOrganizationUser.ts
@@ -1,7 +1,7 @@
 import { deleteOrganizationUser } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   organizationId: z.uuid(),
@@ -20,7 +20,7 @@ const outputSchema = z.object({
 });
 
 export const deleteOrganizationUserRouter = router({
-  deleteOrganizationUser: commonAuthedProcedure({
+  deleteOrganizationUser: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 5 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/deletePost.ts
+++ b/services/api/src/routers/organization/deletePost.ts
@@ -1,10 +1,10 @@
 import { deletePostById } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const deletePost = router({
-  deletePost: commonAuthedProcedure({
+  deletePost: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(

--- a/services/api/src/routers/organization/deletePost.ts
+++ b/services/api/src/routers/organization/deletePost.ts
@@ -1,10 +1,10 @@
 import { deletePostById } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const deletePost = router({
-  deletePost: commonNetworkProcedure({
+  deletePost: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(

--- a/services/api/src/routers/organization/getOrganization.ts
+++ b/services/api/src/routers/organization/getOrganization.ts
@@ -6,14 +6,14 @@ import {
   organizationsTermsEncoder,
   organizationsWithProfileEncoder,
 } from '../../encoders/organizations';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   slug: z.string(),
 });
 
 export const getOrganizationRouter = router({
-  getBySlug: commonNetworkProcedure()
+  getBySlug: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(organizationsWithProfileEncoder)
     .query(async ({ input }) => {
@@ -27,7 +27,7 @@ export const getOrganizationRouter = router({
 
       return organizationsWithProfileEncoder.parse(result);
     }),
-  getTerms: commonNetworkProcedure()
+  getTerms: networkAuthenticatedProcedure()
     .input(z.object({ id: z.string(), termUri: z.string().optional() }))
     .output(organizationsTermsEncoder)
     .query(async ({ input }) => {

--- a/services/api/src/routers/organization/getOrganization.ts
+++ b/services/api/src/routers/organization/getOrganization.ts
@@ -6,14 +6,14 @@ import {
   organizationsTermsEncoder,
   organizationsWithProfileEncoder,
 } from '../../encoders/organizations';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   slug: z.string(),
 });
 
 export const getOrganizationRouter = router({
-  getBySlug: commonAuthedProcedure()
+  getBySlug: commonNetworkProcedure()
     .input(inputSchema)
     .output(organizationsWithProfileEncoder)
     .query(async ({ input }) => {
@@ -27,7 +27,7 @@ export const getOrganizationRouter = router({
 
       return organizationsWithProfileEncoder.parse(result);
     }),
-  getTerms: commonAuthedProcedure()
+  getTerms: commonNetworkProcedure()
     .input(z.object({ id: z.string(), termUri: z.string().optional() }))
     .output(organizationsTermsEncoder)
     .query(async ({ input }) => {

--- a/services/api/src/routers/organization/getOrganizationsByProfile.ts
+++ b/services/api/src/routers/organization/getOrganizationsByProfile.ts
@@ -2,10 +2,10 @@ import { getOrganizationsByProfile } from '@op/common';
 import { z } from 'zod';
 
 import { organizationsWithProfileEncoder } from '../../encoders/organizations';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const getOrganizationsByProfileRouter = router({
-  getOrganizationsByProfile: commonNetworkProcedure()
+  getOrganizationsByProfile: networkAuthenticatedProcedure()
     .input(z.object({ profileId: z.uuid() }))
     .output(z.array(organizationsWithProfileEncoder))
     .query(async ({ input }) => {

--- a/services/api/src/routers/organization/getOrganizationsByProfile.ts
+++ b/services/api/src/routers/organization/getOrganizationsByProfile.ts
@@ -2,10 +2,10 @@ import { getOrganizationsByProfile } from '@op/common';
 import { z } from 'zod';
 
 import { organizationsWithProfileEncoder } from '../../encoders/organizations';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const getOrganizationsByProfileRouter = router({
-  getOrganizationsByProfile: commonAuthedProcedure()
+  getOrganizationsByProfile: commonNetworkProcedure()
     .input(z.object({ profileId: z.uuid() }))
     .output(z.array(organizationsWithProfileEncoder))
     .query(async ({ input }) => {

--- a/services/api/src/routers/organization/getRoles.ts
+++ b/services/api/src/routers/organization/getRoles.ts
@@ -1,7 +1,7 @@
 import { getRoles } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const outputSchema = z.object({
   roles: z.array(
@@ -14,7 +14,7 @@ const outputSchema = z.object({
 });
 
 export const getRolesRouter = router({
-  getRoles: commonNetworkProcedure()
+  getRoles: networkAuthenticatedProcedure()
     .output(outputSchema)
     .query(async () => {
       const result = await getRoles();

--- a/services/api/src/routers/organization/getRoles.ts
+++ b/services/api/src/routers/organization/getRoles.ts
@@ -1,7 +1,7 @@
 import { getRoles } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const outputSchema = z.object({
   roles: z.array(
@@ -14,7 +14,7 @@ const outputSchema = z.object({
 });
 
 export const getRolesRouter = router({
-  getRoles: commonAuthedProcedure()
+  getRoles: commonNetworkProcedure()
     .output(outputSchema)
     .query(async () => {
       const result = await getRoles();

--- a/services/api/src/routers/organization/inviteUser.ts
+++ b/services/api/src/routers/organization/inviteUser.ts
@@ -4,7 +4,7 @@ import { db } from '@op/db/client';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z
   .object({
@@ -54,7 +54,7 @@ const outputSchema = z.object({
 });
 
 export const inviteUserRouter = router({
-  invite: commonNetworkProcedure({
+  invite: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/inviteUser.ts
+++ b/services/api/src/routers/organization/inviteUser.ts
@@ -4,7 +4,7 @@ import { db } from '@op/db/client';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z
   .object({
@@ -54,7 +54,7 @@ const outputSchema = z.object({
 });
 
 export const inviteUserRouter = router({
-  invite: commonAuthedProcedure({
+  invite: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/joinOrganization.ts
+++ b/services/api/src/routers/organization/joinOrganization.ts
@@ -6,14 +6,14 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   organizationId: z.uuid('Organization ID must be a valid UUID'),
 });
 
 export const joinOrganization = router({
-  join: commonNetworkProcedure({
+  join: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 5 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/joinOrganization.ts
+++ b/services/api/src/routers/organization/joinOrganization.ts
@@ -6,14 +6,14 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   organizationId: z.uuid('Organization ID must be a valid UUID'),
 });
 
 export const joinOrganization = router({
-  join: commonAuthedProcedure({
+  join: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 5 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/listOrganizations.ts
+++ b/services/api/src/routers/organization/listOrganizations.ts
@@ -2,11 +2,11 @@ import { listOrganizations } from '@op/common';
 import { z } from 'zod';
 
 import { organizationsWithProfileEncoder } from '../../encoders/organizations';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 export const listOrganizationsRouter = router({
-  list: commonAuthedProcedure()
+  list: commonNetworkProcedure()
     .input(
       dbFilter
         .extend({

--- a/services/api/src/routers/organization/listOrganizations.ts
+++ b/services/api/src/routers/organization/listOrganizations.ts
@@ -2,11 +2,11 @@ import { listOrganizations } from '@op/common';
 import { z } from 'zod';
 
 import { organizationsWithProfileEncoder } from '../../encoders/organizations';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 export const listOrganizationsRouter = router({
-  list: commonNetworkProcedure()
+  list: networkAuthenticatedProcedure()
     .input(
       dbFilter
         .extend({

--- a/services/api/src/routers/organization/listPosts.ts
+++ b/services/api/src/routers/organization/listPosts.ts
@@ -6,7 +6,7 @@ import {
   postsEncoder,
   postsToOrganizationsEncoder,
 } from '../../encoders/posts';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 const inputSchema = dbFilter.extend({
@@ -15,7 +15,7 @@ const inputSchema = dbFilter.extend({
 });
 
 export const listOrganizationPostsRouter = router({
-  listPosts: commonAuthedProcedure()
+  listPosts: commonNetworkProcedure()
     .input(inputSchema)
     .output(
       z.object({

--- a/services/api/src/routers/organization/listPosts.ts
+++ b/services/api/src/routers/organization/listPosts.ts
@@ -6,7 +6,7 @@ import {
   postsEncoder,
   postsToOrganizationsEncoder,
 } from '../../encoders/posts';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 const inputSchema = dbFilter.extend({
@@ -15,7 +15,7 @@ const inputSchema = dbFilter.extend({
 });
 
 export const listOrganizationPostsRouter = router({
-  listPosts: commonNetworkProcedure()
+  listPosts: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(
       z.object({

--- a/services/api/src/routers/organization/listRelatedOrganizationPosts.ts
+++ b/services/api/src/routers/organization/listRelatedOrganizationPosts.ts
@@ -6,11 +6,11 @@ import {
   postsEncoder,
   postsToOrganizationsEncoder,
 } from '../../encoders/posts';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 export const listRelatedOrganizationPostsRouter = router({
-  listAllPosts: commonNetworkProcedure()
+  listAllPosts: networkAuthenticatedProcedure()
     .input(
       dbFilter
         .extend({

--- a/services/api/src/routers/organization/listRelatedOrganizationPosts.ts
+++ b/services/api/src/routers/organization/listRelatedOrganizationPosts.ts
@@ -6,11 +6,11 @@ import {
   postsEncoder,
   postsToOrganizationsEncoder,
 } from '../../encoders/posts';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 export const listRelatedOrganizationPostsRouter = router({
-  listAllPosts: commonAuthedProcedure()
+  listAllPosts: commonNetworkProcedure()
     .input(
       dbFilter
         .extend({

--- a/services/api/src/routers/organization/listRelationships.ts
+++ b/services/api/src/routers/organization/listRelationships.ts
@@ -9,7 +9,7 @@ import { getCurrentOrgId } from '@op/common/src/services/access';
 import { Organization } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const directedInputSchema = z.object({
   from: z.uuid({
@@ -32,7 +32,7 @@ const nonDirectedInputSchema = z.object({
 });
 
 export const listRelationshipsRouter = router({
-  listPendingRelationships: commonNetworkProcedure()
+  listPendingRelationships: networkAuthenticatedProcedure()
     .input(z.void())
     .query(async ({ ctx }) => {
       const { user } = ctx;
@@ -45,7 +45,7 @@ export const listRelationshipsRouter = router({
 
       return { organizations, count };
     }),
-  listDirectedRelationships: commonNetworkProcedure()
+  listDirectedRelationships: networkAuthenticatedProcedure()
     .input(directedInputSchema)
     .query(async ({ ctx, input }) => {
       const { user } = ctx;
@@ -79,7 +79,7 @@ export const listRelationshipsRouter = router({
 
       return { relationships, count };
     }),
-  listRelationships: commonNetworkProcedure()
+  listRelationships: networkAuthenticatedProcedure()
     .input(nonDirectedInputSchema)
     .query(async ({ ctx, input }) => {
       const { user } = ctx;

--- a/services/api/src/routers/organization/listRelationships.ts
+++ b/services/api/src/routers/organization/listRelationships.ts
@@ -9,7 +9,7 @@ import { getCurrentOrgId } from '@op/common/src/services/access';
 import { Organization } from '@op/db/schema';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const directedInputSchema = z.object({
   from: z.uuid({
@@ -32,7 +32,7 @@ const nonDirectedInputSchema = z.object({
 });
 
 export const listRelationshipsRouter = router({
-  listPendingRelationships: commonAuthedProcedure()
+  listPendingRelationships: commonNetworkProcedure()
     .input(z.void())
     .query(async ({ ctx }) => {
       const { user } = ctx;
@@ -45,7 +45,7 @@ export const listRelationshipsRouter = router({
 
       return { organizations, count };
     }),
-  listDirectedRelationships: commonAuthedProcedure()
+  listDirectedRelationships: commonNetworkProcedure()
     .input(directedInputSchema)
     .query(async ({ ctx, input }) => {
       const { user } = ctx;
@@ -79,7 +79,7 @@ export const listRelationshipsRouter = router({
 
       return { relationships, count };
     }),
-  listRelationships: commonAuthedProcedure()
+  listRelationships: commonNetworkProcedure()
     .input(nonDirectedInputSchema)
     .query(async ({ ctx, input }) => {
       const { user } = ctx;

--- a/services/api/src/routers/organization/listUsers.ts
+++ b/services/api/src/routers/organization/listUsers.ts
@@ -1,7 +1,7 @@
 import { getOrganizationUsers } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.uuid(),
@@ -42,7 +42,7 @@ const organizationUserEncoder = z.object({
 });
 
 export const listUsersRouter = router({
-  listUsers: commonNetworkProcedure()
+  listUsers: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(z.array(organizationUserEncoder))
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/organization/listUsers.ts
+++ b/services/api/src/routers/organization/listUsers.ts
@@ -1,7 +1,7 @@
 import { getOrganizationUsers } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.uuid(),
@@ -42,7 +42,7 @@ const organizationUserEncoder = z.object({
 });
 
 export const listUsersRouter = router({
-  listUsers: commonAuthedProcedure()
+  listUsers: commonNetworkProcedure()
     .input(inputSchema)
     .output(z.array(organizationUserEncoder))
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/organization/reactions.ts
+++ b/services/api/src/routers/organization/reactions.ts
@@ -2,11 +2,11 @@ import { channelsForPost, toggleReaction } from '@op/common';
 import { VALID_REACTION_TYPES } from '@op/types';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const reactionTypeEnum = z.enum(VALID_REACTION_TYPES as [string, ...string[]]);
 
-const reactionProcedure = commonNetworkProcedure({
+const reactionProcedure = networkAuthenticatedProcedure({
   rateLimit: { windowSize: 10, maxRequests: 20 },
 });
 

--- a/services/api/src/routers/organization/reactions.ts
+++ b/services/api/src/routers/organization/reactions.ts
@@ -2,11 +2,11 @@ import { channelsForPost, toggleReaction } from '@op/common';
 import { VALID_REACTION_TYPES } from '@op/types';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const reactionTypeEnum = z.enum(VALID_REACTION_TYPES as [string, ...string[]]);
 
-const reactionProcedure = commonAuthedProcedure({
+const reactionProcedure = commonNetworkProcedure({
   rateLimit: { windowSize: 10, maxRequests: 20 },
 });
 

--- a/services/api/src/routers/organization/removeRelationship.ts
+++ b/services/api/src/routers/organization/removeRelationship.ts
@@ -1,7 +1,7 @@
 import { Channels, removeRelationship } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   id: z.uuid({
@@ -10,7 +10,7 @@ const inputSchema = z.object({
 });
 
 export const removeRelationshipRouter = router({
-  removeRelationship: commonNetworkProcedure()
+  removeRelationship: networkAuthenticatedProcedure()
     .input(inputSchema)
     .mutation(async ({ ctx, input }) => {
       const { id } = input;

--- a/services/api/src/routers/organization/removeRelationship.ts
+++ b/services/api/src/routers/organization/removeRelationship.ts
@@ -1,7 +1,7 @@
 import { Channels, removeRelationship } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   id: z.uuid({
@@ -10,7 +10,7 @@ const inputSchema = z.object({
 });
 
 export const removeRelationshipRouter = router({
-  removeRelationship: commonAuthedProcedure()
+  removeRelationship: commonNetworkProcedure()
     .input(inputSchema)
     .mutation(async ({ ctx, input }) => {
       const { id } = input;

--- a/services/api/src/routers/organization/searchOrganizations.ts
+++ b/services/api/src/routers/organization/searchOrganizations.ts
@@ -6,11 +6,11 @@ import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { searchedOrganizationEncoder } from '../../encoders/organizations';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 export const searchOrganizationsRouter = router({
-  search: commonNetworkProcedure()
+  search: networkAuthenticatedProcedure()
     .input(
       dbFilter.extend({
         q: z.string(),

--- a/services/api/src/routers/organization/searchOrganizations.ts
+++ b/services/api/src/routers/organization/searchOrganizations.ts
@@ -6,11 +6,11 @@ import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { searchedOrganizationEncoder } from '../../encoders/organizations';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 export const searchOrganizationsRouter = router({
-  search: commonAuthedProcedure()
+  search: commonNetworkProcedure()
     .input(
       dbFilter.extend({
         q: z.string(),

--- a/services/api/src/routers/organization/updateOrganization.ts
+++ b/services/api/src/routers/organization/updateOrganization.ts
@@ -3,12 +3,12 @@ import { updateOrganization } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 
 import { organizationsEncoder } from '../../encoders/organizations';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { trackFundingToggle } from '../../utils/analytics';
 import { updateOrganizationInputSchema } from './validators';
 
 export const updateOrganizationRouter = router({
-  update: commonNetworkProcedure({
+  update: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(updateOrganizationInputSchema)

--- a/services/api/src/routers/organization/updateOrganization.ts
+++ b/services/api/src/routers/organization/updateOrganization.ts
@@ -3,12 +3,12 @@ import { updateOrganization } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 
 import { organizationsEncoder } from '../../encoders/organizations';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { trackFundingToggle } from '../../utils/analytics';
 import { updateOrganizationInputSchema } from './validators';
 
 export const updateOrganizationRouter = router({
-  update: commonAuthedProcedure({
+  update: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(updateOrganizationInputSchema)

--- a/services/api/src/routers/organization/updateOrganizationUser.ts
+++ b/services/api/src/routers/organization/updateOrganizationUser.ts
@@ -1,7 +1,7 @@
 import { updateOrganizationUser } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   organizationId: z.uuid(),
@@ -33,7 +33,7 @@ const outputSchema = z.object({
 });
 
 export const updateOrganizationUserRouter = router({
-  updateOrganizationUser: commonAuthedProcedure({
+  updateOrganizationUser: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/updateOrganizationUser.ts
+++ b/services/api/src/routers/organization/updateOrganizationUser.ts
@@ -1,7 +1,7 @@
 import { updateOrganizationUser } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   organizationId: z.uuid(),
@@ -33,7 +33,7 @@ const outputSchema = z.object({
 });
 
 export const updateOrganizationUserRouter = router({
-  updateOrganizationUser: commonNetworkProcedure({
+  updateOrganizationUser: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/organization/uploadAvatarImage.ts
+++ b/services/api/src/routers/organization/uploadAvatarImage.ts
@@ -4,7 +4,7 @@ import { waitUntil } from '@vercel/functions';
 import { Buffer } from 'buffer';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
 
@@ -16,7 +16,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadAvatarImage = router({
-  uploadAvatarImage: commonNetworkProcedure()
+  uploadAvatarImage: networkAuthenticatedProcedure()
     .input(
       z.object({
         file: z.string(), // base64 encoded

--- a/services/api/src/routers/organization/uploadAvatarImage.ts
+++ b/services/api/src/routers/organization/uploadAvatarImage.ts
@@ -4,7 +4,7 @@ import { waitUntil } from '@vercel/functions';
 import { Buffer } from 'buffer';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
 
@@ -16,7 +16,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadAvatarImage = router({
-  uploadAvatarImage: commonAuthedProcedure()
+  uploadAvatarImage: commonNetworkProcedure()
     .input(
       z.object({
         file: z.string(), // base64 encoded

--- a/services/api/src/routers/platform/index.ts
+++ b/services/api/src/routers/platform/index.ts
@@ -1,14 +1,14 @@
 import { getPlatformStats } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { platformAdminRouter } from './admin';
 
 /**
  * Handles platform-wide operations such as retrieving statistics, listing profiles, users, organizations, etc,.
  */
 export const platformRouter = router({
-  getStats: commonNetworkProcedure()
+  getStats: networkAuthenticatedProcedure()
     .input(z.void())
     .output(
       z.object({

--- a/services/api/src/routers/platform/index.ts
+++ b/services/api/src/routers/platform/index.ts
@@ -1,14 +1,14 @@
 import { getPlatformStats } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { platformAdminRouter } from './admin';
 
 /**
  * Handles platform-wide operations such as retrieving statistics, listing profiles, users, organizations, etc,.
  */
 export const platformRouter = router({
-  getStats: commonAuthedProcedure()
+  getStats: commonNetworkProcedure()
     .input(z.void())
     .output(
       z.object({

--- a/services/api/src/routers/posts/createPost.ts
+++ b/services/api/src/routers/posts/createPost.ts
@@ -4,13 +4,13 @@ import { createPostSchema } from '@op/types';
 import { waitUntil } from '@vercel/functions';
 
 import { postsEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { trackProposalCommented } from '../../utils/analytics';
 
 const outputSchema = postsEncoder;
 
 export const createPost = router({
-  createPost: commonNetworkProcedure()
+  createPost: networkAuthenticatedProcedure()
     .input(createPostSchema)
     .output(outputSchema)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/posts/createPost.ts
+++ b/services/api/src/routers/posts/createPost.ts
@@ -4,13 +4,13 @@ import { createPostSchema } from '@op/types';
 import { waitUntil } from '@vercel/functions';
 
 import { postsEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { trackProposalCommented } from '../../utils/analytics';
 
 const outputSchema = postsEncoder;
 
 export const createPost = router({
-  createPost: commonAuthedProcedure()
+  createPost: commonNetworkProcedure()
     .input(createPostSchema)
     .output(outputSchema)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/posts/getPost.ts
+++ b/services/api/src/routers/posts/getPost.ts
@@ -2,12 +2,12 @@ import { NotFoundError, getPost as getPostService } from '@op/common';
 import { getPostSchema } from '@op/types';
 
 import { postsEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const outputSchema = postsEncoder;
 
 export const getPost = router({
-  getPost: commonNetworkProcedure({
+  getPost: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(getPostSchema)

--- a/services/api/src/routers/posts/getPost.ts
+++ b/services/api/src/routers/posts/getPost.ts
@@ -2,12 +2,12 @@ import { NotFoundError, getPost as getPostService } from '@op/common';
 import { getPostSchema } from '@op/types';
 
 import { postsEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const outputSchema = postsEncoder;
 
 export const getPost = router({
-  getPost: commonAuthedProcedure({
+  getPost: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(getPostSchema)

--- a/services/api/src/routers/posts/getPosts.ts
+++ b/services/api/src/routers/posts/getPosts.ts
@@ -4,12 +4,12 @@ import { getPostsSchema } from '@op/types';
 import { z } from 'zod';
 
 import { postsEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const outputSchema = z.array(postsEncoder);
 
 export const getPosts = router({
-  getPosts: commonAuthedProcedure()
+  getPosts: commonNetworkProcedure()
     .input(getPostsSchema)
     .output(outputSchema)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/posts/getPosts.ts
+++ b/services/api/src/routers/posts/getPosts.ts
@@ -4,12 +4,12 @@ import { getPostsSchema } from '@op/types';
 import { z } from 'zod';
 
 import { postsEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const outputSchema = z.array(postsEncoder);
 
 export const getPosts = router({
-  getPosts: commonNetworkProcedure()
+  getPosts: networkAuthenticatedProcedure()
     .input(getPostsSchema)
     .output(outputSchema)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/posts/listProfilePosts.ts
+++ b/services/api/src/routers/posts/listProfilePosts.ts
@@ -5,7 +5,7 @@ import {
 import { z } from 'zod';
 
 import { postsEncoder } from '../../encoders';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.string(),
@@ -14,7 +14,7 @@ const inputSchema = z.object({
 });
 
 export const listProfilePosts = router({
-  listProfilePosts: commonAuthedProcedure()
+  listProfilePosts: commonNetworkProcedure()
     .input(inputSchema)
     .output(
       z.object({

--- a/services/api/src/routers/posts/listProfilePosts.ts
+++ b/services/api/src/routers/posts/listProfilePosts.ts
@@ -5,7 +5,7 @@ import {
 import { z } from 'zod';
 
 import { postsEncoder } from '../../encoders';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.string(),
@@ -14,7 +14,7 @@ const inputSchema = z.object({
 });
 
 export const listProfilePosts = router({
-  listProfilePosts: commonNetworkProcedure()
+  listProfilePosts: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(
       z.object({

--- a/services/api/src/routers/posts/uploadPostAttachment.ts
+++ b/services/api/src/routers/posts/uploadPostAttachment.ts
@@ -4,7 +4,7 @@ import { Buffer } from 'buffer';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 
 const ALLOWED_MIME_TYPES = [
@@ -16,7 +16,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadPostAttachment = router({
-  uploadPostAttachment: commonNetworkProcedure({
+  uploadPostAttachment: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .use(withDB)

--- a/services/api/src/routers/posts/uploadPostAttachment.ts
+++ b/services/api/src/routers/posts/uploadPostAttachment.ts
@@ -4,7 +4,7 @@ import { Buffer } from 'buffer';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 
 const ALLOWED_MIME_TYPES = [
@@ -16,7 +16,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadPostAttachment = router({
-  uploadPostAttachment: commonAuthedProcedure({
+  uploadPostAttachment: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .use(withDB)

--- a/services/api/src/routers/profile/acceptInvite.ts
+++ b/services/api/src/routers/profile/acceptInvite.ts
@@ -3,10 +3,10 @@ import { acceptProfileInvite } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const acceptInviteRouter = router({
-  acceptInvite: commonAuthedProcedure()
+  acceptInvite: commonNetworkProcedure()
     .input(
       z.object({
         inviteId: z.string().uuid(),

--- a/services/api/src/routers/profile/acceptInvite.ts
+++ b/services/api/src/routers/profile/acceptInvite.ts
@@ -3,10 +3,10 @@ import { acceptProfileInvite } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const acceptInviteRouter = router({
-  acceptInvite: commonNetworkProcedure()
+  acceptInvite: networkAuthenticatedProcedure()
     .input(
       z.object({
         inviteId: z.string().uuid(),

--- a/services/api/src/routers/profile/createRole.ts
+++ b/services/api/src/routers/profile/createRole.ts
@@ -3,10 +3,10 @@ import { z } from 'zod';
 
 import { permissionsSchema } from '../../encoders/access';
 import { roleEncoder } from '../../encoders/roles';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const createRoleRouter = router({
-  createRole: commonNetworkProcedure()
+  createRole: networkAuthenticatedProcedure()
     .input(
       z.object({
         profileId: z.string().uuid(),

--- a/services/api/src/routers/profile/createRole.ts
+++ b/services/api/src/routers/profile/createRole.ts
@@ -3,10 +3,10 @@ import { z } from 'zod';
 
 import { permissionsSchema } from '../../encoders/access';
 import { roleEncoder } from '../../encoders/roles';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const createRoleRouter = router({
-  createRole: commonAuthedProcedure()
+  createRole: commonNetworkProcedure()
     .input(
       z.object({
         profileId: z.string().uuid(),

--- a/services/api/src/routers/profile/declineInvite.ts
+++ b/services/api/src/routers/profile/declineInvite.ts
@@ -1,10 +1,10 @@
 import { declineProfileInvite } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const declineInviteRouter = router({
-  declineInvite: commonNetworkProcedure()
+  declineInvite: networkAuthenticatedProcedure()
     .input(
       z.object({
         inviteId: z.string().uuid(),

--- a/services/api/src/routers/profile/declineInvite.ts
+++ b/services/api/src/routers/profile/declineInvite.ts
@@ -1,10 +1,10 @@
 import { declineProfileInvite } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const declineInviteRouter = router({
-  declineInvite: commonAuthedProcedure()
+  declineInvite: commonNetworkProcedure()
     .input(
       z.object({
         inviteId: z.string().uuid(),

--- a/services/api/src/routers/profile/deleteProfileInvite.ts
+++ b/services/api/src/routers/profile/deleteProfileInvite.ts
@@ -1,10 +1,10 @@
 import { deleteProfileInvite } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const deleteProfileInviteRouter = router({
-  deleteProfileInvite: commonNetworkProcedure()
+  deleteProfileInvite: networkAuthenticatedProcedure()
     .input(z.object({ inviteId: z.string().uuid() }))
     .output(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/deleteProfileInvite.ts
+++ b/services/api/src/routers/profile/deleteProfileInvite.ts
@@ -1,10 +1,10 @@
 import { deleteProfileInvite } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const deleteProfileInviteRouter = router({
-  deleteProfileInvite: commonAuthedProcedure()
+  deleteProfileInvite: commonNetworkProcedure()
     .input(z.object({ inviteId: z.string().uuid() }))
     .output(z.object({ id: z.string() }))
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/deleteRole.ts
+++ b/services/api/src/routers/profile/deleteRole.ts
@@ -1,10 +1,10 @@
 import { deleteRole } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const deleteRoleRouter = router({
-  deleteRole: commonNetworkProcedure()
+  deleteRole: networkAuthenticatedProcedure()
     .input(z.object({ roleId: z.string().uuid() }))
     .output(z.object({ deletedId: z.string() }))
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/deleteRole.ts
+++ b/services/api/src/routers/profile/deleteRole.ts
@@ -1,10 +1,10 @@
 import { deleteRole } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const deleteRoleRouter = router({
-  deleteRole: commonAuthedProcedure()
+  deleteRole: commonNetworkProcedure()
     .input(z.object({ roleId: z.string().uuid() }))
     .output(z.object({ deletedId: z.string() }))
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/getDecisionRole.ts
+++ b/services/api/src/routers/profile/getDecisionRole.ts
@@ -2,10 +2,10 @@ import { getDecisionRole } from '@op/common';
 import { z } from 'zod';
 
 import { decisionRoleEncoder } from '../../encoders/access';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const getDecisionRoleRouter = router({
-  getDecisionRole: commonAuthedProcedure()
+  getDecisionRole: commonNetworkProcedure()
     .input(
       z.object({
         roleId: z.string().uuid(),

--- a/services/api/src/routers/profile/getDecisionRole.ts
+++ b/services/api/src/routers/profile/getDecisionRole.ts
@@ -2,10 +2,10 @@ import { getDecisionRole } from '@op/common';
 import { z } from 'zod';
 
 import { decisionRoleEncoder } from '../../encoders/access';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const getDecisionRoleRouter = router({
-  getDecisionRole: commonNetworkProcedure()
+  getDecisionRole: networkAuthenticatedProcedure()
     .input(
       z.object({
         roleId: z.string().uuid(),

--- a/services/api/src/routers/profile/getProfile.ts
+++ b/services/api/src/routers/profile/getProfile.ts
@@ -3,7 +3,7 @@ import { EntityType } from '@op/db/schema';
 import { z } from 'zod';
 
 import { profileEncoder } from '../../encoders/profiles';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 const inputSchema = z.object({
@@ -14,7 +14,7 @@ const inputSchema = z.object({
 const universalProfileSchema = profileEncoder;
 
 export const getProfileRouter = router({
-  list: commonAuthedProcedure()
+  list: commonNetworkProcedure()
     .input(
       dbFilter
         .extend({
@@ -44,7 +44,7 @@ export const getProfileRouter = router({
         next,
       };
     }),
-  getBySlug: commonAuthedProcedure()
+  getBySlug: commonNetworkProcedure()
     .input(inputSchema)
     .output(universalProfileSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/getProfile.ts
+++ b/services/api/src/routers/profile/getProfile.ts
@@ -3,7 +3,7 @@ import { EntityType } from '@op/db/schema';
 import { z } from 'zod';
 
 import { profileEncoder } from '../../encoders/profiles';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 const inputSchema = z.object({
@@ -14,7 +14,7 @@ const inputSchema = z.object({
 const universalProfileSchema = profileEncoder;
 
 export const getProfileRouter = router({
-  list: commonNetworkProcedure()
+  list: networkAuthenticatedProcedure()
     .input(
       dbFilter
         .extend({
@@ -44,7 +44,7 @@ export const getProfileRouter = router({
         next,
       };
     }),
-  getBySlug: commonNetworkProcedure()
+  getBySlug: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(universalProfileSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/invite.ts
+++ b/services/api/src/routers/profile/invite.ts
@@ -3,7 +3,7 @@ import { getIndividualProfileId, inviteUsersToProfile } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   invitations: z
@@ -34,7 +34,7 @@ const outputSchema = z.object({
 });
 
 export const inviteProfileUserRouter = router({
-  invite: commonNetworkProcedure({
+  invite: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/invite.ts
+++ b/services/api/src/routers/profile/invite.ts
@@ -3,7 +3,7 @@ import { getIndividualProfileId, inviteUsersToProfile } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   invitations: z
@@ -34,7 +34,7 @@ const outputSchema = z.object({
 });
 
 export const inviteProfileUserRouter = router({
-  invite: commonAuthedProcedure({
+  invite: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/listProfileInvites.ts
+++ b/services/api/src/routers/profile/listProfileInvites.ts
@@ -2,7 +2,7 @@ import { listProfileUserInvites } from '@op/common';
 import { z } from 'zod';
 
 import { profileInviteEncoder } from '../../encoders/profiles';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.string().uuid(),
@@ -12,7 +12,7 @@ const inputSchema = z.object({
 const outputSchema = z.array(profileInviteEncoder);
 
 export const listProfileInvitesRouter = router({
-  listProfileInvites: commonNetworkProcedure()
+  listProfileInvites: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(outputSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/listProfileInvites.ts
+++ b/services/api/src/routers/profile/listProfileInvites.ts
@@ -2,7 +2,7 @@ import { listProfileUserInvites } from '@op/common';
 import { z } from 'zod';
 
 import { profileInviteEncoder } from '../../encoders/profiles';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.string().uuid(),
@@ -12,7 +12,7 @@ const inputSchema = z.object({
 const outputSchema = z.array(profileInviteEncoder);
 
 export const listProfileInvitesRouter = router({
-  listProfileInvites: commonAuthedProcedure()
+  listProfileInvites: commonNetworkProcedure()
     .input(inputSchema)
     .output(outputSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/listRoles.ts
+++ b/services/api/src/routers/profile/listRoles.ts
@@ -2,7 +2,7 @@ import { getRoles } from '@op/common';
 import { z } from 'zod';
 
 import { roleEncoder } from '../../encoders/roles';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import {
   createPaginatedOutput,
   createSortable,
@@ -20,7 +20,7 @@ const inputSchema = z
   .merge(roleSortableSchema);
 
 export const listRolesRouter = router({
-  listRoles: commonAuthedProcedure()
+  listRoles: commonNetworkProcedure()
     .input(inputSchema)
     .output(createPaginatedOutput(roleEncoder))
     .query(async ({ input }) => {

--- a/services/api/src/routers/profile/listRoles.ts
+++ b/services/api/src/routers/profile/listRoles.ts
@@ -2,7 +2,7 @@ import { getRoles } from '@op/common';
 import { z } from 'zod';
 
 import { roleEncoder } from '../../encoders/roles';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import {
   createPaginatedOutput,
   createSortable,
@@ -20,7 +20,7 @@ const inputSchema = z
   .merge(roleSortableSchema);
 
 export const listRolesRouter = router({
-  listRoles: commonNetworkProcedure()
+  listRoles: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(createPaginatedOutput(roleEncoder))
     .query(async ({ input }) => {

--- a/services/api/src/routers/profile/relationships.ts
+++ b/services/api/src/routers/profile/relationships.ts
@@ -8,7 +8,7 @@ import { ProfileRelationshipType, proposals } from '@op/db/schema';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import {
   trackProposalFollowed,
   trackProposalLiked,
@@ -66,7 +66,7 @@ const getRelationshipsInputSchema = z.object({
   profileType: z.string().optional(),
 });
 
-const relationshipProcedure = commonNetworkProcedure({
+const relationshipProcedure = networkAuthenticatedProcedure({
   rateLimit: { windowSize: 10, maxRequests: 20 },
 });
 
@@ -118,7 +118,7 @@ export const profileRelationshipRouter = router({
       });
     }),
 
-  getRelationships: commonNetworkProcedure({
+  getRelationships: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(getRelationshipsInputSchema)

--- a/services/api/src/routers/profile/relationships.ts
+++ b/services/api/src/routers/profile/relationships.ts
@@ -8,7 +8,7 @@ import { ProfileRelationshipType, proposals } from '@op/db/schema';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import {
   trackProposalFollowed,
   trackProposalLiked,
@@ -66,7 +66,7 @@ const getRelationshipsInputSchema = z.object({
   profileType: z.string().optional(),
 });
 
-const relationshipProcedure = commonAuthedProcedure({
+const relationshipProcedure = commonNetworkProcedure({
   rateLimit: { windowSize: 10, maxRequests: 20 },
 });
 
@@ -118,7 +118,7 @@ export const profileRelationshipRouter = router({
       });
     }),
 
-  getRelationships: commonAuthedProcedure({
+  getRelationships: commonNetworkProcedure({
     rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(getRelationshipsInputSchema)

--- a/services/api/src/routers/profile/requests/createJoinRequest.ts
+++ b/services/api/src/routers/profile/requests/createJoinRequest.ts
@@ -2,7 +2,7 @@ import { Channels, createProfileJoinRequest } from '@op/common';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   /** The profile ID of the requester */
@@ -12,7 +12,7 @@ const inputSchema = z.object({
 });
 
 export const createJoinRequestRouter = router({
-  createJoinRequest: commonNetworkProcedure({
+  createJoinRequest: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/requests/createJoinRequest.ts
+++ b/services/api/src/routers/profile/requests/createJoinRequest.ts
@@ -2,7 +2,7 @@ import { Channels, createProfileJoinRequest } from '@op/common';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   /** The profile ID of the requester */
@@ -12,7 +12,7 @@ const inputSchema = z.object({
 });
 
 export const createJoinRequestRouter = router({
-  createJoinRequest: commonAuthedProcedure({
+  createJoinRequest: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/requests/deleteJoinRequest.ts
+++ b/services/api/src/routers/profile/requests/deleteJoinRequest.ts
@@ -2,7 +2,7 @@ import { Channels, deleteProfileJoinRequest } from '@op/common';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   /** The ID of the join profile request to delete */
@@ -10,7 +10,7 @@ const inputSchema = z.object({
 });
 
 export const deleteJoinRequestRouter = router({
-  deleteJoinRequest: commonNetworkProcedure({
+  deleteJoinRequest: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/requests/deleteJoinRequest.ts
+++ b/services/api/src/routers/profile/requests/deleteJoinRequest.ts
@@ -2,7 +2,7 @@ import { Channels, deleteProfileJoinRequest } from '@op/common';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   /** The ID of the join profile request to delete */
@@ -10,7 +10,7 @@ const inputSchema = z.object({
 });
 
 export const deleteJoinRequestRouter = router({
-  deleteJoinRequest: commonAuthedProcedure({
+  deleteJoinRequest: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/requests/getJoinRequest.ts
+++ b/services/api/src/routers/profile/requests/getJoinRequest.ts
@@ -2,7 +2,7 @@ import { Channels, getProfileJoinRequest } from '@op/common';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   /** The profile ID of the requester */
@@ -12,7 +12,7 @@ const inputSchema = z.object({
 });
 
 export const getJoinRequestRouter = router({
-  getJoinRequest: commonNetworkProcedure({
+  getJoinRequest: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 60 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/requests/getJoinRequest.ts
+++ b/services/api/src/routers/profile/requests/getJoinRequest.ts
@@ -2,7 +2,7 @@ import { Channels, getProfileJoinRequest } from '@op/common';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   /** The profile ID of the requester */
@@ -12,7 +12,7 @@ const inputSchema = z.object({
 });
 
 export const getJoinRequestRouter = router({
-  getJoinRequest: commonAuthedProcedure({
+  getJoinRequest: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 60 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/requests/listJoinRequests.ts
+++ b/services/api/src/routers/profile/requests/listJoinRequests.ts
@@ -3,7 +3,7 @@ import { JoinProfileRequestStatus } from '@op/db/schema';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 import { dbFilter } from '../../../utils';
 
 const inputSchema = dbFilter.extend({
@@ -14,7 +14,7 @@ const inputSchema = dbFilter.extend({
 });
 
 export const listJoinRequestsRouter = router({
-  listJoinRequests: commonAuthedProcedure({
+  listJoinRequests: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 60 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/requests/listJoinRequests.ts
+++ b/services/api/src/routers/profile/requests/listJoinRequests.ts
@@ -3,7 +3,7 @@ import { JoinProfileRequestStatus } from '@op/db/schema';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 import { dbFilter } from '../../../utils';
 
 const inputSchema = dbFilter.extend({
@@ -14,7 +14,7 @@ const inputSchema = dbFilter.extend({
 });
 
 export const listJoinRequestsRouter = router({
-  listJoinRequests: commonNetworkProcedure({
+  listJoinRequests: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 60 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/requests/updateJoinRequest.ts
+++ b/services/api/src/routers/profile/requests/updateJoinRequest.ts
@@ -3,7 +3,7 @@ import { JoinProfileRequestStatus } from '@op/db/schema';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   /** The ID of the join profile request to update */
@@ -16,7 +16,7 @@ const inputSchema = z.object({
 });
 
 export const updateJoinRequestRouter = router({
-  updateJoinRequest: commonNetworkProcedure({
+  updateJoinRequest: networkAuthenticatedProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/requests/updateJoinRequest.ts
+++ b/services/api/src/routers/profile/requests/updateJoinRequest.ts
@@ -3,7 +3,7 @@ import { JoinProfileRequestStatus } from '@op/db/schema';
 import { z } from 'zod';
 
 import { joinProfileRequestEncoder } from '../../../encoders/joinProfileRequests';
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   /** The ID of the join profile request to update */
@@ -16,7 +16,7 @@ const inputSchema = z.object({
 });
 
 export const updateJoinRequestRouter = router({
-  updateJoinRequest: commonAuthedProcedure({
+  updateJoinRequest: commonNetworkProcedure({
     rateLimit: { windowSize: 60, maxRequests: 10 },
   })
     .input(inputSchema)

--- a/services/api/src/routers/profile/searchProfiles.ts
+++ b/services/api/src/routers/profile/searchProfiles.ts
@@ -4,11 +4,11 @@ import { EntityType } from '@op/db/schema';
 import { z } from 'zod';
 
 import { searchProfilesResultEncoder } from '../../encoders/searchResults';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 export const searchProfilesRouter = router({
-  search: commonNetworkProcedure()
+  search: networkAuthenticatedProcedure()
     .input(
       dbFilter.extend({
         q: z.string(),

--- a/services/api/src/routers/profile/searchProfiles.ts
+++ b/services/api/src/routers/profile/searchProfiles.ts
@@ -4,11 +4,11 @@ import { EntityType } from '@op/db/schema';
 import { z } from 'zod';
 
 import { searchProfilesResultEncoder } from '../../encoders/searchResults';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 import { dbFilter } from '../../utils';
 
 export const searchProfilesRouter = router({
-  search: commonAuthedProcedure()
+  search: commonNetworkProcedure()
     .input(
       dbFilter.extend({
         q: z.string(),

--- a/services/api/src/routers/profile/updateDecisionRoles.ts
+++ b/services/api/src/routers/profile/updateDecisionRoles.ts
@@ -2,10 +2,10 @@ import { updateDecisionRoles } from '@op/common';
 import { z } from 'zod';
 
 import { decisionRoleEncoder } from '../../encoders/access';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const updateDecisionRolesRouter = router({
-  updateDecisionRoles: commonNetworkProcedure()
+  updateDecisionRoles: networkAuthenticatedProcedure()
     .input(
       z.object({
         roleId: z.string().uuid(),

--- a/services/api/src/routers/profile/updateDecisionRoles.ts
+++ b/services/api/src/routers/profile/updateDecisionRoles.ts
@@ -2,10 +2,10 @@ import { updateDecisionRoles } from '@op/common';
 import { z } from 'zod';
 
 import { decisionRoleEncoder } from '../../encoders/access';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const updateDecisionRolesRouter = router({
-  updateDecisionRoles: commonAuthedProcedure()
+  updateDecisionRoles: commonNetworkProcedure()
     .input(
       z.object({
         roleId: z.string().uuid(),

--- a/services/api/src/routers/profile/updateProfileInvite.ts
+++ b/services/api/src/routers/profile/updateProfileInvite.ts
@@ -2,10 +2,10 @@ import { updateProfileInvite } from '@op/common';
 import { z } from 'zod';
 
 import { profileInviteEncoder } from '../../encoders/profiles';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const updateProfileInviteRouter = router({
-  updateProfileInvite: commonNetworkProcedure()
+  updateProfileInvite: networkAuthenticatedProcedure()
     .input(
       z.object({
         inviteId: z.string().uuid(),

--- a/services/api/src/routers/profile/updateProfileInvite.ts
+++ b/services/api/src/routers/profile/updateProfileInvite.ts
@@ -2,10 +2,10 @@ import { updateProfileInvite } from '@op/common';
 import { z } from 'zod';
 
 import { profileInviteEncoder } from '../../encoders/profiles';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const updateProfileInviteRouter = router({
-  updateProfileInvite: commonAuthedProcedure()
+  updateProfileInvite: commonNetworkProcedure()
     .input(
       z.object({
         inviteId: z.string().uuid(),

--- a/services/api/src/routers/profile/updateRole.ts
+++ b/services/api/src/routers/profile/updateRole.ts
@@ -1,10 +1,10 @@
 import { updateRole } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const updateRoleRouter = router({
-  updateRole: commonAuthedProcedure()
+  updateRole: commonNetworkProcedure()
     .input(
       z.object({
         roleId: z.string().uuid(),

--- a/services/api/src/routers/profile/updateRole.ts
+++ b/services/api/src/routers/profile/updateRole.ts
@@ -1,10 +1,10 @@
 import { updateRole } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const updateRoleRouter = router({
-  updateRole: commonNetworkProcedure()
+  updateRole: networkAuthenticatedProcedure()
     .input(
       z.object({
         roleId: z.string().uuid(),

--- a/services/api/src/routers/profile/updateRolePermission.ts
+++ b/services/api/src/routers/profile/updateRolePermission.ts
@@ -3,12 +3,12 @@ import { accessRoleMinimalSchema } from '@op/common/client';
 import { z } from 'zod';
 
 import { permissionsSchema } from '../../encoders/access';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const DECISIONS_ZONE_NAME = 'decisions';
 
 export const updateRolePermissionRouter = router({
-  updateRolePermission: commonNetworkProcedure()
+  updateRolePermission: networkAuthenticatedProcedure()
     .input(
       z.object({
         roleId: z.string().uuid(),

--- a/services/api/src/routers/profile/updateRolePermission.ts
+++ b/services/api/src/routers/profile/updateRolePermission.ts
@@ -3,12 +3,12 @@ import { accessRoleMinimalSchema } from '@op/common/client';
 import { z } from 'zod';
 
 import { permissionsSchema } from '../../encoders/access';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const DECISIONS_ZONE_NAME = 'decisions';
 
 export const updateRolePermissionRouter = router({
-  updateRolePermission: commonAuthedProcedure()
+  updateRolePermission: commonNetworkProcedure()
     .input(
       z.object({
         roleId: z.string().uuid(),

--- a/services/api/src/routers/profile/users/listUsers.ts
+++ b/services/api/src/routers/profile/users/listUsers.ts
@@ -2,13 +2,13 @@ import { listProfileUsers } from '@op/common';
 import { profileUserWithRolesSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 import { createSortable } from '../../../utils';
 
 const profileUserSortable = createSortable(['name', 'email', 'role'] as const);
 
 export const listUsersRouter = router({
-  listUsers: commonAuthedProcedure()
+  listUsers: commonNetworkProcedure()
     .input(
       z
         .object({

--- a/services/api/src/routers/profile/users/listUsers.ts
+++ b/services/api/src/routers/profile/users/listUsers.ts
@@ -2,13 +2,13 @@ import { listProfileUsers } from '@op/common';
 import { profileUserWithRolesSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 import { createSortable } from '../../../utils';
 
 const profileUserSortable = createSortable(['name', 'email', 'role'] as const);
 
 export const listUsersRouter = router({
-  listUsers: commonNetworkProcedure()
+  listUsers: networkAuthenticatedProcedure()
     .input(
       z
         .object({

--- a/services/api/src/routers/profile/users/removeUser.ts
+++ b/services/api/src/routers/profile/users/removeUser.ts
@@ -2,10 +2,10 @@ import { removeProfileUser } from '@op/common';
 import { profileUserSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const removeUserRouter = router({
-  removeUser: commonAuthedProcedure()
+  removeUser: commonNetworkProcedure()
     .input(z.object({ profileUserId: z.uuid() }))
     .output(profileUserSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/users/removeUser.ts
+++ b/services/api/src/routers/profile/users/removeUser.ts
@@ -2,10 +2,10 @@ import { removeProfileUser } from '@op/common';
 import { profileUserSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const removeUserRouter = router({
-  removeUser: commonNetworkProcedure()
+  removeUser: networkAuthenticatedProcedure()
     .input(z.object({ profileUserId: z.uuid() }))
     .output(profileUserSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/profile/users/updateUserRole.ts
+++ b/services/api/src/routers/profile/users/updateUserRole.ts
@@ -2,10 +2,10 @@ import { updateProfileUserRoles } from '@op/common';
 import { profileUserWithRolesSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const updateUserRolesRouter = router({
-  updateUserRoles: commonNetworkProcedure()
+  updateUserRoles: networkAuthenticatedProcedure()
     .input(
       z.object({
         profileUserId: z.uuid(),

--- a/services/api/src/routers/profile/users/updateUserRole.ts
+++ b/services/api/src/routers/profile/users/updateUserRole.ts
@@ -2,10 +2,10 @@ import { updateProfileUserRoles } from '@op/common';
 import { profileUserWithRolesSchema } from '@op/common/client';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const updateUserRolesRouter = router({
-  updateUserRoles: commonAuthedProcedure()
+  updateUserRoles: commonNetworkProcedure()
     .input(
       z.object({
         profileUserId: z.uuid(),

--- a/services/api/src/routers/resources/attachToCollection.ts
+++ b/services/api/src/routers/resources/attachToCollection.ts
@@ -6,10 +6,10 @@ import {
 import { z } from 'zod';
 
 import { resourceInCollectionEncoder } from '../../encoders/resources';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const attachToCollection = router({
-  attachToCollection: commonAuthedProcedure()
+  attachToCollection: commonNetworkProcedure()
     .input(
       z.object({
         id: z.string().uuid(),

--- a/services/api/src/routers/resources/attachToCollection.ts
+++ b/services/api/src/routers/resources/attachToCollection.ts
@@ -6,10 +6,10 @@ import {
 import { z } from 'zod';
 
 import { resourceInCollectionEncoder } from '../../encoders/resources';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const attachToCollection = router({
-  attachToCollection: commonNetworkProcedure()
+  attachToCollection: networkAuthenticatedProcedure()
     .input(
       z.object({
         id: z.string().uuid(),

--- a/services/api/src/routers/resources/collections/create.ts
+++ b/services/api/src/routers/resources/collections/create.ts
@@ -1,10 +1,10 @@
 import { Channels, collectionSchema, createCollection } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const collectionsCreate = router({
-  create: commonNetworkProcedure()
+  create: networkAuthenticatedProcedure()
     .input(
       z.object({
         profileId: z.string().uuid(),

--- a/services/api/src/routers/resources/collections/create.ts
+++ b/services/api/src/routers/resources/collections/create.ts
@@ -1,10 +1,10 @@
 import { Channels, collectionSchema, createCollection } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 export const collectionsCreate = router({
-  create: commonAuthedProcedure()
+  create: commonNetworkProcedure()
     .input(
       z.object({
         profileId: z.string().uuid(),

--- a/services/api/src/routers/resources/collections/delete.ts
+++ b/services/api/src/routers/resources/collections/delete.ts
@@ -1,7 +1,7 @@
 import { Channels, deleteCollection } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const collectionChannels = (profileIds: string[]) => [
   ...profileIds.map((id) => Channels.profileCollections(id)),
@@ -9,7 +9,7 @@ const collectionChannels = (profileIds: string[]) => [
 ];
 
 export const collectionsDelete = router({
-  delete: commonAuthedProcedure()
+  delete: commonNetworkProcedure()
     .input(z.object({ collectionId: z.string().uuid() }))
     .mutation(async ({ input, ctx }) => {
       const { profileIds } = await deleteCollection({

--- a/services/api/src/routers/resources/collections/delete.ts
+++ b/services/api/src/routers/resources/collections/delete.ts
@@ -1,7 +1,7 @@
 import { Channels, deleteCollection } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const collectionChannels = (profileIds: string[]) => [
   ...profileIds.map((id) => Channels.profileCollections(id)),
@@ -9,7 +9,7 @@ const collectionChannels = (profileIds: string[]) => [
 ];
 
 export const collectionsDelete = router({
-  delete: commonNetworkProcedure()
+  delete: networkAuthenticatedProcedure()
     .input(z.object({ collectionId: z.string().uuid() }))
     .mutation(async ({ input, ctx }) => {
       const { profileIds } = await deleteCollection({

--- a/services/api/src/routers/resources/collections/list.ts
+++ b/services/api/src/routers/resources/collections/list.ts
@@ -6,7 +6,7 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.string().uuid(),
@@ -15,7 +15,7 @@ const inputSchema = z.object({
 });
 
 export const collectionsList = router({
-  list: commonNetworkProcedure()
+  list: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(collectionListSchema)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/collections/list.ts
+++ b/services/api/src/routers/resources/collections/list.ts
@@ -6,7 +6,7 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.string().uuid(),
@@ -15,7 +15,7 @@ const inputSchema = z.object({
 });
 
 export const collectionsList = router({
-  list: commonAuthedProcedure()
+  list: commonNetworkProcedure()
     .input(inputSchema)
     .output(collectionListSchema)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/collections/reorder.ts
+++ b/services/api/src/routers/resources/collections/reorder.ts
@@ -1,7 +1,7 @@
 import { Channels, collectionSchema, reorderCollection } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   id: z.string().uuid(),
@@ -9,7 +9,7 @@ const inputSchema = z.object({
 });
 
 export const collectionsReorder = router({
-  reorder: commonAuthedProcedure()
+  reorder: commonNetworkProcedure()
     .input(inputSchema)
     .output(collectionSchema)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/collections/reorder.ts
+++ b/services/api/src/routers/resources/collections/reorder.ts
@@ -1,7 +1,7 @@
 import { Channels, collectionSchema, reorderCollection } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const inputSchema = z.object({
   id: z.string().uuid(),
@@ -9,7 +9,7 @@ const inputSchema = z.object({
 });
 
 export const collectionsReorder = router({
-  reorder: commonNetworkProcedure()
+  reorder: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(collectionSchema)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/collections/update.ts
+++ b/services/api/src/routers/resources/collections/update.ts
@@ -1,14 +1,14 @@
 import { Channels, collectionSchema, updateCollection } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 const dataSchema = z.object({
   name: z.string().trim().min(1).max(80),
 });
 
 export const collectionsUpdate = router({
-  update: commonNetworkProcedure()
+  update: networkAuthenticatedProcedure()
     .input(z.object({ id: z.string().uuid(), data: dataSchema }))
     .output(collectionSchema)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/collections/update.ts
+++ b/services/api/src/routers/resources/collections/update.ts
@@ -1,14 +1,14 @@
 import { Channels, collectionSchema, updateCollection } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../../trpcFactory';
 
 const dataSchema = z.object({
   name: z.string().trim().min(1).max(80),
 });
 
 export const collectionsUpdate = router({
-  update: commonAuthedProcedure()
+  update: commonNetworkProcedure()
     .input(z.object({ id: z.string().uuid(), data: dataSchema }))
     .output(collectionSchema)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/createDocument.ts
+++ b/services/api/src/routers/resources/createDocument.ts
@@ -10,7 +10,7 @@ import type { ChannelName } from '@op/common/realtime';
 import { z } from 'zod';
 
 import { resourceInCollectionEncoder } from '../../encoders/resources';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const allowedMimeSchema = z.enum(ALLOWED_RESOURCE_MIME_TYPES);
 
@@ -44,7 +44,7 @@ const inputSchema = z.object({
 });
 
 export const createDocument = router({
-  createDocument: commonAuthedProcedure()
+  createDocument: commonNetworkProcedure()
     .input(inputSchema)
     .output(resourceInCollectionEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/createDocument.ts
+++ b/services/api/src/routers/resources/createDocument.ts
@@ -10,7 +10,7 @@ import type { ChannelName } from '@op/common/realtime';
 import { z } from 'zod';
 
 import { resourceInCollectionEncoder } from '../../encoders/resources';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const allowedMimeSchema = z.enum(ALLOWED_RESOURCE_MIME_TYPES);
 
@@ -44,7 +44,7 @@ const inputSchema = z.object({
 });
 
 export const createDocument = router({
-  createDocument: commonNetworkProcedure()
+  createDocument: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(resourceInCollectionEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/createLink.ts
+++ b/services/api/src/routers/resources/createLink.ts
@@ -10,7 +10,7 @@ import type { ChannelName } from '@op/common/realtime';
 import { z } from 'zod';
 
 import { resourceInCollectionEncoder } from '../../encoders/resources';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   target: z.discriminatedUnion('kind', [
@@ -36,7 +36,7 @@ const inputSchema = z.object({
 });
 
 export const createLink = router({
-  createLink: commonAuthedProcedure()
+  createLink: commonNetworkProcedure()
     .input(inputSchema)
     .output(resourceInCollectionEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/createLink.ts
+++ b/services/api/src/routers/resources/createLink.ts
@@ -10,7 +10,7 @@ import type { ChannelName } from '@op/common/realtime';
 import { z } from 'zod';
 
 import { resourceInCollectionEncoder } from '../../encoders/resources';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   target: z.discriminatedUnion('kind', [
@@ -36,7 +36,7 @@ const inputSchema = z.object({
 });
 
 export const createLink = router({
-  createLink: commonNetworkProcedure()
+  createLink: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(resourceInCollectionEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/delete.ts
+++ b/services/api/src/routers/resources/delete.ts
@@ -1,10 +1,10 @@
 import { Channels, deleteResource, getScopesForResource } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const deleteResourceRouter = router({
-  delete: commonNetworkProcedure()
+  delete: networkAuthenticatedProcedure()
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ input, ctx }) => {
       // Resolve scopes BEFORE delete - after delete the resource has no rows.

--- a/services/api/src/routers/resources/delete.ts
+++ b/services/api/src/routers/resources/delete.ts
@@ -1,10 +1,10 @@
 import { Channels, deleteResource, getScopesForResource } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const deleteResourceRouter = router({
-  delete: commonAuthedProcedure()
+  delete: commonNetworkProcedure()
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ input, ctx }) => {
       // Resolve scopes BEFORE delete - after delete the resource has no rows.

--- a/services/api/src/routers/resources/detachFromCollection.ts
+++ b/services/api/src/routers/resources/detachFromCollection.ts
@@ -5,10 +5,10 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const detachFromCollection = router({
-  detachFromCollection: commonAuthedProcedure()
+  detachFromCollection: commonNetworkProcedure()
     .input(
       z.object({
         id: z.string().uuid(),

--- a/services/api/src/routers/resources/detachFromCollection.ts
+++ b/services/api/src/routers/resources/detachFromCollection.ts
@@ -5,10 +5,10 @@ import {
 } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const detachFromCollection = router({
-  detachFromCollection: commonNetworkProcedure()
+  detachFromCollection: networkAuthenticatedProcedure()
     .input(
       z.object({
         id: z.string().uuid(),

--- a/services/api/src/routers/resources/list.ts
+++ b/services/api/src/routers/resources/list.ts
@@ -2,7 +2,7 @@ import { Channels, RESOURCE_LIST_MAX_LIMIT, listResources } from '@op/common';
 import { z } from 'zod';
 
 import { resourceListEncoder } from '../../encoders/resources';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.string().uuid(),
@@ -11,7 +11,7 @@ const inputSchema = z.object({
 });
 
 export const list = router({
-  list: commonNetworkProcedure()
+  list: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(resourceListEncoder)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/list.ts
+++ b/services/api/src/routers/resources/list.ts
@@ -2,7 +2,7 @@ import { Channels, RESOURCE_LIST_MAX_LIMIT, listResources } from '@op/common';
 import { z } from 'zod';
 
 import { resourceListEncoder } from '../../encoders/resources';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   profileId: z.string().uuid(),
@@ -11,7 +11,7 @@ const inputSchema = z.object({
 });
 
 export const list = router({
-  list: commonAuthedProcedure()
+  list: commonNetworkProcedure()
     .input(inputSchema)
     .output(resourceListEncoder)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/listByCollection.ts
+++ b/services/api/src/routers/resources/listByCollection.ts
@@ -6,7 +6,7 @@ import {
 import { z } from 'zod';
 
 import { resourceListEncoder } from '../../encoders/resources';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   collectionId: z.string().uuid(),
@@ -15,7 +15,7 @@ const inputSchema = z.object({
 });
 
 export const listByCollection = router({
-  listByCollection: commonAuthedProcedure()
+  listByCollection: commonNetworkProcedure()
     .input(inputSchema)
     .output(resourceListEncoder)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/listByCollection.ts
+++ b/services/api/src/routers/resources/listByCollection.ts
@@ -6,7 +6,7 @@ import {
 import { z } from 'zod';
 
 import { resourceListEncoder } from '../../encoders/resources';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   collectionId: z.string().uuid(),
@@ -15,7 +15,7 @@ const inputSchema = z.object({
 });
 
 export const listByCollection = router({
-  listByCollection: commonNetworkProcedure()
+  listByCollection: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(resourceListEncoder)
     .query(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/reorder.ts
+++ b/services/api/src/routers/resources/reorder.ts
@@ -6,7 +6,7 @@ import {
 import { z } from 'zod';
 
 import { resourceInCollectionEncoder } from '../../encoders/resources';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   id: z.string().uuid(),
@@ -15,7 +15,7 @@ const inputSchema = z.object({
 });
 
 export const reorder = router({
-  reorder: commonAuthedProcedure()
+  reorder: commonNetworkProcedure()
     .input(inputSchema)
     .output(resourceInCollectionEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/reorder.ts
+++ b/services/api/src/routers/resources/reorder.ts
@@ -6,7 +6,7 @@ import {
 import { z } from 'zod';
 
 import { resourceInCollectionEncoder } from '../../encoders/resources';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   id: z.string().uuid(),
@@ -15,7 +15,7 @@ const inputSchema = z.object({
 });
 
 export const reorder = router({
-  reorder: commonNetworkProcedure()
+  reorder: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(resourceInCollectionEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/update.ts
+++ b/services/api/src/routers/resources/update.ts
@@ -9,7 +9,7 @@ import {
 import { z } from 'zod';
 
 import { resourceWithSignedUrlEncoder } from '../../encoders/resources';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const dataSchema = z
   .object({
@@ -26,7 +26,7 @@ const dataSchema = z
   });
 
 export const update = router({
-  update: commonAuthedProcedure()
+  update: commonNetworkProcedure()
     .input(z.object({ id: z.string().uuid(), data: dataSchema }))
     .output(resourceWithSignedUrlEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/update.ts
+++ b/services/api/src/routers/resources/update.ts
@@ -9,7 +9,7 @@ import {
 import { z } from 'zod';
 
 import { resourceWithSignedUrlEncoder } from '../../encoders/resources';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const dataSchema = z
   .object({
@@ -26,7 +26,7 @@ const dataSchema = z
   });
 
 export const update = router({
-  update: commonNetworkProcedure()
+  update: networkAuthenticatedProcedure()
     .input(z.object({ id: z.string().uuid(), data: dataSchema }))
     .output(resourceWithSignedUrlEncoder)
     .mutation(async ({ input, ctx }) => {

--- a/services/api/src/routers/resources/uploadFile.ts
+++ b/services/api/src/routers/resources/uploadFile.ts
@@ -1,7 +1,7 @@
 import { signResourceUploadUrlForTarget } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   target: z.discriminatedUnion('kind', [
@@ -25,7 +25,7 @@ const outputSchema = z.object({
 });
 
 export const uploadFile = router({
-  uploadFile: commonNetworkProcedure()
+  uploadFile: networkAuthenticatedProcedure()
     .input(inputSchema)
     .output(outputSchema)
     .mutation(({ input, ctx }) =>

--- a/services/api/src/routers/resources/uploadFile.ts
+++ b/services/api/src/routers/resources/uploadFile.ts
@@ -1,7 +1,7 @@
 import { signResourceUploadUrlForTarget } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const inputSchema = z.object({
   target: z.discriminatedUnion('kind', [
@@ -25,7 +25,7 @@ const outputSchema = z.object({
 });
 
 export const uploadFile = router({
-  uploadFile: commonAuthedProcedure()
+  uploadFile: commonNetworkProcedure()
     .input(inputSchema)
     .output(outputSchema)
     .mutation(({ input, ctx }) =>

--- a/services/api/src/routers/taxonomy/geoNames.ts
+++ b/services/api/src/routers/taxonomy/geoNames.ts
@@ -2,7 +2,7 @@ import { cache } from '@op/cache';
 import { logger } from '@op/logging';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const GeoNameSchema = z.object({
   id: z.string(),
@@ -89,7 +89,7 @@ const getGeonames = async ({ q }: { q: string }) => {
 };
 
 export const getGeoNames = router({
-  getGeoNames: commonNetworkProcedure()
+  getGeoNames: networkAuthenticatedProcedure()
     .input(
       z.object({
         q: z.string().min(2).max(255),

--- a/services/api/src/routers/taxonomy/geoNames.ts
+++ b/services/api/src/routers/taxonomy/geoNames.ts
@@ -2,7 +2,7 @@ import { cache } from '@op/cache';
 import { logger } from '@op/logging';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const GeoNameSchema = z.object({
   id: z.string(),
@@ -89,7 +89,7 @@ const getGeonames = async ({ q }: { q: string }) => {
 };
 
 export const getGeoNames = router({
-  getGeoNames: commonAuthedProcedure()
+  getGeoNames: commonNetworkProcedure()
     .input(
       z.object({
         q: z.string().min(2).max(255),

--- a/services/api/src/routers/taxonomy/taxonomyTerms.ts
+++ b/services/api/src/routers/taxonomy/taxonomyTerms.ts
@@ -2,10 +2,10 @@ import { getTerms } from '@op/common';
 import { z } from 'zod';
 
 import { taxonomyTermsWithChildrenEncoder } from '../../encoders/taxonomyTerms';
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const termsRouter = router({
-  getTerms: commonNetworkProcedure()
+  getTerms: networkAuthenticatedProcedure()
     .input(z.object({ name: z.string().min(3), q: z.string().optional() }))
     .output(z.array(taxonomyTermsWithChildrenEncoder))
     .query(async ({ input }) => {

--- a/services/api/src/routers/taxonomy/taxonomyTerms.ts
+++ b/services/api/src/routers/taxonomy/taxonomyTerms.ts
@@ -2,10 +2,10 @@ import { getTerms } from '@op/common';
 import { z } from 'zod';
 
 import { taxonomyTermsWithChildrenEncoder } from '../../encoders/taxonomyTerms';
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const termsRouter = router({
-  getTerms: commonAuthedProcedure()
+  getTerms: commonNetworkProcedure()
     .input(z.object({ name: z.string().min(3), q: z.string().optional() }))
     .output(z.array(taxonomyTermsWithChildrenEncoder))
     .query(async ({ input }) => {

--- a/services/api/src/routers/translation/translateDecision.ts
+++ b/services/api/src/routers/translation/translateDecision.ts
@@ -1,7 +1,7 @@
 import { SUPPORTED_LOCALES, translateDecision } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 const translateDecisionOutput = z.object({
   headline: z.string().optional(),
@@ -14,7 +14,7 @@ const translateDecisionOutput = z.object({
 });
 
 export const translateDecisionRouter = router({
-  translateDecision: commonNetworkProcedure()
+  translateDecision: networkAuthenticatedProcedure()
     .input(
       z.object({
         decisionProfileId: z.string().uuid(),

--- a/services/api/src/routers/translation/translateDecision.ts
+++ b/services/api/src/routers/translation/translateDecision.ts
@@ -1,7 +1,7 @@
 import { SUPPORTED_LOCALES, translateDecision } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 const translateDecisionOutput = z.object({
   headline: z.string().optional(),
@@ -14,7 +14,7 @@ const translateDecisionOutput = z.object({
 });
 
 export const translateDecisionRouter = router({
-  translateDecision: commonAuthedProcedure()
+  translateDecision: commonNetworkProcedure()
     .input(
       z.object({
         decisionProfileId: z.string().uuid(),

--- a/services/api/src/routers/translation/translateProposal.ts
+++ b/services/api/src/routers/translation/translateProposal.ts
@@ -1,7 +1,7 @@
 import { SUPPORTED_LOCALES, translateProposal } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 /**
  * Generic output schema for all translation endpoints.
@@ -14,7 +14,7 @@ export const translateOutput = z.object({
 });
 
 export const translateProposalRouter = router({
-  translateProposal: commonNetworkProcedure()
+  translateProposal: networkAuthenticatedProcedure()
     .input(
       z.object({
         profileId: z.uuid(),

--- a/services/api/src/routers/translation/translateProposal.ts
+++ b/services/api/src/routers/translation/translateProposal.ts
@@ -1,7 +1,7 @@
 import { SUPPORTED_LOCALES, translateProposal } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 /**
  * Generic output schema for all translation endpoints.
@@ -14,7 +14,7 @@ export const translateOutput = z.object({
 });
 
 export const translateProposalRouter = router({
-  translateProposal: commonAuthedProcedure()
+  translateProposal: commonNetworkProcedure()
     .input(
       z.object({
         profileId: z.uuid(),

--- a/services/api/src/routers/translation/translateProposals.ts
+++ b/services/api/src/routers/translation/translateProposals.ts
@@ -1,10 +1,10 @@
 import { SUPPORTED_LOCALES, translateProposals } from '@op/common';
 import { z } from 'zod';
 
-import { commonAuthedProcedure, router } from '../../trpcFactory';
+import { commonNetworkProcedure, router } from '../../trpcFactory';
 
 export const translateProposalsRouter = router({
-  translateProposals: commonAuthedProcedure()
+  translateProposals: commonNetworkProcedure()
     .input(
       z.object({
         profileIds: z.array(z.uuid()).min(1).max(100),

--- a/services/api/src/routers/translation/translateProposals.ts
+++ b/services/api/src/routers/translation/translateProposals.ts
@@ -1,10 +1,10 @@
 import { SUPPORTED_LOCALES, translateProposals } from '@op/common';
 import { z } from 'zod';
 
-import { commonNetworkProcedure, router } from '../../trpcFactory';
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const translateProposalsRouter = router({
-  translateProposals: commonNetworkProcedure()
+  translateProposals: networkAuthenticatedProcedure()
     .input(
       z.object({
         profileIds: z.array(z.uuid()).min(1).max(100),

--- a/services/api/src/test/helpers/gating/decision.ts
+++ b/services/api/src/test/helpers/gating/decision.ts
@@ -13,7 +13,7 @@ export {
 /**
  * Decision-instance endpoints that participate in network gating declare an
  * outcome for the four caller kinds (no-JWT / anon-JWT / user-JWT / network-JWT)
- * against a non-public instance. Decision endpoints are `commonNetworkProcedure`,
+ * against a non-public instance. Decision endpoints are `networkAuthenticatedProcedure`,
  * so the first three are rejected by the tier gate (`AccessTierError`) and
  * network-JWT is admitted. Public-mode cells will be added when the
  * public-instance toggle

--- a/services/api/src/test/helpers/gating/decision.ts
+++ b/services/api/src/test/helpers/gating/decision.ts
@@ -13,7 +13,7 @@ export {
 /**
  * Decision-instance endpoints that participate in network gating declare an
  * outcome for the four caller kinds (no-JWT / anon-JWT / user-JWT / network-JWT)
- * against a non-public instance. Decision endpoints are `commonAuthedProcedure`,
+ * against a non-public instance. Decision endpoints are `commonNetworkProcedure`,
  * so the first three are rejected by the tier gate (`AccessTierError`) and
  * network-JWT is admitted. Public-mode cells will be added when the
  * public-instance toggle

--- a/services/api/src/test/helpers/gating/index.ts
+++ b/services/api/src/test/helpers/gating/index.ts
@@ -22,7 +22,7 @@ export type GatingCell = {
  *   - user-JWT    — an authenticated account that is *not* in the network
  *   - network-JWT — an authenticated in-network user
  *
- * For a `commonNetworkProcedure` endpoint (required tier `network`), the gate
+ * For a `networkAuthenticatedProcedure` endpoint (required tier `network`), the gate
  * rejects the first three with an `AccessTierError` — `callerTier: 'none'`
  * (401) for no-JWT, `callerTier: 'anon'` (403) for anon-JWT, and
  * `callerTier: 'user'` (403) for the out-of-network user-JWT — and admits

--- a/services/api/src/test/helpers/gating/index.ts
+++ b/services/api/src/test/helpers/gating/index.ts
@@ -22,7 +22,7 @@ export type GatingCell = {
  *   - user-JWT    — an authenticated account that is *not* in the network
  *   - network-JWT — an authenticated in-network user
  *
- * For a `commonAuthedProcedure` endpoint (required tier `network`), the gate
+ * For a `commonNetworkProcedure` endpoint (required tier `network`), the gate
  * rejects the first three with an `AccessTierError` — `callerTier: 'none'`
  * (401) for no-JWT, `callerTier: 'anon'` (403) for anon-JWT, and
  * `callerTier: 'user'` (403) for the out-of-network user-JWT — and admits

--- a/services/api/src/trpcFactory.ts
+++ b/services/api/src/trpcFactory.ts
@@ -78,21 +78,13 @@ interface RateLimitedProcedureOptions {
 }
 
 /**
- * Closed-network authenticated procedure (formerly `commonAuthedProcedure`).
- * Includes: requestCache -> channelMeta -> logger -> rateLimited ->
- * networkAuthentication -> analytics.
- *
- * Rejects anonymous and unauthenticated callers at the auth gate and admits
- * only confirmed `@oneproject.org` / allow-listed users. Use this for endpoints
- * that genuinely require closed-network membership.
- *
- * @param opts.rateLimit - Custom rate limit config (default: 10 requests per 10 seconds)
- *
- * Usage:
- * - `commonNetworkProcedure()` - uses default rate limit (10 req/10s)
- * - `commonNetworkProcedure({ rateLimit: { windowSize: 60, maxRequests: 5 } })` - custom rate limit
+ * Closed-network procedure (formerly `commonAuthedProcedure`): admits only
+ * confirmed `@oneproject.org` / allow-listed users via {@link withNetworkAuthentication}.
+ * Default rate limit is 10 requests per 10 seconds.
  */
-export function commonNetworkProcedure(opts?: RateLimitedProcedureOptions) {
+export function networkAuthenticatedProcedure(
+  opts?: RateLimitedProcedureOptions,
+) {
   const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;
   return commonProcedure
     .use(withRateLimited(rateLimit))
@@ -101,16 +93,11 @@ export function commonNetworkProcedure(opts?: RateLimitedProcedureOptions) {
 }
 
 /**
- * Authenticated procedure for any real Supabase user — including anonymous
- * sign-ins. Includes: requestCache -> channelMeta -> logger -> rateLimited ->
- * resolvedUser -> requireUser -> analytics.
- *
- * Requires *a* user but performs no closed-network gating; authorization is
- * deferred to the service layer. Endpoints move here from
- * `commonNetworkProcedure` once gating tests prove anon / out-of-network
- * callers still fail closed (or are intentionally admitted).
- *
- * @param opts.rateLimit - Custom rate limit config (default: 10 requests per 10 seconds)
+ * Requires *a* user (any session, including anonymous sign-ins) but does no
+ * closed-network gating; authorization is deferred to the service layer.
+ * Endpoints migrate here from {@link networkAuthenticatedProcedure} once gating
+ * tests prove out-of-network callers still fail closed. Default rate limit is
+ * 10 requests per 10 seconds.
  */
 export function authenticatedProcedure(opts?: RateLimitedProcedureOptions) {
   const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;
@@ -122,15 +109,9 @@ export function authenticatedProcedure(opts?: RateLimitedProcedureOptions) {
 }
 
 /**
- * Open procedure for no-JWT / public-capable endpoints. Includes: requestCache
- * -> channelMeta -> logger -> rateLimited -> resolvedUser -> analytics.
- *
- * Resolves an optional user (`ctx.user?`) but never rejects at the middleware
- * layer — authorization is fully the service layer's responsibility. Used by
- * nothing yet; endpoints opt in only once their service layer does real role
- * checks and has updated gating coverage.
- *
- * @param opts.rateLimit - Custom rate limit config (default: 10 requests per 10 seconds)
+ * Public-capable procedure: resolves an optional `ctx.user` but never rejects
+ * at the middleware layer — authorization is fully the service layer's job.
+ * Not used yet. Default rate limit is 10 requests per 10 seconds.
  */
 export function openProcedure(opts?: RateLimitedProcedureOptions) {
   const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;

--- a/services/api/src/trpcFactory.ts
+++ b/services/api/src/trpcFactory.ts
@@ -10,12 +10,12 @@ import {
 } from './lib/cookies';
 import { errorFormatter } from './lib/error';
 import withAnalytics from './middlewares/withAnalytics';
+import withAuthenticatedUser from './middlewares/withAuthenticatedUser';
 import withChannelMeta from './middlewares/withChannelMeta';
 import withLogger from './middlewares/withLogger';
-import withNetworkAuthentication from './middlewares/withNetworkAuthentication';
+import withNetworkAuthenticatedUser from './middlewares/withNetworkAuthenticatedUser';
 import withRateLimited from './middlewares/withRateLimited';
 import withRequestCache from './middlewares/withRequestCache';
-import withRequireUser from './middlewares/withRequireUser';
 import withResolvedUser from './middlewares/withResolvedUser';
 import type { TContext } from './types';
 
@@ -79,7 +79,7 @@ interface RateLimitedProcedureOptions {
 
 /**
  * Closed-network procedure (formerly `commonAuthedProcedure`): admits only
- * confirmed `@oneproject.org` / allow-listed users via {@link withNetworkAuthentication}.
+ * confirmed `@oneproject.org` / allow-listed users via {@link withNetworkAuthenticatedUser}.
  * Default rate limit is 10 requests per 10 seconds.
  */
 export function networkAuthenticatedProcedure(
@@ -88,7 +88,7 @@ export function networkAuthenticatedProcedure(
   const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;
   return commonProcedure
     .use(withRateLimited(rateLimit))
-    .use(withNetworkAuthentication)
+    .use(withNetworkAuthenticatedUser)
     .use(withAnalytics);
 }
 
@@ -104,7 +104,7 @@ export function authenticatedProcedure(opts?: RateLimitedProcedureOptions) {
   return commonProcedure
     .use(withRateLimited(rateLimit))
     .use(withResolvedUser)
-    .use(withRequireUser)
+    .use(withAuthenticatedUser)
     .use(withAnalytics);
 }
 

--- a/services/api/src/trpcFactory.ts
+++ b/services/api/src/trpcFactory.ts
@@ -12,6 +12,7 @@ import { errorFormatter } from './lib/error';
 import withAnalytics from './middlewares/withAnalytics';
 import withAuthenticatedUser from './middlewares/withAuthenticatedUser';
 import withChannelMeta from './middlewares/withChannelMeta';
+import withConfirmedUser from './middlewares/withConfirmedUser';
 import withLogger from './middlewares/withLogger';
 import withNetworkAuthenticatedUser from './middlewares/withNetworkAuthenticatedUser';
 import withRateLimited from './middlewares/withRateLimited';
@@ -89,6 +90,22 @@ export function networkAuthenticatedProcedure(
   return commonProcedure
     .use(withRateLimited(rateLimit))
     .use(withNetworkAuthenticatedUser)
+    .use(withAnalytics);
+}
+
+/**
+ * Confirmed-user procedure: admits any confirmed, non-anonymous user (a real
+ * account whose email/phone is confirmed) via {@link withConfirmedUser}, but
+ * applies no closed-network/allow-list gating. Sits one tier below
+ * {@link networkAuthenticatedProcedure} (which adds the `@oneproject.org` /
+ * invite allow list) and one above {@link authenticatedProcedure} (which also
+ * admits anonymous sessions). Default rate limit is 10 requests per 10 seconds.
+ */
+export function confirmedProcedure(opts?: RateLimitedProcedureOptions) {
+  const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;
+  return commonProcedure
+    .use(withRateLimited(rateLimit))
+    .use(withConfirmedUser)
     .use(withAnalytics);
 }
 

--- a/services/api/src/trpcFactory.ts
+++ b/services/api/src/trpcFactory.ts
@@ -10,11 +10,13 @@ import {
 } from './lib/cookies';
 import { errorFormatter } from './lib/error';
 import withAnalytics from './middlewares/withAnalytics';
-import withAuthenticated from './middlewares/withAuthenticated';
 import withChannelMeta from './middlewares/withChannelMeta';
 import withLogger from './middlewares/withLogger';
+import withNetworkAuthentication from './middlewares/withNetworkAuthentication';
 import withRateLimited from './middlewares/withRateLimited';
 import withRequestCache from './middlewares/withRequestCache';
+import withRequireUser from './middlewares/withRequireUser';
+import withResolvedUser from './middlewares/withResolvedUser';
 import type { TContext } from './types';
 
 export const createContext = async ({
@@ -68,7 +70,7 @@ export const commonProcedure = t.procedure
 
 const DEFAULT_RATE_LIMIT = { windowSize: 10, maxRequests: 10 };
 
-interface CommonAuthedProcedureOptions {
+interface RateLimitedProcedureOptions {
   rateLimit?: {
     windowSize: number;
     maxRequests: number;
@@ -76,21 +78,64 @@ interface CommonAuthedProcedureOptions {
 }
 
 /**
- * Creates an authenticated procedure with configurable rate limiting.
- * Includes: channelMeta -> logger -> rateLimited -> authenticated -> analytics
+ * Closed-network authenticated procedure (formerly `commonAuthedProcedure`).
+ * Includes: requestCache -> channelMeta -> logger -> rateLimited ->
+ * networkAuthentication -> analytics.
+ *
+ * Rejects anonymous and unauthenticated callers at the auth gate and admits
+ * only confirmed `@oneproject.org` / allow-listed users. Use this for endpoints
+ * that genuinely require closed-network membership.
  *
  * @param opts.rateLimit - Custom rate limit config (default: 10 requests per 10 seconds)
  *
  * Usage:
- * - `commonAuthedProcedure()` - uses default rate limit (10 req/10s)
- * - `commonAuthedProcedure({ rateLimit: { windowSize: 60, maxRequests: 5 } })` - custom rate limit
- *
- * For unauthenticated endpoints, use `commonProcedure` with explicit middleware.
+ * - `commonNetworkProcedure()` - uses default rate limit (10 req/10s)
+ * - `commonNetworkProcedure({ rateLimit: { windowSize: 60, maxRequests: 5 } })` - custom rate limit
  */
-export function commonAuthedProcedure(opts?: CommonAuthedProcedureOptions) {
+export function commonNetworkProcedure(opts?: RateLimitedProcedureOptions) {
   const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;
   return commonProcedure
     .use(withRateLimited(rateLimit))
-    .use(withAuthenticated)
+    .use(withNetworkAuthentication)
+    .use(withAnalytics);
+}
+
+/**
+ * Authenticated procedure for any real Supabase user — including anonymous
+ * sign-ins. Includes: requestCache -> channelMeta -> logger -> rateLimited ->
+ * resolvedUser -> requireUser -> analytics.
+ *
+ * Requires *a* user but performs no closed-network gating; authorization is
+ * deferred to the service layer. Endpoints move here from
+ * `commonNetworkProcedure` once gating tests prove anon / out-of-network
+ * callers still fail closed (or are intentionally admitted).
+ *
+ * @param opts.rateLimit - Custom rate limit config (default: 10 requests per 10 seconds)
+ */
+export function authenticatedProcedure(opts?: RateLimitedProcedureOptions) {
+  const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;
+  return commonProcedure
+    .use(withRateLimited(rateLimit))
+    .use(withResolvedUser)
+    .use(withRequireUser)
+    .use(withAnalytics);
+}
+
+/**
+ * Open procedure for no-JWT / public-capable endpoints. Includes: requestCache
+ * -> channelMeta -> logger -> rateLimited -> resolvedUser -> analytics.
+ *
+ * Resolves an optional user (`ctx.user?`) but never rejects at the middleware
+ * layer — authorization is fully the service layer's responsibility. Used by
+ * nothing yet; endpoints opt in only once their service layer does real role
+ * checks and has updated gating coverage.
+ *
+ * @param opts.rateLimit - Custom rate limit config (default: 10 requests per 10 seconds)
+ */
+export function openProcedure(opts?: RateLimitedProcedureOptions) {
+  const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;
+  return commonProcedure
+    .use(withRateLimited(rateLimit))
+    .use(withResolvedUser)
     .use(withAnalytics);
 }

--- a/services/api/src/trpcFactory.ts
+++ b/services/api/src/trpcFactory.ts
@@ -101,7 +101,9 @@ export function networkAuthenticatedProcedure(
  * invite allow list) and one above {@link authenticatedProcedure} (which also
  * admits anonymous sessions). Default rate limit is 10 requests per 10 seconds.
  */
-export function confirmedProcedure(opts?: RateLimitedProcedureOptions) {
+export function authenticatedConfirmedProcedure(
+  opts?: RateLimitedProcedureOptions,
+) {
   const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;
   return commonProcedure
     .use(withRateLimited(rateLimit))

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -29,6 +29,16 @@ export interface TContextWithUser {
   user: User;
 }
 
+/**
+ * Context after an optional user resolution: `user` is the real Supabase
+ * identity if the caller presented a valid session (including anonymous
+ * sign-ins), otherwise `undefined`. Used by procedures that resolve the caller
+ * without rejecting unauthenticated requests at the middleware layer.
+ */
+export interface TContextWithMaybeUser {
+  user?: User;
+}
+
 export interface TContextWithAnalytics {
   analyticsDistinctId?: string;
 }

--- a/services/api/src/types.ts
+++ b/services/api/src/types.ts
@@ -29,12 +29,8 @@ export interface TContextWithUser {
   user: User;
 }
 
-/**
- * Context after an optional user resolution: `user` is the real Supabase
- * identity if the caller presented a valid session (including anonymous
- * sign-ins), otherwise `undefined`. Used by procedures that resolve the caller
- * without rejecting unauthenticated requests at the middleware layer.
- */
+/** Context after optional user resolution: `user` is the resolved Supabase
+ * identity, or `undefined` when the caller has no valid session. */
 export interface TContextWithMaybeUser {
   user?: User;
 }

--- a/services/api/src/utils/verifyAuthentication.ts
+++ b/services/api/src/utils/verifyAuthentication.ts
@@ -1,5 +1,4 @@
-import { AccessTierError, UnauthorizedError } from '@op/common';
-import { adminEmails } from '@op/core';
+import { AccessTierError } from '@op/common';
 import type { UserResponse } from '@op/supabase/lib';
 
 /**
@@ -10,11 +9,10 @@ import type { UserResponse } from '@op/supabase/lib';
  *   - no session / auth error  → actual `none` (401)
  *   - anonymous / unconfirmed  → actual `anon` (403)
  *
- * Network membership is checked by the caller (it needs an async allow-list
- * lookup); admin membership is authorization, not a tier, so a non-admin who
- * passed the tier check is rejected with a plain {@link UnauthorizedError}.
+ * Network membership and admin authorization are checked by the caller; this
+ * helper only establishes that a confirmed user is present.
  */
-export const verifyAuthentication = (data: UserResponse, adminOnly = false) => {
+export const verifyAuthentication = (data: UserResponse) => {
   if (!data) {
     throw new AccessTierError('none');
   }
@@ -29,12 +27,6 @@ export const verifyAuthentication = (data: UserResponse, adminOnly = false) => {
 
   if (data.data.user.confirmed_at === null) {
     throw new AccessTierError('anon');
-  }
-
-  // Admin membership is authorization, not a tier: a valid user who is not an
-  // admin has met the tier requirement but lacks permission.
-  if (adminOnly && !adminEmails.includes(data.data.user.email || '')) {
-    throw new UnauthorizedError('User is not an admin');
   }
 
   return data.data.user;


### PR DESCRIPTION
Makes each endpoint's auth posture explicit ahead of opening any public access. Renames the closed-network procedure (commonAuthedProcedure -> networkAuthenticatedProcedure) and adds inert authenticatedConfirmedProcedure, authenticatedProcedure, and openProcedure scaffolding with no endpoint behavior change yet.