### PR TITLE
refactor(common): collapse org fetch-and-assert into assertOrgAccess

### DIFF
--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -13,7 +13,7 @@ import type { ProfileUserBase } from '../profile/schemas/profileUser';
 import { memoize } from './requestCache';
 import { getNormalizedRoles } from './utils';
 
-type OrgUserWithNormalizedRoles = OrganizationUserBase & {
+export type OrgUserWithNormalizedRoles = OrganizationUserBase & {
   roles: NormalizedRole[];
 };
 

--- a/packages/common/src/services/assert/assertOrgAccess.ts
+++ b/packages/common/src/services/assert/assertOrgAccess.ts
@@ -8,7 +8,8 @@ import { type OrgUserWithNormalizedRoles, getOrgAccessUser } from '../access';
  * permissions, returning the resolved org-access user so callers can reuse it.
  *
  * @param notMemberMessage - Optional message for the thrown exception when the
- *   user has no role on the organization. Defaults to 'Not authorized'.
+ *   user has no role on the organization. Defaults to
+ *   'You are not a member of this organization'.
  * @throws UnauthorizedError if the user is not a member of the organization or
  *   their roles don't satisfy the permissions — every denial throws the same
  *   exception type (only the message differs when `notMemberMessage` is given).
@@ -27,7 +28,9 @@ export async function assertOrgAccess({
   const orgUser = await getOrgAccessUser({ user, organizationId });
 
   if (!orgUser) {
-    throw new UnauthorizedError(notMemberMessage ?? 'Not authorized');
+    throw new UnauthorizedError(
+      notMemberMessage ?? 'You are not a member of this organization',
+    );
   }
 
   if (!checkPermission(permissions, orgUser.roles)) {

--- a/packages/common/src/services/assert/assertOrgAccess.ts
+++ b/packages/common/src/services/assert/assertOrgAccess.ts
@@ -1,0 +1,38 @@
+import { type AccessZonePermissionInput, checkPermission } from 'access-zones';
+
+import { UnauthorizedError } from '../../utils';
+import { type OrgUserWithNormalizedRoles, getOrgAccessUser } from '../access';
+
+/**
+ * Fetches the user's roles on an organization and asserts the given
+ * permissions, returning the resolved org-access user so callers can reuse it.
+ *
+ * @param notMemberMessage - Optional message for the thrown exception when the
+ *   user has no role on the organization. Defaults to 'Not authorized'.
+ * @throws UnauthorizedError if the user is not a member of the organization or
+ *   their roles don't satisfy the permissions — every denial throws the same
+ *   exception type (only the message differs when `notMemberMessage` is given).
+ */
+export async function assertOrgAccess({
+  user,
+  organizationId,
+  permissions,
+  notMemberMessage,
+}: {
+  user: { id: string };
+  organizationId: string;
+  permissions: AccessZonePermissionInput;
+  notMemberMessage?: string;
+}): Promise<OrgUserWithNormalizedRoles> {
+  const orgUser = await getOrgAccessUser({ user, organizationId });
+
+  if (!orgUser) {
+    throw new UnauthorizedError(notMemberMessage ?? 'Not authorized');
+  }
+
+  if (!checkPermission(permissions, orgUser.roles)) {
+    throw new UnauthorizedError('Not authorized');
+  }
+
+  return orgUser;
+}

--- a/packages/common/src/services/assert/index.ts
+++ b/packages/common/src/services/assert/index.ts
@@ -1,4 +1,5 @@
 export { assertGlobalRole } from './assertGlobalRole';
+export { assertOrgAccess } from './assertOrgAccess';
 export {
   assertOrganization,
   assertOrganizationByProfileId,

--- a/packages/common/src/services/decision/listLegacyInstances.ts
+++ b/packages/common/src/services/decision/listLegacyInstances.ts
@@ -1,10 +1,10 @@
 import { db, desc, eq } from '@op/db/client';
 import { ProposalStatus, organizations, processInstances } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
-import { assertAccess, permission } from 'access-zones';
+import { permission } from 'access-zones';
 
 import { UnauthorizedError } from '../../utils';
-import { getOrgAccessUser } from '../access';
+import { assertOrgAccess } from '../assert';
 
 export const listLegacyInstances = async ({
   ownerProfileId,
@@ -22,12 +22,11 @@ export const listLegacyInstances = async ({
     throw new UnauthorizedError("You don't have access to do this");
   }
 
-  const orgUser = await getOrgAccessUser({
+  await assertOrgAccess({
     user,
     organizationId: org[0].id,
+    permissions: { decisions: permission.READ },
   });
-
-  assertAccess({ decisions: permission.READ }, orgUser?.roles ?? []);
 
   const instanceList = await db._query.processInstances.findMany({
     where: eq(processInstances.ownerProfileId, ownerProfileId),

--- a/packages/common/src/services/organization/deleteOrganization.ts
+++ b/packages/common/src/services/organization/deleteOrganization.ts
@@ -29,7 +29,6 @@ export async function deleteOrganization({
     user,
     organizationId: organization.id,
     permissions: { profile: permission.DELETE },
-    notMemberMessage: 'You are not a member of this organization',
   });
 
   // Delete the organization profile

--- a/packages/common/src/services/organization/deleteOrganization.ts
+++ b/packages/common/src/services/organization/deleteOrganization.ts
@@ -2,10 +2,11 @@ import { invalidate } from '@op/cache';
 import { db, eq } from '@op/db/client';
 import { profiles } from '@op/db/schema';
 import type { User } from '@supabase/supabase-js';
-import { assertAccess, permission } from 'access-zones';
+import { permission } from 'access-zones';
 
-import { NotFoundError, UnauthorizedError } from '../../utils';
+import { NotFoundError } from '../../utils';
 import { getOrgAccessUser } from '../access';
+import { assertOrgAccess } from '../assert';
 
 export async function deleteOrganization({
   organizationProfileId,
@@ -23,17 +24,13 @@ export async function deleteOrganization({
     throw new NotFoundError('Organization', organizationProfileId);
   }
 
-  // Get the org access user and assert admin DELETE permissions
-  const orgUser = await getOrgAccessUser({
+  // Assert the user has admin DELETE permissions on the organization
+  await assertOrgAccess({
     user,
     organizationId: organization.id,
+    permissions: { profile: permission.DELETE },
+    notMemberMessage: 'You are not a member of this organization',
   });
-
-  if (!orgUser) {
-    throw new UnauthorizedError('You are not a member of this organization');
-  }
-
-  assertAccess({ profile: permission.DELETE }, orgUser?.roles || []);
 
   // Delete the organization profile
   // The cascade delete will handle removing org data

--- a/packages/common/src/services/organization/deleteOrganizationUser.ts
+++ b/packages/common/src/services/organization/deleteOrganizationUser.ts
@@ -2,10 +2,11 @@ import { invalidate } from '@op/cache';
 import { and, db, eq } from '@op/db/client';
 import { organizationUsers } from '@op/db/schema';
 import type { User } from '@supabase/supabase-js';
-import { assertAccess, permission } from 'access-zones';
+import { permission } from 'access-zones';
 
 import { NotFoundError, UnauthorizedError } from '../../utils';
 import { getOrgAccessUser } from '../access';
+import { assertOrgAccess } from '../assert';
 
 export interface DeleteOrganizationUserParams {
   organizationUserId: string;
@@ -18,14 +19,13 @@ export async function deleteOrganizationUser({
   organizationId,
   user,
 }: DeleteOrganizationUserParams) {
-  // Get the org access user and assert admin UPDATE permissions
-  const orgUser = await getOrgAccessUser({ user, organizationId });
-
-  if (!orgUser) {
-    throw new UnauthorizedError('You are not a member of this organization');
-  }
-
-  assertAccess({ admin: permission.UPDATE }, orgUser?.roles || []);
+  // Assert the user has admin UPDATE permissions on the organization
+  await assertOrgAccess({
+    user,
+    organizationId,
+    permissions: { admin: permission.UPDATE },
+    notMemberMessage: 'You are not a member of this organization',
+  });
 
   // Check if the organization user to delete exists
   const targetOrgUser = await db.query.organizationUsers.findFirst({

--- a/packages/common/src/services/organization/deleteOrganizationUser.ts
+++ b/packages/common/src/services/organization/deleteOrganizationUser.ts
@@ -24,7 +24,6 @@ export async function deleteOrganizationUser({
     user,
     organizationId,
     permissions: { admin: permission.UPDATE },
-    notMemberMessage: 'You are not a member of this organization',
   });
 
   // Check if the organization user to delete exists

--- a/packages/common/src/services/organization/getOrganizationUsers.ts
+++ b/packages/common/src/services/organization/getOrganizationUsers.ts
@@ -1,10 +1,8 @@
 import { db, sql } from '@op/db/client';
 import { User } from '@op/supabase/lib';
-import { assertAccess, permission } from 'access-zones';
+import { permission } from 'access-zones';
 
-import { UnauthorizedError } from '../../utils';
-import { getOrgAccessUser } from '../access';
-import { assertOrganizationByProfileId } from '../assert';
+import { assertOrgAccess, assertOrganizationByProfileId } from '../assert';
 
 export const getOrganizationUsers = async ({
   profileId,
@@ -16,16 +14,12 @@ export const getOrganizationUsers = async ({
   // First, find the organization by profileId
   const organization = await assertOrganizationByProfileId(profileId);
 
-  const orgUser = await getOrgAccessUser({
+  await assertOrgAccess({
     user,
     organizationId: organization.id,
+    permissions: { admin: permission.READ },
+    notMemberMessage: 'You are not a member of this organization',
   });
-
-  if (!orgUser) {
-    throw new UnauthorizedError('You are not a member of this organization');
-  }
-
-  assertAccess({ admin: permission.READ }, orgUser?.roles || []);
 
   // Fetch all users in the organization with their roles and avatar images
   const organizationUsers = await db.query.organizationUsers.findMany({

--- a/packages/common/src/services/organization/getOrganizationUsers.ts
+++ b/packages/common/src/services/organization/getOrganizationUsers.ts
@@ -18,7 +18,6 @@ export const getOrganizationUsers = async ({
     user,
     organizationId: organization.id,
     permissions: { admin: permission.READ },
-    notMemberMessage: 'You are not a member of this organization',
   });
 
   // Fetch all users in the organization with their roles and avatar images

--- a/packages/common/src/services/organization/inviteUsers.ts
+++ b/packages/common/src/services/organization/inviteUsers.ts
@@ -11,10 +11,10 @@ import {
 } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
 import { waitUntil } from '@vercel/functions';
-import { assertAccess, permission } from 'access-zones';
+import { permission } from 'access-zones';
 
 import { UnauthorizedError } from '../../utils/error';
-import { getOrgAccessUser } from '../access';
+import { assertOrgAccess } from '../assert';
 import { sendBatchInvitationEmails } from '../email';
 import { AllowListMetadata } from '../user/validators';
 
@@ -61,15 +61,13 @@ export const inviteUsersToOrganization = async (
 ) => {
   const { emails, roleId, organizationId, personalMessage, user } = input;
 
-  const orgUser = await getOrgAccessUser({ user, organizationId });
-
-  if (!orgUser) {
-    throw new UnauthorizedError(
+  const orgUser = await assertOrgAccess({
+    user,
+    organizationId,
+    permissions: { profile: permission.ADMIN },
+    notMemberMessage:
       'User must be associated with an organization to send organization invites',
-    );
-  }
-
-  assertAccess({ profile: permission.ADMIN }, orgUser.roles || []);
+  });
 
   const authUser = (await db.query.users.findFirst({
     where: { authUserId: user.id },

--- a/packages/common/src/services/organization/updateOrganization.ts
+++ b/packages/common/src/services/organization/updateOrganization.ts
@@ -9,12 +9,11 @@ import {
   profiles,
 } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
-import { assertAccess, permission } from 'access-zones';
+import { permission } from 'access-zones';
 import pMap from 'p-map';
 
-import { CommonError, NotFoundError, UnauthorizedError } from '../../utils';
-import { getOrgAccessUser } from '../access';
-import { assertOrganization } from '../assert';
+import { CommonError, NotFoundError } from '../../utils';
+import { assertOrgAccess, assertOrganization } from '../assert';
 import {
   type FundingLinksInput,
   type UpdateOrganizationInput,
@@ -39,13 +38,12 @@ export const updateOrganization = async ({
     throw new CommonError('Organization ID is required');
   }
 
-  const orgUser = await getOrgAccessUser({ user, organizationId });
-
-  if (!orgUser) {
-    throw new UnauthorizedError('You are not a member of this organization');
-  }
-
-  assertAccess({ profile: permission.UPDATE }, orgUser?.roles || []);
+  await assertOrgAccess({
+    user,
+    organizationId,
+    permissions: { profile: permission.UPDATE },
+    notMemberMessage: 'You are not a member of this organization',
+  });
 
   const { ...updateData } = data;
 

--- a/packages/common/src/services/organization/updateOrganization.ts
+++ b/packages/common/src/services/organization/updateOrganization.ts
@@ -42,7 +42,6 @@ export const updateOrganization = async ({
     user,
     organizationId,
     permissions: { profile: permission.UPDATE },
-    notMemberMessage: 'You are not a member of this organization',
   });
 
   const { ...updateData } = data;

--- a/packages/common/src/services/organization/updateOrganizationUser.ts
+++ b/packages/common/src/services/organization/updateOrganizationUser.ts
@@ -6,10 +6,11 @@ import {
   organizationUsers,
 } from '@op/db/schema';
 import type { User } from '@supabase/supabase-js';
-import { assertAccess, permission } from 'access-zones';
+import { permission } from 'access-zones';
 
-import { NotFoundError, UnauthorizedError } from '../../utils';
+import { NotFoundError } from '../../utils';
 import { getOrgAccessUser } from '../access';
+import { assertOrgAccess } from '../assert';
 
 export interface UpdateOrganizationUserData {
   name?: string;
@@ -31,14 +32,13 @@ export async function updateOrganizationUser({
   data,
   user,
 }: UpdateOrganizationUserParams) {
-  // Get the org access user and assert admin UPDATE permissions
-  const orgUser = await getOrgAccessUser({ user, organizationId });
-
-  if (!orgUser) {
-    throw new UnauthorizedError('You are not a member of this organization');
-  }
-
-  assertAccess({ admin: permission.UPDATE }, orgUser?.roles || []);
+  // Assert the user has admin UPDATE permissions on the organization
+  await assertOrgAccess({
+    user,
+    organizationId,
+    permissions: { admin: permission.UPDATE },
+    notMemberMessage: 'You are not a member of this organization',
+  });
 
   // Check if the organization user to update exists
   const targetOrgUser = await db.query.organizationUsers.findFirst({

--- a/packages/common/src/services/organization/updateOrganizationUser.ts
+++ b/packages/common/src/services/organization/updateOrganizationUser.ts
@@ -37,7 +37,6 @@ export async function updateOrganizationUser({
     user,
     organizationId,
     permissions: { admin: permission.UPDATE },
-    notMemberMessage: 'You are not a member of this organization',
   });
 
   // Check if the organization user to update exists

--- a/packages/common/src/services/profile/listProfileUserInvites.ts
+++ b/packages/common/src/services/profile/listProfileUserInvites.ts
@@ -17,10 +17,10 @@ export const listProfileUserInvites = async ({
   user: User;
   query?: string;
 }) => {
-  await Promise.all([
-    assertProfileAdmin({ user, profileId }),
-    assertProfile(profileId),
-  ]);
+  // Check existence before access so a nonexistent profile is a 404
+  // regardless of the caller's permissions.
+  await assertProfile(profileId);
+  await assertProfileAdmin({ user, profileId });
 
   const trimmedQuery = query?.trim();
 

--- a/packages/common/src/services/profile/listProfileUsers.ts
+++ b/packages/common/src/services/profile/listProfileUsers.ts
@@ -50,10 +50,10 @@ export const listProfileUsers = async ({
   cursor?: string | null;
   limit?: number;
 }): Promise<PaginatedResult<ProfileUserWithRelations>> => {
-  await Promise.all([
-    assertProfileAdmin({ user, profileId }),
-    assertProfile(profileId),
-  ]);
+  // Check existence before access so a nonexistent profile is a 404
+  // regardless of the caller's permissions.
+  await assertProfile(profileId);
+  await assertProfileAdmin({ user, profileId });
 
   // Build where clause with optional search filter (minimum 2 characters)
   // Uses ILIKE for substring matching and trigram word_similarity for fuzzy matching

--- a/packages/common/src/services/profile/requests/assertTargetProfileAdminAccess.ts
+++ b/packages/common/src/services/profile/requests/assertTargetProfileAdminAccess.ts
@@ -1,12 +1,11 @@
 import { db } from '@op/db/client';
 import { type Organization, type Profile, organizations } from '@op/db/schema';
 import { User } from '@op/supabase/lib';
-import { assertAccess, permission } from 'access-zones';
+import { permission } from 'access-zones';
 import { eq } from 'drizzle-orm';
 
 import { UnauthorizedError } from '../../../utils';
-import { getOrgAccessUser } from '../../access';
-import { assertProfile } from '../../assert';
+import { assertOrgAccess, assertProfile } from '../../assert';
 
 type TargetProfileAdminContext = {
   targetProfile: Profile;
@@ -42,18 +41,13 @@ export const assertTargetProfileAdminAccess = async ({
   // NOTE: We're using organizationUsers instead of profileUsers because we're in between
   // memberships - the profile user membership (new) and the organization user membership (old).
   // After we migrate to profile users, this code should be changed to use profileUsers.
-  const orgUser = await getOrgAccessUser({
+  await assertOrgAccess({
     user,
     organizationId: organization.id,
-  });
-
-  if (!orgUser) {
-    throw new UnauthorizedError(
+    permissions: { profile: permission.ADMIN },
+    notMemberMessage:
       'You must be a member of this organization to view join requests',
-    );
-  }
-
-  assertAccess({ profile: permission.ADMIN }, orgUser.roles);
+  });
 
   return { targetProfile, organization };
 };

--- a/services/api/src/routers/organization/checkMembership.ts
+++ b/services/api/src/routers/organization/checkMembership.ts
@@ -1,6 +1,6 @@
-import { getOrgAccessUser } from '@op/common';
+import { assertOrgAccess } from '@op/common';
 import { db } from '@op/db/client';
-import { assertAccess, permission } from 'access-zones';
+import { permission } from 'access-zones';
 import { z } from 'zod';
 
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
@@ -24,12 +24,11 @@ export const checkMembershipRouter = router({
       const { email, organizationId } = input;
       const { user } = ctx;
 
-      const orgUser = await getOrgAccessUser({
+      await assertOrgAccess({
         user,
         organizationId,
+        permissions: { profile: permission.ADMIN },
       });
-
-      assertAccess({ profile: permission.ADMIN }, orgUser?.roles ?? []);
 
       // Check if the target email is a member of the organization
       const membershipExists = await db.query.organizationUsers.findFirst({

--- a/services/api/src/routers/profile/requests/listJoinRequests.test.ts
+++ b/services/api/src/routers/profile/requests/listJoinRequests.test.ts
@@ -179,7 +179,7 @@ describe.concurrent('profile.listJoinRequests', () => {
       caller.listJoinRequests({
         targetProfileId: targetProfile.id,
       }),
-    ).rejects.toMatchObject({ cause: { name: 'AccessControlException' } });
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
 
   it('should deny access to users who are not members of the profile', async ({


### PR DESCRIPTION
Mirror the profile-side assertProfileAccess utility for organizations so org-access denials are fetched, checked, and unified on UnauthorizedError in one place.