### PR TITLE
feat(decisions): mark required fields in proposal editor and preview

### DIFF
--- a/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
@@ -20,6 +20,8 @@ interface CollaborativeDropdownFieldProps {
   placeholder?: string;
   /** When true, prepends a "None" option that clears the selection back to null. */
   allowEmpty?: boolean;
+  /** When true, sets `aria-required` on the select for assistive tech. */
+  required?: boolean;
 }
 
 /**
@@ -33,6 +35,7 @@ export function CollaborativeDropdownField({
   fragmentName,
   placeholder,
   allowEmpty = false,
+  required = false,
 }: CollaborativeDropdownFieldProps) {
   const t = useTranslations();
   const { ydoc } = useCollaborativeDoc();
@@ -82,6 +85,7 @@ export function CollaborativeDropdownField({
     <Select
       variant="pill"
       size="medium"
+      isRequired={required}
       placeholder={placeholder ?? t('Select option')}
       selectedKey={selectedValue}
       onSelectionChange={handleSelectionChange}

--- a/apps/app/src/components/collaboration/CollaborativeEditor.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeEditor.tsx
@@ -28,6 +28,8 @@ export interface CollaborativeEditorProps {
   onEditorReady?: (editor: Editor) => void;
   className?: string;
   editorClassName?: string;
+  /** When true, sets `aria-required` on the editable region for assistive tech. */
+  required?: boolean;
 }
 
 /** Rich text editor with real-time collaboration via TipTap Cloud */
@@ -43,6 +45,7 @@ export const CollaborativeEditor = forwardRef<
       onEditorReady,
       className = '',
       editorClassName = '',
+      required = false,
     },
     ref,
   ) => {
@@ -66,6 +69,7 @@ export const CollaborativeEditor = forwardRef<
       extensions: collaborativeExtensions,
       editorClassName,
       onEditorReady,
+      required,
     });
 
     useImperativeHandle(

--- a/apps/app/src/components/collaboration/CollaborativeTextField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTextField.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { RequiredAsterisk } from '@op/ui/RequiredAsterisk';
 import { cn } from '@op/ui/utils';
 import Placeholder from '@tiptap/extension-placeholder';
 import type { Editor } from '@tiptap/react';
@@ -100,12 +101,7 @@ export function CollaborativeTextField({
           {title && (
             <span className="font-serif text-title-sm14 text-neutral-charcoal">
               {title}
-              {required && (
-                <span className="text-functional-red" aria-hidden="true">
-                  {' '}
-                  *
-                </span>
-              )}
+              {required && <RequiredAsterisk />}
             </span>
           )}
           {description && (

--- a/apps/app/src/components/collaboration/CollaborativeTextField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTextField.tsx
@@ -119,6 +119,7 @@ export function CollaborativeTextField({
         placeholder={placeholder}
         onEditorReady={handleEditorReady}
         editorClassName={multiline ? 'min-h-32' : 'min-h-8'}
+        required={required}
       />
       {maxLength != null && (
         <div className="flex justify-end">

--- a/apps/app/src/components/collaboration/CollaborativeTextField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTextField.tsx
@@ -14,6 +14,7 @@ import { CollaborativeEditor } from './CollaborativeEditor';
  * @param fragmentName - Yjs fragment name (required). Each field in the
  *   proposal schema maps to a unique fragment in the shared Y.Doc.
  * @param title - Optional label rendered above the editor.
+ * @param required - When true, renders a red asterisk next to the title.
  * @param description - Optional description rendered below the title.
  * @param placeholder - Placeholder text shown when the editor is empty.
  * @param multiline - When true, renders a taller editor suitable for long text.
@@ -25,6 +26,7 @@ import { CollaborativeEditor } from './CollaborativeEditor';
 interface CollaborativeTextFieldProps {
   fragmentName: string;
   title?: string;
+  required?: boolean;
   description?: string;
   placeholder?: string;
   multiline?: boolean;
@@ -43,6 +45,7 @@ interface CollaborativeTextFieldProps {
 export function CollaborativeTextField({
   fragmentName,
   title,
+  required,
   description,
   placeholder = 'Start typing...',
   multiline = false,
@@ -97,6 +100,12 @@ export function CollaborativeTextField({
           {title && (
             <span className="font-serif text-title-sm14 text-neutral-charcoal">
               {title}
+              {required && (
+                <span className="text-functional-red" aria-hidden="true">
+                  {' '}
+                  *
+                </span>
+              )}
             </span>
           )}
           {description && (

--- a/apps/app/src/components/decisions/forms/FieldHeader.tsx
+++ b/apps/app/src/components/decisions/forms/FieldHeader.tsx
@@ -5,28 +5,45 @@ export function FieldHeader({
   title,
   description,
   badge,
+  required,
   className = 'gap-2',
 }: {
   title?: string;
   description?: string;
   /** Optional trailing element shown inline with the title (e.g. "5 pts", "Yes/No"). */
   badge?: React.ReactNode;
+  /** When true, renders a red asterisk next to the title. */
+  required?: boolean;
   className?: string;
 }) {
   if (!title && !description) {
     return null;
   }
 
+  const titleContent = title ? (
+    required ? (
+      <>
+        {title}
+        <span className="text-functional-red" aria-hidden="true">
+          {' '}
+          *
+        </span>
+      </>
+    ) : (
+      title
+    )
+  ) : undefined;
+
   return (
     <div className={`flex flex-col ${className}`}>
-      {title &&
+      {titleContent &&
         (badge ? (
           <div className="flex items-baseline justify-between gap-2">
-            <Header4 className="font-light">{title}</Header4>
+            <Header4 className="font-light">{titleContent}</Header4>
             <span className="shrink-0 text-xs text-neutral-gray4">{badge}</span>
           </div>
         ) : (
-          <Header4 className="font-light">{title}</Header4>
+          <Header4 className="font-light">{titleContent}</Header4>
         ))}
       {description && (
         <p className="text-sm text-neutral-charcoal">{description}</p>

--- a/apps/app/src/components/decisions/forms/FieldHeader.tsx
+++ b/apps/app/src/components/decisions/forms/FieldHeader.tsx
@@ -21,24 +21,19 @@ export function FieldHeader({
     return null;
   }
 
-  const titleNode = title && (
-    <Header4 className="font-light">
-      {title}
-      {required && <RequiredAsterisk />}
-    </Header4>
-  );
-
   return (
     <div className={`flex flex-col ${className}`}>
-      {titleNode &&
-        (badge ? (
-          <div className="flex items-baseline justify-between gap-2">
-            {titleNode}
+      {title && (
+        <div className="flex items-baseline justify-between gap-2">
+          <Header4 className="font-light">
+            {title}
+            {required && <RequiredAsterisk />}
+          </Header4>
+          {badge && (
             <span className="shrink-0 text-xs text-neutral-gray4">{badge}</span>
-          </div>
-        ) : (
-          titleNode
-        ))}
+          )}
+        </div>
+      )}
       {description && (
         <p className="text-sm text-neutral-charcoal">{description}</p>
       )}

--- a/apps/app/src/components/decisions/forms/FieldHeader.tsx
+++ b/apps/app/src/components/decisions/forms/FieldHeader.tsx
@@ -1,4 +1,5 @@
 import { Header4 } from '@op/ui/Header';
+import { RequiredAsterisk } from '@op/ui/RequiredAsterisk';
 
 /** Renders title + description header for a form field. */
 export function FieldHeader({
@@ -20,30 +21,23 @@ export function FieldHeader({
     return null;
   }
 
-  const titleContent = title ? (
-    required ? (
-      <>
-        {title}
-        <span className="text-functional-red" aria-hidden="true">
-          {' '}
-          *
-        </span>
-      </>
-    ) : (
-      title
-    )
-  ) : undefined;
+  const titleNode = title && (
+    <Header4 className="font-light">
+      {title}
+      {required && <RequiredAsterisk />}
+    </Header4>
+  );
 
   return (
     <div className={`flex flex-col ${className}`}>
-      {titleContent &&
+      {titleNode &&
         (badge ? (
           <div className="flex items-baseline justify-between gap-2">
-            <Header4 className="font-light">{titleContent}</Header4>
+            {titleNode}
             <span className="shrink-0 text-xs text-neutral-gray4">{badge}</span>
           </div>
         ) : (
-          <Header4 className="font-light">{titleContent}</Header4>
+          titleNode
         ))}
       {description && (
         <p className="text-sm text-neutral-charcoal">{description}</p>

--- a/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
@@ -301,6 +301,7 @@ function renderField(
         <CollaborativeTextField
           fragmentName={key}
           title={schema.title}
+          required={field.required}
           description={schema.description}
           placeholder={placeholder}
           multiline={format === 'long-text'}
@@ -364,7 +365,11 @@ function renderField(
 
       return (
         <div className="flex flex-col gap-2">
-          <FieldHeader title={schema.title} description={schema.description} />
+          <FieldHeader
+            title={schema.title}
+            description={schema.description}
+            required={field.required}
+          />
           <CollaborativeDropdownField
             options={options}
             initialValue={(draft[key] as string | null) ?? null}

--- a/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
@@ -376,6 +376,7 @@ function renderField(
             onChange={(value) => onFieldChange(key, value)}
             fragmentName={key}
             allowEmpty={!field.required}
+            required={field.required}
           />
         </div>
       );

--- a/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
@@ -287,6 +287,7 @@ function renderField(
           <ReadonlyTextField
             title={schema.title}
             description={schema.description}
+            required={field.required}
             content={
               mode === 'preview-version' ? (previewContent ?? null) : null
             }
@@ -355,6 +356,7 @@ function renderField(
             value={selectedOption?.label ?? null}
             title={schema.title}
             description={schema.description}
+            required={field.required}
             placeholder={t('Select option')}
           />
         );

--- a/apps/app/src/components/decisions/proposalEditor/ReadonlyProposalFields.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ReadonlyProposalFields.tsx
@@ -25,12 +25,14 @@ export function ReadonlyTitleField({ value }: { value: string | null }) {
 export function ReadonlyTextField({
   title,
   description,
+  required,
   content,
   placeholder,
   multiline,
 }: {
   title?: string;
   description?: string;
+  required?: boolean;
   content: JSONContent | null;
   placeholder: string;
   multiline: boolean;
@@ -44,7 +46,11 @@ export function ReadonlyTextField({
 
   return (
     <div className="flex flex-col gap-4">
-      <FieldHeader title={title} description={description} />
+      <FieldHeader
+        title={title}
+        description={description}
+        required={required}
+      />
       {content ? (
         <RichTextViewer
           key={contentKey}
@@ -68,11 +74,13 @@ export function ReadonlyDropdownField({
   value,
   title,
   description,
+  required,
   placeholder,
 }: {
   value: string | null;
   title?: string;
   description?: string;
+  required?: boolean;
   placeholder: string;
 }) {
   const content = (
@@ -87,7 +95,11 @@ export function ReadonlyDropdownField({
 
   return (
     <div className="flex flex-col gap-2">
-      <FieldHeader title={title} description={description} />
+      <FieldHeader
+        title={title}
+        description={description}
+        required={required}
+      />
       {content}
     </div>
   );

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,6 +50,7 @@
     "./ProfileItem": "./src/components/ProfileItem.tsx",
     "./RadioGroup": "./src/components/RadioGroup.tsx",
     "./ReactionsButton": "./src/components/ReactionsButton.tsx",
+    "./RequiredAsterisk": "./src/components/RequiredAsterisk.tsx",
     "./StatusDot": "./src/components/StatusDot.tsx",
     "./RichTextEditor": "./src/components/RichTextEditor/index.ts",
     "./Sortable": "./src/components/Sortable/index.ts",

--- a/packages/ui/src/components/RequiredAsterisk.tsx
+++ b/packages/ui/src/components/RequiredAsterisk.tsx
@@ -1,0 +1,20 @@
+import { cn } from '../lib/utils';
+
+export interface RequiredAsteriskProps {
+  /** Additional classes applied to the asterisk. */
+  className?: string;
+}
+
+/**
+ * Decorative red asterisk marking a required field. Hidden from assistive
+ * tech (`aria-hidden`) — the required semantics belong on the input itself
+ * via `aria-required`, not on this visual marker.
+ */
+export const RequiredAsterisk = ({ className }: RequiredAsteriskProps) => {
+  return (
+    <span className={cn('text-functional-red', className)} aria-hidden="true">
+      {' '}
+      *
+    </span>
+  );
+};

--- a/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
+++ b/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
@@ -13,6 +13,7 @@ export function useRichTextEditor({
   onChange,
   onEditorReady,
   editable = true,
+  required = false,
 }: {
   extensions?: Extensions;
   content?: Content;
@@ -21,6 +22,8 @@ export function useRichTextEditor({
   onChange?: (content: string) => void;
   onEditorReady?: (editor: Editor) => void;
   editable?: boolean;
+  /** When true, sets `aria-required` on the editable region for assistive tech. */
+  required?: boolean;
 }) {
   const editor = useEditor({
     extensions,
@@ -32,6 +35,7 @@ export function useRichTextEditor({
           baseEditorStyles,
           editorClassName || (editable ? 'min-h-96' : ''),
         ),
+        ...(required ? { 'aria-required': 'true' } : {}),
       },
     },
     onUpdate: ({ editor }) => {

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -101,6 +101,7 @@ export const Select = <T extends object, M extends SelectionMode = 'single'>({
   return (
     <AriaSelect
       {...props}
+      isRequired={isRequired}
       isInvalid={!!errorMessage && errorMessage.length > 0}
       className={cn('flex flex-col gap-1', props.className)}
     >

--- a/packages/ui/stories/RequiredAsterisk.stories.tsx
+++ b/packages/ui/stories/RequiredAsterisk.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { RequiredAsterisk } from '../src/components/RequiredAsterisk';
+
+const meta: Meta<typeof RequiredAsterisk> = {
+  title: 'RequiredAsterisk',
+  component: RequiredAsterisk,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: { type: 'text' },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RequiredAsterisk>;
+
+export const Default: Story = {
+  render: (args) => (
+    <span className="font-serif text-title-sm14 text-neutral-charcoal">
+      Field title
+      <RequiredAsterisk {...args} />
+    </span>
+  ),
+};


### PR DESCRIPTION
- Render a red asterisk next to required field labels in the proposal template preview (readonly text + dropdown fields).
- Mirror the same marking in the live proposal editor (collaborative text + dropdown fields).
- Thread `required` through `FieldHeader`, the readonly field components, and `CollaborativeTextField`.
- Wire `aria-required` on the editable inputs (rich text contenteditable + collaborative select) so the asterisk isn't the only required cue.

Supersedes #1298 (closed by a branch rename).