### PR TITLE
refactor(common): widen access-layer caller to optional AccessUser

### DIFF
--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -22,15 +22,30 @@ export type ProfileUserWithNormalizedRoles = ProfileUserBase & {
   profile: ProfileMinimal;
 };
 
+/**
+ * The caller identity the access layer needs. A subset of the Supabase `User`
+ * (only the id is read today); widen the `Pick` as later auth work needs more
+ * fields. Optional throughout the access layer so a future no-JWT (public)
+ * caller can be represented as `undefined` — resolvers fail closed on it.
+ */
+export type AccessUser = Pick<User, 'id'>;
+
 // gets a user assuming that the user is authenticated
 export const getOrgAccessUser = memoize(
   async ({
     user,
     organizationId,
   }: {
-    user: { id: string };
+    user?: AccessUser;
     organizationId: string;
   }): Promise<OrgUserWithNormalizedRoles | undefined> => {
+    // No caller identity → fail closed. Never let an undefined id reach the
+    // query: Drizzle skips undefined filter conditions, which would drop the
+    // authUserId constraint and match an arbitrary member (auth bypass).
+    if (!user?.id) {
+      throw new UnauthorizedError();
+    }
+
     const getOrgUser = async () => {
       const orgUser = await db.query.organizationUsers.findFirst({
         where: {
@@ -79,7 +94,7 @@ export const getOrgAccessUser = memoize(
       },
     });
   },
-  ({ user, organizationId }) => `${user.id}:${organizationId}`,
+  ({ user, organizationId }) => `${user?.id}:${organizationId}`,
 );
 
 // gets a user's access for a specific profile
@@ -88,9 +103,14 @@ export const getProfileAccessUser = memoize(
     user,
     profileId,
   }: {
-    user: { id: string };
+    user?: AccessUser;
     profileId: string;
   }): Promise<ProfileUserWithNormalizedRoles | undefined> => {
+    // No caller identity → fail closed (see getOrgAccessUser for why).
+    if (!user?.id) {
+      throw new UnauthorizedError();
+    }
+
     const profileUser = await db.query.profileUsers.findFirst({
       where: {
         profileId,
@@ -132,7 +152,7 @@ export const getProfileAccessUser = memoize(
       roles: normalizedRoles,
     };
   },
-  ({ user, profileId }) => `${user.id}:${profileId}`,
+  ({ user, profileId }) => `${user?.id}:${profileId}`,
 );
 
 /**
@@ -288,7 +308,7 @@ export const getCurrentOrgUserId = async (
   }
 
   const orgUser = await getOrgAccessUser({
-    user: { id: session.user.authUserId } as User,
+    user: { id: session.user.authUserId },
     organizationId,
   });
 

--- a/packages/common/src/services/assert/assertOrgAccess.ts
+++ b/packages/common/src/services/assert/assertOrgAccess.ts
@@ -1,7 +1,11 @@
 import { type AccessZonePermissionInput, checkPermission } from 'access-zones';
 
 import { UnauthorizedError } from '../../utils';
-import { type OrgUserWithNormalizedRoles, getOrgAccessUser } from '../access';
+import {
+  type AccessUser,
+  type OrgUserWithNormalizedRoles,
+  getOrgAccessUser,
+} from '../access';
 
 /**
  * Fetches the user's roles on an organization and asserts the given
@@ -20,7 +24,7 @@ export async function assertOrgAccess({
   permissions,
   notMemberMessage,
 }: {
-  user: { id: string };
+  user?: AccessUser;
   organizationId: string;
   permissions: AccessZonePermissionInput;
   notMemberMessage?: string;

--- a/packages/common/src/services/assert/assertProfileAccess.ts
+++ b/packages/common/src/services/assert/assertProfileAccess.ts
@@ -2,6 +2,7 @@ import { type AccessZonePermissionInput, checkPermission } from 'access-zones';
 
 import { UnauthorizedError } from '../../utils';
 import {
+  type AccessUser,
   type ProfileUserWithNormalizedRoles,
   getProfileAccessUser,
 } from '../access';
@@ -22,7 +23,7 @@ export async function assertProfileAccess({
   permissions,
   notMemberMessage,
 }: {
-  user: { id: string };
+  user?: AccessUser;
   profileId: string;
   permissions: AccessZonePermissionInput;
   notMemberMessage?: string;

--- a/packages/common/src/services/assert/assertProfileAdmin.ts
+++ b/packages/common/src/services/assert/assertProfileAdmin.ts
@@ -1,6 +1,6 @@
 import { permission } from 'access-zones';
 
-import type { ProfileUserWithNormalizedRoles } from '../access';
+import type { AccessUser, ProfileUserWithNormalizedRoles } from '../access';
 import { assertProfileAccess } from './assertProfileAccess';
 
 /**
@@ -17,7 +17,7 @@ export async function assertProfileAdmin({
   user,
   profileId,
 }: {
-  user: { id: string };
+  user?: AccessUser;
   profileId: string;
 }): Promise<ProfileUserWithNormalizedRoles> {
   return assertProfileAccess({


### PR DESCRIPTION
Lays the rails for the upcoming no-JWT/public-user substitution (auth-refactor PR4) by making the access-layer caller type optional, without changing current behavior — nothing passes undefined yet, and resolvers fail closed on a missing caller id.