### PR TITLE
fix(app): build with webpack to eliminate Turbopack RSC manifest 500s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,3 @@ ralph.sh
 # Local-only PRDs and verification artifacts
 tasks/
 .gstack/
-
-# Local preview validation scratch scripts (may contain session tokens) — never commit
-tests/e2e/preview-*.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ ralph.sh
 # Local-only PRDs and verification artifacts
 tasks/
 .gstack/
+
+# Local preview validation scratch scripts (may contain session tokens) — never commit
+tests/e2e/preview-*.mjs

--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -73,34 +73,37 @@ const config = {
         : {}),
     },
   },
-  // Webpack equivalent of the turbopack resolveAlias above. The production build
-  // uses webpack (`next build --webpack`) because Turbopack's per-route partial
-  // client-reference manifests cause intermittent "Could not find module ... in
-  // the React Client Manifest" 500s on cross-route RSC navigation
-  // (Asana 1213980160576009; bug entered with the Turbopack migration #685).
-  // Webpack resolves client references across routes correctly. Dev/e2e keep
-  // Turbopack via the config above.
+  // Webpack equivalent of the turbopack resolveAlias above. Both the production
+  // build and e2e build use webpack (`next build --webpack`) because Turbopack's
+  // per-route partial client-reference manifests cause intermittent "Could not
+  // find module ... in the React Client Manifest" 500s on cross-route RSC
+  // navigation (Asana 1213980160576009; bug entered with the Turbopack migration
+  // #685). Webpack resolves client references across routes correctly. Dev still
+  // uses Turbopack via the config above.
   webpack: (config, { isServer }) => {
+    config.resolve = config.resolve || {};
     if (!isServer) {
-      config.resolve = config.resolve || {};
       // Disable the 'tls' node core module on the client side.
       config.resolve.fallback = {
         ...(config.resolve.fallback || {}),
         tls: false,
       };
-      if (process.env.E2E === 'true') {
-        config.resolve.alias = {
-          ...(config.resolve.alias || {}),
-          '@op/collab': path.resolve(
-            __dirname,
-            '../../services/collab/__mocks__/index.ts',
-          ),
-          '@op/analytics/client': path.resolve(
-            __dirname,
-            '../../packages/analytics/src/client.testing.ts',
-          ),
-        };
-      }
+    }
+    // In e2e mode, swap external services for in-process mocks on both the
+    // server and client bundles (mirrors turbopack.resolveAlias, which is not
+    // server/client-scoped) so SSR of these modules is mocked too.
+    if (process.env.E2E === 'true') {
+      config.resolve.alias = {
+        ...(config.resolve.alias || {}),
+        '@op/collab': path.resolve(
+          __dirname,
+          '../../services/collab/__mocks__/index.ts',
+        ),
+        '@op/analytics/client': path.resolve(
+          __dirname,
+          '../../packages/analytics/src/client.testing.ts',
+        ),
+      };
     }
     return config;
   },

--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -3,6 +3,10 @@ import { getPreviewApiUrl } from '@op/core/previews';
 import { withPostHogConfig } from '@posthog/nextjs-config';
 import dotenv from 'dotenv';
 import createNextIntlPlugin from 'next-intl/plugin';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const withNextIntl = createNextIntlPlugin('./src/lib/i18n/request.ts');
 
@@ -68,6 +72,34 @@ const config = {
           }
         : {}),
     },
+  },
+  // Webpack equivalent of the turbopack resolveAlias above. The production build
+  // uses webpack (`next build --webpack`) because Turbopack's per-route partial
+  // client-reference manifests cause intermittent "Could not find module ... in
+  // the React Client Manifest" 500s on cross-route RSC navigation
+  // (Asana 1213980160576009; bug entered with the Turbopack migration #685).
+  // Webpack resolves client references across routes correctly. Dev/e2e keep
+  // Turbopack via the config above.
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.resolve = config.resolve || {};
+      // Disable the 'tls' node core module on the client side.
+      config.resolve.fallback = { ...(config.resolve.fallback || {}), tls: false };
+      if (process.env.E2E === 'true') {
+        config.resolve.alias = {
+          ...(config.resolve.alias || {}),
+          '@op/collab': path.resolve(
+            __dirname,
+            '../../services/collab/__mocks__/index.ts',
+          ),
+          '@op/analytics/client': path.resolve(
+            __dirname,
+            '../../packages/analytics/src/client.testing.ts',
+          ),
+        };
+      }
+    }
+    return config;
   },
   async headers() {
     return [

--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -84,7 +84,10 @@ const config = {
     if (!isServer) {
       config.resolve = config.resolve || {};
       // Disable the 'tls' node core module on the client side.
-      config.resolve.fallback = { ...(config.resolve.fallback || {}), tls: false };
+      config.resolve.fallback = {
+        ...(config.resolve.fallback || {}),
+        tls: false,
+      };
       if (process.env.E2E === 'true') {
         config.resolve.alias = {
           ...(config.resolve.alias || {}),

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -5,8 +5,8 @@
   "license": "SEE LICENSE in /LICENSE",
   "type": "module",
   "scripts": {
-    "build": "next build",
-    "build:e2e": "NEXT_PUBLIC_APP_PORT=4100 NEXT_PUBLIC_API_PORT=4300 next build",
+    "build": "next build --webpack",
+    "build:e2e": "NEXT_PUBLIC_APP_PORT=4100 NEXT_PUBLIC_API_PORT=4300 next build --webpack",
     "check:i18n": "tsx scripts/check-missing-intl-keys.ts",
     "dev": "next dev -p 3100",
     "dev:e2e": "NEXT_PUBLIC_APP_PORT=4100 NEXT_PUBLIC_API_PORT=4300 next dev -p 4100",

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/edit/page.tsx
@@ -48,11 +48,7 @@ import { useRestoreProposalVersion } from '@/components/decisions/proposalEditor
  * Yjs connection, and draft state are never remounted while the aside
  * panel is opened or closed.
  */
-export default function ProposalEditorLayout({
-  children: _children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function ProposalEditorLayout() {
   const { profileId, slug } = useParams<{
     profileId: string;
     slug: string;

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/edit/page.tsx
@@ -48,7 +48,11 @@ import { useRestoreProposalVersion } from '@/components/decisions/proposalEditor
  * Yjs connection, and draft state are never remounted while the aside
  * panel is opened or closed.
  */
-export default function ProposalEditorLayout() {
+export default function ProposalEditorLayout({
+  children: _children,
+}: {
+  children: React.ReactNode;
+}) {
   const { profileId, slug } = useParams<{
     profileId: string;
     slug: string;

--- a/apps/app/src/lib/i18n/routing.tsx
+++ b/apps/app/src/lib/i18n/routing.tsx
@@ -45,17 +45,6 @@ const {
   useRouter,
 } = createNavigation(routing);
 
-// prefetch was previously forced {false} to work around the intermittent
-// "Could not find module ... in the React Client Manifest" 500
-// (Asana 1213980160576009). That 500 is now fixed structurally by unifying the
-// (main)/(no-header) route groups under a single layout (see
-// app/[locale]/(app)/layout.tsx), which removes the cross-route-group layout swap
-// that broke RSC manifest resolution — so prefetch is re-enabled for snappier nav.
-//
-// Caveat: with prefetch enabled, Next/Turbopack still emits a few NON-fatal manifest
-// errors when a *prefetch* render carries a sibling route's router-state-tree (logged
-// only, no 500, navigation returns 200). This is the upstream Turbopack bug
-// (vercel/next.js #52862/#72903); revisit on Next upgrades.
 const Link = ({
   children,
   className,

--- a/apps/app/src/lib/i18n/routing.tsx
+++ b/apps/app/src/lib/i18n/routing.tsx
@@ -55,10 +55,10 @@ const Link = ({
     <NavLink
       {...props}
       className={cn('hover:underline', className)}
-      // Keep prefetch off: under Turbopack (dev/e2e) it reintroduces the RSC
-      // manifest 500 on cross-route navigation. The webpack production build
-      // resolves the manifest correctly, but dev/e2e still run Turbopack.
-      prefetch={false}
+      // prefetch is safe with the webpack build (prod + e2e), which resolves the
+      // RSC client manifest correctly. Local `dev` still uses Turbopack, where
+      // cross-route prefetch can surface the manifest 500.
+      prefetch={true}
     >
       {children}
     </NavLink>

--- a/apps/app/src/lib/i18n/routing.tsx
+++ b/apps/app/src/lib/i18n/routing.tsx
@@ -55,7 +55,10 @@ const Link = ({
     <NavLink
       {...props}
       className={cn('hover:underline', className)}
-      prefetch={true}
+      // Keep prefetch off: under Turbopack (dev/e2e) it reintroduces the RSC
+      // manifest 500 on cross-route navigation. The webpack production build
+      // resolves the manifest correctly, but dev/e2e still run Turbopack.
+      prefetch={false}
     >
       {children}
     </NavLink>

--- a/apps/app/src/lib/i18n/routing.tsx
+++ b/apps/app/src/lib/i18n/routing.tsx
@@ -45,10 +45,17 @@ const {
   useRouter,
 } = createNavigation(routing);
 
-// prefetch={false} works around a Next.js prefetch bug that causes intermittent 500s.
-// With prefetch enabled, the server generates RSC payloads that reference client modules
-// not found in the React Client Manifest, producing:
-//   "Could not find the module ... in the React Client Manifest"
+// prefetch was previously forced {false} to work around the intermittent
+// "Could not find module ... in the React Client Manifest" 500
+// (Asana 1213980160576009). That 500 is now fixed structurally by unifying the
+// (main)/(no-header) route groups under a single layout (see
+// app/[locale]/(app)/layout.tsx), which removes the cross-route-group layout swap
+// that broke RSC manifest resolution — so prefetch is re-enabled for snappier nav.
+//
+// Caveat: with prefetch enabled, Next/Turbopack still emits a few NON-fatal manifest
+// errors when a *prefetch* render carries a sibling route's router-state-tree (logged
+// only, no 500, navigation returns 200). This is the upstream Turbopack bug
+// (vercel/next.js #52862/#72903); revisit on Next upgrades.
 const Link = ({
   children,
   className,
@@ -59,7 +66,7 @@ const Link = ({
     <NavLink
       {...props}
       className={cn('hover:underline', className)}
-      prefetch={false}
+      prefetch={true}
     >
       {children}
     </NavLink>


### PR DESCRIPTION
Switch the app build to webpack to avoid intermittent Turbopack RSC manifest failures behind the recurring 500s.