### PR TITLE
fix(decisions): persist only dirty fields in process builder localStorage

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -13,6 +13,7 @@
     "format:check": "oxfmt --check",
     "start": "next start -p 3100",
     "start:e2e": "NEXT_PUBLIC_APP_PORT=4100 NEXT_PUBLIC_API_PORT=4300 next start -p 4100",
+    "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/edit/page.tsx
@@ -83,7 +83,6 @@ const EditDecisionPage = async ({
           <ProcessBuilderStoreInitializer
             decisionProfileId={decisionProfile.id}
             serverData={serverData}
-            isDraft={isDraft}
           />
           <ProcessBuilderHeader instanceId={instanceId} slug={slug} />
           <ProcessBuilderEditArea

--- a/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
@@ -30,6 +30,7 @@ export const LaunchProcessModal = ({
   const instanceData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
+  const clearInstance = useProcessBuilderStore((s) => s.clearInstance);
 
   const { data: invites, isLoading: invitesLoading } =
     trpc.profile.listProfileInvites.useQuery(
@@ -50,6 +51,10 @@ export const LaunchProcessModal = ({
   const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
     onSuccess: async (data) => {
       onOpenChange(false);
+      // Drop local state so the editor reseeds from fresh server data —
+      // draft edits were already autosaved, and leftover dirty fields
+      // would otherwise overlay the now-published instance.
+      clearInstance(decisionProfileId);
       await utils.decision.getDecisionBySlug.invalidate();
       router.push(`/decisions/${data.slug}`);
     },

--- a/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
@@ -51,9 +51,7 @@ export const LaunchProcessModal = ({
   const updateInstance = trpc.decision.updateDecisionInstance.useMutation({
     onSuccess: async (data) => {
       onOpenChange(false);
-      // Drop local state so the editor reseeds from fresh server data —
-      // draft edits were already autosaved, and leftover dirty fields
-      // would otherwise overlay the now-published instance.
+      // Leftover dirty fields would otherwise overlay the published instance
       clearInstance(decisionProfileId);
       await utils.decision.getDecisionBySlug.invalidate();
       router.push(`/decisions/${data.slug}`);

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { trpc } from '@op/api/client';
+import { ProcessStatus } from '@op/api/encoders';
 import { useDebouncedCallback } from '@op/hooks';
 import { toast } from '@op/ui/Toast';
 import {
@@ -53,16 +54,31 @@ export function useProcessBuilderAutosave(): AutosaveActions & {
 export function ProcessBuilderAutosaveProvider({
   decisionProfileId,
   instanceId,
-  isDraft,
+  isDraft: isDraftInitial,
   children,
 }: {
   decisionProfileId: string;
   instanceId: string;
+  /** SSR snapshot of the instance status — used only until the live query
+   *  resolves. The live value matters when the status changes while the
+   *  editor is open (e.g. another admin or another tab launches the
+   *  process): autosave must stop writing straight to the now-published
+   *  instance and fall back to buffering until "Update Process". */
   isDraft: boolean;
   children: React.ReactNode;
 }) {
   const t = useTranslations();
   const utils = trpc.useUtils();
+
+  // Reactive status: getInstance is already cached (sections suspense-query
+  // it, and autosave invalidates it on settle), so this subscription costs
+  // no extra request. Refetch-on-focus heals the stale-tab case.
+  const { data: liveInstance } = trpc.decision.getInstance.useQuery({
+    instanceId,
+  });
+  const isDraft = liveInstance
+    ? liveInstance.status === ProcessStatus.DRAFT
+    : isDraftInitial;
   const setInstanceData = useProcessBuilderStore((s) => s.setInstanceData);
   const setProposalTemplateSchema = useProcessBuilderStore(
     (s) => s.setProposalTemplateSchema,
@@ -135,13 +151,22 @@ export function ProcessBuilderAutosaveProvider({
           clearDirtyFields(decisionProfileId, payload);
         })
         .catch(() => {
-          // Handled by the mutation's onError callback (toast + status).
-          // This catch only prevents unhandled promise rejection warnings.
+          // Error surfaced by the mutation's onError callback (toast +
+          // status). Restore the failed payload so the next debounced save
+          // retries it — newer edits win on conflict. No retry is scheduled
+          // here: a persistently rejecting payload would loop; the next
+          // user edit (or flush) re-sends naturally.
+          dirtyFieldsRef.current = {
+            ...payload,
+            ...dirtyFieldsRef.current,
+            config: { ...payload.config, ...dirtyFieldsRef.current.config },
+          };
         });
     } else {
-      // Published: data is only in the store (localStorage) until the user
-      // clicks "Update Process". Don't show a save indicator — it would be
-      // misleading since nothing has been persisted to the server yet.
+      // Published: edits stay in the store (the dirty map is persisted to
+      // localStorage) until the user clicks "Update Process". Don't show a
+      // save indicator — it would be misleading since nothing has been
+      // persisted to the server yet.
     }
   }, AUTOSAVE_DEBOUNCE_MS);
   debouncedSaveRef.current = () => debouncedSave.isPending();

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
@@ -72,6 +72,7 @@ export function ProcessBuilderAutosaveProvider({
   );
   const setSaveStatus = useProcessBuilderStore((s) => s.setSaveStatus);
   const markSaved = useProcessBuilderStore((s) => s.markSaved);
+  const clearDirtyFields = useProcessBuilderStore((s) => s.clearDirtyFields);
   const currentStatus = useProcessBuilderStore((s) =>
     s.getSaveState(decisionProfileId),
   );
@@ -125,10 +126,18 @@ export function ProcessBuilderAutosaveProvider({
         ...payload,
       });
       inflightRef.current = promise;
-      promise.catch(() => {
-        // Handled by the mutation's onError callback (toast + status).
-        // This catch only prevents unhandled promise rejection warnings.
-      });
+      promise
+        .then(() => {
+          // Drop confirmed-saved fields from the persisted dirty map so it
+          // only ever holds unsaved (or failed) edits. The seed-time overlay
+          // can then safely re-apply it after a reload: failed autosaves
+          // survive, while saved fields can't shadow newer server data.
+          clearDirtyFields(decisionProfileId, payload);
+        })
+        .catch(() => {
+          // Handled by the mutation's onError callback (toast + status).
+          // This catch only prevents unhandled promise rejection warnings.
+        });
     } else {
       // Published: data is only in the store (localStorage) until the user
       // clicks "Update Process". Don't show a save indicator — it would be

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext.tsx
@@ -59,20 +59,15 @@ export function ProcessBuilderAutosaveProvider({
 }: {
   decisionProfileId: string;
   instanceId: string;
-  /** SSR snapshot of the instance status — used only until the live query
-   *  resolves. The live value matters when the status changes while the
-   *  editor is open (e.g. another admin or another tab launches the
-   *  process): autosave must stop writing straight to the now-published
-   *  instance and fall back to buffering until "Update Process". */
+  /** SSR snapshot, used only until the live query resolves — the status
+   *  can change mid-session (another tab/admin launches the process). */
   isDraft: boolean;
   children: React.ReactNode;
 }) {
   const t = useTranslations();
   const utils = trpc.useUtils();
 
-  // Reactive status: getInstance is already cached (sections suspense-query
-  // it, and autosave invalidates it on settle), so this subscription costs
-  // no extra request. Refetch-on-focus heals the stale-tab case.
+  // Already cached by section queries — no extra request.
   const { data: liveInstance } = trpc.decision.getInstance.useQuery({
     instanceId,
   });
@@ -144,18 +139,13 @@ export function ProcessBuilderAutosaveProvider({
       inflightRef.current = promise;
       promise
         .then(() => {
-          // Drop confirmed-saved fields from the persisted dirty map so it
-          // only ever holds unsaved (or failed) edits. The seed-time overlay
-          // can then safely re-apply it after a reload: failed autosaves
-          // survive, while saved fields can't shadow newer server data.
+          // Keep the persisted dirty map holding unsaved/failed edits only.
           clearDirtyFields(decisionProfileId, payload);
         })
         .catch(() => {
-          // Error surfaced by the mutation's onError callback (toast +
-          // status). Restore the failed payload so the next debounced save
-          // retries it — newer edits win on conflict. No retry is scheduled
-          // here: a persistently rejecting payload would loop; the next
-          // user edit (or flush) re-sends naturally.
+          // Error toasted by onError. Restore the payload so the next save
+          // retries it (newer edits win); no scheduled retry — a rejecting
+          // payload would loop.
           dirtyFieldsRef.current = {
             ...payload,
             ...dirtyFieldsRef.current,
@@ -163,10 +153,8 @@ export function ProcessBuilderAutosaveProvider({
           };
         });
     } else {
-      // Published: edits stay in the store (the dirty map is persisted to
-      // localStorage) until the user clicks "Update Process". Don't show a
-      // save indicator — it would be misleading since nothing has been
-      // persisted to the server yet.
+      // Published: edits stay in the persisted dirty map until "Update
+      // Process". No save indicator — nothing reached the server yet.
     }
   }, AUTOSAVE_DEBOUNCE_MS);
   debouncedSaveRef.current = () => debouncedSave.isPending();

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -100,6 +100,10 @@ export const ProcessBuilderFooter = ({
       // Send only the fields the user actually edited. Sending the full
       // store snapshot would overwrite other admins' saved changes with
       // whatever this client last saw.
+      // A cleared (empty-string) name or steward is not a valid value, so
+      // those coalesce to undefined and keep the server value — the form
+      // already shows a validation error for an empty name. A cleared
+      // description IS valid and is sent through.
       updateInstance.mutate({
         instanceId,
         name: dirtyFields?.name || undefined,

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -97,13 +97,10 @@ export const ProcessBuilderFooter = ({
     if (isDraft) {
       setIsLaunchModalOpen(true);
     } else {
-      // Send only the fields the user actually edited. Sending the full
-      // store snapshot would overwrite other admins' saved changes with
-      // whatever this client last saw.
-      // A cleared (empty-string) name or steward is not a valid value, so
-      // those coalesce to undefined and keep the server value — the form
-      // already shows a validation error for an empty name. A cleared
-      // description IS valid and is sent through.
+      // Send only edited fields — a full snapshot would overwrite other
+      // admins' saved changes. Cleared name/steward are invalid, so they
+      // coalesce to undefined (server keeps its value); cleared
+      // description is valid and goes through.
       updateInstance.mutate({
         instanceId,
         name: dirtyFields?.name || undefined,

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -57,6 +57,7 @@ export const ProcessBuilderFooter = ({
   const storeData = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
+  const dirtyFields = useProcessBuilderStore((s) => s.dirty[decisionProfileId]);
   const clearInstance = useProcessBuilderStore((s) => s.clearInstance);
   const displayName =
     storeData?.name || decisionProfile?.name || t('New process');
@@ -96,15 +97,18 @@ export const ProcessBuilderFooter = ({
     if (isDraft) {
       setIsLaunchModalOpen(true);
     } else {
+      // Send only the fields the user actually edited. Sending the full
+      // store snapshot would overwrite other admins' saved changes with
+      // whatever this client last saw.
       updateInstance.mutate({
         instanceId,
-        name: storeData?.name || undefined,
-        description: storeData?.description || undefined,
-        stewardProfileId: storeData?.stewardProfileId || undefined,
-        phases: storeData?.phases,
-        proposalTemplate: storeData?.proposalTemplate,
-        rubricTemplate: storeData?.rubricTemplate,
-        config: storeData?.config,
+        name: dirtyFields?.name || undefined,
+        description: dirtyFields?.description,
+        stewardProfileId: dirtyFields?.stewardProfileId || undefined,
+        phases: dirtyFields?.phases,
+        proposalTemplate: dirtyFields?.proposalTemplate,
+        rubricTemplate: dirtyFields?.rubricTemplate,
+        config: dirtyFields?.config,
       });
     }
   };

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderStoreInitializer.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderStoreInitializer.tsx
@@ -12,12 +12,9 @@ import {
  * validation (and other consumers) have data immediately — even before
  * the user visits any individual section.
  *
- * Server data is the base layer; locally-dirty fields (the user's own
- * unsaved edits) overlay on top. The dirty map only ever holds unsaved
- * or failed edits — draft autosaves remove confirmed-saved fields
- * (see ProcessBuilderAutosaveContext), and published saves clear the
- * whole instance — so the overlay can't shadow other admins' newer
- * server data, while edits whose autosave failed survive a reload.
+ * Server data is the base; the user's own unsaved edits (`dirty`)
+ * overlay on top. Safe because `dirty` only ever holds unsaved or
+ * failed edits — confirmed saves remove their fields from it.
  */
 export function ProcessBuilderStoreInitializer({
   decisionProfileId,

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderStoreInitializer.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderStoreInitializer.tsx
@@ -13,11 +13,13 @@ import {
  * the user visits any individual section.
  *
  * Merge strategy depends on instance status:
- * - Draft: server data is used directly (localStorage is ignored to avoid
- *   stale edits overwriting already-saved data).
- * - Non-draft: server data is the base layer, localStorage edits overlay
- *   on top for keys with a defined, non-empty value (since non-draft
- *   processes do not save to the API on every edit).
+ * - Draft: server data is used directly, and any persisted dirty fields
+ *   are discarded — draft edits autosave to the API, so anything still
+ *   in localStorage is from an old session and already saved.
+ * - Non-draft: server data is the base layer, with locally-dirty fields
+ *   (the user's own unsaved edits) overlaid on top. Only fields the user
+ *   actually edited are persisted, so server changes made by other
+ *   admins are never shadowed by a stale snapshot.
  *
  * Note: `isDraft` is evaluated once from the server component at page load.
  * This assumes launching a process triggers a navigation/reload so the
@@ -50,37 +52,24 @@ export function ProcessBuilderStoreInitializer({
       }
       hasSeeded.current = true;
 
-      const existing =
-        useProcessBuilderStore.getState().instances[decisionProfileId];
-
+      const store = useProcessBuilderStore.getState();
       const base = serverDataRef.current;
 
-      // For drafts, prefer server data — localStorage may contain stale
-      // edits from a previous session that have already been saved.
-      // For non-draft (launched) processes, overlay localStorage on top
-      // since edits are only buffered locally until explicitly saved.
       let data: ProcessBuilderInstanceData;
       if (isDraft) {
         data = base;
+        store.clearDirty(decisionProfileId);
       } else {
-        // Filter out empty/undefined localStorage values, then overlay
-        // on top of server data so local edits take precedence.
-        const { config: localConfig, ...localRest } = existing ?? {};
-        const filtered = Object.fromEntries(
-          Object.entries(localRest).filter(
-            ([, v]) => v !== undefined && v !== '',
-          ),
-        );
+        // Overlay the user's own unsaved edits on top of server data.
+        const dirtyFields = store.dirty[decisionProfileId];
         data = {
           ...base,
-          ...filtered,
-          config: { ...base.config, ...localConfig },
+          ...dirtyFields,
+          config: { ...base.config, ...dirtyFields?.config },
         };
       }
 
-      useProcessBuilderStore
-        .getState()
-        .setInstanceData(decisionProfileId, data);
+      store.seedInstance(decisionProfileId, data);
     });
 
     void useProcessBuilderStore.persist.rehydrate();

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderStoreInitializer.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderStoreInitializer.tsx
@@ -12,27 +12,19 @@ import {
  * validation (and other consumers) have data immediately — even before
  * the user visits any individual section.
  *
- * Merge strategy depends on instance status:
- * - Draft: server data is used directly, and any persisted dirty fields
- *   are discarded — draft edits autosave to the API, so anything still
- *   in localStorage is from an old session and already saved.
- * - Non-draft: server data is the base layer, with locally-dirty fields
- *   (the user's own unsaved edits) overlaid on top. Only fields the user
- *   actually edited are persisted, so server changes made by other
- *   admins are never shadowed by a stale snapshot.
- *
- * Note: `isDraft` is evaluated once from the server component at page load.
- * This assumes launching a process triggers a navigation/reload so the
- * value cannot go stale during a session.
+ * Server data is the base layer; locally-dirty fields (the user's own
+ * unsaved edits) overlay on top. The dirty map only ever holds unsaved
+ * or failed edits — draft autosaves remove confirmed-saved fields
+ * (see ProcessBuilderAutosaveContext), and published saves clear the
+ * whole instance — so the overlay can't shadow other admins' newer
+ * server data, while edits whose autosave failed survive a reload.
  */
 export function ProcessBuilderStoreInitializer({
   decisionProfileId,
   serverData,
-  isDraft,
 }: {
   decisionProfileId: string;
   serverData: ProcessBuilderInstanceData;
-  isDraft: boolean;
 }) {
   const serverDataRef = useRef(serverData);
   serverDataRef.current = serverData;
@@ -55,26 +47,20 @@ export function ProcessBuilderStoreInitializer({
       const store = useProcessBuilderStore.getState();
       const base = serverDataRef.current;
 
-      let data: ProcessBuilderInstanceData;
-      if (isDraft) {
-        data = base;
-        store.clearDirty(decisionProfileId);
-      } else {
-        // Overlay the user's own unsaved edits on top of server data.
-        const dirtyFields = store.dirty[decisionProfileId];
-        data = {
-          ...base,
-          ...dirtyFields,
-          config: { ...base.config, ...dirtyFields?.config },
-        };
-      }
+      // Overlay the user's own unsaved edits on top of server data.
+      const dirtyFields = store.dirty[decisionProfileId];
+      const data: ProcessBuilderInstanceData = {
+        ...base,
+        ...dirtyFields,
+        config: { ...base.config, ...dirtyFields?.config },
+      };
 
       store.seedInstance(decisionProfileId, data);
     });
 
     void useProcessBuilderStore.persist.rehydrate();
     return unsubscribe;
-  }, [decisionProfileId, isDraft]);
+  }, [decisionProfileId]);
 
   return null;
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.test.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.test.ts
@@ -1,7 +1,7 @@
 /**
  * Regression tests for the process builder store's persistence contract.
  *
- * The COWOP bug: visiting the editor of a published process persisted a
+ * The bug: visiting the editor of a published process persisted a
  * full server snapshot to localStorage. That stale snapshot shadowed other
  * admins' saved changes on later visits, and "Update Process" sent it back
  * to the server, silently reverting their edits.
@@ -80,14 +80,14 @@ const sarahsRubric: RubricTemplateSchema = {
 };
 
 const serverDataV1: ProcessBuilderInstanceData = {
-  name: 'COWOP Pilot',
+  name: 'Budgeting Pilot',
   description: 'Participatory budgeting pilot',
   rubricTemplate: emptyRubric,
   config: { hideBudget: false },
   phases: [{ phaseId: 'phase-1' }],
 };
 
-// Server state after another admin (Sarah) saved her rubric criteria
+// Server state after another admin saved their rubric criteria
 const serverDataV2: ProcessBuilderInstanceData = {
   ...serverDataV1,
   rubricTemplate: sarahsRubric,
@@ -156,8 +156,8 @@ describe('useProcessBuilderStore persistence contract', () => {
       useProcessBuilderStore.getState().dirty[DECISION_ID],
     ).toBeUndefined();
 
-    // Session 2: Sarah saved her rubric in the meantime; seeding with the
-    // new server data must show her criteria
+    // Session 2: another admin saved their rubric in the meantime; seeding
+    // with the new server data must show their criteria
     useProcessBuilderStore.getState().seedInstance(DECISION_ID, serverDataV2);
     expect(
       useProcessBuilderStore.getState().instances[DECISION_ID]?.rubricTemplate,

--- a/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.test.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Regression tests for the process builder store's persistence contract.
+ *
+ * The COWOP bug: visiting the editor of a published process persisted a
+ * full server snapshot to localStorage. That stale snapshot shadowed other
+ * admins' saved changes on later visits, and "Update Process" sent it back
+ * to the server, silently reverting their edits.
+ *
+ * The contract under test: only fields the user actually edited (`dirty`)
+ * are ever persisted. Seeded server data stays in memory.
+ */
+import type { RubricTemplateSchema } from '@op/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The store module calls `createJSONStorage(() => localStorage)` at import
+// time, so localStorage must exist before the import is evaluated.
+vi.hoisted(() => {
+  const store = new Map<string, string>();
+  const memoryStorage: Storage = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: memoryStorage,
+    configurable: true,
+  });
+});
+
+import {
+  type ProcessBuilderInstanceData,
+  useProcessBuilderStore,
+} from './useProcessBuilderStore';
+
+const STORAGE_KEY = 'process-builder';
+const DECISION_ID = 'decision-1';
+
+interface PersistedShape {
+  state?: {
+    dirty?: Record<string, Partial<ProcessBuilderInstanceData>>;
+    instances?: Record<string, ProcessBuilderInstanceData>;
+    saveStates?: Record<string, unknown>;
+  };
+  version?: number;
+}
+
+const readPersisted = (): PersistedShape | null => {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+  const parsed: PersistedShape = JSON.parse(raw);
+  return parsed;
+};
+
+const emptyRubric: RubricTemplateSchema = {
+  type: 'object',
+  properties: {},
+};
+
+const sarahsRubric: RubricTemplateSchema = {
+  type: 'object',
+  properties: {
+    criterion_1: {
+      type: 'string',
+      title: 'Community impact',
+    },
+  },
+};
+
+const serverDataV1: ProcessBuilderInstanceData = {
+  name: 'COWOP Pilot',
+  description: 'Participatory budgeting pilot',
+  rubricTemplate: emptyRubric,
+  config: { hideBudget: false },
+  phases: [{ phaseId: 'phase-1' }],
+};
+
+// Server state after another admin (Sarah) saved her rubric criteria
+const serverDataV2: ProcessBuilderInstanceData = {
+  ...serverDataV1,
+  rubricTemplate: sarahsRubric,
+};
+
+beforeEach(async () => {
+  localStorage.clear();
+  useProcessBuilderStore.setState({
+    instances: {},
+    dirty: {},
+    saveStates: {},
+  });
+  await useProcessBuilderStore.persist.rehydrate();
+});
+
+describe('useProcessBuilderStore persistence contract', () => {
+  it('does not persist seeded server data to localStorage', () => {
+    useProcessBuilderStore.getState().seedInstance(DECISION_ID, serverDataV1);
+
+    const persisted = readPersisted();
+    expect(persisted?.state?.instances).toBeUndefined();
+    expect(persisted?.state?.saveStates).toBeUndefined();
+    expect(persisted?.state?.dirty?.[DECISION_ID]).toBeUndefined();
+  });
+
+  it('persists only the fields the user actually edited', () => {
+    const store = useProcessBuilderStore.getState();
+    store.seedInstance(DECISION_ID, serverDataV1);
+    store.setRubricTemplateSchema(DECISION_ID, sarahsRubric);
+
+    const persisted = readPersisted();
+    expect(persisted?.state?.dirty?.[DECISION_ID]).toEqual({
+      rubricTemplate: sarahsRubric,
+    });
+    // Seeded fields (name, phases, config) must not ride along
+    expect(persisted?.state?.instances).toBeUndefined();
+  });
+
+  it('deep-merges config edits into the dirty map', () => {
+    const store = useProcessBuilderStore.getState();
+    store.seedInstance(DECISION_ID, serverDataV1);
+    store.setInstanceData(DECISION_ID, { config: { hideBudget: true } });
+    store.setInstanceData(DECISION_ID, {
+      config: { organizeByCategories: false },
+    });
+
+    expect(useProcessBuilderStore.getState().dirty[DECISION_ID]).toEqual({
+      config: { hideBudget: true, organizeByCategories: false },
+    });
+  });
+
+  it('leaves no dirty residue after viewing without editing, so fresh server data wins on the next visit', async () => {
+    // Session 1: admin opens the editor, makes no edits
+    useProcessBuilderStore.getState().seedInstance(DECISION_ID, serverDataV1);
+
+    // Simulate a reload: in-memory state is gone, localStorage survives
+    useProcessBuilderStore.setState({
+      instances: {},
+      dirty: {},
+      saveStates: {},
+    });
+    await useProcessBuilderStore.persist.rehydrate();
+
+    // Nothing was edited, so nothing must overlay the next seed
+    expect(
+      useProcessBuilderStore.getState().dirty[DECISION_ID],
+    ).toBeUndefined();
+
+    // Session 2: Sarah saved her rubric in the meantime; seeding with the
+    // new server data must show her criteria
+    useProcessBuilderStore.getState().seedInstance(DECISION_ID, serverDataV2);
+    expect(
+      useProcessBuilderStore.getState().instances[DECISION_ID]?.rubricTemplate,
+    ).toEqual(sarahsRubric);
+  });
+
+  it('discards legacy v0 full-snapshot localStorage on rehydrate', async () => {
+    // Shape persisted by the pre-fix store: full instances + saveStates
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          instances: { [DECISION_ID]: serverDataV1 },
+          saveStates: { [DECISION_ID]: { status: 'saved' } },
+        },
+        version: 0,
+      }),
+    );
+
+    await useProcessBuilderStore.persist.rehydrate();
+
+    const state = useProcessBuilderStore.getState();
+    // The stale snapshot must not leak into either slice
+    expect(state.instances).toEqual({});
+    expect(state.dirty).toEqual({});
+  });
+
+  it('clears dirty fields and persisted residue on clearInstance', () => {
+    const store = useProcessBuilderStore.getState();
+    store.seedInstance(DECISION_ID, serverDataV1);
+    store.setRubricTemplateSchema(DECISION_ID, sarahsRubric);
+
+    useProcessBuilderStore.getState().clearInstance(DECISION_ID);
+
+    expect(
+      useProcessBuilderStore.getState().dirty[DECISION_ID],
+    ).toBeUndefined();
+    const persisted = readPersisted();
+    expect(persisted?.state?.dirty?.[DECISION_ID]).toBeUndefined();
+  });
+});

--- a/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.test.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.test.ts
@@ -185,6 +185,47 @@ describe('useProcessBuilderStore persistence contract', () => {
     expect(state.dirty).toEqual({});
   });
 
+  it('removes confirmed-saved fields from dirty, keeping unsaved ones', () => {
+    const store = useProcessBuilderStore.getState();
+    store.seedInstance(DECISION_ID, serverDataV1);
+    store.setInstanceData(DECISION_ID, { name: 'New name' });
+    store.setRubricTemplateSchema(DECISION_ID, sarahsRubric);
+    store.setInstanceData(DECISION_ID, {
+      config: { hideBudget: true, organizeByCategories: false },
+    });
+
+    // Simulate a successful autosave of name + one config sub-key
+    useProcessBuilderStore.getState().clearDirtyFields(DECISION_ID, {
+      name: 'New name',
+      config: { hideBudget: true },
+    });
+
+    // The failed/unsaved edits must survive — both in memory and persisted
+    expect(useProcessBuilderStore.getState().dirty[DECISION_ID]).toEqual({
+      rubricTemplate: sarahsRubric,
+      config: { organizeByCategories: false },
+    });
+    expect(readPersisted()?.state?.dirty?.[DECISION_ID]).toEqual({
+      rubricTemplate: sarahsRubric,
+      config: { organizeByCategories: false },
+    });
+  });
+
+  it('drops the dirty entry entirely once every field is confirmed saved', () => {
+    const store = useProcessBuilderStore.getState();
+    store.seedInstance(DECISION_ID, serverDataV1);
+    store.setInstanceData(DECISION_ID, { name: 'New name' });
+
+    useProcessBuilderStore
+      .getState()
+      .clearDirtyFields(DECISION_ID, { name: 'New name' });
+
+    expect(
+      useProcessBuilderStore.getState().dirty[DECISION_ID],
+    ).toBeUndefined();
+    expect(readPersisted()?.state?.dirty?.[DECISION_ID]).toBeUndefined();
+  });
+
   it('clears dirty fields and persisted residue on clearInstance', () => {
     const store = useProcessBuilderStore.getState();
     store.seedInstance(DECISION_ID, serverDataV1);

--- a/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.ts
@@ -1,15 +1,23 @@
 /**
  * Process Builder Store
  *
- * Manages form state for the Process Builder with localStorage persistence.
- * This store acts as a client-side cache for in-progress form data, allowing
- * users to navigate away and return without losing their work.
+ * Manages form state for the Process Builder.
  *
  * ## Data Flow
- * 1. Form components read initial values from this store (after hydration)
- * 2. Auto-save writes debounced form values back to this store
- * 3. Store persists to localStorage automatically via Zustand middleware
- * 4. On form submission, data is sent to the API
+ * 1. `ProcessBuilderStoreInitializer` seeds `instances` with server data
+ *    (merged with any locally-dirty fields) via `seedInstance`
+ * 2. Form components read values from `instances` (after hydration)
+ * 3. User edits write through the edit setters, which update `instances`
+ *    AND record the edited fields in `dirty`
+ * 4. On save (autosave for drafts, "Update Process" for published), only
+ *    the dirty fields are sent to the API
+ *
+ * ## Persistence
+ * Only the `dirty` map is persisted to localStorage (via `partialize`).
+ * `instances` is an in-memory merged view, re-seeded from the server on
+ * every editor load. This distinction is what lets us tell "the user's
+ * unsaved edits" apart from "a snapshot of server data" — persisting the
+ * full snapshot caused stale data to shadow other admins' saved changes.
  *
  * ## Hydration
  * This store uses `skipHydration: true` to prevent race conditions in SSR.
@@ -27,7 +35,8 @@
  *
  * ## Structure
  * Data is keyed by `decisionId` to support multiple concurrent drafts:
- * - `instances[decisionId]` - Form data aligned with backend InstanceData
+ * - `instances[decisionId]` - In-memory merged view aligned with backend InstanceData
+ * - `dirty[decisionId]` - Locally-edited fields not yet confirmed saved (persisted)
  * - `saveStates[decisionId]` - UI save indicator state
  */
 import type { InstanceData, InstancePhaseData } from '@op/api/encoders';
@@ -70,12 +79,19 @@ interface SaveState {
 // ============ Store Interface ============
 
 interface ProcessBuilderState {
-  // Instance data keyed by decisionId
+  // In-memory merged view (server data + local edits), keyed by decisionId.
+  // NOT persisted — re-seeded from the server on every editor load.
   instances: Record<string, ProcessBuilderInstanceData>;
+  // Locally-edited fields keyed by decisionId. The only persisted slice.
+  dirty: Record<string, Partial<ProcessBuilderInstanceData>>;
   // Save state keyed by decisionId
   saveStates: Record<string, SaveState>;
 
-  // Actions for instance data
+  // Seeds the in-memory view with server-derived data WITHOUT marking
+  // anything dirty. Replaces the instance entry wholesale.
+  seedInstance: (decisionId: string, data: ProcessBuilderInstanceData) => void;
+
+  // Actions for instance data (user edits — mark fields dirty)
   setInstanceData: (
     decisionId: string,
     data: Partial<ProcessBuilderInstanceData>,
@@ -119,6 +135,7 @@ interface ProcessBuilderState {
   getSaveState: (decisionId: string) => SaveState;
 
   // Cleanup actions
+  clearDirty: (decisionId: string) => void;
   clearInstance: (decisionId: string) => void;
   reset: () => void;
 }
@@ -129,12 +146,22 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
   persist(
     (set, get) => ({
       instances: {},
+      dirty: {},
       saveStates: {},
+
+      seedInstance: (decisionId, data) =>
+        set((state) => ({
+          instances: {
+            ...state.instances,
+            [decisionId]: data,
+          },
+        })),
 
       // Instance data actions
       setInstanceData: (decisionId, data) =>
         set((state) => {
           const existing = state.instances[decisionId];
+          const existingDirty = state.dirty[decisionId];
           return {
             instances: {
               ...state.instances,
@@ -142,6 +169,16 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
                 ...existing,
                 ...data,
                 config: { ...existing?.config, ...data.config },
+              },
+            },
+            dirty: {
+              ...state.dirty,
+              [decisionId]: {
+                ...existingDirty,
+                ...data,
+                config: data.config
+                  ? { ...existingDirty?.config, ...data.config }
+                  : existingDirty?.config,
               },
             },
           };
@@ -179,6 +216,13 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
                 phases: updatedPhases,
               },
             },
+            dirty: {
+              ...state.dirty,
+              [decisionId]: {
+                ...state.dirty[decisionId],
+                phases: updatedPhases,
+              },
+            },
           };
         }),
 
@@ -197,6 +241,13 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
               proposalTemplate: template,
             },
           },
+          dirty: {
+            ...state.dirty,
+            [decisionId]: {
+              ...state.dirty[decisionId],
+              proposalTemplate: template,
+            },
+          },
         })),
 
       getProposalTemplateSchema: (decisionId) =>
@@ -209,6 +260,13 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
             ...state.instances,
             [decisionId]: {
               ...state.instances[decisionId],
+              rubricTemplate: template,
+            },
+          },
+          dirty: {
+            ...state.dirty,
+            [decisionId]: {
+              ...state.dirty[decisionId],
               rubricTemplate: template,
             },
           },
@@ -244,12 +302,20 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
         get().saveStates[decisionId] ?? DEFAULT_SAVE_STATE,
 
       // Cleanup actions
+      clearDirty: (decisionId) =>
+        set((state) => {
+          const { [decisionId]: _, ...restDirty } = state.dirty;
+          return { dirty: restDirty };
+        }),
+
       clearInstance: (decisionId) =>
         set((state) => {
           const { [decisionId]: _, ...restInstances } = state.instances;
-          const { [decisionId]: __, ...restSaveStates } = state.saveStates;
+          const { [decisionId]: __, ...restDirty } = state.dirty;
+          const { [decisionId]: ___, ...restSaveStates } = state.saveStates;
           return {
             instances: restInstances,
+            dirty: restDirty,
             saveStates: restSaveStates,
           };
         }),
@@ -257,6 +323,7 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
       reset: () =>
         set({
           instances: {},
+          dirty: {},
           saveStates: {},
         }),
     }),
@@ -264,6 +331,12 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
       name: 'process-builder',
       storage: createJSONStorage(() => localStorage),
       skipHydration: true,
+      // v1: only `dirty` is persisted. v0 persisted full snapshots
+      // (instances + saveStates), which made stale server data shadow
+      // other admins' saved changes — discard it on migration.
+      version: 1,
+      partialize: (state) => ({ dirty: state.dirty }),
+      migrate: () => ({ dirty: {} }),
     },
   ),
 );

--- a/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.ts
@@ -5,21 +5,16 @@
  *
  * ## Data Flow
  * 1. `ProcessBuilderStoreInitializer` seeds `instances` with server data
- *    (overlaid with locally-dirty fields) via `seedInstance`
- * 2. Form components read values from `instances` (after hydration)
- * 3. User edits write through the edit setters, which update `instances`
- *    AND record the edited fields in `dirty`
- * 4. Only edited fields are sent to the API: draft autosave uses its own
- *    per-debounce accumulator (and removes confirmed-saved fields from
- *    `dirty` via `clearDirtyFields`); "Update Process" for published
- *    processes reads the `dirty` map directly
+ *    overlaid with dirty fields
+ * 2. Form components read from `instances` (after hydration)
+ * 3. Edit setters update `instances` AND record the fields in `dirty`
+ * 4. Only edited fields are sent to the API — draft autosave via its own
+ *    debounce accumulator, "Update Process" via the `dirty` map
  *
  * ## Persistence
- * Only the `dirty` map is persisted to localStorage (via `partialize`).
- * `instances` is an in-memory merged view, re-seeded from the server on
- * every editor load. This distinction is what lets us tell "the user's
- * unsaved edits" apart from "a snapshot of server data" — persisting the
- * full snapshot caused stale data to shadow other admins' saved changes.
+ * Only `dirty` is persisted (`partialize`); `instances` is an in-memory
+ * view re-seeded from the server each load. Persisting more than the
+ * user's own edits lets stale data shadow other admins' saved changes.
  *
  * ## Hydration
  * This store uses `skipHydration: true` to prevent race conditions in SSR.
@@ -138,11 +133,8 @@ interface ProcessBuilderState {
 
   // Cleanup actions
   clearDirty: (decisionId: string) => void;
-  /**
-   * Removes the given fields from the dirty map after they were confirmed
-   * saved. Keeps `dirty` ≈ "unsaved or failed" so seeding can safely
-   * overlay it without already-saved fields shadowing newer server data.
-   */
+  /** Removes confirmed-saved fields — `dirty` must only ever hold
+   *  unsaved or failed edits, or seeding would overlay stale data. */
   clearDirtyFields: (
     decisionId: string,
     fields: Partial<ProcessBuilderInstanceData>,
@@ -175,9 +167,8 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
           const existingDirty = state.dirty[decisionId];
           const { config, ...rest } = data;
 
-          // Only carry a config key when one is actually involved —
-          // a `config: undefined` entry would make the dirty map look
-          // non-empty after all real fields are confirmed saved.
+          // No `config: undefined` entry — it would keep the dirty map
+          // non-empty after everything is confirmed saved.
           const dirtyEntry: Partial<ProcessBuilderInstanceData> = {
             ...existingDirty,
             ...rest,
@@ -389,9 +380,8 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
       name: 'process-builder',
       storage: createJSONStorage(() => localStorage),
       skipHydration: true,
-      // v1: only `dirty` is persisted. v0 persisted full snapshots
-      // (instances + saveStates), which made stale server data shadow
-      // other admins' saved changes — discard it on migration.
+      // v0 persisted full snapshots, which shadowed other admins' saved
+      // changes — discard them on migration.
       version: 1,
       partialize: (state) => ({ dirty: state.dirty }),
       migrate: () => ({ dirty: {} }),

--- a/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/stores/useProcessBuilderStore.ts
@@ -5,12 +5,14 @@
  *
  * ## Data Flow
  * 1. `ProcessBuilderStoreInitializer` seeds `instances` with server data
- *    (merged with any locally-dirty fields) via `seedInstance`
+ *    (overlaid with locally-dirty fields) via `seedInstance`
  * 2. Form components read values from `instances` (after hydration)
  * 3. User edits write through the edit setters, which update `instances`
  *    AND record the edited fields in `dirty`
- * 4. On save (autosave for drafts, "Update Process" for published), only
- *    the dirty fields are sent to the API
+ * 4. Only edited fields are sent to the API: draft autosave uses its own
+ *    per-debounce accumulator (and removes confirmed-saved fields from
+ *    `dirty` via `clearDirtyFields`); "Update Process" for published
+ *    processes reads the `dirty` map directly
  *
  * ## Persistence
  * Only the `dirty` map is persisted to localStorage (via `partialize`).
@@ -136,6 +138,15 @@ interface ProcessBuilderState {
 
   // Cleanup actions
   clearDirty: (decisionId: string) => void;
+  /**
+   * Removes the given fields from the dirty map after they were confirmed
+   * saved. Keeps `dirty` ≈ "unsaved or failed" so seeding can safely
+   * overlay it without already-saved fields shadowing newer server data.
+   */
+  clearDirtyFields: (
+    decisionId: string,
+    fields: Partial<ProcessBuilderInstanceData>,
+  ) => void;
   clearInstance: (decisionId: string) => void;
   reset: () => void;
 }
@@ -162,24 +173,31 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
         set((state) => {
           const existing = state.instances[decisionId];
           const existingDirty = state.dirty[decisionId];
+          const { config, ...rest } = data;
+
+          // Only carry a config key when one is actually involved —
+          // a `config: undefined` entry would make the dirty map look
+          // non-empty after all real fields are confirmed saved.
+          const dirtyEntry: Partial<ProcessBuilderInstanceData> = {
+            ...existingDirty,
+            ...rest,
+          };
+          if (config || existingDirty?.config) {
+            dirtyEntry.config = { ...existingDirty?.config, ...config };
+          }
+
           return {
             instances: {
               ...state.instances,
               [decisionId]: {
                 ...existing,
                 ...data,
-                config: { ...existing?.config, ...data.config },
+                config: { ...existing?.config, ...config },
               },
             },
             dirty: {
               ...state.dirty,
-              [decisionId]: {
-                ...existingDirty,
-                ...data,
-                config: data.config
-                  ? { ...existingDirty?.config, ...data.config }
-                  : existingDirty?.config,
-              },
+              [decisionId]: dirtyEntry,
             },
           };
         }),
@@ -306,6 +324,46 @@ export const useProcessBuilderStore = create<ProcessBuilderState>()(
         set((state) => {
           const { [decisionId]: _, ...restDirty } = state.dirty;
           return { dirty: restDirty };
+        }),
+
+      clearDirtyFields: (decisionId, fields) =>
+        set((state) => {
+          const existing = state.dirty[decisionId];
+          if (!existing) {
+            return state;
+          }
+
+          const { config: savedConfig, ...savedRest } = fields;
+          const remaining: Partial<ProcessBuilderInstanceData> = {
+            ...existing,
+          };
+          for (const key of Object.keys(savedRest)) {
+            delete remaining[key as keyof ProcessBuilderInstanceData];
+          }
+
+          // Config is accumulated per sub-key, so clear at that granularity
+          if (savedConfig && remaining.config) {
+            const remainingConfig = { ...remaining.config };
+            for (const key of Object.keys(savedConfig)) {
+              delete remainingConfig[key as keyof typeof remainingConfig];
+            }
+            if (Object.keys(remainingConfig).length > 0) {
+              remaining.config = remainingConfig;
+            } else {
+              delete remaining.config;
+            }
+          }
+
+          if (Object.keys(remaining).length === 0) {
+            const { [decisionId]: _, ...restDirty } = state.dirty;
+            return { dirty: restDirty };
+          }
+          return {
+            dirty: {
+              ...state.dirty,
+              [decisionId]: remaining,
+            },
+          };
         }),
 
       clearInstance: (decisionId) =>

--- a/apps/app/vitest.config.ts
+++ b/apps/app/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': './src',
+    },
+  },
+});

--- a/tests/e2e/tests/process-builder-multi-admin.spec.ts
+++ b/tests/e2e/tests/process-builder-multi-admin.spec.ts
@@ -16,7 +16,7 @@ import {
 test.use({ viewport: { width: 1440, height: 900 } });
 
 /**
- * Regression test for the COWOP stale-localStorage bug.
+ * Regression test for the process builder stale-localStorage bug.
  *
  * Visiting the editor of a published process used to persist a full server
  * snapshot to localStorage. When another admin later saved changes via
@@ -34,7 +34,7 @@ test.describe('Process Builder multi-admin editing', () => {
     test.setTimeout(180_000);
 
     // 1. Create a published process owned by the worker org.
-    //    `authenticatedPage` (admin A / "Sarah") is an admin of this org.
+    //    `authenticatedPage` (admin A) is an admin of this org.
     const template = await getSeededTemplate();
     const instance = await createDecisionInstance({
       processId: template.id,
@@ -44,7 +44,7 @@ test.describe('Process Builder multi-admin editing', () => {
       schema: template.processSchema,
     });
 
-    // 2. Create a second admin (admin B / "Casimiro") with admin access
+    // 2. Create a second admin (admin B) with admin access
     //    on the decision profile, in their own browser context.
     const otherOrg = await createOrganization({
       testId: `pb-multi-admin-${Date.now()}`,
@@ -85,7 +85,7 @@ test.describe('Process Builder multi-admin editing', () => {
       timeout: 18_000,
     });
 
-    const newName = `Renamed by Sarah ${Date.now()}`;
+    const newName = `Renamed by admin A ${Date.now()}`;
     const nameInputA = nameField(authenticatedPage);
     await expect(nameInputA).toBeVisible({ timeout: 12_000 });
     await nameInputA.fill(newName);

--- a/tests/e2e/tests/process-builder-multi-admin.spec.ts
+++ b/tests/e2e/tests/process-builder-multi-admin.spec.ts
@@ -71,6 +71,22 @@ test.describe('Process Builder multi-admin editing', () => {
     const nameField = (page: typeof pageB) =>
       page.getByRole('textbox', { name: 'Process Name' });
 
+    // The persistence contract: an edit lands in localStorage as a dirty
+    // field. Polling it beats arbitrary timeouts for "has the form watcher
+    // propagated the edit into the store buffer".
+    const hasDirtyField = (page: typeof pageB, field: string) =>
+      page.evaluate(
+        ({ profileId, key }) => {
+          const raw = localStorage.getItem('process-builder');
+          if (!raw) {
+            return false;
+          }
+          const parsed = JSON.parse(raw);
+          return parsed?.state?.dirty?.[profileId]?.[key] !== undefined;
+        },
+        { profileId: instance.profileId, key: field },
+      );
+
     // 3. Admin B opens the editor BEFORE admin A makes any changes.
     //    (Pre-fix, this stamped a full snapshot into B's localStorage.)
     await pageB.goto(editUrl);
@@ -91,8 +107,11 @@ test.describe('Process Builder multi-admin editing', () => {
     await nameInputA.fill(newName);
     await expect(nameInputA).toHaveValue(newName);
 
-    // Let the form watcher propagate the edit into the store buffer
-    await authenticatedPage.waitForTimeout(1_500);
+    await expect
+      .poll(() => hasDirtyField(authenticatedPage, 'name'), {
+        timeout: 6_000,
+      })
+      .toBe(true);
 
     const footer = authenticatedPage.getByRole('contentinfo');
     const saveResponse = authenticatedPage.waitForResponse(
@@ -122,6 +141,40 @@ test.describe('Process Builder multi-admin editing', () => {
       timeout: 18_000,
     });
     await expect(nameField(pageB)).toHaveValue(newName, { timeout: 12_000 });
+
+    // 7. Write path: admin B edits a DIFFERENT field and saves. Only B's
+    //    dirty fields may be sent — pre-fix, B's full snapshot rode along
+    //    and silently reverted A's rename.
+    const newDescription = `Description by admin B ${Date.now()}`;
+    const descriptionInputB = pageB.getByRole('textbox', {
+      name: 'Description',
+    });
+    await expect(descriptionInputB).toBeVisible({ timeout: 6_000 });
+    await descriptionInputB.fill(newDescription);
+    await expect
+      .poll(() => hasDirtyField(pageB, 'description'), { timeout: 6_000 })
+      .toBe(true);
+
+    const footerB = pageB.getByRole('contentinfo');
+    const saveResponseB = pageB.waitForResponse(
+      (resp) =>
+        resp.url().includes('decision.updateDecisionInstance') && resp.ok(),
+      { timeout: 12_000 },
+    );
+    await footerB.getByRole('button', { name: 'Update Process' }).click();
+    await saveResponseB;
+
+    // 8. Both edits must coexist in the DB: B's description saved, A's
+    //    rename untouched.
+    await expect
+      .poll(
+        async () => {
+          const saved = await getDecisionInstance(instance.instance.id);
+          return { name: saved.name, description: saved.description };
+        },
+        { timeout: 6_000 },
+      )
+      .toEqual({ name: newName, description: newDescription });
 
     await contextB.close();
   });

--- a/tests/e2e/tests/process-builder-multi-admin.spec.ts
+++ b/tests/e2e/tests/process-builder-multi-admin.spec.ts
@@ -1,0 +1,128 @@
+import {
+  createDecisionInstance,
+  createOrganization,
+  getDecisionInstance,
+  getSeededTemplate,
+  grantDecisionProfileAccess,
+} from '@op/test';
+
+import {
+  TEST_USER_DEFAULT_PASSWORD,
+  authenticateAsUser,
+  expect,
+  test,
+} from '../fixtures/index.js';
+
+test.use({ viewport: { width: 1440, height: 900 } });
+
+/**
+ * Regression test for the COWOP stale-localStorage bug.
+ *
+ * Visiting the editor of a published process used to persist a full server
+ * snapshot to localStorage. When another admin later saved changes via
+ * "Update Process", the first admin's stale snapshot shadowed the fresh
+ * server data — they couldn't see the other admin's edits in the editor
+ * (and saving would silently revert them).
+ */
+test.describe('Process Builder multi-admin editing', () => {
+  test("admin sees another admin's saved changes after revisiting the editor", async ({
+    authenticatedPage,
+    browser,
+    org,
+    supabaseAdmin,
+  }) => {
+    test.setTimeout(180_000);
+
+    // 1. Create a published process owned by the worker org.
+    //    `authenticatedPage` (admin A / "Sarah") is an admin of this org.
+    const template = await getSeededTemplate();
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: template.processSchema,
+    });
+
+    // 2. Create a second admin (admin B / "Casimiro") with admin access
+    //    on the decision profile, in their own browser context.
+    const otherOrg = await createOrganization({
+      testId: `pb-multi-admin-${Date.now()}`,
+      supabaseAdmin,
+      users: { admin: 1, member: 0 },
+    });
+    await grantDecisionProfileAccess({
+      profileId: instance.profileId,
+      authUserId: otherOrg.adminUser.authUserId,
+      email: otherOrg.adminUser.email,
+      isAdmin: true,
+    });
+
+    const contextB = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+    });
+    const pageB = await contextB.newPage();
+    await authenticateAsUser(pageB, {
+      email: otherOrg.adminUser.email,
+      password: TEST_USER_DEFAULT_PASSWORD,
+    });
+
+    const editUrl = `/en/decisions/${instance.slug}/edit`;
+    const nameField = (page: typeof pageB) =>
+      page.getByRole('textbox', { name: 'Process Name' });
+
+    // 3. Admin B opens the editor BEFORE admin A makes any changes.
+    //    (Pre-fix, this stamped a full snapshot into B's localStorage.)
+    await pageB.goto(editUrl);
+    await expect(pageB.getByText('Process Overview')).toBeVisible({
+      timeout: 18_000,
+    });
+    await expect(nameField(pageB)).toBeVisible({ timeout: 12_000 });
+
+    // 4. Admin A renames the process and clicks "Update Process".
+    await authenticatedPage.goto(editUrl);
+    await expect(authenticatedPage.getByText('Process Overview')).toBeVisible({
+      timeout: 18_000,
+    });
+
+    const newName = `Renamed by Sarah ${Date.now()}`;
+    const nameInputA = nameField(authenticatedPage);
+    await expect(nameInputA).toBeVisible({ timeout: 12_000 });
+    await nameInputA.fill(newName);
+    await expect(nameInputA).toHaveValue(newName);
+
+    // Let the form watcher propagate the edit into the store buffer
+    await authenticatedPage.waitForTimeout(1_500);
+
+    const footer = authenticatedPage.getByRole('contentinfo');
+    const saveResponse = authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes('decision.updateDecisionInstance') && resp.ok(),
+      { timeout: 12_000 },
+    );
+    await footer.getByRole('button', { name: 'Update Process' }).click();
+    await saveResponse;
+
+    // 5. Verify the rename actually reached the DB — isolates any failure
+    //    below to B's read path rather than A's save path.
+    await expect
+      .poll(
+        async () => {
+          const saved = await getDecisionInstance(instance.instance.id);
+          return saved.name;
+        },
+        { timeout: 6_000 },
+      )
+      .toBe(newName);
+
+    // 6. Admin B revisits the editor and must see A's saved name.
+    //    Pre-fix: B's stale localStorage snapshot shadowed it.
+    await pageB.goto(editUrl);
+    await expect(pageB.getByText('Process Overview')).toBeVisible({
+      timeout: 18_000,
+    });
+    await expect(nameField(pageB)).toHaveValue(newName, { timeout: 12_000 });
+
+    await contextB.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Visiting the process builder of a published process stamped a full server snapshot into localStorage, which shadowed other admins' saved changes on later visits (one admin's rubric criteria invisible to other admins)
- "Update Process" sent that stale snapshot back, silently reverting other admins' saved edits
- Store now persists only a per-decision dirty-field map; the merged instance view is in-memory and reseeded from the server on every load
- "Update Process" sends only the fields the user actually edited
- Persist version bump discards everyone's legacy full snapshots on deploy, so stale state self-heals

## Tests

- E2E: two-admin repro in `tests/e2e/tests/process-builder-multi-admin.spec.ts` — fails against pre-fix build, passes with fix
- Unit: store persistence contract in `apps/app` — **note: this adds the first vitest setup to the app workspace** (config + test script). Covers the legacy-snapshot migration discard and per-field dirty semantics that e2e can't reach. Open to dropping if we don't want apps/app as a unit-test surface.