### PR TITLE
feat(decisions): render overview page hero and about body

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/page.tsx
@@ -52,15 +52,22 @@ const CurrentPhasePage = async ({
   const { decisionProfile, instanceId, ownerSlug } = await loadDecision(slug);
 
   return (
-    <Suspense fallback={<DecisionContentSkeleton />}>
-      <CurrentPhaseView
-        instanceId={instanceId}
-        ownerSlug={ownerSlug}
-        decisionSlug={slug}
-        decisionProfileId={decisionProfile.id}
-        isAdmin={decisionProfile.processInstance?.access?.admin}
-      />
-    </Suspense>
+    // On mobile the Overview / Current Phase toggle floats below the sticky
+    // header (DecisionInstanceHeader renders centerSlot as an overlay), so the
+    // page content needs top clearance for it. Route-scoped on purpose: the
+    // legacy /decisions/[slug] page renders the same phase components without
+    // the toggle and must not get this space.
+    <div className="pt-16 md:pt-0">
+      <Suspense fallback={<DecisionContentSkeleton />}>
+        <CurrentPhaseView
+          instanceId={instanceId}
+          ownerSlug={ownerSlug}
+          decisionSlug={slug}
+          decisionProfileId={decisionProfile.id}
+          isAdmin={decisionProfile.processInstance?.access?.admin}
+        />
+      </Suspense>
+    </div>
   );
 };
 

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/page.tsx
@@ -52,12 +52,7 @@ const CurrentPhasePage = async ({
   const { decisionProfile, instanceId, ownerSlug } = await loadDecision(slug);
 
   return (
-    // On mobile the Overview / Current Phase toggle floats below the sticky
-    // header (DecisionInstanceHeader renders centerSlot as an overlay), so the
-    // page content needs top clearance for it. Route-scoped on purpose: the
-    // legacy /decisions/[slug] page renders the same phase components without
-    // the toggle and must not get this space.
-    <div className="pt-16 md:pt-0">
+    <div className="bg-neutral-offWhite pt-8 md:pt-0">
       <Suspense fallback={<DecisionContentSkeleton />}>
         <CurrentPhaseView
           instanceId={instanceId}

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -10,6 +10,7 @@ import { redirect } from '@/lib/i18n/routing';
 
 import { DecisionHeader } from '@/components/decisions/DecisionHeader';
 import { DecisionSidePanel } from '@/components/decisions/DecisionSidePanel';
+import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
 import { DecisionViewToggle } from '@/components/decisions/DecisionViewToggle';
 
 import { loadDecision } from './loadDecision';
@@ -48,21 +49,22 @@ const DecisionViewLayout = async ({
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <DecisionHeader
-        instanceId={instanceId}
-        decisionSlug={slug}
-        isAdmin={access?.admin}
-        canReadUpdates={access?.admin === true || access?.read === true}
-        profileName={decisionProfile.name}
-        showStepper={false}
-        centerSlot={<DecisionViewToggle decisionSlug={slug} />}
-      >
+      <DecisionTranslationProvider>
+        <DecisionHeader
+          instanceId={instanceId}
+          decisionSlug={slug}
+          isAdmin={access?.admin}
+          canReadUpdates={access?.admin === true || access?.read === true}
+          profileName={decisionProfile.name}
+          showStepper={false}
+          centerSlot={<DecisionViewToggle decisionSlug={slug} />}
+        />
         {children}
         <DecisionSidePanel
           decisionProfileId={decisionProfile.id}
           access={access}
         />
-      </DecisionHeader>
+      </DecisionTranslationProvider>
     </HydrationBoundary>
   );
 };

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
@@ -44,16 +44,11 @@ const DecisionOverviewPage = async ({
   params: Promise<{ slug: string }>;
 }) => {
   const { slug } = await params;
-  const { decisionProfile, instanceId, ownerSlug } = await loadDecision(slug);
+  const { instanceId } = await loadDecision(slug);
 
   return (
     <Suspense fallback={<DecisionContentSkeleton />}>
-      <DecisionOverviewSuspense
-        instanceId={instanceId}
-        slug={ownerSlug}
-        decisionSlug={slug}
-        decisionProfileId={decisionProfile.id}
-      />
+      <DecisionOverviewSuspense instanceId={instanceId} decisionSlug={slug} />
     </Suspense>
   );
 };

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { Suspense } from 'react';
 import { DecisionHeader } from '@/components/decisions/DecisionHeader';
 import { DecisionSidePanel } from '@/components/decisions/DecisionSidePanel';
 import { DecisionStateRouter } from '@/components/decisions/DecisionStateRouter';
+import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
 import { DecisionContentSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
 export async function generateMetadata({
@@ -77,29 +78,32 @@ const DecisionPageContent = async ({ slug }: { slug: string }) => {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <DecisionHeader
-        instanceId={instanceId}
-        decisionSlug={slug}
-        isAdmin={decisionProfile.processInstance.access?.admin}
-        canReadUpdates={
-          decisionProfile.processInstance.access?.admin === true ||
-          decisionProfile.processInstance.access?.read === true
-        }
-        profileName={decisionProfile.name}
-      >
-        <Suspense fallback={<DecisionContentSkeleton />}>
-          <DecisionStateRouter
+      <div className="bg-neutral-offWhite text-gray-700">
+        <DecisionTranslationProvider>
+          <DecisionHeader
             instanceId={instanceId}
-            slug={ownerSlug}
             decisionSlug={slug}
-            decisionProfileId={decisionProfile.id}
+            isAdmin={decisionProfile.processInstance.access?.admin}
+            canReadUpdates={
+              decisionProfile.processInstance.access?.admin === true ||
+              decisionProfile.processInstance.access?.read === true
+            }
+            profileName={decisionProfile.name}
           />
-        </Suspense>
-        <DecisionSidePanel
-          decisionProfileId={decisionProfile.id}
-          access={decisionProfile.processInstance.access}
-        />
-      </DecisionHeader>
+          <Suspense fallback={<DecisionContentSkeleton />}>
+            <DecisionStateRouter
+              instanceId={instanceId}
+              slug={ownerSlug}
+              decisionSlug={slug}
+              decisionProfileId={decisionProfile.id}
+            />
+          </Suspense>
+          <DecisionSidePanel
+            decisionProfileId={decisionProfile.id}
+            access={decisionProfile.processInstance.access}
+          />
+        </DecisionTranslationProvider>
+      </div>
     </HydrationBoundary>
   );
 };

--- a/apps/app/src/app/[locale]/(no-header)/profile/[slug]/decisions/[id]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/profile/[slug]/decisions/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Suspense, cache } from 'react';
 
 import { DecisionHeader } from '@/components/decisions/DecisionHeader';
 import { DecisionStateRouter } from '@/components/decisions/DecisionStateRouter';
+import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
 
 // cache() dedupes the read across generateMetadata + page render (one request),
 // so the resolver and its "viewed" event fire once and the data hydrates.
@@ -80,15 +81,18 @@ const DecisionInstancePageContent = async ({
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <Suspense fallback={<DecisionHeaderSkeleton />}>
-        <DecisionHeader instanceId={instanceId} slug={slug} useLegacy>
-          <Suspense fallback={<Skeleton className="h-96" />}>
-            <DecisionStateRouter
-              instanceId={instanceId}
-              slug={slug}
-              useLegacy
-            />
-          </Suspense>
-        </DecisionHeader>
+        <div className="bg-neutral-offWhite text-gray-700">
+          <DecisionTranslationProvider>
+            <DecisionHeader instanceId={instanceId} slug={slug} useLegacy />
+            <Suspense fallback={<Skeleton className="h-96" />}>
+              <DecisionStateRouter
+                instanceId={instanceId}
+                slug={slug}
+                useLegacy
+              />
+            </Suspense>
+          </DecisionTranslationProvider>
+        </div>
       </Suspense>
     </HydrationBoundary>
   );

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -4,19 +4,15 @@ import { useTrackPageView } from '@/hooks/useTrackPageView';
 import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
 import { type ProcessPhase } from '@op/api/encoders';
-import { isLastPhase } from '@op/common/client';
-import { cn } from '@op/ui/utils';
 import { type ReactNode } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
 import { DecisionInstanceHeader } from '@/components/decisions/DecisionInstanceHeader';
 import { DecisionStepperBar } from '@/components/decisions/DecisionStepperBar';
-import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
 
 interface DecisionHeaderProps {
   instanceId: string;
-  children?: ReactNode;
   /** Decision profile slug for building the edit link */
   decisionSlug?: string;
   /** Whether the current user has admin access to this decision */
@@ -35,6 +31,12 @@ interface DecisionHeaderProps {
   showStepper?: boolean;
 }
 
+/**
+ * Header bar + optional phase stepper for a decision. Render inside a
+ * DecisionTranslationProvider — the stepper relies on it for phase-name
+ * translations. Backgrounds are owned by the page (e.g. the results hero),
+ * not the header.
+ */
 export function DecisionHeader(props: DecisionHeaderProps) {
   const { instanceId } = props;
 
@@ -52,7 +54,6 @@ export function DecisionHeader(props: DecisionHeaderProps) {
 
 function DecisionHeaderContent({
   instanceId,
-  children,
   decisionSlug,
   isAdmin,
   canReadUpdates,
@@ -76,18 +77,8 @@ function DecisionHeaderContent({
     advancementMethod: p.rules?.advancement?.method,
   }));
 
-  const isResultsView =
-    isLastPhase(instance.currentStateId, instancePhases) &&
-    instance.selectionsAreConfirmed === true;
-
   return (
-    <div
-      className={cn(
-        isResultsView
-          ? 'bg-redPurple text-neutral-offWhite'
-          : 'bg-neutral-offWhite text-gray-700',
-      )}
-    >
+    <>
       <DecisionInstanceHeader
         backTo={{ href: '/decisions' }}
         title={
@@ -102,25 +93,20 @@ function DecisionHeaderContent({
         canReadUpdates={canReadUpdates}
         centerSlot={centerSlot}
       />
-      <DecisionTranslationProvider>
-        {showStepper ? (
-          <DecisionStepperBar
-            phases={phases}
-            currentStateId={instance.currentStateId || ''}
-            instanceId={instanceId}
-            isAdmin={isAdmin}
-          />
-        ) : null}
-
-        {children}
-      </DecisionTranslationProvider>
-    </div>
+      {showStepper ? (
+        <DecisionStepperBar
+          phases={phases}
+          currentStateId={instance.currentStateId || ''}
+          instanceId={instanceId}
+          isAdmin={isAdmin}
+        />
+      ) : null}
+    </>
   );
 }
 
 function LegacyDecisionHeaderContent({
   instanceId,
-  children,
   decisionSlug,
   isAdmin,
   slug,
@@ -149,7 +135,7 @@ function LegacyDecisionHeaderContent({
   });
 
   return (
-    <div className="bg-redPurple text-neutral-offWhite">
+    <>
       <DecisionInstanceHeader
         backTo={{
           href: slug ? `/profile/${slug}?tab=decisions` : '/decisions',
@@ -158,16 +144,12 @@ function LegacyDecisionHeaderContent({
         decisionSlug={decisionSlug}
         isAdmin={isAdmin}
       />
-      <DecisionTranslationProvider>
-        <DecisionStepperBar
-          phases={phases}
-          currentStateId={instance.currentStateId || ''}
-          instanceId={instanceId}
-          isAdmin={isAdmin}
-        />
-
-        {children}
-      </DecisionTranslationProvider>
-    </div>
+      <DecisionStepperBar
+        phases={phases}
+        currentStateId={instance.currentStateId || ''}
+        instanceId={instanceId}
+        isAdmin={isAdmin}
+      />
+    </>
   );
 }

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -11,31 +11,42 @@ import { useTranslations } from '@/lib/i18n';
 import { DecisionInstanceHeader } from '@/components/decisions/DecisionInstanceHeader';
 import { DecisionStepperBar } from '@/components/decisions/DecisionStepperBar';
 
-interface DecisionHeaderProps {
+interface DecisionHeaderBaseProps {
   instanceId: string;
   /** Decision profile slug for building the edit link */
   decisionSlug?: string;
   /** Whether the current user has admin access to this decision */
   isAdmin?: boolean;
-  /** Whether the current user can read decision updates */
-  canReadUpdates?: boolean;
-  /** Use legacy getInstance endpoint (for /profile/[slug]/decisions/[id] route) */
-  useLegacy?: boolean;
-  /** Profile slug for back button — required when useLegacy is true */
-  slug?: string;
   /** Title from the decision profile */
   profileName?: string;
+}
+
+interface StandardDecisionHeaderProps extends DecisionHeaderBaseProps {
+  useLegacy?: false;
+  /** Whether the current user can read decision updates */
+  canReadUpdates?: boolean;
   /** Center-column content, e.g. the Overview / Current Phase toggle */
   centerSlot?: ReactNode;
   /** Whether to render the phase stepper below the header bar (default true) */
   showStepper?: boolean;
 }
 
+/** Legacy getInstance endpoint (for the /profile/[slug]/decisions/[id] route). */
+interface LegacyDecisionHeaderProps extends DecisionHeaderBaseProps {
+  useLegacy: true;
+  /** Profile slug for the back button */
+  slug: string;
+}
+
+type DecisionHeaderProps =
+  | StandardDecisionHeaderProps
+  | LegacyDecisionHeaderProps;
+
 /**
  * Header bar + optional phase stepper for a decision. Render inside a
  * DecisionTranslationProvider — the stepper relies on it for phase-name
- * translations. Backgrounds are owned by the page (e.g. the results hero),
- * not the header.
+ * translations. Decorative/hero backgrounds are owned by the page (e.g. the
+ * results hero); the header bar itself renders on white.
  */
 export function DecisionHeader(props: DecisionHeaderProps) {
   const { instanceId } = props;
@@ -60,7 +71,7 @@ function DecisionHeaderContent({
   profileName,
   centerSlot,
   showStepper = true,
-}: DecisionHeaderProps) {
+}: StandardDecisionHeaderProps) {
   const t = useTranslations();
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
 
@@ -111,7 +122,7 @@ function LegacyDecisionHeaderContent({
   isAdmin,
   slug,
   profileName,
-}: DecisionHeaderProps) {
+}: LegacyDecisionHeaderProps) {
   const [instance] = trpc.decision.getLegacyInstance.useSuspenseQuery({
     instanceId,
   });
@@ -137,9 +148,7 @@ function LegacyDecisionHeaderContent({
   return (
     <>
       <DecisionInstanceHeader
-        backTo={{
-          href: slug ? `/profile/${slug}?tab=decisions` : '/decisions',
-        }}
+        backTo={{ href: `/profile/${slug}?tab=decisions` }}
         title={profileName || instance.name || instance.process?.name || ''}
         decisionSlug={decisionSlug}
         isAdmin={isAdmin}

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -137,12 +137,20 @@ const OverviewHero = ({
             </p>
           ) : null}
         </div>
-        <div className="flex w-full flex-wrap justify-center gap-4">
-          <ButtonLink color="secondary" href={currentPhaseHref}>
+        <div className="align-stretch flex w-full flex-col gap-4 md:flex-row md:justify-center">
+          <ButtonLink
+            color="secondary"
+            href={currentPhaseHref}
+            className="w-auto"
+          >
             {t('Browse proposals')}
           </ButtonLink>
           {canSubmitProposal ? (
-            <ButtonLink color="primary" href={currentPhaseHref}>
+            <ButtonLink
+              color="primary"
+              href={currentPhaseHref}
+              className="w-auto"
+            >
               {t('Submit a proposal')}
             </ButtonLink>
           ) : null}

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -34,12 +34,22 @@ export function DecisionOverviewSuspense({
   const headline = overview.headline ?? instance.name ?? '';
   const content = overview.content ?? instance.description ?? undefined;
 
+  // Same gate as StandardDecisionPage: the phase must accept proposals and
+  // the viewer must have submit access.
+  const currentPhase = instance.instanceData?.phases?.find(
+    (p) => p.phaseId === instance.currentStateId,
+  );
+  const canSubmitProposal =
+    currentPhase?.rules?.proposals?.submit === true &&
+    instance.access?.submitProposals === true;
+
   return (
     <div className="flex w-full flex-col">
       <OverviewHero
         headline={headline}
         subhead={overview.subhead}
         decisionSlug={decisionSlug}
+        canSubmitProposal={canSubmitProposal}
       />
       {/* 12-col grid mirroring the Figma layout grid: sidebar spans 4 cols,
           body spans 7 starting at col 6. Stacks to one column below md. */}
@@ -58,10 +68,12 @@ const OverviewHero = ({
   headline,
   subhead,
   decisionSlug,
+  canSubmitProposal,
 }: {
   headline: string;
   subhead?: string;
   decisionSlug?: string;
+  canSubmitProposal?: boolean;
 }) => {
   const t = useTranslations();
   const currentPhaseHref = decisionSlug
@@ -71,8 +83,8 @@ const OverviewHero = ({
   return (
     // Gradient stands in until overview header images exist — same radial
     // gradient as the results-view decision header.
-    <section className="w-full bg-redPurple">
-      <div className="mx-auto flex w-full max-w-lg flex-col items-center gap-4 px-6 py-16 text-center text-neutral-offWhite sm:py-24">
+    <section className="grid w-full grid-cols-1 justify-center gap-12 bg-redPurple md:grid-cols-12">
+      <div className="mx-auto flex flex-col items-center gap-4 px-6 py-16 text-center text-neutral-offWhite sm:py-24 md:col-span-6 md:col-start-4">
         <div className="flex flex-col items-center gap-2">
           <h1 className="font-serif text-title-xl font-light sm:text-title-xxl">
             <bdi>{headline}</bdi>
@@ -88,9 +100,11 @@ const OverviewHero = ({
             <ButtonLink color="secondary" href={currentPhaseHref}>
               {t('Browse proposals')}
             </ButtonLink>
-            <ButtonLink color="primary" href={currentPhaseHref}>
-              {t('Submit a proposal')}
-            </ButtonLink>
+            {canSubmitProposal ? (
+              <ButtonLink color="primary" href={currentPhaseHref}>
+                {t('Submit a proposal')}
+              </ButtonLink>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -89,7 +89,7 @@ function DecisionOverviewContent({
         <div className="md:col-span-4" />
         <div className="min-w-0 md:col-span-7 md:col-start-6">
           <OverviewAbout
-            html={overview.content}
+            html={overview.body}
             fallbackText={instance.description ?? undefined}
           />
         </div>

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -60,6 +60,7 @@ function DecisionOverviewContent({
   instanceId,
   decisionSlug,
 }: DecisionOverviewProps) {
+  const t = useTranslations();
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
 
   const overview = decisionOverviewMock;
@@ -86,7 +87,14 @@ function DecisionOverviewContent({
           body spans 7 starting at col 6. Stacks to one column below md. */}
       <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-6 py-12 md:grid-cols-12 md:gap-x-6">
         {/* TODO: phases timeline lands here in a follow-up PR */}
-        <div className="md:col-span-4" />
+        <div className="flex flex-col gap-4 md:col-span-4">
+          <Header3>{t('Process Overview')}</Header3>
+          <div className="flex flex-col gap-6">
+            <div className="h-24 rounded border bg-neutral-offWhite" />
+            <div className="h-24 rounded border bg-neutral-offWhite" />
+            <div className="h-24 rounded border bg-neutral-offWhite" />
+          </div>
+        </div>
         <div className="min-w-0 md:col-span-7 md:col-start-6">
           <OverviewAbout
             html={overview.body}

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { Header1 } from '@op/ui/Header';
+import { ButtonLink } from '@op/ui/Button';
 
 import { useTranslations } from '@/lib/i18n';
+
+import { ProposalHtmlContent } from './ProposalHtmlContent';
+import { decisionOverviewMock } from './decisionOverviewMock';
 
 interface DecisionOverviewProps {
   instanceId: string;
@@ -13,23 +16,97 @@ interface DecisionOverviewProps {
 }
 
 /**
- * Overview tab for a decision process. Rendered at the decision root
- * (/decisions/[slug]) by DecisionRootView when the overview flag is on; the
- * current phase moves to /current.
+ * Overview tab for a decision process (/decisions/[slug]/overview). The shared
+ * header + view toggle come from the (decision-view) layout; this renders the
+ * hero, the phases sidebar slot, and the About body.
  *
- * Scaffold: renders the instance title + a placeholder body. Flesh out with
- * the full process summary (hero, proposals, phases, About) next.
+ * Overview content (headline, subhead, About HTML) is mocked
+ * until `instanceData.overview` exists on the API — swap at the `overview`
+ * read below.
  */
 export function DecisionOverviewSuspense({
   instanceId,
+  decisionSlug,
 }: DecisionOverviewProps) {
-  const t = useTranslations();
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
 
+  const overview = decisionOverviewMock;
+  const headline = overview.headline ?? instance.name ?? '';
+  const content = overview.content ?? instance.description ?? undefined;
+
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-2 px-6 py-8 text-center">
-      <Header1>{instance.name ?? t('Overview')}</Header1>
-      <p>{instance.description}</p>
+    <div className="flex w-full flex-col">
+      <OverviewHero
+        headline={headline}
+        subhead={overview.subhead}
+        decisionSlug={decisionSlug}
+      />
+      {/* 12-col grid mirroring the Figma layout grid: sidebar spans 4 cols,
+          body spans 7 starting at col 6. Stacks to one column below md. */}
+      <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-6 py-12 md:grid-cols-12 md:gap-x-6">
+        {/* Phases timeline lands here in a follow-up PR */}
+        <div className="md:col-span-4" />
+        <div className="min-w-0 md:col-span-7 md:col-start-6">
+          <OverviewAbout content={content} />
+        </div>
+      </div>
     </div>
   );
 }
+
+const OverviewHero = ({
+  headline,
+  subhead,
+  decisionSlug,
+}: {
+  headline: string;
+  subhead?: string;
+  decisionSlug?: string;
+}) => {
+  const t = useTranslations();
+  const currentPhaseHref = decisionSlug
+    ? `/decisions/${decisionSlug}/current`
+    : undefined;
+
+  return (
+    // Gradient stands in until overview header images exist — same radial
+    // gradient as the results-view decision header.
+    <section className="w-full bg-redPurple">
+      <div className="mx-auto flex w-full max-w-lg flex-col items-center gap-4 px-6 py-16 text-center text-neutral-offWhite sm:py-24">
+        <div className="flex flex-col items-center gap-2">
+          <h1 className="font-serif text-title-xl font-light sm:text-title-xxl">
+            <bdi>{headline}</bdi>
+          </h1>
+          {subhead ? (
+            <p dir="auto" className="text-base">
+              {subhead}
+            </p>
+          ) : null}
+        </div>
+        {currentPhaseHref ? (
+          <div className="flex w-full flex-wrap justify-center gap-4">
+            <ButtonLink color="secondary" href={currentPhaseHref}>
+              {t('Browse proposals')}
+            </ButtonLink>
+            <ButtonLink color="primary" href={currentPhaseHref}>
+              {t('Submit a proposal')}
+            </ButtonLink>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+const OverviewAbout = ({ content }: { content?: string }) => {
+  const t = useTranslations();
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className="font-serif text-title-lg text-neutral-black">
+        {t('About the process')}
+      </h2>
+      {content ? <ProposalHtmlContent html={content} /> : null}
+    </section>
+  );
+};

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -1,7 +1,12 @@
 'use client';
 
+import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { trpc } from '@op/api/client';
 import { ButtonLink } from '@op/ui/Button';
+import { EmptyState } from '@op/ui/EmptyState';
+import { Header2, Header3 } from '@op/ui/Header';
+import he from 'he';
+import { LuTriangleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -10,9 +15,7 @@ import { decisionOverviewMock } from './decisionOverviewMock';
 
 interface DecisionOverviewProps {
   instanceId: string;
-  slug: string;
-  decisionSlug?: string;
-  decisionProfileId?: string | null;
+  decisionSlug: string;
 }
 
 /**
@@ -28,11 +31,39 @@ export function DecisionOverviewSuspense({
   instanceId,
   decisionSlug,
 }: DecisionOverviewProps) {
+  const t = useTranslations();
+
+  return (
+    <APIErrorBoundary
+      fallbacks={{
+        default: () => (
+          <EmptyState icon={<LuTriangleAlert className="size-6" />}>
+            <Header3 className="font-serif font-light">
+              {t("Couldn't load the overview")}
+            </Header3>
+            <p className="text-base text-neutral-charcoal">
+              {t('Refresh the page to try again.')}
+            </p>
+          </EmptyState>
+        ),
+      }}
+    >
+      <DecisionOverviewContent
+        instanceId={instanceId}
+        decisionSlug={decisionSlug}
+      />
+    </APIErrorBoundary>
+  );
+}
+
+function DecisionOverviewContent({
+  instanceId,
+  decisionSlug,
+}: DecisionOverviewProps) {
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
 
   const overview = decisionOverviewMock;
-  const headline = overview.headline ?? instance.name ?? '';
-  const content = overview.content ?? instance.description ?? undefined;
+  const headline = overview.headline ?? instance.name;
 
   // Same gate as StandardDecisionPage: the phase must accept proposals and
   // the viewer must have submit access.
@@ -54,10 +85,13 @@ export function DecisionOverviewSuspense({
       {/* 12-col grid mirroring the Figma layout grid: sidebar spans 4 cols,
           body spans 7 starting at col 6. Stacks to one column below md. */}
       <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-6 py-12 md:grid-cols-12 md:gap-x-6">
-        {/* Phases timeline lands here in a follow-up PR */}
+        {/* TODO: phases timeline lands here in a follow-up PR */}
         <div className="md:col-span-4" />
         <div className="min-w-0 md:col-span-7 md:col-start-6">
-          <OverviewAbout content={content} />
+          <OverviewAbout
+            html={overview.content}
+            fallbackText={instance.description ?? undefined}
+          />
         </div>
       </div>
     </div>
@@ -72,17 +106,15 @@ const OverviewHero = ({
 }: {
   headline: string;
   subhead?: string;
-  decisionSlug?: string;
-  canSubmitProposal?: boolean;
+  decisionSlug: string;
+  canSubmitProposal: boolean;
 }) => {
   const t = useTranslations();
-  const currentPhaseHref = decisionSlug
-    ? `/decisions/${decisionSlug}/current`
-    : undefined;
+  const currentPhaseHref = `/decisions/${decisionSlug}/current`;
 
   return (
     // Gradient stands in until overview header images exist — same radial
-    // gradient as the results-view decision header.
+    // gradient as the results page hero.
     <section className="grid w-full grid-cols-1 justify-center gap-12 bg-redPurple md:grid-cols-12">
       <div className="mx-auto flex flex-col items-center gap-4 px-6 py-16 text-center text-neutral-offWhite sm:py-24 md:col-span-6 md:col-start-4">
         <div className="flex flex-col items-center gap-2">
@@ -95,32 +127,48 @@ const OverviewHero = ({
             </p>
           ) : null}
         </div>
-        {currentPhaseHref ? (
-          <div className="flex w-full flex-wrap justify-center gap-4">
-            <ButtonLink color="secondary" href={currentPhaseHref}>
-              {t('Browse proposals')}
+        <div className="flex w-full flex-wrap justify-center gap-4">
+          <ButtonLink color="secondary" href={currentPhaseHref}>
+            {t('Browse proposals')}
+          </ButtonLink>
+          {canSubmitProposal ? (
+            <ButtonLink color="primary" href={currentPhaseHref}>
+              {t('Submit a proposal')}
             </ButtonLink>
-            {canSubmitProposal ? (
-              <ButtonLink color="primary" href={currentPhaseHref}>
-                {t('Submit a proposal')}
-              </ButtonLink>
-            ) : null}
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </div>
     </section>
   );
 };
 
-const OverviewAbout = ({ content }: { content?: string }) => {
+const OverviewAbout = ({
+  html,
+  fallbackText,
+}: {
+  /** TipTap-generated HTML from the overview content. */
+  html?: string;
+  /** Plain-text process description shown when no overview content exists. */
+  fallbackText?: string;
+}) => {
   const t = useTranslations();
+
+  if (!html && !fallbackText) {
+    return null;
+  }
 
   return (
     <section className="flex flex-col gap-4">
-      <h2 className="font-serif text-title-lg text-neutral-black">
-        {t('About the process')}
-      </h2>
-      {content ? <ProposalHtmlContent html={content} /> : null}
+      <Header2 className="font-serif">{t('About the process')}</Header2>
+      {html ? (
+        <ProposalHtmlContent html={html} />
+      ) : fallbackText ? (
+        // The description is plain text (entity-encoded for some orgs, same as
+        // DecisionActionBar) — decode and render as text, not HTML.
+        <p dir="auto" className="text-base">
+          {he.decode(fallbackText)}
+        </p>
+      ) : null}
     </section>
   );
 };

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -88,7 +88,9 @@ function DecisionOverviewContent({
       <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-6 py-12 md:grid-cols-12 md:gap-x-6">
         {/* TODO: phases timeline lands here in a follow-up PR */}
         <div className="flex flex-col gap-4 md:col-span-4">
-          <Header3>{t('Process Overview')}</Header3>
+          <Header3 className="text-sm text-neutral-gray4">
+            {t('Process Overview')}
+          </Header3>
           <div className="flex flex-col gap-6">
             <div className="h-24 rounded border bg-neutral-offWhite" />
             <div className="h-24 rounded border bg-neutral-offWhite" />

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -85,7 +85,7 @@ function DecisionOverviewContent({
       />
       {/* 12-col grid mirroring the Figma layout grid: sidebar spans 4 cols,
           body spans 7 starting at col 6. Stacks to one column below md. */}
-      <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-6 py-12 md:grid-cols-12 md:gap-x-6">
+      <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-4 py-6 md:grid-cols-12 md:gap-x-6 md:px-6 md:py-12">
         {/* TODO: phases timeline lands here in a follow-up PR */}
         <div className="flex flex-col gap-4 md:col-span-4">
           <Header3 className="text-sm text-neutral-gray4">
@@ -126,7 +126,7 @@ const OverviewHero = ({
     // Gradient stands in until overview header images exist — same radial
     // gradient as the results page hero.
     <section className="grid w-full grid-cols-1 justify-center gap-12 bg-redPurple md:grid-cols-12">
-      <div className="mx-auto flex flex-col items-center gap-4 px-6 pt-16 pb-8 text-center text-neutral-offWhite sm:py-24 md:col-span-6 md:col-start-4">
+      <div className="mx-auto flex flex-col items-center gap-4 px-4 pt-16 pb-8 text-center text-neutral-offWhite sm:py-24 md:col-span-6 md:col-start-4 md:px-6">
         <div className="flex flex-col items-center gap-2">
           <h1 className="font-serif text-title-xl font-light sm:text-title-xxl">
             <bdi>{headline}</bdi>

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -126,7 +126,7 @@ const OverviewHero = ({
     // Gradient stands in until overview header images exist — same radial
     // gradient as the results page hero.
     <section className="grid w-full grid-cols-1 justify-center gap-12 bg-redPurple md:grid-cols-12">
-      <div className="mx-auto flex flex-col items-center gap-4 px-6 py-16 text-center text-neutral-offWhite sm:py-24 md:col-span-6 md:col-start-4">
+      <div className="mx-auto flex flex-col items-center gap-4 px-6 pt-16 pb-8 text-center text-neutral-offWhite sm:py-24 md:col-span-6 md:col-start-4">
         <div className="flex flex-col items-center gap-2">
           <h1 className="font-serif text-title-xl font-light sm:text-title-xxl">
             <bdi>{headline}</bdi>

--- a/apps/app/src/components/decisions/decisionOverviewMock.ts
+++ b/apps/app/src/components/decisions/decisionOverviewMock.ts
@@ -1,0 +1,25 @@
+/**
+ * Mock overview content for the decision Overview tab. Shaped like the future
+ * `instanceData.overview` object so swapping to real data is a one-line change
+ * at the read site in DecisionOverview.
+ */
+export interface DecisionOverviewData {
+  /** Hero headline. Falls back to the process name when absent. */
+  headline?: string;
+  /** Hero subhead. No fallback — omitted entirely when absent. */
+  subhead?: string;
+  /** TipTap-generated HTML for the About section. Falls back to the process description. */
+  content?: string;
+}
+
+export const decisionOverviewMock: DecisionOverviewData = {
+  headline: 'Our voice, our choice',
+  subhead:
+    'Columbus residents are deciding how to invest $9 million in capital improvements across nine council districts.',
+  content: [
+    "<p>Each of Columbus's nine council districts has $1 million to allocate toward capital improvements — physical projects like park upgrades, sidewalk repairs, community centers, and public art. Over the course of 2026, residents will decide together how that money gets spent.</p>",
+    '<p>The process moves through four phases. First, anyone living, working, or going to school in Columbus can submit ideas for their district. Then, budget delegates — residents trained by the steering committee — review the ideas and refine them into a ballot of feasible project proposals, working with city staff to confirm scope and cost.</p>',
+    '<p>In the fall, residents vote on the proposals they want funded. Winning projects move into construction in 2027.</p>',
+    "<p>The whole process is run by a community steering committee, not by City Hall — designed to keep decision-making in residents' hands.</p>",
+  ].join(''),
+};

--- a/apps/app/src/components/decisions/decisionOverviewMock.ts
+++ b/apps/app/src/components/decisions/decisionOverviewMock.ts
@@ -4,11 +4,11 @@
  * at the read site in DecisionOverview.
  */
 export interface DecisionOverviewData {
-  /** Hero headline. Falls back to the process name when absent. */
+  /** Hero headline. Falls back to `instance.name` (see DecisionOverview). */
   headline?: string;
   /** Hero subhead. No fallback — omitted entirely when absent. */
   subhead?: string;
-  /** TipTap-generated HTML for the About section. Falls back to the process description. */
+  /** TipTap-generated HTML for the About section. Falls back to `instance.description`. */
   content?: string;
 }
 

--- a/apps/app/src/components/decisions/decisionOverviewMock.ts
+++ b/apps/app/src/components/decisions/decisionOverviewMock.ts
@@ -9,14 +9,14 @@ export interface DecisionOverviewData {
   /** Hero subhead. No fallback — omitted entirely when absent. */
   subhead?: string;
   /** TipTap-generated HTML for the About section. Falls back to `instance.description`. */
-  content?: string;
+  body?: string;
 }
 
 export const decisionOverviewMock: DecisionOverviewData = {
   headline: 'Our voice, our choice',
   subhead:
     'Columbus residents are deciding how to invest $9 million in capital improvements across nine council districts.',
-  content: [
+  body: [
     "<p>Each of Columbus's nine council districts has $1 million to allocate toward capital improvements — physical projects like park upgrades, sidewalk repairs, community centers, and public art. Over the course of 2026, residents will decide together how that money gets spent.</p>",
     '<p>The process moves through four phases. First, anyone living, working, or going to school in Columbus can submit ideas for their district. Then, budget delegates — residents trained by the steering committee — review the ideas and refine them into a ballot of feasible project proposals, working with city staff to confirm scope and cost.</p>',
     '<p>In the fall, residents vote on the proposals they want funded. Winning projects move into construction in 2027.</p>',

--- a/apps/app/src/components/decisions/pages/ResultsPage.tsx
+++ b/apps/app/src/components/decisions/pages/ResultsPage.tsx
@@ -137,8 +137,8 @@ function ResultsPageContent({
     <>
       <FinalPhaseSubmissionSuccessDialog />
       <ProcessSurveyGate instanceId={instanceId} isLegacy={isLegacy} />
-      {/* Hero section - will be inside gradient from DecisionHeader */}
-      <div className="px-4 py-8">
+      {/* Hero section — owns the results gradient; the header above stays neutral */}
+      <div className="bg-redPurple px-4 py-8 text-neutral-offWhite">
         <div className="mx-auto flex max-w-3xl flex-col justify-center gap-4">
           <DecisionHero
             title={heroContent.title}

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -359,6 +359,7 @@
   "Check back again shortly for the results.": "تحقق مرة أخرى قريبًا لمعرفة النتائج.",
   "Couldn't load manual selection": "تعذر تحميل الاختيار اليدوي",
   "Couldn't load proposals": "تعذر تحميل المقترحات",
+  "Couldn't load the overview": "تعذر تحميل النظرة العامة",
   "Refresh the page to try again.": "أعد تحميل الصفحة للمحاولة مرة أخرى.",
   "My Ballot": "بطاقة اقتراعي",
   "You did not vote in this process.": "لم تصوت في هذه العملية.",

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -133,6 +133,8 @@
   "Active processes": "العمليات النشطة",
   "Budget": "الميزانية",
   "Proposals": "المقترحات",
+  "Browse proposals": "تصفّح المقترحات",
+  "Submit a proposal": "قدّم مقترحًا",
   "Participants": "المشاركون",
   "Summary": "الملخص",
   "View Details": "عرض التفاصيل",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -412,6 +412,7 @@
   "Check back again shortly for the results.": "ফলাফলের জন্য শীঘ্রই আবার চেক করুন।",
   "Couldn't load manual selection": "ম্যানুয়াল নির্বাচন লোড করা যায়নি",
   "Couldn't load proposals": "প্রস্তাব লোড করা যায়নি",
+  "Couldn't load the overview": "সারসংক্ষেপ লোড করা যায়নি",
   "Refresh the page to try again.": "আবার চেষ্টা করতে পৃষ্ঠাটি রিফ্রেশ করুন।",
   "My Ballot": "আমার ব্যালট",
   "You did not vote in this process.": "আপনি এই প্রক্রিয়ায় ভোট দেননি।",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -175,6 +175,8 @@
   "Active processes": "সক্রিয় প্রক্রিয়া",
   "Budget": "বাজেট",
   "Proposals": "প্রস্তাবনা",
+  "Browse proposals": "প্রস্তাবগুলি ব্রাউজ করুন",
+  "Submit a proposal": "একটি প্রস্তাব জমা দিন",
   "Proposal options": "প্রস্তাব অপশন",
   "Participants": "অংশগ্রহণকারী",
   "Summary": "সারসংক্ষেপ",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -310,6 +310,8 @@
   "are not valid email addresses": "are not valid email addresses",
   "About the process": "About the process",
   "About this phase": "About this phase",
+  "Browse proposals": "Browse proposals",
+  "Submit a proposal": "Submit a proposal",
   "Delete Proposal": "Delete Proposal",
   "Delete phase": "Delete phase",
   "Delete phase?": "Delete phase?",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -379,6 +379,7 @@
   "Check back again shortly for the results.": "Check back again shortly for the results.",
   "Couldn't load manual selection": "Couldn't load manual selection",
   "Couldn't load proposals": "Couldn't load proposals",
+  "Couldn't load the overview": "Couldn't load the overview",
   "Refresh the page to try again.": "Refresh the page to try again.",
   "My Ballot": "My Ballot",
   "You did not vote in this process.": "You did not vote in this process.",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -412,6 +412,7 @@
   "Check back again shortly for the results.": "Vuelve pronto para ver los resultados.",
   "Couldn't load manual selection": "No se pudo cargar la selección manual",
   "Couldn't load proposals": "No se pudieron cargar las propuestas",
+  "Couldn't load the overview": "No se pudo cargar el resumen",
   "Refresh the page to try again.": "Actualiza la página para volver a intentarlo.",
   "My Ballot": "Mi voto",
   "You did not vote in this process.": "No votaste en este proceso.",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -174,6 +174,8 @@
   "Active processes": "Procesos activos",
   "Budget": "Presupuesto",
   "Proposals": "Propuestas",
+  "Browse proposals": "Explorar propuestas",
+  "Submit a proposal": "Enviar una propuesta",
   "Proposal options": "Opciones de propuesta",
   "Participants": "Participantes",
   "Summary": "Resumen",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -175,6 +175,8 @@
   "Active processes": "Processus actifs",
   "Budget": "Budget",
   "Proposals": "Propositions",
+  "Browse proposals": "Parcourir les propositions",
+  "Submit a proposal": "Soumettre une proposition",
   "Proposal options": "Options de la proposition",
   "Participants": "Participants",
   "Summary": "Résumé",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -413,6 +413,7 @@
   "Check back again shortly for the results.": "Revenez bientôt pour les résultats.",
   "Couldn't load manual selection": "Impossible de charger la sélection manuelle",
   "Couldn't load proposals": "Impossible de charger les propositions",
+  "Couldn't load the overview": "Impossible de charger l'aperçu",
   "Refresh the page to try again.": "Actualisez la page pour réessayer.",
   "My Ballot": "Mon vote",
   "You did not vote in this process.": "Vous n'avez pas voté dans ce processus.",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -413,6 +413,7 @@
   "Check back again shortly for the results.": "Volte em breve para ver os resultados.",
   "Couldn't load manual selection": "Não foi possível carregar a seleção manual",
   "Couldn't load proposals": "Não foi possível carregar as propostas",
+  "Couldn't load the overview": "Não foi possível carregar a visão geral",
   "Refresh the page to try again.": "Atualize a página para tentar novamente.",
   "My Ballot": "Meu voto",
   "You did not vote in this process.": "Você não votou neste processo.",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -175,6 +175,8 @@
   "Active processes": "Processos ativos",
   "Budget": "Orçamento",
   "Proposals": "Propostas",
+  "Browse proposals": "Explorar propostas",
+  "Submit a proposal": "Enviar uma proposta",
   "Proposal options": "Opções de proposta",
   "Participants": "Participantes",
   "Summary": "Resumo",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -133,6 +133,8 @@
   "Active processes": "Habab firfircoon",
   "Budget": "Miisaaniyad",
   "Proposals": "Soo jeedimo",
+  "Browse proposals": "Daalaco soo jeedimaha",
+  "Submit a proposal": "Gudbi soo jeedin",
   "Participants": "Ka qaybgalayaal",
   "Summary": "Kooban",
   "View Details": "Eeg Faahfaahinta",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -364,6 +364,7 @@
   "Check back again shortly for the results.": "Dib ugu soo noqo si dhakhso ah natiijooyinka.",
   "Couldn't load manual selection": "Lama soo dejin karin xulashada gacanta",
   "Couldn't load proposals": "Lama soo dejin karin soo jeedimaha",
+  "Couldn't load the overview": "Lama soo dejin karin guudmarka",
   "Refresh the page to try again.": "Cusboonaysii bogga si aad mar kale u isku daydo.",
   "My Ballot": "Codkaaga",
   "You did not vote in this process.": "Ma aadan cod bixin habkaan.",


### PR DESCRIPTION
Renders the decision Overview tab (`/decisions/[slug]/overview`), behind the server-side `decision_overview` flag.

- **Overview page**: gradient hero (headline, optional subhead, Browse/Submit CTAs), a placeholder slot for the phases timeline, and an "About the process" body. Submit CTA is gated on phase rules + submit access (same gate as `StandardDecisionPage`). Content is mocked (`decisionOverviewMock.ts`) shaped like a future `instanceData.overview`; falls back to `instance.name` / `instance.description`.
- **DecisionHeader refactor**: header is now header-only (bar + stepper) instead of wrapping the page body. The results-view gradient moved into `ResultsPage`'s own hero, and `DecisionTranslationProvider` moved up to the composition root of each route (the `(decision-view)` layout + the two legacy routes) so it still encloses the now-sibling header and body.
- **Mobile**: route-scoped top clearance on the current-phase tab so the floating Overview/Current toggle doesn't block content; the legacy decision route is untouched.

Stacked PR #1291 wires the Submit CTA to create a draft proposal.
