### PR TITLE
feat(decisions): sign in anonymous visitors to start a proposal

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -43,3 +43,8 @@ DEEPL_API_KEY=your-deepl-api-key
 ## Select the active vendor and set its key; swap the key when switching vendors.
 MODERATION_PROVIDER=                 # hive | lasso | checkstep (empty = off)
 MODERATION_API_KEY=
+
+## TEMPORARY: anonymous sign-in rollout gate read by the proxy middleware.
+## Set to "true" to skip the logged-out → /login redirect so anonymous visitors
+## can reach the app. On by default in development/e2e. Remove with the flag.
+ANONYMOUS_SIGNIN_ENABLED=

--- a/apps/app/src/app/[locale]/(main)/layout.tsx
+++ b/apps/app/src/app/[locale]/(main)/layout.tsx
@@ -1,5 +1,6 @@
 import { UserProvider } from '@/utils/UserProvider';
 import { getUser } from '@/utils/getUser';
+import { shouldRedirectToOnboarding } from '@/utils/onboarding';
 import { SidebarLayout, SidebarProvider } from '@op/ui/Sidebar';
 import { redirect } from 'next/navigation';
 import Script from 'next/script';
@@ -17,9 +18,9 @@ export const dynamic = 'force-dynamic';
 const AppRoot = async ({ children }: { children: React.ReactNode }) => {
   const user = await getUser();
 
-  // if (!user?.onboardedAt) {
-  //   redirect('/en/start');
-  // }
+  if (shouldRedirectToOnboarding(user)) {
+    redirect('/en/start');
+  }
 
   return (
     <div className="flex size-full max-h-full flex-col">

--- a/apps/app/src/app/[locale]/(main)/layout.tsx
+++ b/apps/app/src/app/[locale]/(main)/layout.tsx
@@ -17,9 +17,9 @@ export const dynamic = 'force-dynamic';
 const AppRoot = async ({ children }: { children: React.ReactNode }) => {
   const user = await getUser();
 
-  if (!user?.onboardedAt) {
-    redirect('/en/start');
-  }
+  // if (!user?.onboardedAt) {
+  //   redirect('/en/start');
+  // }
 
   return (
     <div className="flex size-full max-h-full flex-col">

--- a/apps/app/src/app/[locale]/(no-header)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/layout.tsx
@@ -1,5 +1,6 @@
 import { UserProvider } from '@/utils/UserProvider';
 import { getUser } from '@/utils/getUser';
+import { shouldRedirectToOnboarding } from '@/utils/onboarding';
 import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
@@ -7,9 +8,9 @@ export const dynamic = 'force-dynamic';
 const Layout = async ({ children }: { children: React.ReactNode }) => {
   const user = await getUser();
 
-  // if (!user?.onboardedAt) {
-  //   redirect('/en/start');
-  // }
+  if (shouldRedirectToOnboarding(user)) {
+    redirect('/en/start');
+  }
 
   return <UserProvider initialUser={user}>{children}</UserProvider>;
 };

--- a/apps/app/src/app/[locale]/(no-header)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/layout.tsx
@@ -7,9 +7,9 @@ export const dynamic = 'force-dynamic';
 const Layout = async ({ children }: { children: React.ReactNode }) => {
   const user = await getUser();
 
-  if (!user?.onboardedAt) {
-    redirect('/en/start');
-  }
+  // if (!user?.onboardedAt) {
+  //   redirect('/en/start');
+  // }
 
   return <UserProvider initialUser={user}>{children}</UserProvider>;
 };

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { shouldRedirectToOnboarding } from '@/utils/onboarding';
 import { trpc } from '@op/api/client';
 import { useAuthUser } from '@op/hooks';
 import { useRouter } from 'next/navigation';
@@ -16,11 +17,11 @@ const MainPage = () => {
       return <ComingSoonScreen />;
     }
 
-    // if (!account?.onboardedAt) {
-    //   router.push('/start');
-    //
-    //   return;
-    // }
+    if (shouldRedirectToOnboarding(account)) {
+      router.push('/start');
+
+      return null;
+    }
   }
 
   return null;

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -16,11 +16,11 @@ const MainPage = () => {
       return <ComingSoonScreen />;
     }
 
-    if (!account?.onboardedAt) {
-      router.push('/start');
-
-      return;
-    }
+    // if (!account?.onboardedAt) {
+    //   router.push('/start');
+    //
+    //   return;
+    // }
   }
 
   return null;

--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
+import { createSBBrowserClient } from '@op/supabase/client';
 import { Button } from '@op/ui/Button';
 import { Dialog, DialogTrigger } from '@op/ui/Dialog';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
@@ -31,28 +34,46 @@ export const DecisionActionBar = ({
   const t = useTranslations();
   const { slug } = useParams();
   const router = useRouter();
+  const { user } = useUser();
   const [isCreating, setIsCreating] = useState(false);
+  const supabase = createSBBrowserClient();
+  const utils = trpc.useUtils();
+  const anonymousSigninEnabled = useFeatureFlag('anonymous_signin');
 
-  const createProposalMutation = trpc.decision.createProposal.useMutation({
-    onSuccess: (proposal) => {
+  const createProposalMutation = trpc.decision.createProposal.useMutation();
+
+  const handleCreateProposal = async () => {
+    setIsCreating(true);
+
+    try {
+      // A public (no-session) visitor has no account to attribute the proposal
+      // to, so give them an anonymous session before creating the draft.
+      if (anonymousSigninEnabled && !user) {
+        const { error } = await supabase.auth.signInAnonymously();
+        if (error) {
+          throw error;
+        }
+
+        // The new session isn't reflected in the cached account query, so
+        // refetch it before navigating — the edit page requires a populated
+        // user in context.
+        await utils.account.getMyAccount.invalidate();
+      }
+
+      const proposal = await createProposalMutation.mutateAsync({
+        processInstanceId: instanceId,
+        proposalData: {}, // Empty draft - user will fill in via edit page
+      });
+
       // Navigate to edit the newly created draft proposal
       router.push(`/decisions/${slug}/proposal/${proposal.profileId}/edit`);
-    },
-    onError: (error) => {
+    } catch (error) {
       setIsCreating(false);
       toast.error({
         title: t('Failed to create proposal'),
-        message: error.message,
+        message: error instanceof Error ? error.message : undefined,
       });
-    },
-  });
-
-  const handleCreateProposal = () => {
-    setIsCreating(true);
-    createProposalMutation.mutate({
-      processInstanceId: instanceId,
-      proposalData: {}, // Empty draft - user will fill in via edit page
-    });
+    }
   };
 
   return (

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRelationshipMutations } from '@/hooks/useRelationshipMutations';
+import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import type { Proposal } from '@op/common/client';
 import { Button, ButtonLink } from '@op/ui/Button';
@@ -21,6 +22,7 @@ export function ProposalCardActions({
   proposal: Proposal;
 }) {
   const t = useTranslations();
+  const { user } = useUser();
 
   // Subscribe to the individual proposal data which gets optimistically updated
   const { data: currentProposal } = trpc.decision.getProposal.useQuery(
@@ -47,6 +49,12 @@ export function ProposalCardActions({
       },
     ],
   });
+
+  // Like/Follow are user-scoped writes gated at the API — anonymous visitors
+  // can read the proposal but aren't offered these actions.
+  if (!user) {
+    return null;
+  }
 
   return (
     <div className="flex w-full items-center gap-4 sm:w-auto">

--- a/apps/app/src/components/decisions/ProposalViewLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalViewLayout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useUser } from '@/utils/UserProvider';
 import { Button } from '@op/ui/Button';
 import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
 import { ReactNode } from 'react';
@@ -51,6 +52,7 @@ export function ProposalViewLayout({
 }) {
   const t = useTranslations();
   const router = useRouter();
+  const { user } = useUser();
   const revisionRequestLabel = t('Revision request');
 
   return (
@@ -82,26 +84,32 @@ export function ProposalViewLayout({
               {t('Edit')}
             </Button>
           )}
-          <Button
-            surface="outline"
-            color={isLiked ? 'verified' : 'secondary'}
-            size="small"
-            onPress={onLike}
-            isDisabled={isLoading}
-          >
-            <LuHeart className="size-4" />
-            {isLiked ? t('Liked') : t('Like')}
-          </Button>
-          <Button
-            surface="outline"
-            color={isFollowing ? 'verified' : 'secondary'}
-            size="small"
-            onPress={onFollow}
-          >
-            <LuBookmark className="size-4" />
+          {/* Like/Follow are user-scoped writes gated at the API — only offer
+              them to a signed-in viewer. */}
+          {user ? (
+            <>
+              <Button
+                surface="outline"
+                color={isLiked ? 'verified' : 'secondary'}
+                size="small"
+                onPress={onLike}
+                isDisabled={isLoading}
+              >
+                <LuHeart className="size-4" />
+                {isLiked ? t('Liked') : t('Like')}
+              </Button>
+              <Button
+                surface="outline"
+                color={isFollowing ? 'verified' : 'secondary'}
+                size="small"
+                onPress={onFollow}
+              >
+                <LuBookmark className="size-4" />
 
-            {isFollowing ? t('Following') : t('Follow')}
-          </Button>
+                {isFollowing ? t('Following') : t('Follow')}
+              </Button>
+            </>
+          ) : null}
           {revisionToggle && (
             <TooltipTrigger>
               <Button
@@ -124,7 +132,9 @@ export function ProposalViewLayout({
           )}
           <div className="hidden gap-4 sm:flex">
             <LocaleChooser />
-            <UserAvatarMenu />
+            {/* Required-user leaf: only mount when a session exists so anonymous
+                visitors can still read the proposal. */}
+            {user ? <UserAvatarMenu /> : null}
           </div>
         </div>
       </div>

--- a/apps/app/src/hooks/useRelationshipMutations.ts
+++ b/apps/app/src/hooks/useRelationshipMutations.ts
@@ -1,3 +1,4 @@
+import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { ProfileRelationshipType } from '@op/api/encoders';
 import { toast } from '@op/ui/Toast';
@@ -53,6 +54,11 @@ export function useRelationshipMutations({
 }: UseRelationshipMutationsOptions) {
   const utils = trpc.useUtils();
 
+  // Relationships are scoped to the signed-in viewer. For anonymous visitors
+  // there's nothing to fetch (and the API rejects the call), so skip the query
+  // and treat the viewer as having no relationships.
+  const { user } = useUser();
+
   // Query key for relationship data
   const relationshipQueryKey = {
     types: [ProfileRelationshipType.LIKES, ProfileRelationshipType.FOLLOWING],
@@ -60,7 +66,9 @@ export function useRelationshipMutations({
 
   // Get user's likes and follows
   const { data: userRelationships, isLoading: isLoadingRelationships } =
-    trpc.profile.getRelationships.useQuery(relationshipQueryKey);
+    trpc.profile.getRelationships.useQuery(relationshipQueryKey, {
+      enabled: !!user,
+    });
 
   // Check if current user has liked/followed this profile
   const isLiked = Boolean(

--- a/apps/app/src/proxy.ts
+++ b/apps/app/src/proxy.ts
@@ -120,21 +120,21 @@ export async function proxy(request: NextRequest, event: NextFetchEvent) {
     return response;
   }
 
-  if (
-    !user &&
-    !request.nextUrl.pathname.startsWith('/login') &&
-    !(request.nextUrl.pathname === '/')
-  ) {
-    // no user, redirect to login with the original path preserved
-    const url = request.nextUrl.clone();
-
-    url.pathname = '/login';
-    if (pathname !== '/') {
-      url.searchParams.set('redirect', pathname);
-    }
-
-    return NextResponse.redirect(url);
-  }
+  // if (
+  //   !user &&
+  //   !request.nextUrl.pathname.startsWith('/login') &&
+  //   !(request.nextUrl.pathname === '/')
+  // ) {
+  //   // no user, redirect to login with the original path preserved
+  //   const url = request.nextUrl.clone();
+  //
+  //   url.pathname = '/login';
+  //   if (pathname !== '/') {
+  //     url.searchParams.set('redirect', pathname);
+  //   }
+  //
+  //   return NextResponse.redirect(url);
+  // }
 
   // IMPORTANT: You *must* return the supabaseResponse object as it is.
   // If you're creating a new response object with NextResponse.next() make sure to:

--- a/apps/app/src/proxy.ts
+++ b/apps/app/src/proxy.ts
@@ -1,5 +1,6 @@
 import {
   OPURLConfig,
+  anonymousSigninEnabled,
   cookieOptionsDomain,
   isOnPreviewAppDomain,
 } from '@op/core';
@@ -120,21 +121,26 @@ export async function proxy(request: NextRequest, event: NextFetchEvent) {
     return response;
   }
 
-  // if (
-  //   !user &&
-  //   !request.nextUrl.pathname.startsWith('/login') &&
-  //   !(request.nextUrl.pathname === '/')
-  // ) {
-  //   // no user, redirect to login with the original path preserved
-  //   const url = request.nextUrl.clone();
-  //
-  //   url.pathname = '/login';
-  //   if (pathname !== '/') {
-  //     url.searchParams.set('redirect', pathname);
-  //   }
-  //
-  //   return NextResponse.redirect(url);
-  // }
+  // TEMPORARY: while anonymous sign-in is behind a flag, keep forcing login for
+  // logged-out visitors. Once `anonymousSigninEnabled` is true this gate is
+  // skipped so anonymous users can reach the app. Remove this block (and the
+  // env flag) when anonymous sign-in is permanently on.
+  if (
+    !anonymousSigninEnabled &&
+    !user &&
+    !request.nextUrl.pathname.startsWith('/login') &&
+    !(request.nextUrl.pathname === '/')
+  ) {
+    // no user, redirect to login with the original path preserved
+    const url = request.nextUrl.clone();
+
+    url.pathname = '/login';
+    if (pathname !== '/') {
+      url.searchParams.set('redirect', pathname);
+    }
+
+    return NextResponse.redirect(url);
+  }
 
   // IMPORTANT: You *must* return the supabaseResponse object as it is.
   // If you're creating a new response object with NextResponse.next() make sure to:

--- a/apps/app/src/utils/UserProvider.tsx
+++ b/apps/app/src/utils/UserProvider.tsx
@@ -3,7 +3,6 @@
 import { trpc } from '@op/api/client';
 import type { CommonUser } from '@op/api/encoders';
 import type { Permission } from 'access-zones';
-import { useRouter } from 'next/navigation';
 import posthog from 'posthog-js';
 import React, { Suspense, createContext, useContext } from 'react';
 
@@ -46,7 +45,6 @@ export const UserProviderSuspense = ({
   children: React.ReactNode;
   initialUser: CommonUser | null;
 }) => {
-  const router = useRouter();
   // Use initialUser as initialData to avoid redundant client-side fetch.
   // staleTime prevents immediate background revalidation — the server already
   // fetched fresh data for this layout render, so there's no need to re-fetch
@@ -62,10 +60,6 @@ export const UserProviderSuspense = ({
   // full-page navigation (fresh tree, null initialUser), so inside a mounted
   // tree a null refetch is a transient cookie/token race, not a sign-out.
   const user = account ?? initialUser ?? undefined;
-
-  // if (user && !user.onboardedAt) {
-  //   router.push('/start');
-  // }
 
   if (user) {
     // We are only identifying One Project users by email.

--- a/apps/app/src/utils/UserProvider.tsx
+++ b/apps/app/src/utils/UserProvider.tsx
@@ -63,9 +63,9 @@ export const UserProviderSuspense = ({
   // tree a null refetch is a transient cookie/token race, not a sign-out.
   const user = account ?? initialUser ?? undefined;
 
-  if (user && !user.onboardedAt) {
-    router.push('/start');
-  }
+  // if (user && !user.onboardedAt) {
+  //   router.push('/start');
+  // }
 
   if (user) {
     // We are only identifying One Project users by email.

--- a/apps/app/src/utils/onboarding.ts
+++ b/apps/app/src/utils/onboarding.ts
@@ -9,5 +9,4 @@ import type { CommonUser } from '@op/api/encoders';
  */
 export const shouldRedirectToOnboarding = (
   user: CommonUser | null | undefined,
-): boolean =>
-  Boolean(user && !user.authUser?.isAnonymous && !user.onboardedAt);
+): boolean => Boolean(user && !user.authUser?.isAnonymous && !user.onboardedAt);

--- a/apps/app/src/utils/onboarding.ts
+++ b/apps/app/src/utils/onboarding.ts
@@ -1,0 +1,13 @@
+import type { CommonUser } from '@op/api/encoders';
+
+/**
+ * Whether a viewer must be sent through the onboarding flow at /start.
+ *
+ * Only a genuine, not-yet-onboarded account qualifies. Public (no-session)
+ * visitors have no account, and anonymous sign-ins are intentionally
+ * email-less and never onboarded — neither should be pulled into onboarding.
+ */
+export const shouldRedirectToOnboarding = (
+  user: CommonUser | null | undefined,
+): boolean =>
+  Boolean(user && !user.authUser?.isAnonymous && !user.onboardedAt);

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -64,7 +64,9 @@ export const getUserByAuthId = async ({
   const user = await db._query.users.findFirst({
     where: (table, { eq }) => eq(table.authUserId, authUserId),
     with: {
-      authUser: true,
+      authUser: {
+        columns: { isAnonymous: true },
+      },
       avatarImage: true,
       organizationUsers: {
         with: {

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -64,6 +64,7 @@ export const getUserByAuthId = async ({
   const user = await db._query.users.findFirst({
     where: (table, { eq }) => eq(table.authUserId, authUserId),
     with: {
+      authUser: true,
       avatarImage: true,
       organizationUsers: {
         with: {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -214,6 +214,17 @@ export const cookieDomains = [
 // PostHog config. Eventually to be moved to env vars
 export const posthogUIHost = 'https://eu.posthog.com';
 
+// TEMPORARY: env-flag gate for the anonymous sign-in rollout. The PostHog
+// `anonymous_signin` flag governs client UI (e.g. DecisionActionBar), but the
+// proxy middleware runs in the Edge runtime where PostHog flag evaluation isn't
+// viable, so the login-redirect gate there reads this env flag instead. On by
+// default in development and e2e to match useFeatureFlag/getServerFeatureFlag.
+// Remove this (and the proxy gate) once anonymous sign-in is permanently on.
+export const anonymousSigninEnabled =
+  process.env.NODE_ENV === 'development' ||
+  process.env.NEXT_PUBLIC_E2E === 'true' ||
+  process.env.ANONYMOUS_SIGNIN_ENABLED === 'true';
+
 export const allowedEmailDomains = ['oneproject.org', 'team.oneproject.org'];
 
 export const genericEmail = 'support@oneproject.org';

--- a/services/api/src/encoders/users.ts
+++ b/services/api/src/encoders/users.ts
@@ -64,7 +64,10 @@ const profileUserWithPermissionsEncoder = profileUserWithProfileSchema.extend({
  */
 export const userEncoder = createSelectSchema(users).extend({
   onboardedAt: z.string().nullish(),
-  authUser: createSelectSchema(authUsers).nullish(),
+  // Callers project different subsets of the auth user (e.g. getMyAccount only
+  // selects `isAnonymous`), so keep every column optional. `.nullish()` already
+  // covers an absent relation; `.partial()` covers a present-but-partial row.
+  authUser: createSelectSchema(authUsers).partial().nullish(),
   avatarImage: storageItemEncoder.nullish(),
   organizationUsers: organizationUserWithPermissionsEncoder.array().nullish(),
   profileUsers: profileUserWithPermissionsEncoder.array().nullish(),


### PR DESCRIPTION
Lets public visitors start a proposal by giving them an anonymous session (behind the anonymous_signin flag) so the draft has an account to attribute.