### PR TITLE
refactor(access): migrate profile and org access lookups to Drizzle RBQ v2

### DIFF
--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -1,6 +1,5 @@
 import { cache } from '@op/cache';
 import { db, eq } from '@op/db/client';
-import type { Profile, ProfileUser } from '@op/db/schema';
 import { organizations, users } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 import type { AccessZonePermissionInput, NormalizedRole } from 'access-zones';
@@ -8,25 +7,19 @@ import { checkPermission } from 'access-zones';
 import { z } from 'zod';
 
 import { UnauthorizedError } from '../../utils/error';
+import type { OrganizationUserBase } from '../organization/schemas/organizationUser';
+import type { ProfileMinimal } from '../profile/schemas/profileMinimal';
+import type { ProfileUserBase } from '../profile/schemas/profileUser';
 import { memoize } from './requestCache';
 import { getNormalizedRoles } from './utils';
 
-type OrgUserWithNormalizedRoles = {
-  id: string;
-  authUserId: string;
-  name: string | null;
-  email: string;
-  about: string | null;
-  organizationId: string;
-  createdAt: string | Date | null;
-  updatedAt: string | Date | null;
-  deletedAt?: string | Date | null;
+type OrgUserWithNormalizedRoles = OrganizationUserBase & {
   roles: NormalizedRole[];
 };
 
-type ProfileUserWithNormalizedRoles = ProfileUser & {
+type ProfileUserWithNormalizedRoles = ProfileUserBase & {
   roles: NormalizedRole[];
-  profile: Profile;
+  profile: ProfileMinimal;
 };
 
 // gets a user assuming that the user is authenticated
@@ -104,7 +97,11 @@ export const getProfileAccessUser = memoize(
         authUserId: user.id,
       },
       with: {
-        profile: true,
+        profile: {
+          with: {
+            avatarImage: true,
+          },
+        },
         roles: {
           with: {
             accessRole: {

--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -1,5 +1,5 @@
 import { cache } from '@op/cache';
-import { and, db, eq } from '@op/db/client';
+import { db, eq } from '@op/db/client';
 import type { Profile, ProfileUser } from '@op/db/schema';
 import { organizations, users } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
@@ -9,7 +9,7 @@ import { z } from 'zod';
 
 import { UnauthorizedError } from '../../utils/error';
 import { memoize } from './requestCache';
-import { type RoleJunction, getNormalizedRoles } from './utils';
+import { getNormalizedRoles } from './utils';
 
 type OrgUserWithNormalizedRoles = {
   id: string;
@@ -39,12 +39,11 @@ export const getOrgAccessUser = memoize(
     organizationId: string;
   }): Promise<OrgUserWithNormalizedRoles | undefined> => {
     const getOrgUser = async () => {
-      const orgUser = await db._query.organizationUsers.findFirst({
-        where: (table, { eq }) =>
-          and(
-            eq(table.organizationId, organizationId),
-            eq(table.authUserId, user.id),
-          ),
+      const orgUser = await db.query.organizationUsers.findFirst({
+        where: {
+          organizationId,
+          authUserId: user.id,
+        },
         with: {
           roles: {
             with: {
@@ -67,10 +66,7 @@ export const getOrgAccessUser = memoize(
       }
 
       // Transform the relational data into normalized format for access-zones library
-      // Type assertion needed because Drizzle query result type is complex but we know it has the right structure
-      const normalizedRoles = getNormalizedRoles(
-        orgUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
-      );
+      const normalizedRoles = getNormalizedRoles(orgUser.roles);
 
       const { roles: _, ...orgUserWithoutRoles } = orgUser;
 
@@ -130,10 +126,7 @@ export const getProfileAccessUser = memoize(
     }
 
     // Transform the relational data into normalized format for access-zones library
-    // Type assertion needed because Drizzle query result type is complex but we know it has the right structure
-    const normalizedRoles = getNormalizedRoles(
-      profileUser.roles as Array<Pick<RoleJunction, 'accessRole'>>,
-    );
+    const normalizedRoles = getNormalizedRoles(profileUser.roles);
 
     const { roles: _, ...profileUserWithoutRoles } = profileUser;
     return {

--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -102,9 +102,11 @@ export const getProfileAccessUser = memoize(
     user: { id: string };
     profileId: string;
   }): Promise<ProfileUserWithNormalizedRoles | undefined> => {
-    const profileUser = await db._query.profileUsers.findFirst({
-      where: (table, { eq }) =>
-        and(eq(table.profileId, profileId), eq(table.authUserId, user.id)),
+    const profileUser = await db.query.profileUsers.findFirst({
+      where: {
+        profileId,
+        authUserId: user.id,
+      },
       with: {
         profile: true,
         roles: {
@@ -136,7 +138,7 @@ export const getProfileAccessUser = memoize(
     const { roles: _, ...profileUserWithoutRoles } = profileUser;
     return {
       ...profileUserWithoutRoles,
-      profile: profileUser.profile as Profile,
+      profile: profileUser.profile,
       roles: normalizedRoles,
     };
   },

--- a/packages/common/src/services/access/utils.ts
+++ b/packages/common/src/services/access/utils.ts
@@ -24,13 +24,6 @@ interface AccessRole {
   zonePermissions?: ZonePermission[];
 }
 
-// Primary interface for when we have the exact structure
-export interface RoleJunction {
-  organizationUserId: string;
-  accessRoleId: string;
-  accessRole: AccessRole;
-}
-
 // For Drizzle query results that we know have the right structure but TypeScript can't verify
 export const getNormalizedRoles = (
   roleJunctions: Array<{ accessRole: AccessRole }>,

--- a/packages/common/src/services/organization/schemas/organizationUser.ts
+++ b/packages/common/src/services/organization/schemas/organizationUser.ts
@@ -1,0 +1,21 @@
+import { organizationUsers } from '@op/db/schema';
+import { createSelectSchema } from 'drizzle-zod';
+import { z } from 'zod';
+
+// Member-facing shape of an `organization_users` row. Explicitly picked rather
+// than a full table select so columns aren't leaked at API boundaries by
+// default — new columns must be opted in here. Mirrors `profileUserSchema`.
+export const organizationUserSchema = createSelectSchema(
+  organizationUsers,
+).pick({
+  id: true,
+  authUserId: true,
+  name: true,
+  email: true,
+  about: true,
+  organizationId: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export type OrganizationUserBase = z.infer<typeof organizationUserSchema>;

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -483,6 +483,11 @@ export const relations = defineRelations(schema, (r) => ({
    * Links profile users to their assigned roles.
    */
   profileUsers: {
+    profile: r.one.profiles({
+      from: r.profileUsers.profileId,
+      to: r.profiles.id,
+      optional: false,
+    }),
     roles: r.many.profileUserToAccessRoles({
       from: r.profileUsers.id,
       to: r.profileUserToAccessRoles.profileUserId,


### PR DESCRIPTION
Move both access-user lookups off the legacy db._query API onto db.query, the source of truth for relations going forward. The v2 result types match the normalizer, so the role and profile type assertions are no longer needed.