### PR TITLE
refactor(analytics): track proposal/process views client-side

### DIFF
--- a/apps/app/src/components/PostHogProvider.tsx
+++ b/apps/app/src/components/PostHogProvider.tsx
@@ -15,10 +15,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       capture_pageleave: true,
       capture_exceptions: true,
       __add_tracing_headers: true,
-      // Logs every capture to the browser console so events can be verified in
-      // devtools. NOTE: this is enabled for all users in production — revert
-      // once view tracking is verified.
-      debug: true,
+      // debug: process.env.NODE_ENV === 'development',
     });
   }, []);
 

--- a/apps/app/src/components/PostHogProvider.tsx
+++ b/apps/app/src/components/PostHogProvider.tsx
@@ -15,7 +15,6 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       capture_pageleave: true,
       capture_exceptions: true,
       __add_tracing_headers: true,
-      // debug: process.env.NODE_ENV === 'development',
     });
   }, []);
 

--- a/apps/app/src/components/PostHogProvider.tsx
+++ b/apps/app/src/components/PostHogProvider.tsx
@@ -15,7 +15,10 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       capture_pageleave: true,
       capture_exceptions: true,
       __add_tracing_headers: true,
-      // debug: process.env.NODE_ENV === 'development',
+      // Logs every capture to the browser console so events can be verified in
+      // devtools. NOTE: this is enabled for all users in production — revert
+      // once view tracking is verified.
+      debug: true,
     });
   }, []);
 

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -34,9 +34,11 @@ interface DecisionHeaderProps {
 export function DecisionHeader(props: DecisionHeaderProps) {
   const { instanceId } = props;
 
-  useTrackPageView('process_viewed', getDecisionCommonProperties(instanceId), [
-    instanceId,
-  ]);
+  useTrackPageView(
+    'process_viewed',
+    getDecisionCommonProperties({ decisionInstanceId: instanceId }),
+    [instanceId],
+  );
 
   if (props.useLegacy) {
     return <LegacyDecisionHeaderContent {...props} />;

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
 import { type ProcessPhase } from '@op/api/encoders';
 import { isLastPhase } from '@op/common/client';
 import { cn } from '@op/ui/utils';
-import { type ReactNode } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import { type ReactNode, useEffect } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -30,6 +32,17 @@ interface DecisionHeaderProps {
 }
 
 export function DecisionHeader(props: DecisionHeaderProps) {
+  const posthog = usePostHog();
+  const { instanceId } = props;
+
+  // Track the process view once per instance. This lives in the header (shared
+  // by the new and legacy routes) rather than the getInstance procedure so it
+  // fires on an actual view — not on every server prefetch, refetch, or cache
+  // invalidation (vote/transition/edit) that re-runs the query.
+  useEffect(() => {
+    posthog.capture('process_viewed', getDecisionCommonProperties(instanceId));
+  }, [posthog, instanceId]);
+
   if (props.useLegacy) {
     return <LegacyDecisionHeaderContent {...props} />;
   }

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -1,12 +1,12 @@
 'use client';
 
+import { useTrackPageView } from '@/hooks/useTrackPageView';
 import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
 import { type ProcessPhase } from '@op/api/encoders';
 import { isLastPhase } from '@op/common/client';
 import { cn } from '@op/ui/utils';
-import { usePostHog } from 'posthog-js/react';
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -32,16 +32,17 @@ interface DecisionHeaderProps {
 }
 
 export function DecisionHeader(props: DecisionHeaderProps) {
-  const posthog = usePostHog();
   const { instanceId } = props;
 
-  // Track the process view once per instance. This lives in the header (shared
-  // by the new and legacy routes) rather than the getInstance procedure so it
+  // Track the process view once per instance. Lives in the header (shared by
+  // the new and legacy routes) rather than the getInstance procedure so it
   // fires on an actual view — not on every server prefetch, refetch, or cache
   // invalidation (vote/transition/edit) that re-runs the query.
-  useEffect(() => {
-    posthog.capture('process_viewed', getDecisionCommonProperties(instanceId));
-  }, [posthog, instanceId]);
+  useTrackPageView(
+    'process_viewed',
+    getDecisionCommonProperties(instanceId),
+    instanceId,
+  );
 
   if (props.useLegacy) {
     return <LegacyDecisionHeaderContent {...props} />;

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -34,15 +34,9 @@ interface DecisionHeaderProps {
 export function DecisionHeader(props: DecisionHeaderProps) {
   const { instanceId } = props;
 
-  // Track the process view once per instance. Lives in the header (shared by
-  // the new and legacy routes) rather than the getInstance procedure so it
-  // fires on an actual view — not on every server prefetch, refetch, or cache
-  // invalidation (vote/transition/edit) that re-runs the query.
-  useTrackPageView(
-    'process_viewed',
-    getDecisionCommonProperties(instanceId),
+  useTrackPageView('process_viewed', getDecisionCommonProperties(instanceId), [
     instanceId,
-  );
+  ]);
 
   if (props.useLegacy) {
     return <LegacyDecisionHeaderContent {...props} />;

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -47,15 +47,11 @@ export function ProposalView({
   // Safety check - fallback to initial data if query returns undefined
   const currentProposal = proposal || initialProposal;
 
-  // Track the proposal view once per proposal. Lives in the view component
-  // (not the getProposal procedure) so it fires on an actual view — not on
-  // every prefetch, refetch, cache invalidation, or editor/review fetch that
-  // re-runs the query.
   const { processInstanceId, id: proposalId } = currentProposal;
   useTrackPageView(
     'proposal_viewed',
     getDecisionCommonProperties(processInstanceId, proposalId),
-    `${processInstanceId}:${proposalId}`,
+    [processInstanceId, proposalId],
   );
 
   // Use relationship mutations hook for like/follow functionality

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -50,7 +50,10 @@ export function ProposalView({
   const { processInstanceId, id: proposalId } = currentProposal;
   useTrackPageView(
     'proposal_viewed',
-    getDecisionCommonProperties(processInstanceId, proposalId),
+    getDecisionCommonProperties({
+      decisionInstanceId: processInstanceId,
+      proposalId,
+    }),
     [processInstanceId, proposalId],
   );
 

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRelationshipMutations } from '@/hooks/useRelationshipMutations';
+import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
 import {
   type Proposal,
@@ -12,7 +13,8 @@ import {
 import { SplitPane } from '@op/ui/SplitPane';
 import { useLocale } from 'next-intl';
 import { useQueryStates } from 'nuqs';
-import { type ReactNode, useCallback, useState } from 'react';
+import { usePostHog } from 'posthog-js/react';
+import { type ReactNode, useCallback, useEffect, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -37,6 +39,7 @@ export function ProposalView({
 }) {
   const t = useTranslations();
   const locale = useLocale();
+  const posthog = usePostHog();
 
   const { data: proposal } = trpc.decision.getProposal.useQuery({
     profileId: initialProposal.profileId,
@@ -44,6 +47,18 @@ export function ProposalView({
 
   // Safety check - fallback to initial data if query returns undefined
   const currentProposal = proposal || initialProposal;
+
+  // Track the proposal view once per proposal. This lives in the view
+  // component (rather than the getProposal procedure) so it fires on an actual
+  // view — not on every prefetch, refetch, cache invalidation, or editor/review
+  // fetch that re-runs the query.
+  const { processInstanceId, id: proposalId } = currentProposal;
+  useEffect(() => {
+    posthog.capture(
+      'proposal_viewed',
+      getDecisionCommonProperties(processInstanceId, proposalId),
+    );
+  }, [posthog, processInstanceId, proposalId]);
 
   // Use relationship mutations hook for like/follow functionality
   const {

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRelationshipMutations } from '@/hooks/useRelationshipMutations';
+import { useTrackPageView } from '@/hooks/useTrackPageView';
 import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
 import {
@@ -13,8 +14,7 @@ import {
 import { SplitPane } from '@op/ui/SplitPane';
 import { useLocale } from 'next-intl';
 import { useQueryStates } from 'nuqs';
-import { usePostHog } from 'posthog-js/react';
-import { type ReactNode, useCallback, useEffect, useState } from 'react';
+import { type ReactNode, useCallback, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -39,7 +39,6 @@ export function ProposalView({
 }) {
   const t = useTranslations();
   const locale = useLocale();
-  const posthog = usePostHog();
 
   const { data: proposal } = trpc.decision.getProposal.useQuery({
     profileId: initialProposal.profileId,
@@ -48,17 +47,16 @@ export function ProposalView({
   // Safety check - fallback to initial data if query returns undefined
   const currentProposal = proposal || initialProposal;
 
-  // Track the proposal view once per proposal. This lives in the view
-  // component (rather than the getProposal procedure) so it fires on an actual
-  // view — not on every prefetch, refetch, cache invalidation, or editor/review
-  // fetch that re-runs the query.
+  // Track the proposal view once per proposal. Lives in the view component
+  // (not the getProposal procedure) so it fires on an actual view — not on
+  // every prefetch, refetch, cache invalidation, or editor/review fetch that
+  // re-runs the query.
   const { processInstanceId, id: proposalId } = currentProposal;
-  useEffect(() => {
-    posthog.capture(
-      'proposal_viewed',
-      getDecisionCommonProperties(processInstanceId, proposalId),
-    );
-  }, [posthog, processInstanceId, proposalId]);
+  useTrackPageView(
+    'proposal_viewed',
+    getDecisionCommonProperties(processInstanceId, proposalId),
+    `${processInstanceId}:${proposalId}`,
+  );
 
   // Use relationship mutations hook for like/follow functionality
   const {

--- a/apps/app/src/hooks/useTrackPageView.ts
+++ b/apps/app/src/hooks/useTrackPageView.ts
@@ -4,14 +4,8 @@ import { usePostHog } from 'posthog-js/react';
 import { type DependencyList, useEffect } from 'react';
 
 /**
- * Fires a PostHog "view" event from the component that renders the thing being
- * viewed, once per `deps` change. Prefer this over tracking inside a tRPC query
- * procedure, which re-runs on prefetch, refetch, window-refocus, and cache
- * invalidation — none of which is an actual view.
- *
- * `deps` controls when the event re-fires (e.g. the proposal/process id), so
- * pass the stable identity of the view there rather than `properties`, which
- * may carry volatile fields like a query-param-bearing `location`.
+ * Fires a PostHog "view" event once per `deps` change. Pass the stable identity
+ * of the view (e.g. the proposal/process id) as `deps`, not `properties`.
  */
 export function useTrackPageView(
   event: string,

--- a/apps/app/src/hooks/useTrackPageView.ts
+++ b/apps/app/src/hooks/useTrackPageView.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { usePostHog } from 'posthog-js/react';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Fires a PostHog "view" event once per unique view, from the component that
+ * actually renders the thing being viewed.
+ *
+ * Prefer this over tracking inside a tRPC query procedure: a query re-runs on
+ * prefetch, refetch, window-refocus, and cache invalidation, none of which is
+ * an actual view. A component effect fires on a real render instead.
+ *
+ * Dedupe is keyed on `dedupeKey` (falling back to the serialized `properties`)
+ * rather than the raw `properties` object, so volatile fields — e.g. a
+ * `location` that carries query params — don't re-fire the event. Pass a stable
+ * identifier (the proposal/process id) as `dedupeKey` when `properties` contains
+ * anything that changes within the same logical view.
+ *
+ * @param event The PostHog event name (e.g. `proposal_viewed`).
+ * @param properties Event properties captured on the first view.
+ * @param dedupeKey Stable identity for the view; re-firing only happens when it changes.
+ */
+export function useTrackPageView(
+  event: string,
+  properties?: Record<string, unknown>,
+  dedupeKey?: string,
+) {
+  const posthog = usePostHog();
+  const key = dedupeKey ?? JSON.stringify(properties ?? {});
+
+  // Hold the latest properties without retriggering the effect, so the capture
+  // uses fresh values while the effect only depends on the stable key.
+  const propertiesRef = useRef(properties);
+  propertiesRef.current = properties;
+
+  const trackedKey = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (trackedKey.current === key) {
+      return;
+    }
+    trackedKey.current = key;
+    posthog.capture(event, propertiesRef.current);
+  }, [posthog, event, key]);
+}

--- a/apps/app/src/hooks/useTrackPageView.ts
+++ b/apps/app/src/hooks/useTrackPageView.ts
@@ -1,46 +1,26 @@
 'use client';
 
 import { usePostHog } from 'posthog-js/react';
-import { useEffect, useRef } from 'react';
+import { type DependencyList, useEffect } from 'react';
 
 /**
- * Fires a PostHog "view" event once per unique view, from the component that
- * actually renders the thing being viewed.
+ * Fires a PostHog "view" event from the component that renders the thing being
+ * viewed, once per `deps` change. Prefer this over tracking inside a tRPC query
+ * procedure, which re-runs on prefetch, refetch, window-refocus, and cache
+ * invalidation — none of which is an actual view.
  *
- * Prefer this over tracking inside a tRPC query procedure: a query re-runs on
- * prefetch, refetch, window-refocus, and cache invalidation, none of which is
- * an actual view. A component effect fires on a real render instead.
- *
- * Dedupe is keyed on `dedupeKey` (falling back to the serialized `properties`)
- * rather than the raw `properties` object, so volatile fields — e.g. a
- * `location` that carries query params — don't re-fire the event. Pass a stable
- * identifier (the proposal/process id) as `dedupeKey` when `properties` contains
- * anything that changes within the same logical view.
- *
- * @param event The PostHog event name (e.g. `proposal_viewed`).
- * @param properties Event properties captured on the first view.
- * @param dedupeKey Stable identity for the view; re-firing only happens when it changes.
+ * `deps` controls when the event re-fires (e.g. the proposal/process id), so
+ * pass the stable identity of the view there rather than `properties`, which
+ * may carry volatile fields like a query-param-bearing `location`.
  */
 export function useTrackPageView(
   event: string,
   properties?: Record<string, unknown>,
-  dedupeKey?: string,
+  deps: DependencyList = [],
 ) {
   const posthog = usePostHog();
-  const key = dedupeKey ?? JSON.stringify(properties ?? {});
-
-  // Hold the latest properties without retriggering the effect, so the capture
-  // uses fresh values while the effect only depends on the stable key.
-  const propertiesRef = useRef(properties);
-  propertiesRef.current = properties;
-
-  const trackedKey = useRef<string | null>(null);
 
   useEffect(() => {
-    if (trackedKey.current === key) {
-      return;
-    }
-    trackedKey.current = key;
-    posthog.capture(event, propertiesRef.current);
-  }, [posthog, event, key]);
+    posthog.capture(event, properties);
+  }, [posthog, event, ...deps]);
 }

--- a/packages/analytics/src/client-utils.ts
+++ b/packages/analytics/src/client-utils.ts
@@ -12,3 +12,43 @@ import { posthogUIHost } from '@op/core';
 export const getAnalyticsUserUrl = (distinctUserId: string) => {
   return `${posthogUIHost}/person/${encodeURIComponent(distinctUserId)}`;
 };
+
+export interface DecisionCommonProperties {
+  process_id: string;
+  proposal_id?: string;
+  location?: string;
+  timezone?: string;
+  language?: string;
+}
+
+/**
+ * Builds the common property bag for decision-making analytics events.
+ *
+ * Client-safe mirror of the server helper in `./utils`. Prefer this when
+ * tracking decision events from the frontend (e.g. `proposal_viewed`,
+ * `process_viewed`): firing client-side means `location`/`timezone`/`language`
+ * are actually populated, whereas server-side calls always skip them because
+ * `window` is undefined.
+ */
+export function getDecisionCommonProperties(
+  processId: string,
+  proposalId?: string,
+  additionalProps?: Record<string, unknown>,
+): DecisionCommonProperties & Record<string, unknown> {
+  const baseProps: DecisionCommonProperties & Record<string, unknown> = {
+    process_id: processId,
+    ...additionalProps,
+  };
+
+  if (proposalId) {
+    baseProps.proposal_id = proposalId;
+  }
+
+  if (typeof window !== 'undefined') {
+    baseProps.location = window.location.href;
+    baseProps.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    baseProps.language = navigator.language;
+  }
+
+  return baseProps;
+}

--- a/packages/analytics/src/client-utils.ts
+++ b/packages/analytics/src/client-utils.ts
@@ -24,19 +24,26 @@ export interface DecisionCommonProperties {
 /**
  * Builds the common property bag for decision-making analytics events.
  *
- * Client-safe mirror of the server helper in `./utils`. Prefer this when
- * tracking decision events from the frontend (e.g. `proposal_viewed`,
- * `process_viewed`): firing client-side means `location`/`timezone`/`language`
- * are actually populated, whereas server-side calls always skip them because
- * `window` is undefined.
+ * Client-safe and the single source of truth (the server `./utils` re-exports
+ * it). Firing client-side means `location`/`timezone`/`language` are actually
+ * populated, whereas server-side calls always skip them because `window` is
+ * undefined.
+ *
+ * Note: the value is emitted under the `process_id` property for backwards
+ * compatibility with existing PostHog dashboards, even though the input is the
+ * decision instance id.
  */
-export function getDecisionCommonProperties(
-  processId: string,
-  proposalId?: string,
-  additionalProps?: Record<string, unknown>,
-): DecisionCommonProperties & Record<string, unknown> {
+export function getDecisionCommonProperties({
+  decisionInstanceId,
+  proposalId,
+  additionalProps,
+}: {
+  decisionInstanceId: string;
+  proposalId?: string;
+  additionalProps?: Record<string, unknown>;
+}): DecisionCommonProperties & Record<string, unknown> {
   const baseProps: DecisionCommonProperties & Record<string, unknown> = {
-    process_id: processId,
+    process_id: decisionInstanceId,
     ...additionalProps,
   };
 

--- a/packages/analytics/src/client-utils.ts
+++ b/packages/analytics/src/client-utils.ts
@@ -23,15 +23,8 @@ export interface DecisionCommonProperties {
 
 /**
  * Builds the common property bag for decision-making analytics events.
- *
- * Client-safe and the single source of truth (the server `./utils` re-exports
- * it). Firing client-side means `location`/`timezone`/`language` are actually
- * populated, whereas server-side calls always skip them because `window` is
- * undefined.
- *
- * Note: the value is emitted under the `process_id` property for backwards
- * compatibility with existing PostHog dashboards, even though the input is the
- * decision instance id.
+ * `location`/`timezone`/`language` are only populated client-side. The instance
+ * id is emitted as `process_id` for backwards compatibility with PostHog.
  */
 export function getDecisionCommonProperties({
   decisionInstanceId,

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -1,5 +1,10 @@
 import PostHogClient from '@op/analytics/client';
 
+import {
+  type DecisionCommonProperties,
+  getDecisionCommonProperties,
+} from './client-utils';
+
 const posthog = PostHogClient();
 
 /**
@@ -254,41 +259,9 @@ export async function trackRelationshipAccepted(userId: string): Promise<void> {
  * Decision-making process analytics
  */
 
-export interface DecisionCommonProperties {
-  process_id: string;
-  proposal_id?: string;
-  location?: string;
-  timezone?: string;
-  language?: string;
-}
-
-/**
- * Helper function to get common properties for decision events
- */
-export function getDecisionCommonProperties(
-  processId: string,
-  proposalId?: string,
-  additionalProps?: Record<string, any>,
-): DecisionCommonProperties & Record<string, any> {
-  // Server-side safe implementation - only add client-side properties if available
-  const baseProps: DecisionCommonProperties & Record<string, any> = {
-    process_id: processId,
-    ...additionalProps,
-  };
-
-  if (proposalId) {
-    baseProps.proposal_id = proposalId;
-  }
-
-  // Only add browser-specific properties if we're on the client side
-  if (typeof window !== 'undefined') {
-    baseProps.location = window.location.href;
-    baseProps.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    baseProps.language = navigator.language;
-  }
-
-  return baseProps;
-}
+// Re-exported from the client-safe module so there is a single definition
+// shared by server-side tracking here and client-side tracking in the app.
+export { type DecisionCommonProperties, getDecisionCommonProperties };
 
 /**
  * Track when a user views a decision-making process

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -274,7 +274,10 @@ export async function trackProcessViewed(
   await trackEventWithContext(
     userId,
     'process_viewed',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      additionalProps,
+    }),
   );
 }
 
@@ -290,7 +293,11 @@ export async function trackProposalSubmitted(
   await trackEventWithContext(
     userId,
     'proposal_submitted',
-    getDecisionCommonProperties(processId, proposalId, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      proposalId,
+      additionalProps,
+    }),
   );
 }
 
@@ -306,7 +313,11 @@ export async function trackProposalViewed(
   await trackEventWithContext(
     userId,
     'proposal_viewed',
-    getDecisionCommonProperties(processId, proposalId, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      proposalId,
+      additionalProps,
+    }),
   );
 }
 
@@ -322,7 +333,11 @@ export async function trackProposalCommented(
   await trackEventWithContext(
     userId,
     'proposal_commented',
-    getDecisionCommonProperties(processId, proposalId, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      proposalId,
+      additionalProps,
+    }),
   );
 }
 
@@ -338,7 +353,11 @@ export async function trackProposalLiked(
   await trackEventWithContext(
     userId,
     'proposal_liked',
-    getDecisionCommonProperties(processId, proposalId, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      proposalId,
+      additionalProps,
+    }),
   );
 }
 
@@ -354,7 +373,11 @@ export async function trackProposalFollowed(
   await trackEventWithContext(
     userId,
     'proposal_followed',
-    getDecisionCommonProperties(processId, proposalId, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      proposalId,
+      additionalProps,
+    }),
   );
 }
 
@@ -365,7 +388,7 @@ export async function trackUserVoted(
   await trackEventWithContext(
     userId,
     'user_voted',
-    getDecisionCommonProperties(processId),
+    getDecisionCommonProperties({ decisionInstanceId: processId }),
   );
 }
 
@@ -381,7 +404,11 @@ export async function trackProposalReviewed(
   await trackEventWithContext(
     userId,
     'user_reviewed_proposal',
-    getDecisionCommonProperties(processId, proposalId, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      proposalId,
+      additionalProps,
+    }),
   );
 }
 
@@ -396,7 +423,10 @@ export async function trackReviewListFinished(
   await trackEventWithContext(
     userId,
     'user_finished_review',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      additionalProps,
+    }),
   );
 }
 
@@ -411,7 +441,10 @@ export async function trackAdminSetProcess(
   await trackEventWithContext(
     userId,
     'admin_set_process',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      additionalProps,
+    }),
   );
 }
 
@@ -456,7 +489,10 @@ export async function trackAdminSetRubric(
   await trackEventWithContext(
     userId,
     'admin_set_rubric',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      additionalProps,
+    }),
   );
 }
 
@@ -486,7 +522,10 @@ export async function trackManualTransitionConfirmed(
   await trackEventWithContext(
     userId,
     'manual_transition_confirmed',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      additionalProps,
+    }),
   );
 }
 
@@ -498,7 +537,10 @@ export async function trackManualSelectionSubmitted(
   await trackEventWithContext(
     userId,
     'manual_selection_submitted',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      additionalProps,
+    }),
   );
 }
 
@@ -510,6 +552,9 @@ export async function trackPhaseEndDateChanged(
   await trackEventWithContext(
     userId,
     'phase_end_date_changed',
-    getDecisionCommonProperties(processId, undefined, additionalProps),
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      additionalProps,
+    }),
   );
 }

--- a/services/api/src/routers/decision/instances/getInstance.ts
+++ b/services/api/src/routers/decision/instances/getInstance.ts
@@ -30,10 +30,6 @@ export const getLegacyInstanceRouter = router({
         user,
       });
 
-      // Note: the `process_viewed` analytics event is tracked client-side in
-      // DecisionHeader so it fires on an actual view rather than on every query
-      // execution (prefetch/refetch/invalidation).
-
       return legacyProcessInstanceEncoder.parse({
         ...instance,
         instanceData: instance.instanceData,
@@ -74,10 +70,6 @@ export const getInstanceRouter = router({
         instanceId: input.instanceId,
         user,
       });
-
-      // Note: the `process_viewed` analytics event is tracked client-side in
-      // DecisionHeader so it fires on an actual view rather than on every query
-      // execution (prefetch/refetch/invalidation).
 
       ctx.registerQueryChannels([Channels.decisionInstance(input.instanceId)]);
 

--- a/services/api/src/routers/decision/instances/getInstance.ts
+++ b/services/api/src/routers/decision/instances/getInstance.ts
@@ -1,5 +1,4 @@
 import { Channels, getInstance } from '@op/common';
-import { waitUntil } from '@vercel/functions';
 
 import {
   getInstanceInputSchema,
@@ -10,7 +9,6 @@ import {
   legacyProcessInstanceEncoder,
 } from '../../../encoders/legacyDecision';
 import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
-import { trackProcessViewed } from '../../../utils/analytics';
 
 /**
  * Legacy getInstance endpoint - uses legacy encoders with state-based format.
@@ -32,8 +30,9 @@ export const getLegacyInstanceRouter = router({
         user,
       });
 
-      // Track process viewed event
-      waitUntil(trackProcessViewed(ctx, input.instanceId));
+      // Note: the `process_viewed` analytics event is tracked client-side in
+      // DecisionHeader so it fires on an actual view rather than on every query
+      // execution (prefetch/refetch/invalidation).
 
       return legacyProcessInstanceEncoder.parse({
         ...instance,
@@ -76,8 +75,9 @@ export const getInstanceRouter = router({
         user,
       });
 
-      // Track process viewed event
-      waitUntil(trackProcessViewed(ctx, input.instanceId));
+      // Note: the `process_viewed` analytics event is tracked client-side in
+      // DecisionHeader so it fires on an actual view rather than on every query
+      // execution (prefetch/refetch/invalidation).
 
       ctx.registerQueryChannels([Channels.decisionInstance(input.instanceId)]);
 

--- a/services/api/src/routers/decision/proposals/get.ts
+++ b/services/api/src/routers/decision/proposals/get.ts
@@ -45,10 +45,6 @@ export const getProposalRouter = router({
         return { access: undefined };
       });
 
-      // Note: the `proposal_viewed` analytics event is tracked client-side in
-      // ProposalView so it fires on an actual view rather than on every query
-      // execution (prefetch/refetch/invalidation/editor+review fetches).
-
       ctx.registerQueryChannels([
         Channels.decisionProposal(proposal.processInstanceId, proposal.id),
       ]);

--- a/services/api/src/routers/decision/proposals/get.ts
+++ b/services/api/src/routers/decision/proposals/get.ts
@@ -3,11 +3,9 @@ import { Channels, getPermissionsOnProposal, getProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 import { ProposalStatus } from '@op/db/schema';
 import { logger } from '@op/logging';
-import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
 import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
-import { trackProposalViewed } from '../../../utils/analytics';
 
 export const getProposalRouter = router({
   getProposal: networkAuthenticatedProcedure()
@@ -47,17 +45,9 @@ export const getProposalRouter = router({
         return { access: undefined };
       });
 
-      // Track proposal viewed event
-      if (
-        proposal.processInstance &&
-        typeof proposal.processInstance === 'object' &&
-        !Array.isArray(proposal.processInstance) &&
-        'id' in proposal.processInstance
-      ) {
-        waitUntil(
-          trackProposalViewed(ctx, proposal.processInstance.id, proposal.id),
-        );
-      }
+      // Note: the `proposal_viewed` analytics event is tracked client-side in
+      // ProposalView so it fires on an actual view rather than on every query
+      // execution (prefetch/refetch/invalidation/editor+review fetches).
 
       ctx.registerQueryChannels([
         Channels.decisionProposal(proposal.processInstanceId, proposal.id),

--- a/services/api/src/utils/analytics.ts
+++ b/services/api/src/utils/analytics.ts
@@ -4,12 +4,10 @@ import {
   trackImageUpload as trackImageUploadOriginal,
   trackManualSelectionSubmitted as trackManualSelectionSubmittedOriginal,
   trackManualTransitionConfirmed as trackManualTransitionConfirmedOriginal,
-  trackProcessViewed as trackProcessViewedOriginal,
   trackProposalCommented as trackProposalCommentedOriginal,
   trackProposalFollowed as trackProposalFollowedOriginal,
   trackProposalLiked as trackProposalLikedOriginal,
   trackProposalSubmitted as trackProposalSubmittedOriginal,
-  trackProposalViewed as trackProposalViewedOriginal,
   trackRelationshipAccepted as trackRelationshipAcceptedOriginal,
   trackRelationshipAdded as trackRelationshipAddedOriginal,
   trackUserPost as trackUserPostOriginal,
@@ -51,34 +49,6 @@ export const trackProposalFollowed = (
   additionalProps?: Record<string, any>,
 ) => {
   return trackProposalFollowedOriginal(
-    ctx.user.id,
-    processId,
-    proposalId,
-    additionalProps,
-  );
-};
-
-/**
- * Track a process being viewed with automatic context injection
- */
-export const trackProcessViewed = (
-  ctx: AnalyticsContext,
-  processId: string,
-  additionalProps?: Record<string, any>,
-) => {
-  return trackProcessViewedOriginal(ctx.user.id, processId, additionalProps);
-};
-
-/**
- * Track a proposal being viewed with automatic context injection
- */
-export const trackProposalViewed = (
-  ctx: AnalyticsContext,
-  processId: string,
-  proposalId: string,
-  additionalProps?: Record<string, any>,
-) => {
-  return trackProposalViewedOriginal(
     ctx.user.id,
     processId,
     proposalId,


### PR DESCRIPTION
The proposal_viewed and process_viewed events fired inside the getProposal/getInstance query procedures, so they re-fired on every prefetch, refetch, and cache invalidation (including when the proposal editor or review summary fetched the same query). Moving them into the view components fires them once per viewed entity and lets the client-side common properties (location/timezone/language) populate.