### PR TITLE
feat(decisions): show a log in button for signed-out visitors in the decision header

### DIFF
--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -105,11 +105,7 @@ export const DecisionInstanceHeader = ({
         {user && !user.isAnonymous ? (
           <UserAvatarMenu />
         ) : (
-          // Shown to both no-session and anonymous visitors so the latter can
-          // upgrade to a real account. `/login` lives outside the [locale]
-          // route tree, so a RAC ButtonLink would client-navigate through
-          // next-intl and land on the dead `/en/login`; a native navigation
-          // keeps the path locale-free.
+          // Native nav: /login is outside the [locale] tree, so a RAC link 404s at /en/login.
           <Button
             color="primary"
             size="small"

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -102,12 +102,14 @@ export const DecisionInstanceHeader = ({
           </ButtonLink>
         )}
         <LocaleChooser />
-        {user ? (
+        {user && !user.isAnonymous ? (
           <UserAvatarMenu />
         ) : (
-          // `/login` lives outside the [locale] route tree, so a RAC
-          // ButtonLink would client-navigate through next-intl and land on
-          // the dead `/en/login`. A native navigation keeps the path locale-free.
+          // Shown to both no-session and anonymous visitors so the latter can
+          // upgrade to a real account. `/login` lives outside the [locale]
+          // route tree, so a RAC ButtonLink would client-navigate through
+          // next-intl and land on the dead `/en/login`; a native navigation
+          // keeps the path locale-free.
           <Button
             color="primary"
             size="small"

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useUser } from '@/utils/UserProvider';
-import { ButtonLink } from '@op/ui/Button';
+import { Button, ButtonLink } from '@op/ui/Button';
 import { Header1 } from '@op/ui/Header';
 import { IconButton } from '@op/ui/IconButton';
 import { MegaphoneIcon } from '@op/ui/MegaphoneIcon';
@@ -102,9 +102,20 @@ export const DecisionInstanceHeader = ({
           </ButtonLink>
         )}
         <LocaleChooser />
-        {/* TODO(public decision view): render a Login / upgrade-account CTA
-            for signed-out visitors here once anonymous sessions ship. */}
-        {user ? <UserAvatarMenu /> : null}
+        {user ? (
+          <UserAvatarMenu />
+        ) : (
+          // `/login` lives outside the [locale] route tree, so a RAC
+          // ButtonLink would client-navigate through next-intl and land on
+          // the dead `/en/login`. A native navigation keeps the path locale-free.
+          <Button
+            color="primary"
+            size="small"
+            onPress={() => window.location.assign('/login')}
+          >
+            {t('Log in')}
+          </Button>
+        )}
       </div>
 
       {centerSlot ? (

--- a/apps/app/src/utils/onboarding.ts
+++ b/apps/app/src/utils/onboarding.ts
@@ -9,4 +9,4 @@ import type { CommonUser } from '@op/api/encoders';
  */
 export const shouldRedirectToOnboarding = (
   user: CommonUser | null | undefined,
-): boolean => Boolean(user && !user.authUser?.isAnonymous && !user.onboardedAt);
+): boolean => Boolean(user && !user.isAnonymous && !user.onboardedAt);

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -64,9 +64,6 @@ export const getUserByAuthId = async ({
   const user = await db._query.users.findFirst({
     where: (table, { eq }) => eq(table.authUserId, authUserId),
     with: {
-      authUser: {
-        columns: { isAnonymous: true },
-      },
       avatarImage: true,
       organizationUsers: {
         with: {

--- a/services/api/src/encoders/users.ts
+++ b/services/api/src/encoders/users.ts
@@ -64,9 +64,14 @@ const profileUserWithPermissionsEncoder = profileUserWithProfileSchema.extend({
  */
 export const userEncoder = createSelectSchema(users).extend({
   onboardedAt: z.string().nullish(),
-  // Callers project different subsets of the auth user (e.g. getMyAccount only
-  // selects `isAnonymous`), so keep every column optional. `.nullish()` already
-  // covers an absent relation; `.partial()` covers a present-but-partial row.
+  // Whether the underlying auth identity is an anonymous sign-in. Sourced by
+  // every producer from the Supabase session (`ctx.user.is_anonymous`) — or the
+  // admin's own auth fetch for cross-user procedures — so it never depends on
+  // loading the `authUser` relation.
+  isAnonymous: z.boolean(),
+  // The `authUser` relation is loaded only by the platform-admin user list
+  // (for `lastSignInAt`); callers project different column subsets, so keep
+  // every column optional. `.nullish()` covers procedures that don't load it.
   authUser: createSelectSchema(authUsers).partial().nullish(),
   avatarImage: storageItemEncoder.nullish(),
   organizationUsers: organizationUserWithPermissionsEncoder.array().nullish(),
@@ -77,3 +82,19 @@ export const userEncoder = createSelectSchema(users).extend({
 });
 
 export type CommonUser = z.infer<typeof userEncoder>;
+
+/**
+ * Encode a DB user row into a `CommonUser`, deriving the required `isAnonymous`
+ * flag from the caller's Supabase auth identity (`ctx.user`, or an admin
+ * `getUserById` result) rather than the DB `authUser` relation. Centralizes the
+ * "read it from the live session, never query `authUser` for it" rule so every
+ * producer of the caller's-own (or an admin-fetched) account stays consistent.
+ */
+export const encodeUser = ({
+  user,
+  authUser,
+}: {
+  user: Record<string, unknown>;
+  authUser: { is_anonymous?: boolean | null };
+}): CommonUser =>
+  userEncoder.parse({ ...user, isAnonymous: Boolean(authUser.is_anonymous) });

--- a/services/api/src/encoders/users.ts
+++ b/services/api/src/encoders/users.ts
@@ -64,14 +64,9 @@ const profileUserWithPermissionsEncoder = profileUserWithProfileSchema.extend({
  */
 export const userEncoder = createSelectSchema(users).extend({
   onboardedAt: z.string().nullish(),
-  // Whether the underlying auth identity is an anonymous sign-in. Sourced by
-  // every producer from the Supabase session (`ctx.user.is_anonymous`) — or the
-  // admin's own auth fetch for cross-user procedures — so it never depends on
-  // loading the `authUser` relation.
+  // Populated by encodeUser from the auth session, not the authUser relation.
   isAnonymous: z.boolean(),
-  // The `authUser` relation is loaded only by the platform-admin user list
-  // (for `lastSignInAt`); callers project different column subsets, so keep
-  // every column optional. `.nullish()` covers procedures that don't load it.
+  // Loaded only by the platform-admin user list (for lastSignInAt).
   authUser: createSelectSchema(authUsers).partial().nullish(),
   avatarImage: storageItemEncoder.nullish(),
   organizationUsers: organizationUserWithPermissionsEncoder.array().nullish(),
@@ -84,11 +79,8 @@ export const userEncoder = createSelectSchema(users).extend({
 export type CommonUser = z.infer<typeof userEncoder>;
 
 /**
- * Encode a DB user row into a `CommonUser`, deriving the required `isAnonymous`
- * flag from the caller's Supabase auth identity (`ctx.user`, or an admin
- * `getUserById` result) rather than the DB `authUser` relation. Centralizes the
- * "read it from the live session, never query `authUser` for it" rule so every
- * producer of the caller's-own (or an admin-fetched) account stays consistent.
+ * Encode a DB user row into a `CommonUser`, taking `isAnonymous` from the
+ * Supabase auth identity (`ctx.user` or an admin `getUserById` result).
  */
 export const encodeUser = ({
   user,

--- a/services/api/src/routers/account/getMyAccount.ts
+++ b/services/api/src/routers/account/getMyAccount.ts
@@ -2,7 +2,7 @@ import { cache } from '@op/cache';
 import { CommonError, getUserByAuthId } from '@op/common';
 import { z } from 'zod';
 
-import { userEncoder } from '../../encoders';
+import { encodeUser, userEncoder } from '../../encoders';
 import { openProcedure, router } from '../../trpcFactory';
 
 export const getMyAccount = router({
@@ -37,6 +37,6 @@ export const getMyAccount = router({
         throw new CommonError('Common user not found');
       }
 
-      return userEncoder.parse(user);
+      return encodeUser({ user, authUser: ctx.user });
     }),
 });

--- a/services/api/src/routers/account/switchProfile.ts
+++ b/services/api/src/routers/account/switchProfile.ts
@@ -10,7 +10,7 @@ import type { Profile } from '@op/db/schema';
 import { assertAccess, permission } from 'access-zones';
 import { z } from 'zod';
 
-import { userEncoder } from '../../encoders';
+import { encodeUser, userEncoder } from '../../encoders';
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const switchProfile = router({
@@ -67,6 +67,6 @@ export const switchProfile = router({
         params: [id],
       });
 
-      return userEncoder.parse(result[0]);
+      return encodeUser({ user: result[0], authUser: ctx.user });
     }),
 });

--- a/services/api/src/routers/account/updateLastOrgId.ts
+++ b/services/api/src/routers/account/updateLastOrgId.ts
@@ -1,7 +1,7 @@
 import { switchUserOrganization } from '@op/common';
 import { z } from 'zod';
 
-import { userEncoder } from '../../encoders';
+import { encodeUser, userEncoder } from '../../encoders';
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const switchOrganization = router({
@@ -18,6 +18,6 @@ export const switchOrganization = router({
         organizationId: input.organizationId,
       });
 
-      return userEncoder.parse(result);
+      return encodeUser({ user: result, authUser: ctx.user });
     }),
 });

--- a/services/api/src/routers/account/updateUserProfile.ts
+++ b/services/api/src/routers/account/updateUserProfile.ts
@@ -1,6 +1,6 @@
 import { updateUserProfile as updateUserProfileService } from '@op/common';
 
-import { userEncoder } from '../../encoders';
+import { encodeUser, userEncoder } from '../../encoders';
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { updateUserProfileDataSchema } from '../shared/profile';
 
@@ -18,7 +18,7 @@ const updateUserProfile = router({
         user,
       });
 
-      return userEncoder.parse(result);
+      return encodeUser({ user: result, authUser: user });
     }),
 });
 

--- a/services/api/src/routers/platform/admin/listAllUsers.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.ts
@@ -37,7 +37,15 @@ export const listAllUsersRouter = router({
       });
 
       return {
-        items: items.map((user) => userEncoder.parse(user)),
+        // The list already loads the `authUser` relation (for `lastSignInAt`),
+        // so read `isAnonymous` from it — no extra query, and there's no
+        // per-user session available here.
+        items: items.map((user) =>
+          userEncoder.parse({
+            ...user,
+            isAnonymous: Boolean(user.authUser?.isAnonymous),
+          }),
+        ),
         next,
         total,
       };

--- a/services/api/src/routers/platform/admin/listAllUsers.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.ts
@@ -37,9 +37,6 @@ export const listAllUsersRouter = router({
       });
 
       return {
-        // The list already loads the `authUser` relation (for `lastSignInAt`),
-        // so read `isAnonymous` from it — no extra query, and there's no
-        // per-user session available here.
         items: items.map((user) =>
           userEncoder.parse({
             ...user,

--- a/services/api/src/routers/platform/admin/updateUserProfile.ts
+++ b/services/api/src/routers/platform/admin/updateUserProfile.ts
@@ -2,7 +2,7 @@ import { NotFoundError, updateUserProfile } from '@op/common';
 import { createSBServiceClient } from '@op/supabase/server';
 import { z } from 'zod';
 
-import { userEncoder } from '../../../encoders';
+import { encodeUser, userEncoder } from '../../../encoders';
 import { withAuthenticatedPlatformAdmin } from '../../../middlewares/withAuthenticatedPlatformAdmin';
 import withRateLimited from '../../../middlewares/withRateLimited';
 import { commonProcedure, router } from '../../../trpcFactory';
@@ -35,6 +35,8 @@ export const updateUserProfileRouter = router({
         user: targetUserData.user,
       });
 
-      return userEncoder.parse(result);
+      // The target user's auth identity is already fetched above, so derive
+      // `isAnonymous` from it rather than re-querying the `authUser` relation.
+      return encodeUser({ user: result, authUser: targetUserData.user });
     }),
 });

--- a/services/api/src/routers/platform/admin/updateUserProfile.ts
+++ b/services/api/src/routers/platform/admin/updateUserProfile.ts
@@ -35,8 +35,6 @@ export const updateUserProfileRouter = router({
         user: targetUserData.user,
       });
 
-      // The target user's auth identity is already fetched above, so derive
-      // `isAnonymous` from it rather than re-querying the `authUser` relation.
       return encodeUser({ user: result, authUser: targetUserData.user });
     }),
 });


### PR DESCRIPTION
Signed-out visitors viewing a public decision saw nothing in the header where the account menu sits; this surfaces a log in CTA so they can sign in.