### PR TITLE
refactor(api): move decision authoring + management mutations off the network gate

### DIFF
--- a/services/api/src/routers/decision/instances/createInstanceFromTemplate.test.ts
+++ b/services/api/src/routers/decision/instances/createInstanceFromTemplate.test.ts
@@ -13,6 +13,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 import {
   createIsolatedSession,
@@ -386,19 +387,18 @@ describeDecisionAccessTierGating('createInstanceFromTemplate', {
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       await testData.createDecisionSetup({ instanceCount: 0 });
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.createInstanceFromTemplate({
           templateId: '00000000-0000-0000-0000-000000000000',
           name: `anon ${task.id}`,
         }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/instances/createInstanceFromTemplate.ts
+++ b/services/api/src/routers/decision/instances/createInstanceFromTemplate.ts
@@ -5,10 +5,10 @@ import {
   createInstanceFromTemplateInputSchema,
   decisionProfileWithSchemaEncoder,
 } from '../../../encoders/decision';
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../../trpcFactory';
 
 export const createInstanceFromTemplateRouter = router({
-  createInstanceFromTemplate: networkAuthenticatedProcedure()
+  createInstanceFromTemplate: authenticatedConfirmedProcedure()
     .input(createInstanceFromTemplateInputSchema)
     .output(decisionProfileWithSchemaEncoder)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/instances/deleteDecision.test.ts
+++ b/services/api/src/routers/decision/instances/deleteDecision.test.ts
@@ -7,6 +7,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 import {
   createIsolatedSession,
@@ -250,7 +251,7 @@ describeDecisionAccessTierGating('deleteDecision', {
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -264,9 +265,8 @@ describeDecisionAccessTierGating('deleteDecision', {
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.deleteDecision({ instanceId: instance.instance.id }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/instances/deleteDecision.ts
+++ b/services/api/src/routers/decision/instances/deleteDecision.ts
@@ -1,10 +1,10 @@
 import { Channels, deleteDecision } from '@op/common';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../../trpcFactory';
 
 export const deleteDecisionRouter = router({
-  deleteDecision: networkAuthenticatedProcedure({
+  deleteDecision: authenticatedConfirmedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(

--- a/services/api/src/routers/decision/instances/duplicateInstance.test.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.test.ts
@@ -10,6 +10,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 import {
   createIsolatedSession,
@@ -615,7 +616,7 @@ describeDecisionAccessTierGating('duplicateInstance', {
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -629,7 +630,7 @@ describeDecisionAccessTierGating('duplicateInstance', {
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.duplicateInstance({
           instanceId: instance.instance.id,
           name: 'anon copy',
@@ -643,7 +644,6 @@ describeDecisionAccessTierGating('duplicateInstance', {
             roles: false,
           },
         }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/instances/duplicateInstance.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.ts
@@ -2,7 +2,7 @@ import { duplicateInstance } from '@op/common';
 import { z } from 'zod';
 
 import { decisionProfileWithSchemaEncoder } from '../../../encoders/decision';
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../../trpcFactory';
 
 const duplicateInstanceInputSchema = z.object({
   instanceId: z.string().uuid(),
@@ -20,7 +20,7 @@ const duplicateInstanceInputSchema = z.object({
 });
 
 export const duplicateInstanceRouter = router({
-  duplicateInstance: networkAuthenticatedProcedure({
+  duplicateInstance: authenticatedConfirmedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(duplicateInstanceInputSchema)

--- a/services/api/src/routers/decision/instances/submitManualSelection.test.ts
+++ b/services/api/src/routers/decision/instances/submitManualSelection.test.ts
@@ -20,6 +20,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 import { schemaWithoutPipeline } from '../../../test/helpers/pipelineSchemas';
 import {
@@ -725,7 +726,7 @@ describeDecisionAccessTierGating('submitManualSelection', {
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -739,12 +740,11 @@ describeDecisionAccessTierGating('submitManualSelection', {
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.submitManualSelection({
           processInstanceId: instance.instance.id,
           proposalIds: [crypto.randomUUID()],
         }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/instances/submitManualSelection.ts
+++ b/services/api/src/routers/decision/instances/submitManualSelection.ts
@@ -2,7 +2,7 @@ import { Channels, submitManualSelection } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../../trpcFactory';
 import { trackManualSelectionSubmitted } from '../../../utils/analytics';
 
 const submitManualSelectionInputSchema = z.object({
@@ -11,7 +11,7 @@ const submitManualSelectionInputSchema = z.object({
 });
 
 export const submitManualSelectionRouter = router({
-  submitManualSelection: networkAuthenticatedProcedure()
+  submitManualSelection: authenticatedConfirmedProcedure()
     .input(submitManualSelectionInputSchema)
     .mutation(async ({ ctx, input }) => {
       await submitManualSelection({

--- a/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
@@ -15,6 +15,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 import {
   createIsolatedSession,
@@ -488,7 +489,7 @@ describeDecisionAccessTierGating('transitionFromPhase', {
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -502,11 +503,10 @@ describeDecisionAccessTierGating('transitionFromPhase', {
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.transitionFromPhase({
           instanceId: instance.instance.id,
         }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/instances/transitionFromPhase.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.ts
@@ -2,11 +2,11 @@ import { Channels, triggerPhaseAdvancement } from '@op/common';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../../trpcFactory';
 import { trackManualTransitionConfirmed } from '../../../utils/analytics';
 
 export const transitionFromPhaseRouter = router({
-  transitionFromPhase: networkAuthenticatedProcedure()
+  transitionFromPhase: authenticatedConfirmedProcedure()
     .input(
       z.object({
         instanceId: z.uuid(),

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -12,6 +12,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 import {
   createIsolatedSession,
@@ -962,7 +963,7 @@ describeDecisionAccessTierGating('updateDecisionInstance', {
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -976,12 +977,11 @@ describeDecisionAccessTierGating('updateDecisionInstance', {
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.updateDecisionInstance({
           instanceId: instance.instance.id,
           name: 'should bounce',
         }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.ts
@@ -6,10 +6,10 @@ import {
   decisionProfileWithSchemaEncoder,
   updateDecisionInstanceInputSchema,
 } from '../../../encoders/decision';
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../../trpcFactory';
 
 export const updateDecisionInstanceRouter = router({
-  updateDecisionInstance: networkAuthenticatedProcedure()
+  updateDecisionInstance: authenticatedConfirmedProcedure()
     .input(updateDecisionInstanceInputSchema)
     .output(decisionProfileWithSchemaEncoder)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/create.test.ts
+++ b/services/api/src/routers/decision/proposals/create.test.ts
@@ -6,6 +6,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 
 describeDecisionAccessTierGating('createProposal', {
@@ -36,7 +37,7 @@ describeDecisionAccessTierGating('createProposal', {
   ),
 
   anonJwtNonPublic: accessTierGatingCell(
-    'rejects anon-JWT caller on non-public instance',
+    'admits anon-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
@@ -51,18 +52,17 @@ describeDecisionAccessTierGating('createProposal', {
 
       const caller = await callers.anonJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.createProposal({
           processInstanceId: instance.instance.id,
           proposalData: { title: 'Non-public; anon should bounce' },
         }),
-        'anon',
       );
     },
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
@@ -77,12 +77,11 @@ describeDecisionAccessTierGating('createProposal', {
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.createProposal({
           processInstanceId: instance.instance.id,
           proposalData: { title: 'Non-public; anon should bounce' },
         }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/proposals/create.ts
+++ b/services/api/src/routers/decision/proposals/create.ts
@@ -2,11 +2,11 @@ import { Channels, createProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 
 import { createProposalInputSchema } from '../../../encoders/decision';
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedProcedure, router } from '../../../trpcFactory';
 
 export const createProposalRouter = router({
   /** Creates a new proposal in draft status. Use submitProposal to transition to submitted. */
-  createProposal: networkAuthenticatedProcedure()
+  createProposal: authenticatedProcedure()
     .input(createProposalInputSchema)
     .output(proposalSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/delete.test.ts
+++ b/services/api/src/routers/decision/proposals/delete.test.ts
@@ -5,6 +5,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 
 describeDecisionAccessTierGating('deleteProposal', {
@@ -36,7 +37,7 @@ describeDecisionAccessTierGating('deleteProposal', {
   ),
 
   anonJwtNonPublic: accessTierGatingCell(
-    'rejects anon-JWT caller on non-public instance',
+    'admits anon-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -55,15 +56,14 @@ describeDecisionAccessTierGating('deleteProposal', {
 
       const caller = await callers.anonJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.deleteProposal({ proposalId: proposal.id }),
-        'anon',
       );
     },
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -82,9 +82,8 @@ describeDecisionAccessTierGating('deleteProposal', {
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.deleteProposal({ proposalId: proposal.id }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/proposals/delete.ts
+++ b/services/api/src/routers/decision/proposals/delete.ts
@@ -1,10 +1,10 @@
 import { Channels, deleteProposal as deleteProposalService } from '@op/common';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedProcedure, router } from '../../../trpcFactory';
 
 export const deleteProposalRouter = router({
-  deleteProposal: networkAuthenticatedProcedure({
+  deleteProposal: authenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 5 },
   })
     .input(

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -15,6 +15,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 import {
   createIsolatedSession,
@@ -1110,7 +1111,7 @@ describeDecisionAccessTierGating('submitProposal', {
   ),
 
   anonJwtNonPublic: accessTierGatingCell(
-    'rejects anon-JWT caller on non-public instance',
+    'admits anon-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
@@ -1130,15 +1131,14 @@ describeDecisionAccessTierGating('submitProposal', {
 
       const caller = await callers.anonJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.submitProposal({ proposalId: proposal.id }),
-        'anon',
       );
     },
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
@@ -1158,9 +1158,8 @@ describeDecisionAccessTierGating('submitProposal', {
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.submitProposal({ proposalId: proposal.id }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/proposals/submit.ts
+++ b/services/api/src/routers/decision/proposals/submit.ts
@@ -4,7 +4,7 @@ import { Events, inngest } from '@op/events';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedProcedure, router } from '../../../trpcFactory';
 import { trackProposalSubmitted } from '../../../utils/analytics';
 
 const submitProposalInputSchema = z.object({
@@ -12,7 +12,7 @@ const submitProposalInputSchema = z.object({
 });
 
 export const submitProposalRouter = router({
-  submitProposal: networkAuthenticatedProcedure()
+  submitProposal: authenticatedProcedure()
     .input(submitProposalInputSchema)
     .output(proposalSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -8,6 +8,7 @@ import {
   accessTierGatingCell,
   describeDecisionAccessTierGating,
   expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
 } from '../../../test/helpers/gating/decision';
 import {
   createIsolatedSession,
@@ -763,7 +764,7 @@ describeDecisionAccessTierGating('updateProposal', {
   ),
 
   anonJwtNonPublic: accessTierGatingCell(
-    'rejects anon-JWT caller on non-public instance',
+    'admits anon-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
@@ -783,18 +784,17 @@ describeDecisionAccessTierGating('updateProposal', {
 
       const caller = await callers.anonJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.updateProposal({
           proposalId: proposal.id,
           data: { visibility: Visibility.HIDDEN },
         }),
-        'anon',
       );
     },
   ),
 
   userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+    'admits user-JWT caller past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
@@ -814,12 +814,11 @@ describeDecisionAccessTierGating('updateProposal', {
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.updateProposal({
           proposalId: proposal.id,
           data: { visibility: Visibility.HIDDEN },
         }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/decision/proposals/update.ts
+++ b/services/api/src/routers/decision/proposals/update.ts
@@ -4,10 +4,10 @@ import { proposalSchema } from '@op/common/client';
 import { z } from 'zod';
 
 import { updateProposalInputSchema } from '../../../encoders/decision';
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedProcedure, router } from '../../../trpcFactory';
 
 export const updateProposalRouter = router({
-  updateProposal: networkAuthenticatedProcedure({
+  updateProposal: authenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(


### PR DESCRIPTION
Decision-management mutations → `authenticatedConfirmedProcedure` (confirmed user, no network membership). Proposal authoring → `authenticatedProcedure` (owner identity, no network membership). Authz deferred to the service-layer membership check, which fails closed. Reads, reviews/voting, attachments, and export stay network-gated until a follow-up batch.