### PR TITLE
fix(posts): Add translation to comment button

### DIFF
--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -181,13 +181,21 @@ const PostCommentButton = ({
   post: Post;
   onCommentClick: () => void;
 }) => {
+  const t = useTranslations();
+
   // we can disable this to allow for threads in the future
   if (!post?.id || post.parentPostId) {
     return null;
   }
 
+  const count = post.commentCount || 0;
+
   return (
-    <CommentButton count={post.commentCount || 0} onPress={onCommentClick} />
+    <CommentButton
+      count={count}
+      label={t('{count} comments', { count })}
+      onPress={onCommentClick}
+    />
   );
 };
 
@@ -420,6 +428,7 @@ export const PostItemOnDetailPage = ({
   commentCount: number;
   className?: string;
 }) => {
+  const t = useTranslations();
   const { urls } = useMemo(() => detectLinks(post?.content), [post?.content]);
   const { displayPost, handleReactionClick } = useOptimisticReaction(
     post,
@@ -466,7 +475,11 @@ export const PostItemOnDetailPage = ({
               post={displayPost}
               onReactionClick={handleReactionClick}
             />
-            <CommentButton count={commentCount} isDisabled />
+            <CommentButton
+              count={commentCount}
+              label={t('{count} comments', { count: commentCount })}
+              isDisabled
+            />
           </div>
         </FeedContent>
       </FeedMain>

--- a/packages/ui/src/components/CommentButton.tsx
+++ b/packages/ui/src/components/CommentButton.tsx
@@ -38,18 +38,25 @@ export interface CommentButtonProps extends Omit<
   'children'
 > {
   count?: number;
+  /**
+   * Fully-formatted, translated label (e.g. "3 comments"). Consumers should
+   * pass an i18n-translated string since this package is locale-agnostic.
+   * Falls back to an English default when omitted.
+   */
+  label?: string;
   className?: string;
 }
 
 export const CommentButton = ({
   count = 0,
+  label,
   className,
   ...props
 }: CommentButtonProps) => {
   return (
     <RACButton {...props} className={commentButtonStyle({ className })}>
       <MessageCircleIcon className={iconStyle()} />
-      <span>{count} comments</span>
+      <span>{label ?? `${count} comments`}</span>
     </RACButton>
   );
 };


### PR DESCRIPTION
Shifts the comment button label over to a translated label. We are passing in the key due to @op/ui not having i18n functionality within the library specifically.