### PR TITLE
fix(decisions): multi-select dropdown options + editable-field template validation

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/validation/processBuilderValidation.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/validation/processBuilderValidation.ts
@@ -44,7 +44,9 @@ const phasesSchema = z.object({
  * skip them to avoid surfacing dead-end errors. Budget is a system field
  * but IS editable (BudgetFieldConfig), so it stays in scope.
  */
-const LOCKED_PROPOSAL_FIELD_KEYS = new Set(['title', 'category']);
+const LOCKED_PROPOSAL_FIELD_KEYS = new Set(
+  [...SYSTEM_FIELD_KEYS].filter((key) => key !== 'budget'),
+);
 
 // ============ Helpers ============
 

--- a/apps/app/src/components/decisions/ProcessBuilder/validation/processBuilderValidation.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/validation/processBuilderValidation.ts
@@ -38,6 +38,14 @@ const phasesSchema = z.object({
   phases: z.array(phaseSchema).min(1),
 });
 
+/**
+ * Proposal fields the template editor renders as locked/auto-generated
+ * (title, category) — the user can't edit them here, so error validators
+ * skip them to avoid surfacing dead-end errors. Budget is a system field
+ * but IS editable (BudgetFieldConfig), so it stays in scope.
+ */
+const LOCKED_PROPOSAL_FIELD_KEYS = new Set(['title', 'category']);
+
 // ============ Helpers ============
 
 /** Returns true when at least one phase has review enabled. */
@@ -76,7 +84,12 @@ function validateTemplateEditor(
   if (!data?.proposalTemplate) {
     return false;
   }
-  const fields = getFields(data.proposalTemplate);
+  // Skip locked, non-editable fields (title/category): an error there can't be
+  // fixed from this editor, so flagging it would be a dead-end. Budget stays
+  // in scope because it IS editable here.
+  const fields = getFields(data.proposalTemplate).filter(
+    (field) => !LOCKED_PROPOSAL_FIELD_KEYS.has(field.id),
+  );
   return fields.every((field) => getFieldErrors(field).length === 0);
 }
 
@@ -153,7 +166,7 @@ const LAUNCH_CHECKLIST: ChecklistItem[] = [
         return true;
       }
       const fields = getFields(data.proposalTemplate).filter(
-        (f) => !SYSTEM_FIELD_KEYS.has(f.id),
+        (f) => !LOCKED_PROPOSAL_FIELD_KEYS.has(f.id),
       );
       return fields.every((field) => getFieldErrors(field).length === 0);
     },

--- a/apps/app/src/components/decisions/proposalTemplate.ts
+++ b/apps/app/src/components/decisions/proposalTemplate.ts
@@ -189,8 +189,13 @@ export function getFieldOptions(
     return [];
   }
 
-  // dropdown / category: prefer oneOf, fall back to legacy enum
-  if (schema.type === 'string' || Array.isArray(schema.type)) {
+  // dropdown / category: prefer oneOf, fall back to legacy enum.
+  // `array` covers multi-select dropdowns whose options live on `items`.
+  if (
+    schema.type === 'string' ||
+    schema.type === 'array' ||
+    Array.isArray(schema.type)
+  ) {
     return parseSchemaOptions(schema).map((opt, i) => ({
       id: `${fieldId}-opt-${i}`,
       value: String(opt.value),

--- a/apps/app/src/components/decisions/proposalTemplate.ts
+++ b/apps/app/src/components/decisions/proposalTemplate.ts
@@ -189,20 +189,13 @@ export function getFieldOptions(
     return [];
   }
 
-  // dropdown / category: prefer oneOf, fall back to legacy enum.
-  // `array` covers multi-select dropdowns whose options live on `items`.
-  if (
-    schema.type === 'string' ||
-    schema.type === 'array' ||
-    Array.isArray(schema.type)
-  ) {
-    return parseSchemaOptions(schema).map((opt, i) => ({
-      id: `${fieldId}-opt-${i}`,
-      value: String(opt.value),
-    }));
-  }
-
-  return [];
+  // Option-bearing shapes (dropdown, multi-select category) are detected by
+  // parseSchemaOptions, which reads oneOf / items.oneOf / enum and returns []
+  // for everything else — so no type gate is needed here.
+  return parseSchemaOptions(schema).map((opt, i) => ({
+    id: `${fieldId}-opt-${i}`,
+    value: String(opt.value),
+  }));
 }
 
 export { schemaHasOptions };

--- a/tests/e2e/tests/proposal-template-multiselect.spec.ts
+++ b/tests/e2e/tests/proposal-template-multiselect.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '../fixtures/index.js';
+
+// Wider viewport so the participant preview panel (xl:block >= 1280px) is visible.
+test.use({ viewport: { width: 1440, height: 900 } });
+
+/** Resolves when the next matching updateDecisionInstance mutation succeeds. */
+function waitForAutoSave(
+  page: import('@playwright/test').Page,
+  requestBodyIncludes?: string,
+) {
+  return page.waitForResponse(
+    (resp) => {
+      if (
+        !resp.url().includes('decision.updateDecisionInstance') ||
+        !resp.ok()
+      ) {
+        return false;
+      }
+
+      if (!requestBodyIncludes) {
+        return true;
+      }
+
+      return resp.request().postData()?.includes(requestBodyIncludes) ?? false;
+    },
+    { timeout: 12_000 },
+  );
+}
+
+test.describe('Proposal template — multi-select category', () => {
+  // Regression guard for the multi-select category fix:
+  //   - getFieldOptions now reads options off array-typed (multi-select) dropdowns
+  //   - validateTemplateEditor skips locked fields (title/category)
+  // Before the fix, a multi-select category resolved to zero options, tripped the
+  // "needs 2+ options" dropdown check, and lit the Proposal Template section's
+  // incomplete dot — an error the user could not fix from the editor.
+  test('multi-select category does not flag the Proposal Template section as incomplete', async ({
+    authenticatedPage: page,
+  }) => {
+    test.setTimeout(144_000);
+
+    // 1. Create a draft process from the seeded template.
+    await page.goto('/en/');
+    await page.getByRole('button', { name: 'Create' }).click();
+    await page
+      .getByRole('menuitem', { name: 'Decision-making process' })
+      .click();
+    await page.waitForURL(/\/decisions\/[^/]+\/edit/, { timeout: 12_000 });
+    await expect(page.getByText('Process Overview')).toBeVisible({
+      timeout: 36_000,
+    });
+
+    const sidebarNav = page.getByRole('navigation', {
+      name: 'Section navigation',
+    });
+
+    // 2. Jump straight to Proposal Categories.
+    await sidebarNav
+      .getByRole('button', { name: 'Proposal Categories' })
+      .click();
+    await expect(page.getByText('Proposal Categories').first()).toBeVisible({
+      timeout: 12_000,
+    });
+
+    // 3. Add two categories.
+    await page.getByRole('button', { name: 'Create first category' }).click();
+    await page.getByLabel('Shorthand').fill('Education');
+    let saved = waitForAutoSave(page);
+    await page.getByRole('button', { name: 'Add category' }).click();
+    await expect(page.getByText('Education', { exact: true })).toBeVisible();
+    await saved;
+
+    await page.getByRole('button', { name: 'Add category' }).click();
+    await page.getByLabel('Shorthand').fill('Health');
+    saved = waitForAutoSave(page);
+    await page.getByRole('button', { name: 'Add category' }).click();
+    await expect(page.getByText('Health', { exact: true })).toBeVisible();
+    await saved;
+
+    // 4. Enable "Allow multiple categories" (the toggle is unlabeled, so scope
+    //    by the row that contains the label text).
+    const multiRow = page.locator('div.flex.items-center.justify-between', {
+      has: page.getByText('Allow multiple categories', { exact: true }),
+    });
+    const multiToggle = multiRow.getByRole('button');
+    const multiSaved = waitForAutoSave(page, 'allowMultipleCategories');
+    await multiToggle.click();
+    await multiSaved;
+    await expect(multiToggle).toHaveAttribute('aria-pressed', 'true');
+
+    // 5. Open the Proposal Template editor and make one edit so the normalized
+    //    template (now carrying the multi-select category) is persisted — the
+    //    section validator reads the persisted template, not editor-local state.
+    await sidebarNav.getByRole('button', { name: 'Proposal Template' }).click();
+    await expect(page.getByText('Proposal template').first()).toBeVisible({
+      timeout: 12_000,
+    });
+
+    const addFieldButton = page.getByRole('button', { name: 'Add field' });
+    await expect(addFieldButton).toBeVisible({ timeout: 6_000 });
+    await addFieldButton.click();
+    const fieldSaved = waitForAutoSave(page);
+    await page.getByRole('menuitem', { name: 'Short text' }).click();
+    await fieldSaved;
+
+    // 6. Positive control: Overview was left blank, so its section MUST show the
+    //    incomplete dot. This proves the selector matches real indicators, so the
+    //    assertion below is meaningful rather than a never-matching selector.
+    const overviewNav = sidebarNav.getByRole('button', { name: 'Overview' });
+    await expect(overviewNav.locator('span.bg-primary-teal')).toHaveCount(1);
+
+    // 7. The Proposal Template section must NOT show the incomplete dot.
+    const templateNav = sidebarNav.getByRole('button', {
+      name: 'Proposal Template',
+    });
+    await expect(templateNav.locator('span.bg-primary-teal')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Two fixes for the process builder's proposal template, surfaced while debugging a dev template that read as invalid until edited.

- **`getFieldOptions`** now resolves options for array-typed (multi-select) dropdowns via `parseSchemaOptions`, not just `string`/union-typed fields. Multi-select category options were rendering empty in the editor preview/field cards.
- **Process builder validation** skips locked, non-editable fields (`title`, `category`) when checking proposal-template field errors, so errors the user can't fix from this editor aren't surfaced as dead-end dots. Budget stays in scope (it *is* editable via `BudgetFieldConfig`).

Note: the originating template also needed its categories moved from `fields.categories` to `config.categories` — that's a DB data fix, applied separately.

## Follow-ups (out of scope, separate)

- **Budget validation gap:** budget is editable but never validated — its `money` x-format isn't in `X_FORMAT_TO_FIELD_TYPE`, so it's absent from `getFields`, and `getFieldErrors` has no money checks. To actually validate it: map `money` in `X_FORMAT_TO_FIELD_TYPE` + add budget checks to `getFieldErrors`.
## Test

Added `tests/e2e/tests/proposal-template-multiselect.spec.ts` — creates a process, defines 2 categories, enables "Allow multiple categories", then asserts the Proposal Template section shows no incomplete dot (the dot is the signal; the bug never blocked Launch). Includes a positive control: the blank Overview section *must* show the dot, proving the selector matches real indicators. Verified green against a local e2e build.

Note: the assertion targets the dot via its tailwind class (`bg-primary-teal`) since the indicator has no testid. A follow-up could add a testid to the dot in `SidebarNavItems.tsx` and `aria-label`s to the unlabeled category toggles to harden the selectors.
- **Drift risk:** `LOCKED_PROPOSAL_FIELD_KEYS` hardcodes the editor's locked/editable split; if a field is locked/unlocked in `TemplateEditorContent` later, the validator set drifts. A shared constant would be sturdier.
