### PR TITLE
feat(decisions): overview submit CTA creates a draft proposal directly

### DIFF
--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -30,7 +30,11 @@ export const DecisionActionBar = ({
   const { slug } = useParams<{ slug: string }>();
 
   const { createProposal: handleCreateProposal, isCreating } =
-    useCreateProposal({ instanceId, decisionSlug: slug });
+    useCreateProposal({
+      instanceId,
+      getRedirectHref: (proposal) =>
+        `/decisions/${slug}/proposal/${proposal.profileId}/edit`,
+    });
 
   return (
     <div className="flex w-full justify-center">

--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -32,7 +32,7 @@ export const DecisionActionBar = ({
   const { createProposal: handleCreateProposal, isCreating } =
     useCreateProposal({
       instanceId,
-      getRedirectHref: (proposal) =>
+      navigateTo: (proposal) =>
         `/decisions/${slug}/proposal/${proposal.profileId}/edit`,
     });
 

--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -1,22 +1,17 @@
 'use client';
 
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
-import { useUser } from '@/utils/UserProvider';
-import { trpc } from '@op/api/client';
-import { createSBBrowserClient } from '@op/supabase/client';
 import { Button } from '@op/ui/Button';
 import { Dialog, DialogTrigger } from '@op/ui/Dialog';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Modal, ModalBody, ModalHeader } from '@op/ui/Modal';
 import { RichTextViewer } from '@op/ui/RichTextEditor';
-import { toast } from '@op/ui/Toast';
 import he from 'he';
 import { useParams } from 'next/navigation';
-import { useState } from 'react';
 
-import { useRouter, useTranslations } from '@/lib/i18n';
+import { useTranslations } from '@/lib/i18n';
 
 import { getViewerExtensions } from '../RichTextEditor/editorConfig';
+import { useCreateProposal } from './useCreateProposal';
 
 export const DecisionActionBar = ({
   instanceId,
@@ -32,49 +27,10 @@ export const DecisionActionBar = ({
   showSubmitButton?: boolean;
 }) => {
   const t = useTranslations();
-  const { slug } = useParams();
-  const router = useRouter();
-  const { user } = useUser();
-  const [isCreating, setIsCreating] = useState(false);
-  const supabase = createSBBrowserClient();
-  const utils = trpc.useUtils();
-  const anonymousSigninEnabled = useFeatureFlag('anonymous_signin');
+  const { slug } = useParams<{ slug: string }>();
 
-  const createProposalMutation = trpc.decision.createProposal.useMutation();
-
-  const handleCreateProposal = async () => {
-    setIsCreating(true);
-
-    try {
-      // A public (no-session) visitor has no account to attribute the proposal
-      // to, so give them an anonymous session before creating the draft.
-      if (anonymousSigninEnabled && !user) {
-        const { error } = await supabase.auth.signInAnonymously();
-        if (error) {
-          throw error;
-        }
-
-        // The new session isn't reflected in the cached account query, so
-        // refetch it before navigating — the edit page requires a populated
-        // user in context.
-        await utils.account.getMyAccount.invalidate();
-      }
-
-      const proposal = await createProposalMutation.mutateAsync({
-        processInstanceId: instanceId,
-        proposalData: {}, // Empty draft - user will fill in via edit page
-      });
-
-      // Navigate to edit the newly created draft proposal
-      router.push(`/decisions/${slug}/proposal/${proposal.profileId}/edit`);
-    } catch (error) {
-      setIsCreating(false);
-      toast.error({
-        title: t('Failed to create proposal'),
-        message: error instanceof Error ? error.message : undefined,
-      });
-    }
-  };
+  const { createProposal: handleCreateProposal, isCreating } =
+    useCreateProposal({ instanceId, decisionSlug: slug });
 
   return (
     <div className="flex w-full justify-center">

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -128,7 +128,8 @@ const OverviewHero = ({
   const currentPhaseHref = `/decisions/${decisionSlug}/current`;
   const { createProposal, isCreating } = useCreateProposal({
     instanceId,
-    decisionSlug,
+    getRedirectHref: (proposal) =>
+      `/decisions/${decisionSlug}/proposal/${proposal.profileId}/edit`,
   });
 
   return (

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -128,7 +128,7 @@ const OverviewHero = ({
   const currentPhaseHref = `/decisions/${decisionSlug}/current`;
   const { createProposal, isCreating } = useCreateProposal({
     instanceId,
-    getRedirectHref: (proposal) =>
+    navigateTo: (proposal) =>
       `/decisions/${decisionSlug}/proposal/${proposal.profileId}/edit`,
   });
 

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -2,15 +2,17 @@
 
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { trpc } from '@op/api/client';
-import { ButtonLink } from '@op/ui/Button';
+import { Button, ButtonLink } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header2, Header3 } from '@op/ui/Header';
+import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import he from 'he';
 import { LuTriangleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
 import { ProposalHtmlContent } from './ProposalHtmlContent';
+import { useCreateProposal } from './useCreateProposal';
 
 interface DecisionOverviewProps {
   instanceId: string;
@@ -80,6 +82,7 @@ function DecisionOverviewContent({
       <OverviewHero
         headline={headline}
         subhead={overview?.description}
+        instanceId={instanceId}
         decisionSlug={decisionSlug}
         canSubmitProposal={canSubmitProposal}
       />
@@ -111,16 +114,22 @@ function DecisionOverviewContent({
 const OverviewHero = ({
   headline,
   subhead,
+  instanceId,
   decisionSlug,
   canSubmitProposal,
 }: {
   headline: string;
   subhead?: string;
+  instanceId: string;
   decisionSlug: string;
   canSubmitProposal: boolean;
 }) => {
   const t = useTranslations();
   const currentPhaseHref = `/decisions/${decisionSlug}/current`;
+  const { createProposal, isCreating } = useCreateProposal({
+    instanceId,
+    decisionSlug,
+  });
 
   return (
     // Gradient stands in until overview header images exist — same radial
@@ -146,13 +155,15 @@ const OverviewHero = ({
             {t('Browse proposals')}
           </ButtonLink>
           {canSubmitProposal ? (
-            <ButtonLink
+            <Button
               color="primary"
-              href={currentPhaseHref}
               className="w-auto"
+              isDisabled={isCreating}
+              onPress={createProposal}
             >
+              {isCreating ? <LoadingSpinner /> : null}
               {t('Submit a proposal')}
-            </ButtonLink>
+            </Button>
           ) : null}
         </div>
       </div>

--- a/apps/app/src/components/decisions/useCreateProposal.ts
+++ b/apps/app/src/components/decisions/useCreateProposal.ts
@@ -5,69 +5,67 @@ import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { createSBBrowserClient } from '@op/supabase/client';
 import { toast } from '@op/ui/Toast';
-import { useState } from 'react';
+import { useTransition } from 'react';
 
 import { useRouter, useTranslations } from '@/lib/i18n';
 
 /**
- * Creates an empty draft proposal for the instance and navigates to its edit
- * page. `isCreating` stays true through the redirect on success so buttons
- * can keep showing a pending state.
+ * Creates an empty draft proposal for the instance and navigates to the href
+ * the caller builds from the created proposal. `isCreating` stays true through
+ * the navigation so buttons can keep showing a pending state.
  *
  * Public (no-session) visitors are given an anonymous session first when the
  * `anonymous_signin` flag is on, so the draft has an account to attribute to.
  */
 export function useCreateProposal({
   instanceId,
-  decisionSlug,
+  getRedirectHref,
 }: {
   instanceId: string;
-  decisionSlug: string;
+  /** Builds the post-create destination from the new draft proposal. */
+  getRedirectHref: (proposal: { profileId: string }) => string;
 }) {
   const t = useTranslations();
   const router = useRouter();
   const { user } = useUser();
-  const [isCreating, setIsCreating] = useState(false);
+  const [isCreating, startCreating] = useTransition();
   const supabase = createSBBrowserClient();
   const utils = trpc.useUtils();
   const anonymousSigninEnabled = useFeatureFlag('anonymous_signin');
 
   const createProposalMutation = trpc.decision.createProposal.useMutation();
 
-  const createProposal = async () => {
-    setIsCreating(true);
+  const createProposal = () => {
+    startCreating(async () => {
+      try {
+        // A public (no-session) visitor has no account to attribute the
+        // proposal to, so give them an anonymous session before creating the
+        // draft.
+        if (anonymousSigninEnabled && !user) {
+          const { error } = await supabase.auth.signInAnonymously();
+          if (error) {
+            throw error;
+          }
 
-    try {
-      // A public (no-session) visitor has no account to attribute the proposal
-      // to, so give them an anonymous session before creating the draft.
-      if (anonymousSigninEnabled && !user) {
-        const { error } = await supabase.auth.signInAnonymously();
-        if (error) {
-          throw error;
+          // The new session isn't reflected in the cached account query, so
+          // refetch it before navigating — the edit page requires a populated
+          // user in context.
+          await utils.account.getMyAccount.invalidate();
         }
 
-        // The new session isn't reflected in the cached account query, so
-        // refetch it before navigating — the edit page requires a populated
-        // user in context.
-        await utils.account.getMyAccount.invalidate();
+        const proposal = await createProposalMutation.mutateAsync({
+          processInstanceId: instanceId,
+          proposalData: {}, // Empty draft - user will fill in via edit page
+        });
+
+        router.push(getRedirectHref(proposal));
+      } catch (error) {
+        toast.error({
+          title: t('Failed to create proposal'),
+          message: error instanceof Error ? error.message : undefined,
+        });
       }
-
-      const proposal = await createProposalMutation.mutateAsync({
-        processInstanceId: instanceId,
-        proposalData: {}, // Empty draft - user will fill in via edit page
-      });
-
-      // Navigate to edit the newly created draft proposal
-      router.push(
-        `/decisions/${decisionSlug}/proposal/${proposal.profileId}/edit`,
-      );
-    } catch (error) {
-      setIsCreating(false);
-      toast.error({
-        title: t('Failed to create proposal'),
-        message: error instanceof Error ? error.message : undefined,
-      });
-    }
+    });
   };
 
   return { createProposal, isCreating };

--- a/apps/app/src/components/decisions/useCreateProposal.ts
+++ b/apps/app/src/components/decisions/useCreateProposal.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useUser } from '@/utils/UserProvider';
+import { trpc } from '@op/api/client';
+import { createSBBrowserClient } from '@op/supabase/client';
+import { toast } from '@op/ui/Toast';
+import { useState } from 'react';
+
+import { useRouter, useTranslations } from '@/lib/i18n';
+
+/**
+ * Creates an empty draft proposal for the instance and navigates to its edit
+ * page. `isCreating` stays true through the redirect on success so buttons
+ * can keep showing a pending state.
+ *
+ * Public (no-session) visitors are given an anonymous session first when the
+ * `anonymous_signin` flag is on, so the draft has an account to attribute to.
+ */
+export function useCreateProposal({
+  instanceId,
+  decisionSlug,
+}: {
+  instanceId: string;
+  decisionSlug: string;
+}) {
+  const t = useTranslations();
+  const router = useRouter();
+  const { user } = useUser();
+  const [isCreating, setIsCreating] = useState(false);
+  const supabase = createSBBrowserClient();
+  const utils = trpc.useUtils();
+  const anonymousSigninEnabled = useFeatureFlag('anonymous_signin');
+
+  const createProposalMutation = trpc.decision.createProposal.useMutation();
+
+  const createProposal = async () => {
+    setIsCreating(true);
+
+    try {
+      // A public (no-session) visitor has no account to attribute the proposal
+      // to, so give them an anonymous session before creating the draft.
+      if (anonymousSigninEnabled && !user) {
+        const { error } = await supabase.auth.signInAnonymously();
+        if (error) {
+          throw error;
+        }
+
+        // The new session isn't reflected in the cached account query, so
+        // refetch it before navigating — the edit page requires a populated
+        // user in context.
+        await utils.account.getMyAccount.invalidate();
+      }
+
+      const proposal = await createProposalMutation.mutateAsync({
+        processInstanceId: instanceId,
+        proposalData: {}, // Empty draft - user will fill in via edit page
+      });
+
+      // Navigate to edit the newly created draft proposal
+      router.push(
+        `/decisions/${decisionSlug}/proposal/${proposal.profileId}/edit`,
+      );
+    } catch (error) {
+      setIsCreating(false);
+      toast.error({
+        title: t('Failed to create proposal'),
+        message: error instanceof Error ? error.message : undefined,
+      });
+    }
+  };
+
+  return { createProposal, isCreating };
+}

--- a/apps/app/src/components/decisions/useCreateProposal.ts
+++ b/apps/app/src/components/decisions/useCreateProposal.ts
@@ -19,11 +19,11 @@ import { useRouter, useTranslations } from '@/lib/i18n';
  */
 export function useCreateProposal({
   instanceId,
-  getRedirectHref,
+  navigateTo,
 }: {
   instanceId: string;
   /** Builds the post-create destination from the new draft proposal. */
-  getRedirectHref: (proposal: { profileId: string }) => string;
+  navigateTo: (proposal: { profileId: string }) => string;
 }) {
   const t = useTranslations();
   const router = useRouter();
@@ -58,7 +58,7 @@ export function useCreateProposal({
           proposalData: {}, // Empty draft - user will fill in via edit page
         });
 
-        router.push(getRedirectHref(proposal));
+        router.push(navigateTo(proposal));
       } catch (error) {
         toast.error({
           title: t('Failed to create proposal'),


### PR DESCRIPTION
Stacked on #1288.

- extracts a shared `useCreateProposal` hook from `DecisionActionBar` (creates an empty draft via `decision.createProposal`, redirects to its edit page, pending state + error toast)
- the overview hero's "Submit a proposal" button now creates the draft and lands on the proposal editor instead of linking to the Current Phase view
- `DecisionActionBar` reuses the hook (behavior unchanged)