### PR TITLE
feat(api): make CommonUser.isAnonymous a required field sourced from the session

### DIFF
--- a/apps/app/src/components/screens/PlatformAdmin/UsersRow.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/UsersRow.tsx
@@ -33,9 +33,7 @@ export const UsersRowCells = ({ user }: { user: User }) => {
   const [isAddToOrgModalOpen, setIsAddToOrgModalOpen] = useState(false);
   const createdAt = user.createdAt ? new Date(user.createdAt) : null;
   const relativeCreatedAt = createdAt ? useRelativeTime(createdAt) : null;
-  const lastSignInAt = user.authUser?.lastSignInAt
-    ? new Date(user.authUser.lastSignInAt)
-    : null;
+  const lastSignInAt = user.lastSignInAt ? new Date(user.lastSignInAt) : null;
   const relativeLastSignIn = lastSignInAt
     ? useRelativeTime(lastSignInAt)
     : null;

--- a/apps/app/src/utils/onboarding.ts
+++ b/apps/app/src/utils/onboarding.ts
@@ -9,4 +9,4 @@ import type { CommonUser } from '@op/api/encoders';
  */
 export const shouldRedirectToOnboarding = (
   user: CommonUser | null | undefined,
-): boolean => Boolean(user && !user.authUser?.isAnonymous && !user.onboardedAt);
+): boolean => Boolean(user && !user.isAnonymous && !user.onboardedAt);

--- a/packages/common/src/services/user/index.ts
+++ b/packages/common/src/services/user/index.ts
@@ -64,9 +64,6 @@ export const getUserByAuthId = async ({
   const user = await db._query.users.findFirst({
     where: (table, { eq }) => eq(table.authUserId, authUserId),
     with: {
-      authUser: {
-        columns: { isAnonymous: true },
-      },
       avatarImage: true,
       organizationUsers: {
         with: {

--- a/services/api/src/encoders/users.ts
+++ b/services/api/src/encoders/users.ts
@@ -64,10 +64,7 @@ const profileUserWithPermissionsEncoder = profileUserWithProfileSchema.extend({
  */
 export const userEncoder = createSelectSchema(users).extend({
   onboardedAt: z.string().nullish(),
-  // Callers project different subsets of the auth user (e.g. getMyAccount only
-  // selects `isAnonymous`), so keep every column optional. `.nullish()` already
-  // covers an absent relation; `.partial()` covers a present-but-partial row.
-  authUser: createSelectSchema(authUsers).partial().nullish(),
+  isAnonymous: z.boolean(),
   avatarImage: storageItemEncoder.nullish(),
   organizationUsers: organizationUserWithPermissionsEncoder.array().nullish(),
   profileUsers: profileUserWithPermissionsEncoder.array().nullish(),
@@ -77,3 +74,21 @@ export const userEncoder = createSelectSchema(users).extend({
 });
 
 export type CommonUser = z.infer<typeof userEncoder>;
+
+// Platform-admin list entry: shared fields plus last sign-in (admin-only).
+export const adminUserEncoder = userEncoder.extend({
+  lastSignInAt: createSelectSchema(authUsers).shape.lastSignInAt.nullish(),
+});
+
+/**
+ * Encode a DB user row into a `CommonUser`, taking `isAnonymous` from the
+ * Supabase auth identity (`ctx.user` or an admin `getUserById` result).
+ */
+export const encodeUser = ({
+  user,
+  authUser,
+}: {
+  user: Record<string, unknown>;
+  authUser: { is_anonymous?: boolean | null };
+}): CommonUser =>
+  userEncoder.parse({ ...user, isAnonymous: Boolean(authUser.is_anonymous) });

--- a/services/api/src/routers/account/getMyAccount.ts
+++ b/services/api/src/routers/account/getMyAccount.ts
@@ -2,7 +2,7 @@ import { cache } from '@op/cache';
 import { CommonError, getUserByAuthId } from '@op/common';
 import { z } from 'zod';
 
-import { userEncoder } from '../../encoders';
+import { encodeUser, userEncoder } from '../../encoders';
 import { openProcedure, router } from '../../trpcFactory';
 
 export const getMyAccount = router({
@@ -37,6 +37,6 @@ export const getMyAccount = router({
         throw new CommonError('Common user not found');
       }
 
-      return userEncoder.parse(user);
+      return encodeUser({ user, authUser: ctx.user });
     }),
 });

--- a/services/api/src/routers/account/switchProfile.ts
+++ b/services/api/src/routers/account/switchProfile.ts
@@ -10,7 +10,7 @@ import type { Profile } from '@op/db/schema';
 import { assertAccess, permission } from 'access-zones';
 import { z } from 'zod';
 
-import { userEncoder } from '../../encoders';
+import { encodeUser, userEncoder } from '../../encoders';
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const switchProfile = router({
@@ -67,6 +67,6 @@ export const switchProfile = router({
         params: [id],
       });
 
-      return userEncoder.parse(result[0]);
+      return encodeUser({ user: result[0], authUser: ctx.user });
     }),
 });

--- a/services/api/src/routers/account/updateLastOrgId.ts
+++ b/services/api/src/routers/account/updateLastOrgId.ts
@@ -1,7 +1,7 @@
 import { switchUserOrganization } from '@op/common';
 import { z } from 'zod';
 
-import { userEncoder } from '../../encoders';
+import { encodeUser, userEncoder } from '../../encoders';
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 
 export const switchOrganization = router({
@@ -18,6 +18,6 @@ export const switchOrganization = router({
         organizationId: input.organizationId,
       });
 
-      return userEncoder.parse(result);
+      return encodeUser({ user: result, authUser: ctx.user });
     }),
 });

--- a/services/api/src/routers/account/updateUserProfile.ts
+++ b/services/api/src/routers/account/updateUserProfile.ts
@@ -1,6 +1,6 @@
 import { updateUserProfile as updateUserProfileService } from '@op/common';
 
-import { userEncoder } from '../../encoders';
+import { encodeUser, userEncoder } from '../../encoders';
 import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
 import { updateUserProfileDataSchema } from '../shared/profile';
 
@@ -18,7 +18,7 @@ const updateUserProfile = router({
         user,
       });
 
-      return userEncoder.parse(result);
+      return encodeUser({ user: result, authUser: user });
     }),
 });
 

--- a/services/api/src/routers/platform/admin/listAllUsers.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.ts
@@ -1,7 +1,7 @@
 import { listAllUsers } from '@op/common';
 import { z } from 'zod';
 
-import { userEncoder } from '../../../encoders/';
+import { adminUserEncoder } from '../../../encoders/';
 import { withAuthenticatedPlatformAdmin } from '../../../middlewares/withAuthenticatedPlatformAdmin';
 import withRateLimited from '../../../middlewares/withRateLimited';
 import { commonProcedure, router } from '../../../trpcFactory';
@@ -21,7 +21,7 @@ export const listAllUsersRouter = router({
     )
     .output(
       z.object({
-        items: z.array(userEncoder),
+        items: z.array(adminUserEncoder),
         next: z.string().nullish(),
         total: z.number(),
       }),
@@ -37,7 +37,13 @@ export const listAllUsersRouter = router({
       });
 
       return {
-        items: items.map((user) => userEncoder.parse(user)),
+        items: items.map((user) =>
+          adminUserEncoder.parse({
+            ...user,
+            isAnonymous: Boolean(user.authUser?.isAnonymous),
+            lastSignInAt: user.authUser?.lastSignInAt ?? null,
+          }),
+        ),
         next,
         total,
       };

--- a/services/api/src/routers/platform/admin/updateUserProfile.ts
+++ b/services/api/src/routers/platform/admin/updateUserProfile.ts
@@ -2,7 +2,7 @@ import { NotFoundError, updateUserProfile } from '@op/common';
 import { createSBServiceClient } from '@op/supabase/server';
 import { z } from 'zod';
 
-import { userEncoder } from '../../../encoders';
+import { encodeUser, userEncoder } from '../../../encoders';
 import { withAuthenticatedPlatformAdmin } from '../../../middlewares/withAuthenticatedPlatformAdmin';
 import withRateLimited from '../../../middlewares/withRateLimited';
 import { commonProcedure, router } from '../../../trpcFactory';
@@ -35,6 +35,6 @@ export const updateUserProfileRouter = router({
         user: targetUserData.user,
       });
 
-      return userEncoder.parse(result);
+      return encodeUser({ user: result, authUser: targetUserData.user });
     }),
 });


### PR DESCRIPTION
Adds an encodeUser helper that derives isAnonymous from the Supabase auth identity (ctx.user, or an admin getUserById result) instead of the authUser DB relation, and drops the now-unused authUser join in getUserByAuthId.