### PR TITLE
feat(access-control): add global public user

### DIFF
--- a/packages/common/src/services/platform/index.ts
+++ b/packages/common/src/services/platform/index.ts
@@ -1,1 +1,2 @@
+export * from './listAllUsers';
 export * from './stats';

--- a/packages/common/src/services/platform/listAllUsers.ts
+++ b/packages/common/src/services/platform/listAllUsers.ts
@@ -1,0 +1,125 @@
+import { GLOBAL_USER_IDS } from '@op/core';
+import { and, count, db, ilike, notInArray } from '@op/db/client';
+import { users } from '@op/db/schema';
+import type { SQL } from 'drizzle-orm';
+
+import {
+  type SortDir,
+  decodeCursor,
+  encodeCursor,
+  getGenericCursorCondition,
+} from '../../utils/db';
+
+/**
+ * List every user on the platform with cursor-based pagination and optional
+ * email search. Used by the platform-admin dashboard.
+ *
+ * The access-control sentinel users (GLOBAL_USER_PUBLIC / GLOBAL_USER_ANONYMOUS)
+ * are always excluded from both the items and the total. Their UUIDs are the
+ * auth.users ids, which map to public.users.authUserId — not the autoId()
+ * primary key.
+ */
+export const listAllUsers = async ({
+  cursor,
+  dir = 'desc',
+  query,
+  limit,
+}: {
+  cursor?: string | null;
+  dir?: SortDir;
+  query?: string;
+  limit?: number;
+}) => {
+  const decodedCursor = cursor ? decodeCursor(cursor) : undefined;
+  const hasSearch = !!(query && query.length >= 2);
+  const sentinelIds = [...GLOBAL_USER_IDS];
+
+  // Used by the count() select below; references the raw schema table.
+  const searchCondition = hasSearch
+    ? and(
+        notInArray(users.authUserId, sentinelIds),
+        ilike(users.email, `%${query}%`),
+      )
+    : notInArray(users.authUserId, sentinelIds);
+
+  // Uses V2 `db.query` (single SQL via LATERAL joins) instead of V1 `db._query`
+  // to avoid fan-out that saturates the Supavisor transaction-mode pool.
+  // The RAW callback receives the aliased table used inside V2's generated
+  // SQL — conditions must be built against that alias, not the schema ref.
+  const [allUsers, [totalCountResult]] = await Promise.all([
+    db.query.users.findMany({
+      where: {
+        RAW: (table) => {
+          const conds: SQL[] = [notInArray(table.authUserId, sentinelIds)];
+          if (decodedCursor) {
+            const cursorCond = getGenericCursorCondition({
+              columns: { id: table.id, date: table.createdAt },
+              cursor: decodedCursor,
+            });
+            if (cursorCond) conds.push(cursorCond);
+          }
+          if (hasSearch) {
+            conds.push(ilike(table.email, `%${query}%`));
+          }
+          return conds.length > 1 ? and(...conds)! : conds[0]!;
+        },
+      },
+      with: {
+        authUser: true,
+        profile: true,
+        avatarImage: true,
+        organizationUsers: {
+          with: {
+            organization: {
+              with: {
+                profile: {
+                  with: {
+                    avatarImage: true,
+                  },
+                },
+                whereWeWork: {
+                  with: {
+                    location: true,
+                  },
+                },
+              },
+            },
+            roles: {
+              with: {
+                accessRole: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: dir },
+      ...(limit !== undefined && { limit: limit + 1 }),
+    }),
+    db.select({ value: count() }).from(users).where(searchCondition),
+  ]);
+
+  const totalCount = totalCountResult?.value ?? 0;
+  const hasMore = limit !== undefined && allUsers.length > limit;
+  const items = hasMore ? allUsers.slice(0, limit) : allUsers;
+  const lastItem = items[items.length - 1];
+  const next =
+    hasMore && lastItem && lastItem.createdAt
+      ? encodeCursor({
+          date: new Date(lastItem.createdAt),
+          id: lastItem.id,
+        })
+      : null;
+
+  // Transform whereWeWork from join table to location array for each organization
+  items.forEach((user) => {
+    user.organizationUsers?.forEach((orgUser) => {
+      if (orgUser.organization?.whereWeWork) {
+        orgUser.organization.whereWeWork = orgUser.organization.whereWeWork.map(
+          (item: any) => item.location,
+        );
+      }
+    });
+  });
+
+  return { items, next, total: totalCount };
+};

--- a/packages/common/src/services/platform/listAllUsers.ts
+++ b/packages/common/src/services/platform/listAllUsers.ts
@@ -2,6 +2,7 @@ import { GLOBAL_USER_IDS } from '@op/core';
 import { and, count, db, ilike, notInArray } from '@op/db/client';
 import { users } from '@op/db/schema';
 import type { SQL } from 'drizzle-orm';
+import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
 import {
   type SortDir,
@@ -12,12 +13,8 @@ import {
 
 /**
  * List every user on the platform with cursor-based pagination and optional
- * email search. Used by the platform-admin dashboard.
- *
- * The access-control sentinel users (GLOBAL_USER_PUBLIC / GLOBAL_USER_ANONYMOUS)
- * are always excluded from both the items and the total. Their UUIDs are the
- * auth.users ids, which map to public.users.authUserId — not the autoId()
- * primary key.
+ * email search. Used by the platform-admin dashboard. Skips the global
+ * access-control sentinel users.
  */
 export const listAllUsers = async ({
   cursor,
@@ -34,32 +31,31 @@ export const listAllUsers = async ({
   const hasSearch = !!(query && query.length >= 2);
   const sentinelIds = [...GLOBAL_USER_IDS];
 
-  // Used by the count() select below; references the raw schema table.
-  const searchCondition = hasSearch
-    ? and(
-        notInArray(users.authUserId, sentinelIds),
-        ilike(users.email, `%${query}%`),
-      )
-    : notInArray(users.authUserId, sentinelIds);
+  // Filter shared by the paginated query and the total count: exclude the
+  // sentinel users and, when searching, match the email. The cursor condition
+  // is added only to the paginated query.
+  const baseConds = (table: {
+    authUserId: AnyPgColumn;
+    email: AnyPgColumn;
+  }): SQL[] => {
+    const conds: SQL[] = [notInArray(table.authUserId, sentinelIds)];
+    if (hasSearch) {
+      conds.push(ilike(table.email, `%${query}%`));
+    }
+    return conds;
+  };
 
-  // Uses V2 `db.query` (single SQL via LATERAL joins) instead of V1 `db._query`
-  // to avoid fan-out that saturates the Supavisor transaction-mode pool.
-  // The RAW callback receives the aliased table used inside V2's generated
-  // SQL — conditions must be built against that alias, not the schema ref.
   const [allUsers, [totalCountResult]] = await Promise.all([
     db.query.users.findMany({
       where: {
         RAW: (table) => {
-          const conds: SQL[] = [notInArray(table.authUserId, sentinelIds)];
+          const conds = baseConds(table);
           if (decodedCursor) {
             const cursorCond = getGenericCursorCondition({
               columns: { id: table.id, date: table.createdAt },
               cursor: decodedCursor,
             });
             if (cursorCond) conds.push(cursorCond);
-          }
-          if (hasSearch) {
-            conds.push(ilike(table.email, `%${query}%`));
           }
           return conds.length > 1 ? and(...conds)! : conds[0]!;
         },
@@ -95,7 +91,10 @@ export const listAllUsers = async ({
       orderBy: { createdAt: dir },
       ...(limit !== undefined && { limit: limit + 1 }),
     }),
-    db.select({ value: count() }).from(users).where(searchCondition),
+    db
+      .select({ value: count() })
+      .from(users)
+      .where(and(...baseConds(users))),
   ]);
 
   const totalCount = totalCountResult?.value ?? 0;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -220,18 +220,15 @@ export const genericEmail = 'support@oneproject.org';
 
 export const adminEmails = ['scott@oneproject.org'];
 
-// Sentinel "global" user identities used by the access-control substitution
-// layer. GLOBAL_USER_PUBLIC stands in for no-JWT public callers and
-// GLOBAL_USER_ANONYMOUS for anon-JWT callers when resolving role grants. Their
-// UUIDs are hardcoded so every environment references the same rows; the rows
-// are created by the database seed (services/db/seed-global-users.ts). They are
-// quarantined: cannot sign in, and never surface in user/profile lists.
+// Sentinel "global" user identity used by the access-control substitution
+// layer. GLOBAL_USER_PUBLIC stands in for no-JWT public callers when resolving
+// role grants. Anonymous (anon-JWT) callers are not substituted: they already
+// have a real auth.users identity, so their own id carries their grants and
+// participation. Its UUID is hardcoded so every environment references the same
+// row; the row is created by the database seed (services/db/seed-global-users.ts).
+// It is quarantined: cannot sign in, and never surfaces in user/profile lists.
 export const GLOBAL_USER_PUBLIC = '00000000-0000-4000-a000-000000000001';
-export const GLOBAL_USER_ANONYMOUS = '00000000-0000-4000-a000-000000000002';
-export const GLOBAL_USER_IDS = [
-  GLOBAL_USER_PUBLIC,
-  GLOBAL_USER_ANONYMOUS,
-] as const;
+export const GLOBAL_USER_IDS = [GLOBAL_USER_PUBLIC] as const;
 
 // NOTE: This allowlist will eventually be moved to the database
 export const platformAdminEmails = new Set([

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -220,6 +220,19 @@ export const genericEmail = 'support@oneproject.org';
 
 export const adminEmails = ['scott@oneproject.org'];
 
+// Sentinel "global" user identities used by the access-control substitution
+// layer. GLOBAL_USER_PUBLIC stands in for no-JWT public callers and
+// GLOBAL_USER_ANONYMOUS for anon-JWT callers when resolving role grants. Their
+// UUIDs are hardcoded so every environment references the same rows; the rows
+// are created by the database seed (services/db/seed-global-users.ts). They are
+// quarantined: cannot sign in, and never surface in user/profile lists.
+export const GLOBAL_USER_PUBLIC = '00000000-0000-4000-a000-000000000001';
+export const GLOBAL_USER_ANONYMOUS = '00000000-0000-4000-a000-000000000002';
+export const GLOBAL_USER_IDS = [
+  GLOBAL_USER_PUBLIC,
+  GLOBAL_USER_ANONYMOUS,
+] as const;
+
 // NOTE: This allowlist will eventually be moved to the database
 export const platformAdminEmails = new Set([
   'iza@oneproject.org',

--- a/services/api/src/routers/platform/admin/listAllUsers.test.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.test.ts
@@ -1,3 +1,4 @@
+import { GLOBAL_USER_IDS } from '@op/core';
 import { describe, expect, it } from 'vitest';
 
 import { platformAdminRouter } from '.';
@@ -346,6 +347,30 @@ describe.concurrent('platform.admin.listAllUsers', () => {
       items.every((user: (typeof result2.items)[number]) =>
         customDomainUserEmails.has(user.email!),
       ),
+    );
+  });
+
+  it('should never surface the global sentinel users', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestOrganizationDataManager(task.id, onTestFinished);
+    const { adminUser } = await testData.createOrganization({
+      users: { admin: 1 },
+    });
+
+    // Create isolated session for this test
+    const { session } = await createIsolatedSession(adminUser.email);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    const sentinelIds = new Set<string>(GLOBAL_USER_IDS);
+
+    // The sentinels are seeded before any test user, so ascending order by
+    // createdAt would surface them first if they weren't filtered out.
+    const result = await caller.listAllUsers({ limit: 100, dir: 'asc' });
+
+    expect(result.items.some((user) => sentinelIds.has(user.authUserId))).toBe(
+      false,
     );
   });
 });

--- a/services/api/src/routers/platform/admin/listAllUsers.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.ts
@@ -3,7 +3,8 @@ import {
   encodeCursor,
   getGenericCursorCondition,
 } from '@op/common';
-import { and, count, db, ilike } from '@op/db/client';
+import { GLOBAL_USER_IDS } from '@op/core';
+import { and, count, db, ilike, notInArray } from '@op/db/client';
 import { users } from '@op/db/schema';
 import type { SQL } from 'drizzle-orm';
 import { z } from 'zod';
@@ -38,12 +39,18 @@ export const listAllUsersRouter = router({
       const decodedCursor = cursor ? decodeCursor(cursor) : undefined;
       const hasSearch = !!(query && query.length >= 2);
 
+      // Always exclude the access-control sentinel users (GLOBAL_USER_PUBLIC /
+      // GLOBAL_USER_ANONYMOUS). Their UUIDs are auth.users ids, which map to
+      // public.users.authUserId — not the autoId() primary key.
+      const sentinelIds = [...GLOBAL_USER_IDS];
+
       // Used by the count() select below; references the raw schema table.
       const searchCondition = hasSearch
-        ? ilike(users.email, `%${query}%`)
-        : undefined;
-
-      const hasWhere = !!decodedCursor || hasSearch;
+        ? and(
+            notInArray(users.authUserId, sentinelIds),
+            ilike(users.email, `%${query}%`),
+          )
+        : notInArray(users.authUserId, sentinelIds);
 
       // Uses V2 `db.query` (single SQL via LATERAL joins) instead of V1 `db._query`
       // to avoid fan-out that saturates the Supavisor transaction-mode pool.
@@ -51,24 +58,22 @@ export const listAllUsersRouter = router({
       // SQL — conditions must be built against that alias, not the schema ref.
       const [allUsers, [totalCountResult]] = await Promise.all([
         db.query.users.findMany({
-          where: hasWhere
-            ? {
-                RAW: (table) => {
-                  const conds: SQL[] = [];
-                  if (decodedCursor) {
-                    const cursorCond = getGenericCursorCondition({
-                      columns: { id: table.id, date: table.createdAt },
-                      cursor: decodedCursor,
-                    });
-                    if (cursorCond) conds.push(cursorCond);
-                  }
-                  if (hasSearch) {
-                    conds.push(ilike(table.email, `%${query}%`));
-                  }
-                  return conds.length > 1 ? and(...conds)! : conds[0]!;
-                },
+          where: {
+            RAW: (table) => {
+              const conds: SQL[] = [notInArray(table.authUserId, sentinelIds)];
+              if (decodedCursor) {
+                const cursorCond = getGenericCursorCondition({
+                  columns: { id: table.id, date: table.createdAt },
+                  cursor: decodedCursor,
+                });
+                if (cursorCond) conds.push(cursorCond);
               }
-            : undefined,
+              if (hasSearch) {
+                conds.push(ilike(table.email, `%${query}%`));
+              }
+              return conds.length > 1 ? and(...conds)! : conds[0]!;
+            },
+          },
           with: {
             authUser: true,
             profile: true,

--- a/services/api/src/routers/platform/admin/listAllUsers.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.ts
@@ -1,12 +1,4 @@
-import {
-  decodeCursor,
-  encodeCursor,
-  getGenericCursorCondition,
-} from '@op/common';
-import { GLOBAL_USER_IDS } from '@op/core';
-import { and, count, db, ilike, notInArray } from '@op/db/client';
-import { users } from '@op/db/schema';
-import type { SQL } from 'drizzle-orm';
+import { listAllUsers } from '@op/common';
 import { z } from 'zod';
 
 import { userEncoder } from '../../../encoders/';
@@ -35,107 +27,19 @@ export const listAllUsersRouter = router({
       }),
     )
     .query(async ({ input }) => {
-      const { cursor, dir = 'desc', query, limit } = input ?? {};
-      const decodedCursor = cursor ? decodeCursor(cursor) : undefined;
-      const hasSearch = !!(query && query.length >= 2);
+      const { cursor, dir, query, limit } = input ?? {};
 
-      // Always exclude the access-control sentinel users (GLOBAL_USER_PUBLIC /
-      // GLOBAL_USER_ANONYMOUS). Their UUIDs are auth.users ids, which map to
-      // public.users.authUserId — not the autoId() primary key.
-      const sentinelIds = [...GLOBAL_USER_IDS];
-
-      // Used by the count() select below; references the raw schema table.
-      const searchCondition = hasSearch
-        ? and(
-            notInArray(users.authUserId, sentinelIds),
-            ilike(users.email, `%${query}%`),
-          )
-        : notInArray(users.authUserId, sentinelIds);
-
-      // Uses V2 `db.query` (single SQL via LATERAL joins) instead of V1 `db._query`
-      // to avoid fan-out that saturates the Supavisor transaction-mode pool.
-      // The RAW callback receives the aliased table used inside V2's generated
-      // SQL — conditions must be built against that alias, not the schema ref.
-      const [allUsers, [totalCountResult]] = await Promise.all([
-        db.query.users.findMany({
-          where: {
-            RAW: (table) => {
-              const conds: SQL[] = [notInArray(table.authUserId, sentinelIds)];
-              if (decodedCursor) {
-                const cursorCond = getGenericCursorCondition({
-                  columns: { id: table.id, date: table.createdAt },
-                  cursor: decodedCursor,
-                });
-                if (cursorCond) conds.push(cursorCond);
-              }
-              if (hasSearch) {
-                conds.push(ilike(table.email, `%${query}%`));
-              }
-              return conds.length > 1 ? and(...conds)! : conds[0]!;
-            },
-          },
-          with: {
-            authUser: true,
-            profile: true,
-            avatarImage: true,
-            organizationUsers: {
-              with: {
-                organization: {
-                  with: {
-                    profile: {
-                      with: {
-                        avatarImage: true,
-                      },
-                    },
-                    whereWeWork: {
-                      with: {
-                        location: true,
-                      },
-                    },
-                  },
-                },
-                roles: {
-                  with: {
-                    accessRole: true,
-                  },
-                },
-              },
-            },
-          },
-          orderBy: { createdAt: dir },
-          ...(limit !== undefined && { limit: limit + 1 }),
-        }),
-        db.select({ value: count() }).from(users).where(searchCondition),
-      ]);
-
-      const totalCount = totalCountResult?.value ?? 0;
-      const hasMore = limit !== undefined && allUsers.length > limit;
-      const items = hasMore ? allUsers.slice(0, limit) : allUsers;
-      const lastItem = items[items.length - 1];
-      const nextCursor =
-        hasMore && lastItem && lastItem.createdAt
-          ? encodeCursor({
-              date: new Date(lastItem.createdAt),
-              id: lastItem.id,
-            })
-          : null;
-
-      // Transform whereWeWork from join table to location array for each organization
-      items.forEach((user) => {
-        user.organizationUsers?.forEach((orgUser) => {
-          if (orgUser.organization?.whereWeWork) {
-            orgUser.organization.whereWeWork =
-              orgUser.organization.whereWeWork.map(
-                (item: any) => item.location,
-              );
-          }
-        });
+      const { items, next, total } = await listAllUsers({
+        cursor,
+        dir,
+        query,
+        limit,
       });
 
       return {
         items: items.map((user) => userEncoder.parse(user)),
-        next: nextCursor,
-        total: totalCount,
+        next,
+        total,
       };
     }),
 });

--- a/services/api/src/test/globalSetup.ts
+++ b/services/api/src/test/globalSetup.ts
@@ -1,3 +1,4 @@
+import { GLOBAL_USER_IDS } from '@op/core';
 import * as schema from '@op/db/schema';
 import { ACCESS_ROLES, ACCESS_ZONES } from '@op/db/seedData/accessControl';
 import { count, eq, getTableName, inArray } from 'drizzle-orm';
@@ -121,6 +122,15 @@ export async function teardown() {
   await db
     .delete(schema.accessZones)
     .where(inArray(schema.accessZones.id, accessZoneIds));
+
+  // Delete the global sentinel users seeded by seedGlobalUsers(). Remove the
+  // public.users mirror first, then the auth.users source row.
+  await db
+    .delete(schema.users)
+    .where(inArray(schema.users.authUserId, [...GLOBAL_USER_IDS]));
+  await db
+    .delete(schema.authUsers)
+    .where(inArray(schema.authUsers.id, [...GLOBAL_USER_IDS]));
 
   console.log('✅ Deseeding completed');
 

--- a/services/db/seed-access-control.ts
+++ b/services/db/seed-access-control.ts
@@ -66,7 +66,7 @@ console.log(`Inserted ${ACCESS_ROLE_PERMISSIONS.length} role permissions`);
 // Global sentinel users (PUBLIC / ANONYMOUS) for the access-control
 // substitution layer. Must exist in every environment.
 // ---------------------------------------------------------------------------
-await seedGlobalUsers(db);
+await seedGlobalUsers();
 
 // ---------------------------------------------------------------------------
 // Default organization: One Project

--- a/services/db/seed-access-control.ts
+++ b/services/db/seed-access-control.ts
@@ -63,8 +63,8 @@ await db
 console.log(`Inserted ${ACCESS_ROLE_PERMISSIONS.length} role permissions`);
 
 // ---------------------------------------------------------------------------
-// Global sentinel users (PUBLIC / ANONYMOUS) for the access-control
-// substitution layer. Must exist in every environment.
+// Global sentinel user (PUBLIC) for the access-control substitution layer.
+// Must exist in every environment.
 // ---------------------------------------------------------------------------
 await seedGlobalUsers();
 

--- a/services/db/seed-access-control.ts
+++ b/services/db/seed-access-control.ts
@@ -31,6 +31,7 @@ import {
 import { organizations } from './schema/tables/organizations.sql';
 import { profiles } from './schema/tables/profiles.sql';
 import { users } from './schema/tables/users.sql';
+import { seedGlobalUsers } from './seed-global-users';
 import {
   ACCESS_ROLES,
   ACCESS_ROLE_PERMISSIONS,
@@ -60,6 +61,12 @@ await db
   .values(ACCESS_ROLE_PERMISSIONS)
   .onConflictDoNothing();
 console.log(`Inserted ${ACCESS_ROLE_PERMISSIONS.length} role permissions`);
+
+// ---------------------------------------------------------------------------
+// Global sentinel users (PUBLIC / ANONYMOUS) for the access-control
+// substitution layer. Must exist in every environment.
+// ---------------------------------------------------------------------------
+await seedGlobalUsers(db);
 
 // ---------------------------------------------------------------------------
 // Default organization: One Project

--- a/services/db/seed-global-users.ts
+++ b/services/db/seed-global-users.ts
@@ -1,0 +1,67 @@
+import { GLOBAL_USER_ANONYMOUS, GLOBAL_USER_PUBLIC } from '@op/core';
+import { sql } from 'drizzle-orm';
+
+import type { db } from '.';
+
+/**
+ * Seeds the two sentinel "global" user identities the access-control
+ * substitution layer resolves against:
+ *
+ *   - GLOBAL_USER_PUBLIC    stands in for no-JWT public callers
+ *   - GLOBAL_USER_ANONYMOUS stands in for anon-JWT callers
+ *
+ * They must exist in every environment before the substitution layer ships,
+ * otherwise sentinel role-grant lookups have nothing to resolve and fail
+ * closed. They are seeded (not migrated) because this repo keeps migrations
+ * DDL-only and seeds reference data through idempotent scripts.
+ *
+ * Each sentinel is identity-only: an `auth.users` row (hardcoded UUID, NULL
+ * email) plus its `public.users` mirror. No individual profile, no
+ * `profile_users` owner row, and no Admin grant — so they can never sign in
+ * and never surface in profile/user search, invite flows, or people lists.
+ *
+ * We direct-INSERT into `auth.users` (the Supabase Admin API can't pin a UUID)
+ * and suppress the `on_auth_signup_create_user` trigger so it doesn't build the
+ * profile/owner/Admin scaffolding it creates for real signups. The trigger is
+ * suppressed via `SET LOCAL session_replication_role = 'replica'` rather than
+ * `ALTER TABLE ... DISABLE TRIGGER`, because `auth.users` is owned by
+ * `supabase_auth_admin` (not even `postgres` can ALTER it). `session_replication_role`
+ * needs no table ownership, is scoped to the transaction by SET LOCAL, and is
+ * agnostic to which trigger version an environment has. It requires the seed to
+ * connect as `postgres` (the direct DB role all seed scripts use), not the
+ * PostgREST `service_role`.
+ *
+ * Idempotent: safe to re-run. `auth.users` uses ON CONFLICT (id) DO NOTHING and
+ * the `public.users` mirror is guarded by WHERE NOT EXISTS (the table has no
+ * unique constraint on auth_user_id to conflict on).
+ */
+export async function seedGlobalUsers(database: typeof db): Promise<void> {
+  const sentinels = [
+    { id: GLOBAL_USER_PUBLIC, name: 'Public', isAnonymous: false },
+    { id: GLOBAL_USER_ANONYMOUS, name: 'Anonymous', isAnonymous: true },
+  ];
+
+  await database.transaction(async (tx) => {
+    // Suppress all triggers (notably on_auth_signup_create_user) for the inserts
+    // below. SET LOCAL resets automatically when the transaction commits.
+    await tx.execute(sql`SET LOCAL session_replication_role = 'replica'`);
+
+    for (const sentinel of sentinels) {
+      await tx.execute(sql`
+        INSERT INTO auth.users (id, email, is_anonymous, created_at, updated_at)
+        VALUES (${sentinel.id}, NULL, ${sentinel.isAnonymous}, now(), now())
+        ON CONFLICT (id) DO NOTHING
+      `);
+
+      await tx.execute(sql`
+        INSERT INTO public.users (auth_user_id, name, email, created_at, updated_at)
+        SELECT ${sentinel.id}, ${sentinel.name}, NULL, now(), now()
+        WHERE NOT EXISTS (
+          SELECT 1 FROM public.users WHERE auth_user_id = ${sentinel.id}
+        )
+      `);
+    }
+  });
+
+  console.log(`Seeded ${sentinels.length} global sentinel users`);
+}

--- a/services/db/seed-global-users.ts
+++ b/services/db/seed-global-users.ts
@@ -1,27 +1,25 @@
-import { GLOBAL_USER_ANONYMOUS, GLOBAL_USER_PUBLIC } from '@op/core';
+import { GLOBAL_USER_PUBLIC } from '@op/core';
 import { sql } from 'drizzle-orm';
 
 import { db } from '.';
 
 /**
- * Seeds the two sentinel "global" user identities the access-control
- * substitution layer resolves role grants against (GLOBAL_USER_PUBLIC for
- * no-JWT callers, GLOBAL_USER_ANONYMOUS for anon-JWT callers). They must exist
- * in every environment or sentinel lookups fail closed.
+ * Seeds the sentinel "global" user identity the access-control substitution
+ * layer resolves role grants against (GLOBAL_USER_PUBLIC for no-JWT callers).
+ * It must exist in every environment or sentinel lookups fail closed. Anonymous
+ * (anon-JWT) callers are not substituted — they have their own real identity —
+ * so there is no anonymous sentinel.
  *
- * Each is identity-only — an `auth.users` row + `public.users` mirror, no
- * profile/owner/Admin scaffolding — so they can never sign in or surface in
+ * It is identity-only — an `auth.users` row + `public.users` mirror, no
+ * profile/owner/Admin scaffolding — so it can never sign in or surface in
  * search, invites, or people lists. We direct-INSERT (the Admin API can't pin
  * a UUID) and suppress `on_auth_signup_create_user` via SET LOCAL
  * session_replication_role rather than DISABLE TRIGGER, since `auth.users` is
  * owned by `supabase_auth_admin`. Idempotent: safe to re-run.
  */
 export async function seedGlobalUsers(): Promise<void> {
-  // TODO: protect these two rows from deletion.
-  const sentinels = [
-    { id: GLOBAL_USER_PUBLIC, name: 'Public' },
-    { id: GLOBAL_USER_ANONYMOUS, name: 'Anonymous' },
-  ];
+  // TODO: protect this row from deletion.
+  const sentinels = [{ id: GLOBAL_USER_PUBLIC, name: 'Public' }];
 
   await db.transaction(async (tx) => {
     // Suppress all triggers (notably on_auth_signup_create_user) for the inserts
@@ -45,5 +43,5 @@ export async function seedGlobalUsers(): Promise<void> {
     }
   });
 
-  console.log(`Seeded ${sentinels.length} global sentinel users`);
+  console.log(`Seeded ${sentinels.length} global sentinel user(s)`);
 }

--- a/services/db/seed-global-users.ts
+++ b/services/db/seed-global-users.ts
@@ -19,8 +19,8 @@ import { db } from '.';
 export async function seedGlobalUsers(): Promise<void> {
   // TODO: protect these two rows from deletion.
   const sentinels = [
-    { id: GLOBAL_USER_PUBLIC, name: 'Public', isAnonymous: false },
-    { id: GLOBAL_USER_ANONYMOUS, name: 'Anonymous', isAnonymous: true },
+    { id: GLOBAL_USER_PUBLIC, name: 'Public' },
+    { id: GLOBAL_USER_ANONYMOUS, name: 'Anonymous' },
   ];
 
   await db.transaction(async (tx) => {
@@ -30,8 +30,8 @@ export async function seedGlobalUsers(): Promise<void> {
 
     for (const sentinel of sentinels) {
       await tx.execute(sql`
-        INSERT INTO auth.users (id, email, is_anonymous, created_at, updated_at)
-        VALUES (${sentinel.id}, NULL, ${sentinel.isAnonymous}, now(), now())
+        INSERT INTO auth.users (id, email, created_at, updated_at)
+        VALUES (${sentinel.id}, NULL, now(), now())
         ON CONFLICT (id) DO NOTHING
       `);
 

--- a/services/db/seed-global-users.ts
+++ b/services/db/seed-global-users.ts
@@ -1,47 +1,28 @@
 import { GLOBAL_USER_ANONYMOUS, GLOBAL_USER_PUBLIC } from '@op/core';
 import { sql } from 'drizzle-orm';
 
-import type { db } from '.';
+import { db } from '.';
 
 /**
  * Seeds the two sentinel "global" user identities the access-control
- * substitution layer resolves against:
+ * substitution layer resolves role grants against (GLOBAL_USER_PUBLIC for
+ * no-JWT callers, GLOBAL_USER_ANONYMOUS for anon-JWT callers). They must exist
+ * in every environment or sentinel lookups fail closed.
  *
- *   - GLOBAL_USER_PUBLIC    stands in for no-JWT public callers
- *   - GLOBAL_USER_ANONYMOUS stands in for anon-JWT callers
- *
- * They must exist in every environment before the substitution layer ships,
- * otherwise sentinel role-grant lookups have nothing to resolve and fail
- * closed. They are seeded (not migrated) because this repo keeps migrations
- * DDL-only and seeds reference data through idempotent scripts.
- *
- * Each sentinel is identity-only: an `auth.users` row (hardcoded UUID, NULL
- * email) plus its `public.users` mirror. No individual profile, no
- * `profile_users` owner row, and no Admin grant — so they can never sign in
- * and never surface in profile/user search, invite flows, or people lists.
- *
- * We direct-INSERT into `auth.users` (the Supabase Admin API can't pin a UUID)
- * and suppress the `on_auth_signup_create_user` trigger so it doesn't build the
- * profile/owner/Admin scaffolding it creates for real signups. The trigger is
- * suppressed via `SET LOCAL session_replication_role = 'replica'` rather than
- * `ALTER TABLE ... DISABLE TRIGGER`, because `auth.users` is owned by
- * `supabase_auth_admin` (not even `postgres` can ALTER it). `session_replication_role`
- * needs no table ownership, is scoped to the transaction by SET LOCAL, and is
- * agnostic to which trigger version an environment has. It requires the seed to
- * connect as `postgres` (the direct DB role all seed scripts use), not the
- * PostgREST `service_role`.
- *
- * Idempotent: safe to re-run. `auth.users` uses ON CONFLICT (id) DO NOTHING and
- * the `public.users` mirror is guarded by WHERE NOT EXISTS (the table has no
- * unique constraint on auth_user_id to conflict on).
+ * Each is identity-only — an `auth.users` row + `public.users` mirror, no
+ * profile/owner/Admin scaffolding — so they can never sign in or surface in
+ * search, invites, or people lists. We direct-INSERT (the Admin API can't pin
+ * a UUID) and suppress `on_auth_signup_create_user` via SET LOCAL
+ * session_replication_role rather than DISABLE TRIGGER, since `auth.users` is
+ * owned by `supabase_auth_admin`. Idempotent: safe to re-run.
  */
-export async function seedGlobalUsers(database: typeof db): Promise<void> {
+export async function seedGlobalUsers(): Promise<void> {
   const sentinels = [
     { id: GLOBAL_USER_PUBLIC, name: 'Public', isAnonymous: false },
     { id: GLOBAL_USER_ANONYMOUS, name: 'Anonymous', isAnonymous: true },
   ];
 
-  await database.transaction(async (tx) => {
+  await db.transaction(async (tx) => {
     // Suppress all triggers (notably on_auth_signup_create_user) for the inserts
     // below. SET LOCAL resets automatically when the transaction commits.
     await tx.execute(sql`SET LOCAL session_replication_role = 'replica'`);

--- a/services/db/seed-global-users.ts
+++ b/services/db/seed-global-users.ts
@@ -17,6 +17,7 @@ import { db } from '.';
  * owned by `supabase_auth_admin`. Idempotent: safe to re-run.
  */
 export async function seedGlobalUsers(): Promise<void> {
+  // TODO: protect these two rows from deletion.
   const sentinels = [
     { id: GLOBAL_USER_PUBLIC, name: 'Public', isAnonymous: false },
     { id: GLOBAL_USER_ANONYMOUS, name: 'Anonymous', isAnonymous: true },

--- a/services/db/seed-test.ts
+++ b/services/db/seed-test.ts
@@ -372,7 +372,7 @@ async function seed() {
 
   await wipeDatabase();
   await seedAccessControl();
-  await seedGlobalUsers(db);
+  await seedGlobalUsers();
   await seedDecisionTemplates();
 
   console.log('\n✅ Database seeding completed successfully!');

--- a/services/db/seed-test.ts
+++ b/services/db/seed-test.ts
@@ -4,6 +4,7 @@ import { reset } from 'drizzle-seed';
 
 import { db } from '.';
 import * as schema from './schema';
+import { seedGlobalUsers } from './seed-global-users';
 import {
   ACCESS_ROLES,
   ACCESS_ROLE_PERMISSIONS,
@@ -371,6 +372,7 @@ async function seed() {
 
   await wipeDatabase();
   await seedAccessControl();
+  await seedGlobalUsers(db);
   await seedDecisionTemplates();
 
   console.log('\n✅ Database seeding completed successfully!');

--- a/services/db/seed.ts
+++ b/services/db/seed.ts
@@ -154,7 +154,7 @@ for (const email of adminEmails) {
 
 // Seed the global sentinel users (PUBLIC / ANONYMOUS) used by the
 // access-control substitution layer.
-await seedGlobalUsers(db);
+await seedGlobalUsers();
 
 // Run the SQL seed scripts
 const seedDataPath = path.join(process.cwd(), 'seedData');

--- a/services/db/seed.ts
+++ b/services/db/seed.ts
@@ -22,6 +22,7 @@ import {
   organizations,
   organizationsWhereWeWork,
 } from './schema/tables/organizations.sql';
+import { seedGlobalUsers } from './seed-global-users';
 
 // For local development, we need to load the .env.local file from the root of the monorepo
 dotenv.config({
@@ -150,6 +151,10 @@ for (const email of adminEmails) {
     console.warn(e);
   }
 }
+
+// Seed the global sentinel users (PUBLIC / ANONYMOUS) used by the
+// access-control substitution layer.
+await seedGlobalUsers(db);
 
 // Run the SQL seed scripts
 const seedDataPath = path.join(process.cwd(), 'seedData');

--- a/services/db/seed.ts
+++ b/services/db/seed.ts
@@ -152,8 +152,8 @@ for (const email of adminEmails) {
   }
 }
 
-// Seed the global sentinel users (PUBLIC / ANONYMOUS) used by the
-// access-control substitution layer.
+// Seed the global sentinel user (PUBLIC) used by the access-control
+// substitution layer.
 await seedGlobalUsers();
 
 // Run the SQL seed scripts


### PR DESCRIPTION
feat(db): seed the GLOBAL_USER_PUBLIC sentinel for no-JWT public callers
feat(access-control): exclude the sentinel from listAllUsers so it never surfaces in user lists
refactor(access-control): move the listAllUsers query into an @op/common service