### PR TITLE
fix(styles): correct color tokens

### DIFF
--- a/packages/styles/intent-ui-theme.css
+++ b/packages/styles/intent-ui-theme.css
@@ -43,7 +43,7 @@
   --primary-fg: var(--color-white);
   --primary-subtle: color-mix(
     in srgb,
-    var(--color-primary-500) 15%,
+    var(--color-primary) 15%,
     transparent
   );
   --primary-subtle-fg: var(--color-primary-700);
@@ -84,11 +84,11 @@
   --success-subtle-fg: var(--color-functional-green-600);
 
   /* Info - teal */
-  --info: var(--color-primary-500);
+  --info: var(--color-primary);
   --info-fg: var(--color-white);
   --info-subtle: color-mix(
     in srgb,
-    var(--color-primary-500) 15%,
+    var(--color-primary) 15%,
     transparent
   );
   --info-subtle-fg: var(--color-primary-700);
@@ -118,7 +118,7 @@
    * ============================================ */
   --border: var(--color-neutral-gray-1);
   --input: var(--color-neutral-gray-1);
-  --ring: var(--color-primary-500);
+  --ring: var(--color-primary);
 
   /* ============================================
    * Layout
@@ -130,19 +130,19 @@
   --sidebar-fg: var(--color-neutral-charcoal);
   --sidebar-primary: color-mix(
     in srgb,
-    var(--color-primary-500) 15%,
+    var(--color-primary) 15%,
     transparent
   );
   --sidebar-primary-fg: var(--color-primary-700);
   --sidebar-accent: var(--color-neutral-gray-1);
   --sidebar-accent-fg: var(--color-neutral-charcoal);
   --sidebar-border: var(--color-neutral-gray-1);
-  --sidebar-ring: var(--color-primary-500);
+  --sidebar-ring: var(--color-primary);
 
   /* ============================================
    * Charts
    * ============================================ */
-  --chart-1: var(--color-primary-500);
+  --chart-1: var(--color-primary);
   --chart-2: var(--color-functional-green-600);
   --chart-3: var(--color-primary-yellow-500);
   --chart-4: var(--color-data-purple);
@@ -155,11 +155,11 @@
   --bg: var(--color-neutral-black);
   --fg: var(--color-neutral-off-white);
 
-  --primary: var(--color-primary-500);
+  --primary: var(--color-primary);
   --primary-fg: var(--color-neutral-black);
   --primary-subtle: color-mix(
     in srgb,
-    var(--color-primary-500) 10%,
+    var(--color-primary) 10%,
     transparent
   );
   --primary-subtle-fg: var(--color-primary-100);
@@ -191,7 +191,7 @@
 
   --info-subtle: color-mix(
     in srgb,
-    var(--color-primary-500) 10%,
+    var(--color-primary) 10%,
     transparent
   );
   --info-subtle-fg: var(--color-primary-100);
@@ -220,7 +220,7 @@
   --sidebar-fg: var(--color-neutral-off-white);
   --sidebar-primary: color-mix(
     in srgb,
-    var(--color-primary-500) 10%,
+    var(--color-primary) 10%,
     transparent
   );
   --sidebar-primary-fg: var(--color-primary-100);

--- a/packages/styles/sense-theme.css
+++ b/packages/styles/sense-theme.css
@@ -158,7 +158,7 @@
    * of what shared-styles/intent-ui-theme also declares. */
   --border: var(--color-neutral-gray-2);
   --input: var(--color-neutral-gray-2);
-  --ring: var(--color-primary-500);
+  --ring: var(--color-primary);
 
   /* `--radius` is the base radius shadcn primitives derive their scale from
    * (and consume directly, e.g. `rounded-[var(--radius)]`). Safe to declare
@@ -168,15 +168,15 @@
   /* Sidebar */
   --sidebar: var(--color-neutral-off-white);
   --sidebar-foreground: var(--color-neutral-charcoal);
-  --sidebar-primary: var(--color-primary-500);
+  --sidebar-primary: var(--color-primary);
   --sidebar-primary-foreground: var(--color-white);
   --sidebar-accent: var(--color-neutral-gray-1);
   --sidebar-accent-foreground: var(--color-neutral-charcoal);
   --sidebar-border: var(--color-neutral-gray-2);
-  --sidebar-ring: var(--color-primary-500);
+  --sidebar-ring: var(--color-primary);
 
   /* Chart palette — uses brand + data tokens */
-  --chart-1: var(--color-primary-500);
+  --chart-1: var(--color-primary);
   --chart-2: var(--color-primary-yellow-500);
   --chart-3: var(--color-primary-orange-500);
   --chart-4: var(--color-data-purple);


### PR DESCRIPTION
Replace undefined `--color-primary-500` refs with `--color-primary`.

`--color-primary-500` was never mapped in the Tailwind `@theme` layer (`shared-styles.css` only maps 50/100/600/700), so every `var()` referencing it resolved to nothing. Most visibly, `--ring` fell back to `currentColor`, rendering focus rings as solid charcoal instead of 50%-alpha teal.

Affects `--ring`, `--sidebar-ring`, `--sidebar-primary`, `--chart-1`, `--info`, and the `primary`/`info` subtle color-mix values in both `sense-theme.css` and `intent-ui-theme.css`.