### PR TITLE
feat: RTL-aware text direction handling for Arabic

### DIFF
--- a/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
+++ b/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
@@ -169,7 +169,7 @@ export const AddResourceDocumentForm = ({
                   size="small"
                   onPress={handleRemoveFile}
                   isDisabled={uploading}
-                  className="absolute top-2 right-2 bg-white/90 shadow-sm hover:bg-white"
+                  className="absolute end-2 top-2 bg-white/90 shadow-sm hover:bg-white"
                   aria-label={t('Remove file')}
                 >
                   <LuX className="size-5" />

--- a/apps/app/src/components/Resources/PinnedResourceCard.tsx
+++ b/apps/app/src/components/Resources/PinnedResourceCard.tsx
@@ -62,7 +62,9 @@ export const PinnedResourceCard = ({
           <Icon className="size-4 text-neutral-black" />
         </div>
         <div className="flex min-w-0 flex-col gap-0.5">
-          <p className="truncate text-base text-neutral-black">{title}</p>
+          <p dir="auto" className="truncate text-base text-neutral-black">
+            {title}
+          </p>
           {resource.createdAt ? (
             <p className="truncate text-sm text-neutral-gray4">
               {t('Added {date}', { date: formatDate(resource.createdAt) })}

--- a/apps/app/src/components/Resources/ResourceCard.tsx
+++ b/apps/app/src/components/Resources/ResourceCard.tsx
@@ -163,7 +163,7 @@ const ResourceCardShell = ({
       <p
         className={cn(
           'truncate font-serif text-title-sm text-neutral-black',
-          trailing && 'pr-8',
+          trailing && 'pe-8',
         )}
       >
         {title}
@@ -198,7 +198,7 @@ const ResourceCardShell = ({
         body
       )}
       {trailing ? (
-        <div className="absolute top-3 right-3 rounded-full bg-white/80 p-1">
+        <div className="absolute end-3 top-3 rounded-full bg-white/80 p-1">
           {trailing}
         </div>
       ) : null}

--- a/apps/app/src/components/Resources/ResourceCard.tsx
+++ b/apps/app/src/components/Resources/ResourceCard.tsx
@@ -161,6 +161,7 @@ const ResourceCardShell = ({
   const body = (
     <div className="flex flex-col gap-2">
       <p
+        dir="auto"
         className={cn(
           'truncate font-serif text-title-sm text-neutral-black',
           trailing && 'pe-8',
@@ -171,12 +172,14 @@ const ResourceCardShell = ({
       {preview}
       <div className="flex flex-col gap-0.5">
         {description ? (
-          <p className="line-clamp-2 text-sm text-neutral-charcoal">
+          <p dir="auto" className="line-clamp-2 text-sm text-neutral-charcoal">
             {description}
           </p>
         ) : null}
         {subtitle ? (
-          <p className="truncate text-sm text-neutral-gray4">{subtitle}</p>
+          <p dir="auto" className="truncate text-sm text-neutral-gray4">
+            {subtitle}
+          </p>
         ) : null}
       </div>
     </div>

--- a/apps/app/src/components/SearchInput/index.tsx
+++ b/apps/app/src/components/SearchInput/index.tsx
@@ -5,11 +5,11 @@ import { useDebounce } from '@op/hooks';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { TextField } from '@op/ui/TextField';
 import { cn } from '@op/ui/utils';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { useEffect, useRef, useState } from 'react';
 import { LuSearch } from 'react-icons/lu';
 
-import { Link, useRouter } from '@/lib/i18n';
+import { getLocaleDirection, Link, useRouter } from '@/lib/i18n';
 
 import { ProfileResults } from './ProfileResults';
 import { RecentSearches } from './RecentSearches';
@@ -25,6 +25,8 @@ export const SearchInput = ({ onBlur }: { onBlur?: () => void } = {}) => {
   const [showResults, setShowResults] = useState<boolean>(false);
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
   const [isMobile, setIsMobile] = useState(false);
+  const locale = useLocale();
+  const localeDirection = getLocaleDirection(locale);
 
   // Check if we're on mobile using the same breakpoint as the header
   useEffect(() => {
@@ -169,6 +171,7 @@ export const SearchInput = ({ onBlur }: { onBlur?: () => void } = {}) => {
       <TextField
         ref={inputRef}
         inputProps={{
+          dir: query.length > 0 ? 'auto' : undefined,
           placeholder: t('Search'),
           color: 'muted',
           size: 'small',
@@ -181,6 +184,7 @@ export const SearchInput = ({ onBlur }: { onBlur?: () => void } = {}) => {
             'bg-transparent placeholder:text-neutral-gray4 focus-visible:bg-white active:bg-white active:text-neutral-gray3',
             'active:border-inherit', // override TextField input styles that are used everywhere
             dropdownShowing && 'sm:rounded-b-none',
+            localeDirection === 'rtl' && 'pl-4', // override logical padding property due to dir="auto" in inputProps
           ),
           onKeyDown: handleKeyDown,
           'aria-expanded': dropdownShowing,

--- a/apps/app/src/components/collaboration/CollaborativeEditor.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeEditor.tsx
@@ -88,7 +88,11 @@ export const CollaborativeEditor = forwardRef<
 
     return (
       <div className={className}>
-        <StyledRichTextContent editor={editor} placeholder={placeholder} />
+        <StyledRichTextContent
+          dir={editor?.isEmpty ? undefined : 'auto'}
+          editor={editor}
+          placeholder={placeholder}
+        />
       </div>
     );
   },

--- a/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
@@ -86,5 +86,7 @@ export function CollaborativeTitleField({
     return <Skeleton className="h-8" />;
   }
 
-  return <EditorContent editor={editor} />;
+  return (
+    <EditorContent dir={editor.isEmpty ? undefined : 'auto'} editor={editor} />
+  );
 }

--- a/apps/app/src/components/decisions/DecisionSidePanel.tsx
+++ b/apps/app/src/components/decisions/DecisionSidePanel.tsx
@@ -142,7 +142,7 @@ const PanelContents = ({
       }}
       className="min-h-0 flex-1 gap-0"
     >
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-neutral-gray1 pr-4 sm:pt-4 sm:pr-0">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-neutral-gray1 pe-4 sm:pe-0 sm:pt-4">
         <TabList
           aria-label={t('Decision side panel tabs')}
           className="grow border-b-0 px-4 sm:px-6"

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -91,7 +91,7 @@ const PromoteAccountModalContent = ({
       </div>
 
       <div className="flex flex-col gap-4">
-        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-white p-4 text-left">
+        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-white p-4 text-start">
           <div className="flex items-center gap-1">
             <LuUserRoundMinus
               className="size-4 text-neutral-charcoal"
@@ -132,7 +132,7 @@ const PromoteAccountModalContent = ({
           </Button>
         </section>
 
-        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-neutral-off-white p-4 text-left">
+        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-neutral-off-white p-4 text-start">
           <div className="flex items-center gap-1">
             <LuUserRoundPlus
               className="size-4 text-neutral-charcoal"

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -139,6 +139,7 @@ export function ProposalCardTitle({
           className,
           'transition-colors hover:text-primary-teal',
         )}
+        dir="auto"
       >
         {titleText}
       </Link>
@@ -430,6 +431,7 @@ export function ProposalCardPreview({
   return (
     <p
       className={cn('line-clamp-3 text-base text-neutral-charcoal', className)}
+      dir="auto"
     >
       {displayText}
     </p>

--- a/apps/app/src/components/decisions/ProposalHtmlContent.tsx
+++ b/apps/app/src/components/decisions/ProposalHtmlContent.tsx
@@ -25,6 +25,7 @@ export function ProposalHtmlContent({ html }: { html: string }) {
   if (!hasEmbeds) {
     return (
       <div
+        dir="auto"
         className={viewerProseStyles}
         dangerouslySetInnerHTML={{ __html: html }}
       />
@@ -32,7 +33,7 @@ export function ProposalHtmlContent({ html }: { html: string }) {
   }
 
   return (
-    <div className={viewerProseStyles}>
+    <div dir="auto" className={viewerProseStyles}>
       {segments.map((segment, i) => {
         if (segment.type === 'embed') {
           return <LinkPreview key={i} url={segment.url} className="my-4" />;

--- a/apps/app/src/components/decisions/ProposalMasonry.tsx
+++ b/apps/app/src/components/decisions/ProposalMasonry.tsx
@@ -12,11 +12,11 @@ const BREAKPOINT_COLS = { default: 3, [lg - 1]: 2, [md - 1]: 1 };
 
 export function ProposalMasonry({ children }: { children: ReactNode }) {
   return (
-    // -ml-6/pl-6 are the column gutter.
+    // -ms-6/ps-6 are the column gutter (logical, so it flips in RTL).
     <Masonry
       breakpointCols={BREAKPOINT_COLS}
-      className="-ml-6 flex w-auto"
-      columnClassName="flex min-w-0 flex-col gap-6 pl-6"
+      className="-ms-6 flex w-auto"
+      columnClassName="flex min-w-0 flex-col gap-6 ps-6"
     >
       {children}
     </Masonry>

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -131,7 +131,7 @@ export function ProposalPreview({
           </div>
         )}
 
-        <Header1 className="font-serif text-title-lg">
+        <Header1 dir="auto" className="font-serif text-title-lg">
           {title || t('Untitled Proposal')}
         </Header1>
 

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -131,7 +131,7 @@ export function ProposalPreview({
           </div>
         )}
 
-        <Header1 dir="auto" className="font-serif text-title-lg">
+        <Header1 className="font-serif text-title-lg">
           {title || t('Untitled Proposal')}
         </Header1>
 

--- a/apps/app/src/components/decisions/RichTextRenderer.tsx
+++ b/apps/app/src/components/decisions/RichTextRenderer.tsx
@@ -83,7 +83,11 @@ export function RichTextRenderer({
       : null;
   }
 
-  return <div className={viewerProseStyles}>{body}</div>;
+  return (
+    <div dir="auto" className={viewerProseStyles}>
+      {body}
+    </div>
+  );
 }
 
 /**

--- a/packages/ui/src/components/Field.tsx
+++ b/packages/ui/src/components/Field.tsx
@@ -22,6 +22,7 @@ import { twMerge } from 'tailwind-merge';
 import { tv } from 'tailwind-variants';
 import type { VariantProps } from 'tailwind-variants';
 
+import { cn } from '../lib/utils';
 import { composeTailwindRenderProps, focusRing } from '../utils';
 
 export const Label = (props: LabelProps) => {
@@ -126,8 +127,11 @@ const CONSTRAINED_INPUT_TYPES = new Set([
   'password',
 ]);
 
+const isAlwaysLTR = (type: string | undefined) =>
+  CONSTRAINED_INPUT_TYPES.has(type ?? '');
+
 const inputDir = (type: string | undefined) =>
-  CONSTRAINED_INPUT_TYPES.has(type ?? '') ? undefined : 'auto';
+  CONSTRAINED_INPUT_TYPES.has(type ?? '') ? 'ltr' : 'auto';
 
 export const Input = ({
   ref,
@@ -183,7 +187,12 @@ export const InputWithIcon = ({
           className,
         })}
       />
-      <span className="absolute start-3 top-1/2 -translate-y-1/2">
+      <span
+        className={cn(
+          isAlwaysLTR(props.type) ? 'left-3' : 'start-3',
+          'absolute top-1/2 -translate-y-1/2',
+        )}
+      >
         {props.icon}
       </span>
     </span>

--- a/packages/ui/src/components/Field.tsx
+++ b/packages/ui/src/components/Field.tsx
@@ -130,8 +130,16 @@ const CONSTRAINED_INPUT_TYPES = new Set([
 const isAlwaysLTR = (type: string | undefined) =>
   CONSTRAINED_INPUT_TYPES.has(type ?? '');
 
+// Constrained types (email/url/number/etc) are always Latin → force LTR.
+// Free-text inputs use `unicode-bidi: plaintext` instead of `dir="auto"`:
+// auto resolves an empty input to LTR (ignoring the placeholder), which
+// left-aligns RTL placeholders; plaintext lets an empty field inherit the
+// locale direction and a filled field follow its own content.
 const inputDir = (type: string | undefined) =>
-  CONSTRAINED_INPUT_TYPES.has(type ?? '') ? 'ltr' : 'auto';
+  isAlwaysLTR(type) ? 'ltr' : undefined;
+
+const bidiClass = (type: string | undefined) =>
+  isAlwaysLTR(type) ? undefined : '[unicode-bidi:plaintext]';
 
 export const Input = ({
   ref,
@@ -160,7 +168,11 @@ export const Input = ({
       dir={inputDir(props.type)}
       ref={ref}
       {...props}
-      className={inputStyles({ ...props, size, className })}
+      className={inputStyles({
+        ...props,
+        size,
+        className: cn(bidiClass(props.type), className),
+      })}
     />
   );
 };
@@ -184,7 +196,7 @@ export const InputWithIcon = ({
           ...props,
           size,
           hasIcon: true,
-          className,
+          className: cn(bidiClass(props.type), className),
         })}
       />
       <span
@@ -231,10 +243,12 @@ export const TextArea = ({
 } & TextAreaVariantProps) => {
   return (
     <RACTextArea
-      dir="auto"
       ref={ref}
       {...props}
-      className={textAreaStyles({ variant, className })}
+      className={textAreaStyles({
+        variant,
+        className: cn('[unicode-bidi:plaintext]', className),
+      })}
     />
   );
 };

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -5,41 +5,65 @@ import { cn } from '../lib/utils';
 export const Header1 = ({
   children,
   className,
+  dir,
 }: {
   children: React.ReactNode;
   className?: string;
+  dir?: 'ltr' | 'rtl' | 'auto';
 }) => {
-  return <h1 className={cn(headingClasses.h1, className)}>{children}</h1>;
+  return (
+    <h1 dir={dir} className={cn(headingClasses.h1, className)}>
+      {children}
+    </h1>
+  );
 };
 
 export const Header2 = ({
   children,
   className,
+  dir,
 }: {
   children: React.ReactNode;
   className?: string;
+  dir?: 'ltr' | 'rtl' | 'auto';
 }) => {
-  return <h2 className={cn(headingClasses.h2, className)}>{children}</h2>;
+  return (
+    <h2 dir={dir} className={cn(headingClasses.h2, className)}>
+      {children}
+    </h2>
+  );
 };
 
 export const Header3 = ({
   children,
   className,
+  dir,
 }: {
   children: React.ReactNode;
   className?: string;
+  dir?: 'ltr' | 'rtl' | 'auto';
 }) => {
-  return <h3 className={cn(headingClasses.h3, className)}>{children}</h3>;
+  return (
+    <h3 dir={dir} className={cn(headingClasses.h3, className)}>
+      {children}
+    </h3>
+  );
 };
 
 export const Header4 = ({
   children,
   className,
+  dir,
 }: {
   children: React.ReactNode;
   className?: string;
+  dir?: 'ltr' | 'rtl' | 'auto';
 }) => {
-  return <h4 className={cn(headingClasses.h4, className)}>{children}</h4>;
+  return (
+    <h4 dir={dir} className={cn(headingClasses.h4, className)}>
+      {children}
+    </h4>
+  );
 };
 
 export const GradientHeader = ({

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { cn } from '../lib/utils';
 export const Header1 = ({
   children,
   className,
-  dir,
+  dir = 'auto',
 }: {
   children: React.ReactNode;
   className?: string;
@@ -21,7 +21,7 @@ export const Header1 = ({
 export const Header2 = ({
   children,
   className,
-  dir,
+  dir = 'auto',
 }: {
   children: React.ReactNode;
   className?: string;
@@ -37,7 +37,7 @@ export const Header2 = ({
 export const Header3 = ({
   children,
   className,
-  dir,
+  dir = 'auto',
 }: {
   children: React.ReactNode;
   className?: string;
@@ -53,7 +53,7 @@ export const Header3 = ({
 export const Header4 = ({
   children,
   className,
-  dir,
+  dir = 'auto',
 }: {
   children: React.ReactNode;
   className?: string;

--- a/packages/ui/src/components/NumberField.tsx
+++ b/packages/ui/src/components/NumberField.tsx
@@ -35,8 +35,19 @@ export interface NumberFieldProps extends Omit<
   onInput?: (value: number | null) => void;
 }
 
-const filterNumericInput = (value: string) => {
+// Normalize non-ASCII numerals to ASCII so the field accepts Arabic input.
+// Arabic-Indic (U+0660–0669) and Extended Arabic-Indic/Persian (U+06F0–06F9)
+// digits map to ASCII; Arabic decimal/thousands separators map to `.`/``.
+const normalizeDigits = (value: string) => {
   return value
+    .replace(/[٠-٩]/g, (d) => String(d.charCodeAt(0) - 0x0660))
+    .replace(/[۰-۹]/g, (d) => String(d.charCodeAt(0) - 0x06f0))
+    .replace(/٫/g, '.') // Arabic decimal separator
+    .replace(/٬/g, ''); // Arabic thousands separator
+};
+
+const filterNumericInput = (value: string) => {
+  return normalizeDigits(value)
     .replace(/[^0-9.-]/g, '') // Keep only digits, minus, and decimal
     .replace(/(?!^)-/g, '') // Remove minus signs that aren't at the beginning
     .replace(/\.(?=.*\.)/g, ''); // Remove decimal points except the last one

--- a/packages/ui/src/components/PhaseCard.tsx
+++ b/packages/ui/src/components/PhaseCard.tsx
@@ -64,7 +64,7 @@ const CompletedPhaseCard = ({
 }: PhaseContentProps) => (
   <li
     className={cn(
-      'flex flex-col gap-2 border-l border-functional-green-100 px-4 py-2',
+      'flex flex-col gap-2 border-s border-functional-green-100 px-4 py-2',
       className,
     )}
   >
@@ -162,7 +162,7 @@ const UpcomingPhaseCard = ({
 }: PhaseContentProps) => (
   <li
     className={cn(
-      'flex flex-col gap-2 border-l border-neutral-gray1 px-4 py-2',
+      'flex flex-col gap-2 border-s border-neutral-gray1 px-4 py-2',
       className,
     )}
   >

--- a/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
@@ -85,7 +85,10 @@ export const RichTextEditor = forwardRef<
 
     return (
       <div className={className}>
-        <StyledRichTextContent editor={editor} />
+        <StyledRichTextContent
+          dir={editor.isEmpty ? undefined : 'auto'}
+          editor={editor}
+        />
       </div>
     );
   },

--- a/packages/ui/src/components/RichTextEditor/RichTextViewer.tsx
+++ b/packages/ui/src/components/RichTextEditor/RichTextViewer.tsx
@@ -40,7 +40,7 @@ export function RichTextViewer({
 
   return (
     <div className={className}>
-      <StyledRichTextContent editor={editor} />
+      <StyledRichTextContent dir="auto" editor={editor} />
     </div>
   );
 }

--- a/packages/ui/src/components/RichTextEditor/StyledRichTextContent.tsx
+++ b/packages/ui/src/components/RichTextEditor/StyledRichTextContent.tsx
@@ -7,7 +7,6 @@ export const StyledRichTextContent = ({
   ...props
 }: EditorContentProps) => (
   <EditorContent
-    dir="auto"
     {...props}
     className={cn(
       '[&_div:focus-visible]:outline-auto',

--- a/packages/ui/src/components/RichTextEditor/viewerStyles.ts
+++ b/packages/ui/src/components/RichTextEditor/viewerStyles.ts
@@ -20,6 +20,10 @@ export const viewerProseStyles = [
   '[&_li_p]:my-0',
   '[&_blockquote]:font-normal',
   '[&_:is(h1,h2,h3)]:my-4',
+  // Per-block bidi: each paragraph/heading/list-item resolves its own
+  // direction from content, so mixed LTR/RTL prose aligns correctly without
+  // a per-element dir attribute (text-align: start follows each block's dir).
+  '[&_:is(p,h1,h2,h3,h4,li,blockquote)]:[unicode-bidi:plaintext]',
   'leading-5 max-w-none break-words overflow-wrap-anywhere',
   // Details/Summary (collapsible) chrome lives in one raw-CSS block in
   // `@op/styles` (`.details` in shared-styles.css), shared by the editor's


### PR DESCRIPTION
RTL/Arabic text-direction support across UI primitives and decision views.

- `@op/ui`: free-text inputs use `unicode-bidi: plaintext` (empty inherits locale dir, filled follows content); constrained types (email/url/number/tel/password) forced LTR with icon pinned left. `NumberField` normalizes Arabic-Indic/Persian numerals to ASCII. `Header1-4` accept `dir` (default `auto`). RichText components forward `dir` instead of hardcoding it.
- App: `dir="auto"` on content that can be either script (proposal title/body, prose renderer, resource cards, search, collaborative editors) so LTR content lays out correctly in an RTL locale (alignment, list markers, truncation side).
- Prose: per-block `unicode-bidi: plaintext` in `viewerProseStyles` so mixed LTR/RTL paragraphs each align correctly.
- Swapped remaining physical Tailwind classes (`pr-`/`right-`/`text-left`/`border-l`/masonry gutter) for logical equivalents.