### PR TITLE
feat(api): open account.getMyAccount to public and anonymous callers

### DIFF
--- a/apps/app/src/app/[locale]/(main)/admin/layout.tsx
+++ b/apps/app/src/app/[locale]/(main)/admin/layout.tsx
@@ -16,7 +16,7 @@ export default async function AdminLayout({
   const client = await createClient();
   const user = await client.account.getMyAccount();
 
-  if (!user.email || !isUserEmailPlatformAdmin(user.email)) {
+  if (!user?.email || !isUserEmailPlatformAdmin(user.email)) {
     notFound();
   }
 

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/ProposalViewClient.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/ProposalViewClient.tsx
@@ -35,7 +35,7 @@ function ProposalViewPageContent({
   );
   const isInReviewPhase = currentPhase?.rules?.proposals?.review === true;
   const isAuthor =
-    !!user.currentProfile?.id &&
+    !!user?.currentProfile?.id &&
     proposal.submittedBy?.id === user.currentProfile.id;
   // Author, admin, or explicit review access — only in a review phase.
   const canSeeRevisions =

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/edit/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import type { ProcessInstance } from '@op/api/encoders';
 import {
@@ -85,7 +85,7 @@ export default function ProposalEditorLayout() {
     document.title = parts.join(' | ');
   }, [proposalTitle, decisionProfile.name, t]);
 
-  const { user } = useUser();
+  const { user } = useRequiredUser();
 
   // The server throws UnauthorizedError when the viewer lacks review access;
   // treat any error as "no revision requests" so the editor still loads.

--- a/apps/app/src/app/login/page.tsx
+++ b/apps/app/src/app/login/page.tsx
@@ -2,13 +2,9 @@
 
 import { isSafeRedirectPath } from '@op/common/client';
 import { useAuthUser } from '@op/hooks';
-import { redirect, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 
 import { LoginPanel } from '@/components/LoginPanel';
-
-const LoginPageWithLayout = () => {
-  return <LoginPanel />;
-};
 
 const LoginPage = () => {
   const user = useAuthUser();
@@ -19,15 +15,15 @@ const LoginPage = () => {
     return null;
   }
 
-  if (user.isFetchedAfterMount && !user.isFetching && !user.data?.user) {
-    return <LoginPageWithLayout />;
+  if (user.isFetchedAfterMount && !user.data?.user) {
+    return <LoginPanel />;
   }
 
-  if (isSafeRedirectPath(redirectParam)) {
-    redirect(redirectParam);
-  }
-
-  redirect('/');
+  // Signed in: hard-navigate so the authed tree mounts with a fresh query
+  // cache (client routing would carry the signed-out null account in).
+  const target = isSafeRedirectPath(redirectParam) ? redirectParam : '/';
+  window.location.assign(target);
+  return null;
 };
 
 export default LoginPage;

--- a/apps/app/src/components/DeleteOrganizationModal/index.tsx
+++ b/apps/app/src/components/DeleteOrganizationModal/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { getPublicUrl } from '@/utils';
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { RouterOutput } from '@op/api';
 import { trpc } from '@op/api/client';
 import { EntityType } from '@op/api/encoders';
@@ -37,7 +37,7 @@ export const DeleteOrganizationModal = ({
 
   const [isSubmitting, startTransition] = useTransition();
   const utils = trpc.useUtils();
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const deleteProfile = trpc.organization.deleteOrganization.useMutation();
   const switchProfile = trpc.account.switchProfile.useMutation();
 

--- a/apps/app/src/components/DiscussionModal/index.tsx
+++ b/apps/app/src/components/DiscussionModal/index.tsx
@@ -152,7 +152,7 @@ export function DiscussionModal({
             <PostUpdate
               parentPostId={post.id}
               placeholder={
-                user.currentProfile?.name
+                user?.currentProfile?.name
                   ? t('Comment as {name}...', {
                       name: user.currentProfile.name,
                     })

--- a/apps/app/src/components/InviteUserModal/InviteNewOrganization.tsx
+++ b/apps/app/src/components/InviteUserModal/InviteNewOrganization.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { Tag, TagGroup } from '@op/ui/TagGroup';
 import { toast } from '@op/ui/Toast';
 import { LuX } from 'react-icons/lu';
@@ -27,7 +27,7 @@ export const InviteNewOrganization = ({
   setPersonalMessage,
 }: InviteNewOrganizationProps) => {
   const t = useTranslations();
-  const { user } = useUser();
+  const { user } = useRequiredUser();
 
   const isValidEmail = (email: string): boolean => {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/apps/app/src/components/InviteUserModal/InviteToExistingOrganization.tsx
+++ b/apps/app/src/components/InviteUserModal/InviteToExistingOrganization.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { Select, SelectItem } from '@op/ui/Select';
 import { Tag, TagGroup } from '@op/ui/TagGroup';
@@ -36,7 +36,7 @@ export const InviteToExistingOrganization = ({
   setSelectedOrganization,
 }: InviteToExistingOrganizationProps) => {
   const t = useTranslations();
-  const { user } = useUser();
+  const { user } = useRequiredUser();
 
   const [rolesData] = trpc.organization.getRoles.useSuspenseQuery();
 

--- a/apps/app/src/components/InviteUserModal/index.tsx
+++ b/apps/app/src/components/InviteUserModal/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { analyzeError, useConnectionStatus } from '@/utils/connectionErrors';
 import { trpc } from '@op/api/client';
 import { Button } from '@op/ui/Button';
@@ -41,7 +41,7 @@ export const InviteUserModal = ({
   const [invitedCount, setInvitedCount] = useState(0);
   const [activeTab, setActiveTab] = useState('existing');
   const t = useTranslations();
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const isOnline = useConnectionStatus();
 
   const isModalOpen = controlledIsOpen ?? internalIsModalOpen;

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import { getPublicUrl } from '@/utils';
-import { OrganizationUser, useUser } from '@/utils/UserProvider';
+import { useUser } from '@/utils/UserProvider';
 import { detectLinks, linkifyText } from '@/utils/linkDetection';
 import { trpc } from '@op/api/client';
-import type { Organization, Post, PostAttachment } from '@op/api/encoders';
+import type {
+  CommonUser,
+  Organization,
+  Post,
+  PostAttachment,
+} from '@op/api/encoders';
 import { useRelativeTime } from '@op/hooks';
 import { REACTION_OPTIONS } from '@op/types';
 import { AvatarSkeleton } from '@op/ui/Avatar';
@@ -206,7 +211,7 @@ const PostMenu = ({
 }: {
   organization?: Organization | null;
   post: Post;
-  user?: OrganizationUser;
+  user?: CommonUser;
 }) => {
   const t = useTranslations();
   const { getPermissionsForProfile } = useUser();
@@ -346,7 +351,7 @@ export const PostItem = ({
 }: {
   post: Post;
   organization: Organization | null;
-  user?: OrganizationUser;
+  user?: CommonUser;
   withLinks: boolean;
   onReactionClick: (postId: string, emoji: string) => void;
   onCommentClick?: (post: Post, organization: Organization | null) => void;
@@ -422,7 +427,7 @@ export const PostItemOnDetailPage = ({
 }: {
   post: Post;
   organization: Organization | null;
-  user?: OrganizationUser;
+  user?: CommonUser;
   withLinks: boolean;
   onReactionClick: (postId: string, emoji: string) => void;
   commentCount: number;

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -163,8 +163,8 @@ const PostUpdateWithUser = ({
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
           deletedAt: null,
-          profile: user.currentProfile || null,
-          profileId: user.currentProfileId || null,
+          profile: user?.currentProfile || null,
+          profileId: user?.currentProfileId || null,
           parentPostId: variables.parentPostId,
           rootProfileId: null,
           rootPostId: null,
@@ -212,8 +212,8 @@ const PostUpdateWithUser = ({
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
           deletedAt: null,
-          profile: user.currentProfile || null,
-          profileId: user.currentProfileId || null,
+          profile: user?.currentProfile || null,
+          profileId: user?.currentProfileId || null,
           parentPostId: null,
           rootProfileId: null,
           rootPostId: null,
@@ -308,7 +308,7 @@ const PostUpdateWithUser = ({
         // Enhance server data with user profile if not present
         const enhancedData = {
           ...data,
-          profile: data.profile || user.currentProfile || null,
+          profile: data.profile || user?.currentProfile || null,
         };
 
         // For comments (posts with parentPostId)
@@ -592,7 +592,7 @@ const PostUpdateWithUser = ({
     }
   }, [content]);
 
-  if (!user.currentProfile) {
+  if (!user?.currentProfile) {
     return null;
   }
 
@@ -771,7 +771,7 @@ export const PostUpdate = ({
   processInstanceId?: string;
 }) => {
   const { user } = useUser();
-  const currentProfileId = user.currentProfileId;
+  const currentProfileId = user?.currentProfileId;
 
   // For profile-based associations (like proposals), we don't need an organization
   if (profileId) {
@@ -801,13 +801,13 @@ export const PostUpdate = ({
   // TODO: Ugly! Still a stopgap until we migrate off of organizationId
   if (
     organization &&
-    (user.currentOrganization?.profile.id !== currentProfileId ||
-      !user.currentOrganization)
+    (user?.currentOrganization?.profile.id !== currentProfileId ||
+      !user?.currentOrganization)
   ) {
     return null;
   }
 
-  const org = organization ?? user.currentOrganization;
+  const org = organization ?? user?.currentOrganization;
 
   return (
     <PostUpdateWithUser

--- a/apps/app/src/components/Profile/ProfileContent/index.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { type Organization, ProcessStatus } from '@op/api/encoders';
 import { formatToUrl } from '@op/common/validation';
@@ -302,8 +302,8 @@ export const OrganizationProfileGrid = ({
   profile: Organization;
 }) => {
   const t = useTranslations();
-  const { user } = useUser();
-  const isOrg = user?.currentProfile?.type === 'org';
+  const { user } = useRequiredUser();
+  const isOrg = user.currentProfile?.type === 'org';
 
   return (
     <ProfileGridWrapper>

--- a/apps/app/src/components/Profile/ProfileContent/index.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/index.tsx
@@ -303,7 +303,7 @@ export const OrganizationProfileGrid = ({
 }) => {
   const t = useTranslations();
   const { user } = useUser();
-  const isOrg = user.currentProfile?.type === 'org';
+  const isOrg = user?.currentProfile?.type === 'org';
 
   return (
     <ProfileGridWrapper>

--- a/apps/app/src/components/Profile/ProfileDecisions/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDecisions/index.tsx
@@ -78,7 +78,7 @@ const EmptyDecisions = ({ profileId }: { profileId: string }) => {
   const access = useUser();
   const { user } = access;
   const permission = access.getPermissionsForProfile(profileId);
-  const isOwnProfile = user.currentProfile?.id === profileId;
+  const isOwnProfile = user?.currentProfile?.id === profileId;
   const isProcessAdmin = permission.decisions.create && isOwnProfile;
 
   return (

--- a/apps/app/src/components/Profile/ProfileDetails/AddRelationshipModal.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/AddRelationshipModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { skipBatch, trpc } from '@op/api/client';
 import { Organization } from '@op/api/encoders';
 import { relationshipMap } from '@op/types';
@@ -98,7 +98,7 @@ export const AddRelationshipModalSuspense = ({
 }: {
   profile: Organization;
 }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const t = useTranslations();
   const utils = trpc.useUtils();
   const [selectedRelationshipId, setSelectedRelationshipId] = useState<

--- a/apps/app/src/components/Profile/ProfileDetails/FollowButton.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/FollowButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { Organization, ProfileRelationshipType } from '@op/api/encoders';
 import { Button } from '@op/ui/Button';
@@ -12,7 +12,7 @@ import { LuCheck, LuPlus } from 'react-icons/lu';
 import ErrorBoundary from '@/components/ErrorBoundary';
 
 const FollowButtonSuspense = ({ profile }: { profile: Organization }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const utils = trpc.useUtils();
   const [isPending, startTransition] = useTransition();
 

--- a/apps/app/src/components/Profile/ProfileDetails/InviteToOrganizationButton.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/InviteToOrganizationButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { analyzeError, useConnectionStatus } from '@/utils/connectionErrors';
 import { trpc } from '@op/api/client';
 import type { Organization } from '@op/api/encoders';
@@ -18,7 +18,7 @@ interface InviteToOrganizationButtonProps {
 export const InviteToOrganizationButton = ({
   profile,
 }: InviteToOrganizationButtonProps) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const isOnline = useConnectionStatus();
 
   const [[rolesData, membershipData]] = trpc.useSuspenseQueries((t) => [

--- a/apps/app/src/components/Profile/ProfileDetails/RequestMembershipButton.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/RequestMembershipButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { JoinProfileRequestStatus, type Organization } from '@op/api/encoders';
 import { Button, ButtonTooltip } from '@op/ui/Button';
@@ -43,7 +43,7 @@ const RequestMembershipButtonSuspense = ({
   profile: Organization;
 }) => {
   const t = useTranslations();
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const [isPending, startTransition] = useTransition();
 
   const currentProfileId = user.currentProfile?.id;

--- a/apps/app/src/components/Profile/ProfileDetails/RespondButton.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/RespondButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { skipBatch, trpc } from '@op/api/client';
 import { Organization } from '@op/api/encoders';
 import { DropDownButton } from '@op/ui/DropDownButton';
@@ -12,7 +12,7 @@ import { LuCheck, LuUserPlus, LuX } from 'react-icons/lu';
 import ErrorBoundary from '@/components/ErrorBoundary';
 
 const RespondButtonSuspense = ({ profile }: { profile: Organization }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const utils = trpc.useUtils();
 
   if (!user.currentOrganization?.id) {

--- a/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationModal.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import type { Organization } from '@op/api/encoders';
 import { Button } from '@op/ui/Button';
 import { Modal, ModalHeader } from '@op/ui/Modal';
@@ -19,7 +19,7 @@ interface UpdateOrganizationModalProps {
 export const UpdateOrganizationModal = ({
   organization,
 }: UpdateOrganizationModalProps) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const t = useTranslations();
   const [isOpen, setIsOpen] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);

--- a/apps/app/src/components/Profile/ProfileDetails/UpdateProfile/UpdateProfileModal.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/UpdateProfile/UpdateProfileModal.tsx
@@ -1,4 +1,4 @@
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { Dialog } from '@op/ui/Dialog';
 import { Modal, ModalHeader } from '@op/ui/Modal';
 import { DialogTrigger } from '@op/ui/RAC';
@@ -15,7 +15,7 @@ export const UpdateProfileModal = ({
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
 }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const t = useTranslations();
   const formRef = useRef<HTMLFormElement>(null);
 
@@ -35,10 +35,6 @@ export const UpdateProfileModal = ({
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isOpen]);
-
-  if (!user) {
-    return null;
-  }
 
   return (
     <DialogTrigger>

--- a/apps/app/src/components/Profile/ProfileDetails/UpdateProfile/UpdateUserProfileModal.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/UpdateProfile/UpdateUserProfileModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import type { Profile } from '@op/api/encoders';
 import { Button } from '@op/ui/Button';
 import { Modal, ModalHeader } from '@op/ui/Modal';
@@ -19,7 +19,7 @@ interface UpdateUserProfileModalProps {
 export const UpdateUserProfileModal = ({
   profile,
 }: UpdateUserProfileModalProps) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const t = useTranslations();
   const formRef = useRef<HTMLFormElement>(null);
   const [isOpen, setIsOpen] = useState(false);

--- a/apps/app/src/components/Profile/ProfileDetails/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import type { Organization } from '@op/api/encoders';
 import { EntityType } from '@op/api/encoders';
 import { formatToUrl } from '@op/common/validation';
@@ -18,7 +18,7 @@ import { UpdateOrganizationModal } from './UpdateOrganizationModal';
 import { UpdateUserProfileModal } from './UpdateProfile';
 
 const ProfileInteractions = ({ profile }: { profile: Organization }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const { isReceivingFunds, isOfferingFunds, links } = profile;
 
   // split funding links up by type
@@ -31,25 +31,25 @@ const ProfileInteractions = ({ profile }: { profile: Organization }) => {
 
   const isOrganizationProfile = profile.profile?.type === EntityType.ORG;
   const isViewingOwnProfile =
-    user?.currentProfile?.id ===
+    user.currentProfile?.id ===
     (isOrganizationProfile ? profile.profile.id : profile.id);
 
   // Check if current user is Individual viewing an Organization
   const isCurrentUserIndividual =
-    user?.currentProfile?.type === EntityType.INDIVIDUAL;
+    user.currentProfile?.type === EntityType.INDIVIDUAL;
   const shouldShowFollowButton =
     isCurrentUserIndividual && isOrganizationProfile && !isViewingOwnProfile;
 
   // Check if current user is Organization viewing an Individual
   const isCurrentUserOrganization =
-    user?.currentProfile?.type === EntityType.ORG;
+    user.currentProfile?.type === EntityType.ORG;
   const shouldShowInviteButton =
     isCurrentUserOrganization &&
     profile.profile.type === EntityType.INDIVIDUAL &&
     !isViewingOwnProfile;
 
   // Check if user is already a member of this organization
-  const isAlreadyMember = user?.organizationUsers?.some(
+  const isAlreadyMember = user.organizationUsers?.some(
     (orgUser) => orgUser.organization?.profile?.id === profile.profile.id,
   );
   const shouldShowRequestMembershipButton =
@@ -83,12 +83,9 @@ const ProfileInteractions = ({ profile }: { profile: Organization }) => {
           {shouldShowRequestMembershipButton && (
             <RequestMembershipButton profile={profile} />
           )}
-          {/* Relationships are an authed feature; visitors only see funding links. */}
-          {user &&
-            !shouldShowFollowButton &&
-            !shouldShowRequestMembershipButton && (
-              <AddRelationshipModal profile={profile} />
-            )}
+          {!shouldShowFollowButton && !shouldShowRequestMembershipButton && (
+            <AddRelationshipModal profile={profile} />
+          )}
         </>
       )}
       {isReceivingFunds

--- a/apps/app/src/components/Profile/ProfileDetails/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/index.tsx
@@ -31,25 +31,25 @@ const ProfileInteractions = ({ profile }: { profile: Organization }) => {
 
   const isOrganizationProfile = profile.profile?.type === EntityType.ORG;
   const isViewingOwnProfile =
-    user.currentProfile?.id ===
+    user?.currentProfile?.id ===
     (isOrganizationProfile ? profile.profile.id : profile.id);
 
   // Check if current user is Individual viewing an Organization
   const isCurrentUserIndividual =
-    user.currentProfile?.type === EntityType.INDIVIDUAL;
+    user?.currentProfile?.type === EntityType.INDIVIDUAL;
   const shouldShowFollowButton =
     isCurrentUserIndividual && isOrganizationProfile && !isViewingOwnProfile;
 
   // Check if current user is Organization viewing an Individual
   const isCurrentUserOrganization =
-    user.currentProfile?.type === EntityType.ORG;
+    user?.currentProfile?.type === EntityType.ORG;
   const shouldShowInviteButton =
     isCurrentUserOrganization &&
     profile.profile.type === EntityType.INDIVIDUAL &&
     !isViewingOwnProfile;
 
   // Check if user is already a member of this organization
-  const isAlreadyMember = user.organizationUsers?.some(
+  const isAlreadyMember = user?.organizationUsers?.some(
     (orgUser) => orgUser.organization?.profile?.id === profile.profile.id,
   );
   const shouldShowRequestMembershipButton =
@@ -83,9 +83,12 @@ const ProfileInteractions = ({ profile }: { profile: Organization }) => {
           {shouldShowRequestMembershipButton && (
             <RequestMembershipButton profile={profile} />
           )}
-          {!shouldShowFollowButton && !shouldShowRequestMembershipButton && (
-            <AddRelationshipModal profile={profile} />
-          )}
+          {/* Relationships are an authed feature; visitors only see funding links. */}
+          {user &&
+            !shouldShowFollowButton &&
+            !shouldShowRequestMembershipButton && (
+              <AddRelationshipModal profile={profile} />
+            )}
         </>
       )}
       {isReceivingFunds

--- a/apps/app/src/components/Profile/ProfileFeed/index.tsx
+++ b/apps/app/src/components/Profile/ProfileFeed/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import type {
   CommonUser,
@@ -31,8 +31,7 @@ type DiscussionModalState = {
 export type ProfileFeedRenderProps = {
   posts: PostToOrganization[];
   isEmpty: boolean;
-  // Absent for public (signed-out) viewers; the feed itself is public.
-  user?: CommonUser;
+  user: CommonUser;
   infiniteScrollRef: RefObject<HTMLElement | null>;
   shouldShowTrigger: boolean;
   isFetchingNextPage: boolean;
@@ -51,7 +50,7 @@ export const ProfileFeedProvider = ({
   limit?: number;
   children: (props: ProfileFeedRenderProps) => React.ReactNode;
 }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const {
     data: paginatedData,
     fetchNextPage,

--- a/apps/app/src/components/Profile/ProfileFeed/index.tsx
+++ b/apps/app/src/components/Profile/ProfileFeed/index.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import type { OrganizationUser } from '@/utils/UserProvider';
 import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
-import type { Organization, Post, PostToOrganization } from '@op/api/encoders';
+import type {
+  CommonUser,
+  Organization,
+  Post,
+  PostToOrganization,
+} from '@op/api/encoders';
 import { useInfiniteScroll } from '@op/hooks';
 import { HorizontalList, HorizontalListItem } from '@op/ui/HorizontalList';
 import { SkeletonLine } from '@op/ui/Skeleton';
@@ -28,7 +32,7 @@ export type ProfileFeedRenderProps = {
   posts: PostToOrganization[];
   isEmpty: boolean;
   // Absent for public (signed-out) viewers; the feed itself is public.
-  user?: OrganizationUser;
+  user?: CommonUser;
   infiniteScrollRef: RefObject<HTMLElement | null>;
   shouldShowTrigger: boolean;
   isFetchingNextPage: boolean;

--- a/apps/app/src/components/Profile/ProfileFeed/index.tsx
+++ b/apps/app/src/components/Profile/ProfileFeed/index.tsx
@@ -27,7 +27,8 @@ type DiscussionModalState = {
 export type ProfileFeedRenderProps = {
   posts: PostToOrganization[];
   isEmpty: boolean;
-  user: OrganizationUser;
+  // Absent for public (signed-out) viewers; the feed itself is public.
+  user?: OrganizationUser;
   infiniteScrollRef: RefObject<HTMLElement | null>;
   shouldShowTrigger: boolean;
   isFetchingNextPage: boolean;

--- a/apps/app/src/components/SiteHeader/CreateMenu.tsx
+++ b/apps/app/src/components/SiteHeader/CreateMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { EntityType } from '@op/api/encoders';
 import { useMediaQuery } from '@op/hooks';
@@ -29,7 +29,7 @@ export const CreateMenu = () => {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
   const [isCreateOrganizationModalOpen, setIsCreateOrganizationModalOpen] =
     useState(false);
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const isOrg = user.currentProfile?.type === EntityType.ORG;
   const isMobile = useMediaQuery(`(max-width: ${SM_BREAKPOINT})`);
   const createDecisionEnabled = useFeatureFlag('create_decision_process');

--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -3,7 +3,7 @@
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { getPublicUrl } from '@/utils';
 import { ClientOnly } from '@/utils/ClientOnly';
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser, useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { EntityType, Profile } from '@op/api/encoders';
 import { useAuthLogout, useMediaQuery } from '@op/hooks';
@@ -55,7 +55,7 @@ const ProfileMenuItem = ({
   }) => void;
   children?: React.ReactNode;
 }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const router = useRouter();
   const utils = trpc.useUtils();
   const switchProfile = trpc.account.switchProfile.useMutation({
@@ -123,9 +123,8 @@ const AvatarMenuContent = ({
     avatarImage?: { name: string } | null;
   }) => void;
 }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const logout = useAuthLogout();
-  const router = useRouter();
   const t = useTranslations();
 
   const { data: profiles } = trpc.account.getUserProfiles.useQuery();
@@ -275,7 +274,9 @@ const AvatarMenuContent = ({
         id="logout"
         className="px-0 py-2 text-neutral-charcoal hover:bg-neutral-offWhite focus-visible:bg-neutral-offWhite"
         onAction={() => {
-          void logout.refetch().finally(() => router.push('/'));
+          // Full-page navigation: client-side routing would re-render the
+          // authed tree with a dead session before the redirect lands.
+          void logout.refetch().finally(() => window.location.assign('/'));
           onClose?.();
         }}
       >
@@ -336,7 +337,7 @@ const AvatarMenuContent = ({
 };
 
 export const UserAvatarMenu = ({ className }: { className?: string }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const isMobile = useMediaQuery(`(max-width: ${screens.sm})`);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isProfileOpen, setIsProfileOpen] = useState(false);
@@ -469,6 +470,36 @@ export const UserAvatarMenu = ({ className }: { className?: string }) => {
   );
 };
 
+/**
+ * Right-side header actions. Creating and the account menu are authed
+ * features; signed-out visitors only get the locale chooser.
+ */
+const HeaderActions = () => {
+  const { user } = useUser();
+
+  return (
+    <ClientOnly>
+      {user && <CreateMenu />}
+      <LocaleChooser />
+      {user && (
+        <ErrorBoundary
+          fallback={
+            <div className="size-8 rounded-full border bg-white shadow" />
+          }
+        >
+          <Suspense
+            fallback={
+              <Skeleton className="size-8 rounded-full border bg-white shadow" />
+            }
+          >
+            <UserAvatarMenu />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </ClientOnly>
+  );
+};
+
 export const SiteHeader = () => {
   const t = useTranslations();
   const [isMobileSearchExpanded, setIsMobileSearchExpanded] = useState(false);
@@ -488,23 +519,7 @@ export const SiteHeader = () => {
           </ErrorBoundary>
         </span>
         <div className="flex items-center gap-3">
-          <ClientOnly>
-            <CreateMenu />
-            <LocaleChooser />
-            <ErrorBoundary
-              fallback={
-                <div className="size-8 rounded-full border bg-white shadow" />
-              }
-            >
-              <Suspense
-                fallback={
-                  <Skeleton className="size-8 rounded-full border bg-white shadow" />
-                }
-              >
-                <UserAvatarMenu />
-              </Suspense>
-            </ErrorBoundary>
-          </ClientOnly>
+          <HeaderActions />
         </div>
       </header>
 
@@ -554,23 +569,7 @@ export const SiteHeader = () => {
               </Button>
 
               <div className="flex items-center gap-3">
-                <ClientOnly>
-                  <CreateMenu />
-                  <LocaleChooser />
-                  <ErrorBoundary
-                    fallback={
-                      <div className="size-8 rounded-full border bg-white shadow" />
-                    }
-                  >
-                    <Suspense
-                      fallback={
-                        <Skeleton className="size-8 rounded-full border bg-white shadow" />
-                      }
-                    >
-                      <UserAvatarMenu />
-                    </Suspense>
-                  </ErrorBoundary>
-                </ClientOnly>
+                <HeaderActions />
               </div>
             </>
           )}

--- a/apps/app/src/components/decisions/AllDecisions/index.tsx
+++ b/apps/app/src/components/decisions/AllDecisions/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { ProcessStatus } from '@op/api/encoders';
 import { match } from '@op/core';
@@ -111,7 +111,7 @@ const DecisionsListSuspense = ({
 
 const AllDecisionsTabs = () => {
   const t = useTranslations();
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const [tab, setTab] = useQueryState('tab');
   const ownerProfileId = user.currentProfile?.id;
 
@@ -173,7 +173,7 @@ const AllDecisionsTabs = () => {
 };
 
 export const AllDecisions = () => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
 
   return (
     <ErrorBoundary

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useUser } from '@/utils/UserProvider';
 import { ButtonLink } from '@op/ui/Button';
 import { Header1 } from '@op/ui/Header';
 import { IconButton } from '@op/ui/IconButton';
@@ -41,6 +42,7 @@ export const DecisionInstanceHeader = ({
   centerSlot?: ReactNode;
 }) => {
   const t = useTranslations();
+  const { user } = useUser();
 
   return (
     <header className="sticky top-0 z-10 grid grid-cols-[auto_1fr_auto] items-center border-b bg-white p-2 px-6 sm:grid-cols-3 md:py-3">
@@ -92,7 +94,9 @@ export const DecisionInstanceHeader = ({
           </ButtonLink>
         )}
         <LocaleChooser />
-        <UserAvatarMenu />
+        {/* TODO(public decision view): render a Login / upgrade-account CTA
+            for signed-out visitors here once anonymous sessions ship. */}
+        {user ? <UserAvatarMenu /> : null}
       </div>
     </header>
   );

--- a/apps/app/src/components/decisions/ManualSelectionList.tsx
+++ b/apps/app/src/components/decisions/ManualSelectionList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { ProposalFilter } from '@op/api/encoders';
 import type { Proposal } from '@op/common/client';
@@ -45,7 +45,7 @@ export const ManualSelectionList = ({
   confirmVariant = 'standard',
 }: ManualSelectionListProps) => {
   const t = useTranslations();
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const posthog = usePostHog();
   const router = useRouter();
   const pathname = usePathname();

--- a/apps/app/src/components/decisions/MyBallot.tsx
+++ b/apps/app/src/components/decisions/MyBallot.tsx
@@ -41,7 +41,7 @@ export const MyBallot = ({
 }) => {
   const user = useUser();
 
-  if (!user.user.id) {
+  if (!user.user?.id) {
     return <NoVoteFound />;
   }
 

--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -57,7 +57,7 @@ export function ProposalComments({
             <Surface className="border-0 p-0 sm:border sm:p-4">
               <PostUpdate
                 profileId={proposal.profileId || undefined}
-                placeholder={`${t('Comment')}${user.currentProfile?.name ? ` as ${user.currentProfile?.name}` : ''}...`}
+                placeholder={`${t('Comment')}${user?.currentProfile?.name ? ` as ${user?.currentProfile?.name}` : ''}...`}
                 label={t('Comment')}
                 onSuccess={scrollToComments}
                 proposalId={proposal.id}

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -616,7 +616,7 @@ export const ProposalsList = ({
   );
 
   // Get current user's profile ID for "My Proposals" filter
-  const currentProfileId = user.currentProfile?.id;
+  const currentProfileId = user?.currentProfile?.id;
   const [[categoriesData, voteStatus]] = trpc.useSuspenseQueries((t) => [
     t.decision.getCategories({
       processInstanceId: instanceId,

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { DATE_TIME_UTC_FORMAT, formatDate } from '@/utils/formatting';
 import { trpc } from '@op/api/client';
 import { type ProcessInstance, ProposalStatus } from '@op/api/encoders';
@@ -104,7 +104,7 @@ export function ProposalEditor({
   showHeaderActions?: boolean;
   revisionRequest?: ProposalReviewRequest | null;
 }) {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const t = useTranslations();
 
   // -- Collaboration ---------------------------------------------------------

--- a/apps/app/src/components/posts/PostDetailView.tsx
+++ b/apps/app/src/components/posts/PostDetailView.tsx
@@ -57,7 +57,7 @@ export function PostDetail({ postId, slug }: { postId: string; slug: string }) {
             <Surface className="border-0 px-0 py-4">
               <PostUpdate
                 parentPostId={post.id}
-                placeholder={`${t('Comment')}${user.currentProfile?.name ? ` ${t('as')} ${user.currentProfile?.name}` : ''}...`}
+                placeholder={`${t('Comment')}${user?.currentProfile?.name ? ` ${t('as')} ${user?.currentProfile?.name}` : ''}...`}
                 label={t('Comment')}
               />
             </Surface>

--- a/apps/app/src/components/screens/LandingScreen/Feed.tsx
+++ b/apps/app/src/components/screens/LandingScreen/Feed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from '@/utils/UserProvider';
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { useInfiniteScroll } from '@op/hooks';
 import { Fragment, useCallback } from 'react';
@@ -28,7 +28,7 @@ export const Feed = () => {
 
 /** Feed content component with live data */
 const FeedContent = ({ limit = 10 }: { limit?: number }) => {
-  const { user } = useUser();
+  const { user } = useRequiredUser();
   const t = useTranslations();
 
   const {
@@ -67,7 +67,7 @@ const FeedContent = ({ limit = 10 }: { limit?: number }) => {
     handleModalClose,
   } = usePostFeedActions();
 
-  if (!paginatedData || !user) {
+  if (!paginatedData) {
     return <PostFeedSkeleton numPosts={4} />;
   }
 

--- a/apps/app/src/components/screens/LandingScreen/Welcome.tsx
+++ b/apps/app/src/components/screens/LandingScreen/Welcome.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import type { OrganizationUser } from '@/utils/UserProvider';
+import type { CommonUser } from '@op/api/encoders';
 import { Header1 } from '@op/ui/Header';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { useMemo } from 'react';
 
-export const Welcome = ({ user }: { user: OrganizationUser }) => {
+export const Welcome = ({ user }: { user: CommonUser }) => {
   const searchParams = useSearchParams();
   const t = useTranslations();
 

--- a/apps/app/src/components/screens/LandingScreen/Welcome.tsx
+++ b/apps/app/src/components/screens/LandingScreen/Welcome.tsx
@@ -1,16 +1,12 @@
 'use client';
 
-import { RouterOutput } from '@op/api/client';
+import type { OrganizationUser } from '@/utils/UserProvider';
 import { Header1 } from '@op/ui/Header';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { useMemo } from 'react';
 
-export const Welcome = ({
-  user,
-}: {
-  user: RouterOutput['account']['getMyAccount'];
-}) => {
+export const Welcome = ({ user }: { user: OrganizationUser }) => {
   const searchParams = useSearchParams();
   const t = useTranslations();
 

--- a/apps/app/src/components/screens/LandingScreen/index.tsx
+++ b/apps/app/src/components/screens/LandingScreen/index.tsx
@@ -1,4 +1,4 @@
-import { getUser } from '@/utils/getUser';
+import { getRequiredUser } from '@/utils/getUser';
 import { Organization } from '@op/api/encoders';
 import {
   HydrationBoundary,
@@ -210,7 +210,7 @@ const LandingScreenFeeds = ({
  * Async component that fetches user data and renders user-dependent content.
  */
 const WelcomeSection = async () => {
-  const user = await getUser();
+  const user = await getRequiredUser();
 
   return (
     <div className="flex flex-col gap-2">
@@ -238,7 +238,7 @@ const WelcomeSkeleton = () => {
 };
 
 const UserContent = async () => {
-  const user = await getUser();
+  const user = await getRequiredUser();
 
   return (
     <>

--- a/apps/app/src/utils/UserProvider.tsx
+++ b/apps/app/src/utils/UserProvider.tsx
@@ -34,10 +34,13 @@ const defaultPermissions = AccessZones.reduce<CommonZonePermissions>(
 // You can refine this type by importing the correct type from your trpc/encoders if available
 // import type { User } from '@op/api/encoders';
 
-export type OrganizationUser = RouterOutput['account']['getMyAccount'];
+export type OrganizationUser = NonNullable<
+  RouterOutput['account']['getMyAccount']
+>;
 
 interface UserContextValue {
-  user: OrganizationUser;
+  // Absent for public (no-session) visitors.
+  user?: OrganizationUser;
   getPermissionsForProfile: (profileId: string) => CommonZonePermissions;
 }
 
@@ -48,7 +51,7 @@ export const UserProviderSuspense = ({
   initialUser,
 }: {
   children: React.ReactNode;
-  initialUser: OrganizationUser;
+  initialUser: OrganizationUser | null;
 }) => {
   const router = useRouter();
   // Use initialUser as initialData to avoid redundant client-side fetch.
@@ -56,27 +59,39 @@ export const UserProviderSuspense = ({
   // fetched fresh data for this layout render, so there's no need to re-fetch
   // on mount. This also avoids a race condition where the client-side refetch
   // fires before middleware cookie refresh is complete during navigation.
-  const [user] = trpc.account.getMyAccount.useSuspenseQuery(undefined, {
+  const [account] = trpc.account.getMyAccount.useSuspenseQuery(undefined, {
     initialData: initialUser,
     staleTime: 30 * 1000,
   });
 
-  if (!user.onboardedAt) {
+  // Map the API's `null` (JSON has no undefined) to match `user?:` props.
+  // Fall back to the server-rendered user: sign-outs always arrive via a
+  // full-page navigation (fresh tree, null initialUser), so inside a mounted
+  // tree a null refetch is a transient cookie/token race, not a sign-out.
+  const user = account ?? initialUser ?? undefined;
+
+  if (user && !user.onboardedAt) {
     router.push('/start');
   }
 
-  // We are only identifying One Project users by email.
-  if (user?.email?.match(/.+@oneproject\.org$|.+@peoplepowered\.org$/)) {
-    posthog.identify(user.authUserId, { email: user.email, name: user.name });
-  } else {
-    // others are given anonymous IDs
-    posthog.identify(user.authUserId);
+  if (user) {
+    // We are only identifying One Project users by email.
+    if (user.email?.match(/.+@oneproject\.org$|.+@peoplepowered\.org$/)) {
+      posthog.identify(user.authUserId, { email: user.email, name: user.name });
+    } else {
+      // others are given anonymous IDs
+      posthog.identify(user.authUserId);
+    }
   }
 
   // Utility function to get permissions for a specific profile
   const getPermissionsForProfile = (
     profileId: string,
   ): CommonZonePermissions => {
+    if (!user) {
+      return defaultPermissions;
+    }
+
     // First check profileUsers for a direct profile match
     const matchingProfileUser = user.profileUsers?.find(
       (profileUser) => profileUser.profileId === profileId,
@@ -109,7 +124,7 @@ export const UserProvider = ({
   initialUser,
 }: {
   children: React.ReactNode;
-  initialUser: OrganizationUser;
+  initialUser: OrganizationUser | null;
 }) => {
   return (
     <Suspense fallback={null}>
@@ -120,10 +135,37 @@ export const UserProvider = ({
   );
 };
 
+/**
+ * `user` is undefined for public (no-session) visitors. An anonymous sign-in
+ * is NOT absent: it has a real account, just with no email or profiles.
+ *
+ * Use this on public-capable surfaces (decision views, profile pages) and
+ * branch on `user` explicitly. For components that only render in auth-gated
+ * trees, use `useRequiredUser` instead.
+ */
 export function useUser() {
   const ctx = useContext(UserContext);
   if (!ctx) {
     throw new Error('useUser must be used within a UserProvider');
   }
   return ctx;
+}
+
+/**
+ * For components that only render in auth-gated trees (the middleware or a
+ * server layout has already redirected signed-out visitors). Throwing here
+ * means an auth-only component leaked onto a public surface — a bug, not a
+ * user-facing state.
+ */
+export function useRequiredUser() {
+  const ctx = useUser();
+  const { user } = ctx;
+
+  if (!user) {
+    throw new Error(
+      'useRequiredUser: no session. This component must only render in auth-gated trees.',
+    );
+  }
+
+  return { ...ctx, user };
 }

--- a/apps/app/src/utils/UserProvider.tsx
+++ b/apps/app/src/utils/UserProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { RouterOutput, trpc } from '@op/api/client';
+import { trpc } from '@op/api/client';
+import type { CommonUser } from '@op/api/encoders';
 import type { Permission } from 'access-zones';
 import { useRouter } from 'next/navigation';
 import posthog from 'posthog-js';
@@ -30,17 +31,9 @@ const defaultPermissions = AccessZones.reduce<CommonZonePermissions>(
   {} as CommonZonePermissions,
 );
 
-// Type for the user data returned by getMyAccount
-// You can refine this type by importing the correct type from your trpc/encoders if available
-// import type { User } from '@op/api/encoders';
-
-export type OrganizationUser = NonNullable<
-  RouterOutput['account']['getMyAccount']
->;
-
 interface UserContextValue {
   // Absent for public (no-session) visitors.
-  user?: OrganizationUser;
+  user?: CommonUser;
   getPermissionsForProfile: (profileId: string) => CommonZonePermissions;
 }
 
@@ -51,7 +44,7 @@ export const UserProviderSuspense = ({
   initialUser,
 }: {
   children: React.ReactNode;
-  initialUser: OrganizationUser | null;
+  initialUser: CommonUser | null;
 }) => {
   const router = useRouter();
   // Use initialUser as initialData to avoid redundant client-side fetch.
@@ -124,7 +117,7 @@ export const UserProvider = ({
   initialUser,
 }: {
   children: React.ReactNode;
-  initialUser: OrganizationUser | null;
+  initialUser: CommonUser | null;
 }) => {
   return (
     <Suspense fallback={null}>

--- a/apps/app/src/utils/getUser.ts
+++ b/apps/app/src/utils/getUser.ts
@@ -1,10 +1,26 @@
 import { createClient } from '@op/api/serverClient';
+import { redirect } from 'next/navigation';
 import { cache } from 'react';
 
 /**
- * Cached user fetch for server components.
+ * Cached user fetch for server components. Resolves null for public
+ * (no-session) visitors.
  */
 export const getUser = cache(async () => {
   const client = await createClient();
   return client.account.getMyAccount();
 });
+
+/**
+ * For server components in auth-gated route groups: resolves a non-null user
+ * or redirects to login (mirroring the middleware) if there is no session.
+ */
+export const getRequiredUser = async () => {
+  const user = await getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  return user;
+};

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -204,28 +204,6 @@ export const getUserByAuthId = async ({
   return userWithPermissions;
 };
 
-export const createUserByAuthId = async ({
-  authUserId,
-  email,
-}: {
-  authUserId: string;
-  email: string;
-}) => {
-  const [newUser] = await db
-    .insert(users)
-    .values({
-      authUserId,
-      email,
-    })
-    .returning();
-
-  if (!newUser) {
-    throw new Error('Could not create user');
-  }
-
-  return await getUserByAuthId({ authUserId, includePermissions: false });
-};
-
 export const getUserWithProfiles = async ({
   authUserId,
   includeRoles = false,

--- a/packages/hooks/src/useAuthLogout.tsx
+++ b/packages/hooks/src/useAuthLogout.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { trpc } from '@op/api/client';
 import type { AuthError } from '@op/supabase/lib';
 import { useQuery } from '@tanstack/react-query';
 import type { DefinedUseQueryResult } from '@tanstack/react-query';
 
-import useAuthUser from './useAuthUser';
 import nukeCookies from './utils/nukeCookies';
 
 const useAuthLogout: () => DefinedUseQueryResult<
@@ -14,8 +12,6 @@ const useAuthLogout: () => DefinedUseQueryResult<
   } | null,
   Error
 > = () => {
-  const user = useAuthUser();
-  const utils = trpc.useUtils();
   const logout = useQuery<{
     error: AuthError | null;
   } | null>({
@@ -29,9 +25,10 @@ const useAuthLogout: () => DefinedUseQueryResult<
 
       nukeCookies();
 
-      await user.refetch();
-      utils.account.getMyAccount.invalidate();
-
+      // No in-place cache update (neither getMyAccount invalidation nor an
+      // auth-user refetch): both would re-render the still-mounted authed
+      // tree with a dead session. Callers must follow up with a full-page
+      // navigation, which tears down the client cache wholesale.
       if (locData.error) {
         throw new Error(locData.error.message);
       }

--- a/services/api/src/routers/account/getMyAccount.test.ts
+++ b/services/api/src/routers/account/getMyAccount.test.ts
@@ -1,37 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
 import {
   accessTierGatingCell,
   describeAccessTierGating,
-  expectFailsAccessTierGate,
   expectPassesAccessTierGate,
 } from '../../test/helpers/gating';
+import { createGatingCallers } from '../../test/helpers/gating/callers';
+
+// Open procedure: every tier is admitted past the gate; what each tier
+// resolves to is covered separately below.
 
 describeAccessTierGating('account.getMyAccount', {
-  noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {
-    const caller = await callers.noJwt();
-    await expectFailsAccessTierGate(caller.account.getMyAccount(), 'none');
-  }),
+  noJwt: accessTierGatingCell(
+    'admits no-JWT past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.noJwt();
+      await expectPassesAccessTierGate(caller.account.getMyAccount());
+    },
+  ),
 
   anonJwt: accessTierGatingCell(
-    'rejects anon-JWT caller',
+    'admits anon-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.anonJwt();
-      await expectFailsAccessTierGate(caller.account.getMyAccount(), 'anon');
+      await expectPassesAccessTierGate(caller.account.getMyAccount());
     },
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits out-of-network user-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(caller.account.getMyAccount(), 'user');
+      await expectPassesAccessTierGate(caller.account.getMyAccount());
     },
   ),
 
   networkJwt: accessTierGatingCell(
-    'admits network-JWT caller',
+    'admits network-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.networkJwt();
       await expectPassesAccessTierGate(caller.account.getMyAccount());
     },
   ),
+});
+
+describe.concurrent('account.getMyAccount: resolution by tier', () => {
+  it('resolves null for a no-JWT (public) caller', async ({
+    onTestFinished,
+  }) => {
+    const callers = createGatingCallers(onTestFinished);
+    const caller = await callers.noJwt();
+
+    await expect(caller.account.getMyAccount()).resolves.toBeNull();
+  });
+
+  it('resolves the email-less account for an anonymous caller', async ({
+    onTestFinished,
+  }) => {
+    const callers = createGatingCallers(onTestFinished);
+    const caller = await callers.anonJwt();
+
+    const account = await caller.account.getMyAccount();
+    expect(account).not.toBeNull();
+    expect(account?.authUserId).toBeDefined();
+    expect(account?.email).toBeNull();
+  });
+
+  it('resolves the account for an authenticated user', async ({
+    onTestFinished,
+  }) => {
+    const callers = createGatingCallers(onTestFinished);
+    const caller = await callers.userJwt();
+
+    const account = await caller.account.getMyAccount();
+    expect(account).not.toBeNull();
+    expect(account?.authUserId).toBeDefined();
+  });
 });

--- a/services/api/src/routers/account/getMyAccount.ts
+++ b/services/api/src/routers/account/getMyAccount.ts
@@ -1,5 +1,5 @@
 import { cache } from '@op/cache';
-import { CommonError, createUserByAuthId, getUserByAuthId } from '@op/common';
+import { CommonError, getUserByAuthId } from '@op/common';
 import { z } from 'zod';
 
 import { userEncoder } from '../../encoders';
@@ -33,17 +33,8 @@ export const getMyAccount = router({
       });
 
       if (!user) {
-        // if there is no user but the user is authenticated, create one
-        const newUserWithRelations = await createUserByAuthId({
-          authUserId: id,
-          email: ctx.user.email!,
-        });
-
-        if (!newUserWithRelations) {
-          throw new CommonError('Could not create user');
-        }
-
-        return userEncoder.parse(newUserWithRelations);
+        // This should never happen, but if it does throw an error so we can investigate.
+        throw new CommonError('Common user not found');
       }
 
       return userEncoder.parse(user);

--- a/services/api/src/routers/account/getMyAccount.ts
+++ b/services/api/src/routers/account/getMyAccount.ts
@@ -1,20 +1,21 @@
 import { cache } from '@op/cache';
-import {
-  CommonError,
-  NotFoundError,
-  createUserByAuthId,
-  getUserByAuthId,
-} from '@op/common';
+import { CommonError, createUserByAuthId, getUserByAuthId } from '@op/common';
 import { z } from 'zod';
 
 import { userEncoder } from '../../encoders';
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { openProcedure, router } from '../../trpcFactory';
 
 export const getMyAccount = router({
-  getMyAccount: networkAuthenticatedProcedure()
+  getMyAccount: openProcedure()
     .input(z.undefined())
-    .output(userEncoder)
+    .output(userEncoder.nullable())
     .query(async ({ ctx }) => {
+      // No session → no account. Anonymous sign-ins do have one (the signup
+      // trigger creates a users row for every auth user), so they fall through.
+      if (!ctx.user) {
+        return null;
+      }
+
       const { id, email } = ctx.user;
 
       const user = await cache({
@@ -32,14 +33,15 @@ export const getMyAccount = router({
       });
 
       if (!user) {
+        // Backfill accounts predating the signup trigger; without an email
+        // there is nothing to create from.
         if (!email) {
-          throw new NotFoundError('User', id);
+          return null;
         }
 
-        // if there is no user but the user is authenticated, create one
         const newUserWithRelations = await createUserByAuthId({
           authUserId: id,
-          email: ctx.user.email!,
+          email,
         });
 
         if (!newUserWithRelations) {

--- a/services/api/src/routers/account/getMyAccount.ts
+++ b/services/api/src/routers/account/getMyAccount.ts
@@ -16,7 +16,7 @@ export const getMyAccount = router({
         return null;
       }
 
-      const { id, email } = ctx.user;
+      const { id } = ctx.user;
 
       const user = await cache({
         type: 'user',
@@ -33,15 +33,10 @@ export const getMyAccount = router({
       });
 
       if (!user) {
-        // Backfill accounts predating the signup trigger; without an email
-        // there is nothing to create from.
-        if (!email) {
-          return null;
-        }
-
+        // if there is no user but the user is authenticated, create one
         const newUserWithRelations = await createUserByAuthId({
           authUserId: id,
-          email,
+          email: ctx.user.email!,
         });
 
         if (!newUserWithRelations) {


### PR DESCRIPTION
Lets public pages resolve the viewer without rejecting: no-session callers get null, while anonymous sign-ins resolve their real (email-less) account created by the signup trigger. Keeps a single useUser() hook with a nullable user instead of a separate useOptionalUser, so there is one way to read the viewer everywhere. Ships independently — anonymous sessions and public routes stay gated until the follow-up PR.

feat(api): convert account.getMyAccount to an openProcedure with nullable output
refactor(app): make useUser()'s user nullable and null-safe across call sites
test(api): gating matrix asserts admission only; resolution-by-tier covered separately