### PR TITLE
fix(styles): bridge unmapped functional color tokens

### DIFF
--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -199,8 +199,10 @@
    * ============================================ */
   --color-functional-red-50: var(--op-functional-red-50);
   --color-functional-red-100: var(--op-functional-red-100);
+  --color-functional-red-300: var(--op-functional-red-300);
   --color-functional-red-600: var(--op-functional-red-600);
   --color-functional-red-800: var(--op-functional-red-800);
+  --color-functional-green-50: var(--op-functional-green-50);
   --color-functional-green-100: var(--op-functional-green-100);
   --color-functional-green-600: var(--op-functional-green-600);
 
@@ -238,7 +240,7 @@
    *
    * Notes on Figma↔code gaps:
    *   - primary-orange1 and primary-orange2 collapse to one orange (hue distinction lost)
-   *   - functional-greenWhite maps to green-100 (Figma has no green-50)
+   *   - functional-greenWhite maps to green-50
    *   - functional-yellowWhite borrows the orange-50 tint
    *   - status-green / status-greenBg share the functional green scale
    * ============================================ */

--- a/packages/styles/tokens.css
+++ b/packages/styles/tokens.css
@@ -8,7 +8,6 @@
  * Naming: --op-<category>[-<role>]-<scale>
  *
  * Figma↔code gaps (handled by semantic aliases in shared-styles.css):
- *   - no green-50  → functional-greenWhite alias uses green-100
  *   - one orange   → orange1 + orange2 collapse to a single hue
  *   - no separate status-green → uses functional-green-600 / -100
  */


### PR DESCRIPTION
PR #1231 added new `--op-*` color scales but only repointed aliases without extending the `--op→--color` bridge layer. Two tokens broke:

- `--color-functional-greenWhite` → `green-50` (known)
- `--color-red-300` → `red-300` (also broken, undiscovered)

Both intermediates were referenced but never bridged, resolving to empty.

- Add bridge mappings for `--color-functional-green-50` and `--color-functional-red-300`
- Correct stale "no green-50" comments