### PR TITLE
refactor(decisions): address non-blocking PR #1257 review comments

### DIFF
--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -53,8 +53,8 @@ export const resolveAccessUserIds = (user?: AccessUser): string[] =>
 
 /**
  * Cache key for the durable `orgUser` cache. Shared by the write site and every
- * invalidator so the key shape can't drift — the resolved id set (own ∪ public)
- * is part of the identity, so a stale `[organizationId, user.id]` key would miss
+ * invalidator so the key shape can't drift — the resolved id set (own plus
+ * public) is part of the identity, so a stale `[organizationId, user.id]` key would miss
  * and serve removed/demoted members their old roles until TTL.
  */
 export const orgUserCacheKey = ({
@@ -67,7 +67,7 @@ export const orgUserCacheKey = ({
 
 /**
  * Cache key for profile-access lookups. Mirrors {@link orgUserCacheKey}: the
- * resolved id set (own ∪ public) is part of the identity. NOTE:
+ * resolved id set (own plus public) is part of the identity. NOTE:
  * {@link getProfileAccessUser} has no durable cache today, so this currently
  * only keys the request-scoped memo — but it keeps the shape in one place for
  * symmetry and if a durable profile-access cache is ever added.
@@ -81,9 +81,9 @@ export const profileUserCacheKey = ({
 }): [string, string] => [profileId, resolveAccessUserIds(user).join(':')];
 
 /**
- * Collapse the grant rows matched for a caller (their own ∪ the public
+ * Merge the grant rows matched for a caller (their own grant plus the public
  * {@link GLOBAL_USER_PUBLIC} grant) into a single access record: prefer the
- * caller's own row for identity fields, but union the roles across every
+ * caller's own row for identity fields, but collect the roles across every
  * matched row. `rows` must be non-empty.
  */
 const mergeGrantRows = <

--- a/packages/common/src/services/decision/getProposalsForPhase.ts
+++ b/packages/common/src/services/decision/getProposalsForPhase.ts
@@ -12,6 +12,7 @@ import {
   isNull,
   lt,
   ne,
+  sql,
 } from '@op/db/client';
 import type { Proposal } from '@op/db/schema';
 import {
@@ -326,28 +327,30 @@ export async function getProposalIdsForPhase({
 export async function getPhaseProposalAndDraftIds({
   instance,
   phaseId,
-  authUserIds,
+  ownerAuthUserId,
   db = defaultDb,
 }: {
   instance: PhaseScopedInstance;
   phaseId?: string;
-  authUserIds: string[];
+  ownerAuthUserId: string | undefined;
   db?: DbClient;
 }): Promise<{ nonDraftIds: string[]; draftIds: string[] }> {
   const ctx = deriveInstanceContext(instance);
   const instanceId = instance.id;
 
   const nonDraftPredicate = ne(proposals.status, ProposalStatus.DRAFT);
-  const draftAccessPredicate = and(
-    eq(proposals.status, ProposalStatus.DRAFT),
-    inArray(
-      proposals.profileId,
-      db
-        .select({ profileId: profileUsers.profileId })
-        .from(profileUsers)
-        .where(inArray(profileUsers.authUserId, authUserIds)),
-    ),
-  );
+  const draftAccessPredicate = ownerAuthUserId
+    ? and(
+        eq(proposals.status, ProposalStatus.DRAFT),
+        inArray(
+          proposals.profileId,
+          db
+            .select({ profileId: profileUsers.profileId })
+            .from(profileUsers)
+            .where(eq(profileUsers.authUserId, ownerAuthUserId)),
+        ),
+      )
+    : sql`false`;
 
   const resolvedPhaseId = ctx.isLegacy
     ? undefined

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -169,9 +169,7 @@ export const listProposals = async ({
   if (user) {
     try {
       currentProfileId = await getCurrentProfileId(user.id);
-    } catch {
-      currentProfileId = undefined;
-    }
+    } catch {}
   }
 
   // Caller's own grants unioned with public (GLOBAL_USER_PUBLIC) grants — used

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -18,7 +18,6 @@ import {
   type ProfileUserWithNormalizedRoles,
   assertInstanceProfileAccess,
   getCurrentProfileId,
-  resolveAccessUserIds,
 } from '../access';
 import { getProposalDocumentsContent } from './getProposalDocumentsContent';
 import { getProposalRelationshipData } from './getProposalRelationshipData';
@@ -172,12 +171,7 @@ export const listProposals = async ({
     } catch {}
   }
 
-  // Caller's own grants unioned with public (GLOBAL_USER_PUBLIC) grants — used
-  // for the draft and HIDDEN visibility subqueries below.
-  // INVARIANT: public grants must only be placed on the process/decision
-  // profile, never on an individual proposal profile — otherwise this would
-  // surface every caller's drafts/HIDDEN proposals to the public.
-  const accessUserIds = resolveAccessUserIds(user);
+  const ownerAuthUserId = user?.id;
 
   // Fetch the instance row up front and resolve the explicit ID scope in
   // parallel. The row is reused for the phase-resolution context (instead of
@@ -234,7 +228,7 @@ export const listProposals = async ({
     const ids = await getPhaseProposalAndDraftIds({
       instance,
       phaseId: input.phaseId,
-      authUserIds: accessUserIds,
+      ownerAuthUserId,
     });
     return { phaseProposalIds: ids.nonDraftIds, phaseDraftIds: ids.draftIds };
   })();
@@ -372,20 +366,23 @@ export const listProposals = async ({
     // invited collaborators on the proposal's profile — same pattern the
     // draft filter uses, so a collaborator's view of a co-authored proposal
     // doesn't change the moment it's submitted with HIDDEN visibility.
+    const ownsProposalProfile = ownerAuthUserId
+      ? inArray(
+          t.profileId,
+          db
+            .select({ profileId: profileUsers.profileId })
+            .from(profileUsers)
+            .where(eq(profileUsers.authUserId, ownerAuthUserId)),
+        )
+      : undefined;
+
     const nonDraftVisibilityFilter = canManageProposals
       ? phaseScopedNonDraftIdFilter
       : and(
           phaseScopedNonDraftIdFilter,
-          or(
-            eq(t.visibility, Visibility.VISIBLE),
-            inArray(
-              t.profileId,
-              db
-                .select({ profileId: profileUsers.profileId })
-                .from(profileUsers)
-                .where(inArray(profileUsers.authUserId, accessUserIds)),
-            ),
-          )!,
+          ownsProposalProfile
+            ? or(eq(t.visibility, Visibility.VISIBLE), ownsProposalProfile)!
+            : eq(t.visibility, Visibility.VISIBLE),
         )!;
 
     return and(clause, or(draftFilter, nonDraftVisibilityFilter)!)!;

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -348,9 +348,7 @@ export const getVotingStatus = async ({
     if (user) {
       try {
         profileId = await getIndividualProfileId(user.id);
-      } catch {
-        profileId = undefined;
-      }
+      } catch {}
     }
 
     // Get process instance and schema
@@ -388,14 +386,11 @@ export const getVotingStatus = async ({
     // Check if user has voted
     let voteSubmission = null;
     if (profileId) {
-      voteSubmission = await db._query.decisionsVoteSubmissions.findFirst({
-        where: and(
-          eq(
-            decisionsVoteSubmissions.processInstanceId,
-            data.processInstanceId,
-          ),
-          eq(decisionsVoteSubmissions.submittedByProfileId, profileId),
-        ),
+      voteSubmission = await db.query.decisionsVoteSubmissions.findFirst({
+        where: {
+          processInstanceId: data.processInstanceId,
+          submittedByProfileId: profileId,
+        },
         with: {
           voteProposals: {
             with: {

--- a/services/api/src/routers/decision/proposals/get.ts
+++ b/services/api/src/routers/decision/proposals/get.ts
@@ -9,7 +9,7 @@ export const getProposalRouter = router({
   /**
    * NOTE: not wrapped in a shared `cache()` here. The cache key is keyed by
    * profileId only (no caller identity), so a cache hit would serve the
-   * proposal to a non-member and bypass the authz inside `getProposal`. The
+   * proposal to a non-member and bypass the authorization inside `getProposal`. The
    * proposal is fetched (and authorized) on every request.
    */
   getProposal: openProcedure()

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -1,4 +1,5 @@
 import { mockCollab, textFragment } from '@op/collab/testing';
+import { GLOBAL_USER_PUBLIC } from '@op/core';
 import { db } from '@op/db/client';
 import {
   ProcessStatus,
@@ -267,6 +268,115 @@ describe.concurrent('listProposals', () => {
     // Non-admin should only see visible proposal
     expect(result.proposals).toHaveLength(1);
     expect(result.proposals[0]?.id).toBe(visibleProposal.id);
+  });
+
+  it('does NOT surface a HIDDEN proposal via a public grant on the proposal profile', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const [visibleProposal, hiddenProposal, adminCaller, memberUser] =
+      await Promise.all([
+        testData.createProposal({
+          userEmail: setup.userEmail,
+          processInstanceId: instance.instance.id,
+          proposalData: { title: 'Visible Proposal' },
+        }),
+        testData.createProposal({
+          userEmail: setup.userEmail,
+          processInstanceId: instance.instance.id,
+          proposalData: { title: 'Hidden Proposal' },
+        }),
+        createAuthenticatedCaller(setup.userEmail),
+        testData.createMemberUser({
+          organization: setup.organization,
+          instanceProfileIds: [instance.profileId],
+        }),
+      ]);
+
+    await Promise.all([
+      adminCaller.decision.submitProposal({ proposalId: visibleProposal.id }),
+      adminCaller.decision.submitProposal({ proposalId: hiddenProposal.id }),
+    ]);
+
+    await adminCaller.decision.updateProposal({
+      proposalId: hiddenProposal.id,
+      data: { visibility: Visibility.HIDDEN },
+    });
+
+    await testData.grantProfileAccess(
+      hiddenProposal.profileId!,
+      GLOBAL_USER_PUBLIC,
+      'public-sentinel@example.com',
+      false,
+    );
+
+    const memberCaller = await createAuthenticatedCaller(memberUser.email);
+    const result = await memberCaller.decision.listProposals({
+      processInstanceId: instance.instance.id,
+    });
+
+    expect(result.proposals).toHaveLength(1);
+    expect(result.proposals[0]?.id).toBe(visibleProposal.id);
+  });
+
+  it('does NOT surface a draft proposal via a public grant on the proposal profile', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const [creator, memberUser] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+    ]);
+
+    const draftProposal = await testData.createProposal({
+      userEmail: creator.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Private Draft' },
+    });
+
+    await testData.grantProfileAccess(
+      draftProposal.profileId!,
+      GLOBAL_USER_PUBLIC,
+      'public-sentinel@example.com',
+      false,
+    );
+
+    const memberCaller = await createAuthenticatedCaller(memberUser.email);
+    const result = await memberCaller.decision.listProposals({
+      processInstanceId: instance.instance.id,
+    });
+
+    expect(result.proposals.map((p) => p.id)).not.toContain(draftProposal.id);
   });
 
   it('should show hidden proposals to admin users', async ({

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -842,4 +842,47 @@ export const relations = defineRelations(schema, (r) => ({
       alias: 'moderationFlag_flaggedBy',
     }),
   },
+
+  /**
+   * Decision vote submission relations
+   *
+   * processInstanceId and submittedByProfileId are NOT NULL. A submission
+   * fans out to its selected proposals via the decisionsVoteProposals junction.
+   */
+  decisionsVoteSubmissions: {
+    processInstance: r.one.processInstances({
+      from: r.decisionsVoteSubmissions.processInstanceId,
+      to: r.processInstances.id,
+      optional: false,
+    }),
+    submittedBy: r.one.profiles({
+      from: r.decisionsVoteSubmissions.submittedByProfileId,
+      to: r.profiles.id,
+      alias: 'decisionsVoteSubmission_submittedBy',
+      optional: false,
+    }),
+    voteProposals: r.many.decisionsVoteProposals({
+      from: r.decisionsVoteSubmissions.id,
+      to: r.decisionsVoteProposals.voteSubmissionId,
+    }),
+  },
+
+  /**
+   * Decision vote proposals relations (junction table)
+   *
+   * Links a vote submission to each proposal it selected. Both columns are
+   * NOT NULL.
+   */
+  decisionsVoteProposals: {
+    voteSubmission: r.one.decisionsVoteSubmissions({
+      from: r.decisionsVoteProposals.voteSubmissionId,
+      to: r.decisionsVoteSubmissions.id,
+      optional: false,
+    }),
+    proposal: r.one.proposals({
+      from: r.decisionsVoteProposals.proposalId,
+      to: r.proposals.id,
+      optional: false,
+    }),
+  },
 }));


### PR DESCRIPTION
Follow-up to #1257 applying non-blocking review feedback: doc wording cleanups, dropping redundant reassignments, and migrating the getVotingStatus vote-submission lookup to relations v2.