### PR TITLE
fix(api): open companion read procedures to anonymous callers

### DIFF
--- a/apps/app/src/hooks/useRelationshipMutations.ts
+++ b/apps/app/src/hooks/useRelationshipMutations.ts
@@ -54,9 +54,6 @@ export function useRelationshipMutations({
 }: UseRelationshipMutationsOptions) {
   const utils = trpc.useUtils();
 
-  // Relationships are scoped to the signed-in viewer. For anonymous visitors
-  // there's nothing to fetch (and the API rejects the call), so skip the query
-  // and treat the viewer as having no relationships.
   const { user } = useUser();
 
   // Query key for relationship data

--- a/packages/common/src/services/posts/getPosts.ts
+++ b/packages/common/src/services/posts/getPosts.ts
@@ -26,7 +26,7 @@ export interface GetPostsInput {
   offset?: number;
   includeChildren?: boolean;
   maxDepth?: number;
-  authUserId: string;
+  authUserId?: string;
 }
 
 export const getPosts = async (input: GetPostsInput) => {
@@ -111,7 +111,7 @@ export const getPosts = async (input: GetPostsInput) => {
   }
 
   await assertProfileTypeAccess({
-    user: { id: authUserId },
+    user: authUserId ? { id: authUserId } : undefined,
     profileIds: profileIdsToAuthorize,
     policies: {
       [EntityType.DECISION]: { decisions: permission.READ },
@@ -121,13 +121,15 @@ export const getPosts = async (input: GetPostsInput) => {
   // Flagged posts/comments stay visible to their author and to admins of the
   // governing profile; everyone else has them filtered out in SQL (so a
   // flagged comment doesn't leak into a thread, and pagination stays correct).
-  const actorProfileId = await getCurrentProfileId(authUserId);
-  const governingRoles = profileIdsToAuthorize[0]
-    ? await getProfileAccessRolesWithOrgFallback({
-        user: { id: authUserId },
-        profileId: profileIdsToAuthorize[0],
-      })
-    : [];
+  const [actorProfileId, governingRoles] = await Promise.all([
+    authUserId ? getCurrentProfileId(authUserId) : undefined,
+    profileIdsToAuthorize[0]
+      ? getProfileAccessRolesWithOrgFallback({
+          user: authUserId ? { id: authUserId } : undefined,
+          profileId: profileIdsToAuthorize[0],
+        })
+      : [],
+  ]);
   const isProfileAdmin = checkPermission(
     { profile: permission.ADMIN },
     governingRoles,

--- a/packages/common/src/services/profile/profileRelationships.ts
+++ b/packages/common/src/services/profile/profileRelationships.ts
@@ -8,7 +8,7 @@ import {
 } from '@op/db/schema';
 import { alias } from 'drizzle-orm/pg-core';
 
-import { ValidationError } from '../../utils/error';
+import { UnauthorizedError, ValidationError } from '../../utils/error';
 import { getCurrentProfileId } from '../access';
 
 export const addRelationship = async ({
@@ -94,7 +94,7 @@ export const getRelationships = async ({
   sourceProfileId?: string;
   relationshipTypes?: string[];
   profileType?: string;
-  authUserId: string;
+  authUserId?: string;
 }): Promise<
   Array<{
     relationshipType: string;
@@ -175,11 +175,12 @@ export const getRelationships = async ({
   if (sourceProfileId) {
     conditions.push(eq(profileRelationships.sourceProfileId, sourceProfileId));
   } else if (!targetProfileId) {
-    // Only resolve currentProfileId when needed as fallback (avoids extra DB query)
-    const currentProfileId = await getCurrentProfileId(authUserId);
-    if (!currentProfileId) {
-      throw new ValidationError('You must be logged in to view relationships');
+    if (!authUserId) {
+      throw new UnauthorizedError(
+        'You must be logged in to view your relationships',
+      );
     }
+    const currentProfileId = await getCurrentProfileId(authUserId);
     conditions.push(eq(profileRelationships.sourceProfileId, currentProfileId));
   }
 

--- a/services/api/src/routers/account/getUserProfiles.test.ts
+++ b/services/api/src/routers/account/getUserProfiles.test.ts
@@ -12,18 +12,18 @@ describeAccessTierGating('account.getUserProfiles', {
   }),
 
   anonJwt: accessTierGatingCell(
-    'rejects anon-JWT caller',
+    'admits anon-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.anonJwt();
-      await expectFailsAccessTierGate(caller.account.getUserProfiles(), 'anon');
+      await expectPassesAccessTierGate(caller.account.getUserProfiles());
     },
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits out-of-network user-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(caller.account.getUserProfiles(), 'user');
+      await expectPassesAccessTierGate(caller.account.getUserProfiles());
     },
   ),
 

--- a/services/api/src/routers/account/getUserProfiles.ts
+++ b/services/api/src/routers/account/getUserProfiles.ts
@@ -2,7 +2,7 @@ import { UnauthorizedError, getUserWithProfiles } from '@op/common';
 import { EntityType, ObjectsInStorage, Profile } from '@op/db/schema';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedProcedure, router } from '../../trpcFactory';
 
 export const userProfileSchema = z.object({
   id: z.string(),
@@ -19,7 +19,7 @@ export const userProfileSchema = z.object({
 });
 
 export const getUserProfiles = router({
-  getUserProfiles: networkAuthenticatedProcedure()
+  getUserProfiles: authenticatedProcedure()
     .input(z.undefined())
     .output(
       z.array(

--- a/services/api/src/routers/decision/reviews/listProposalRevisionRequests.test.ts
+++ b/services/api/src/routers/decision/reviews/listProposalRevisionRequests.test.ts
@@ -9,9 +9,10 @@ import { appRouter } from '../..';
 import { TestReviewsDataManager } from '../../../test/helpers/TestReviewsDataManager';
 import {
   accessTierGatingCell,
-  describeDecisionAccessTierGating,
+  describeAccessTierGating,
   expectFailsAccessTierGate,
-} from '../../../test/helpers/gating/decision';
+  expectPassesAccessTierGate,
+} from '../../../test/helpers/gating';
 import {
   createIsolatedSession,
   createTestContextWithSession,
@@ -208,73 +209,54 @@ describe.concurrent('listProposalRevisionRequests', () => {
   });
 });
 
-describeDecisionAccessTierGating('listProposalRevisionRequests', {
-  noJwtNonPublic: accessTierGatingCell(
-    'rejects no-JWT caller on non-public instance',
-    async ({ task, onTestFinished, callers }) => {
-      const testData = new TestReviewsDataManager(task.id, onTestFinished);
-      await testData.createContext();
+describeAccessTierGating('listProposalRevisionRequests', {
+  noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {
+    const caller = await callers.noJwt();
 
-      const caller = await callers.noJwt();
+    await expectFailsAccessTierGate(
+      caller.decision.listProposalRevisionRequests({
+        proposalId: crypto.randomUUID(),
+      }),
+      'none',
+    );
+  }),
 
-      await expectFailsAccessTierGate(
-        caller.decision.listProposalRevisionRequests({
-          proposalId: crypto.randomUUID(),
-        }),
-        'none',
-      );
-    },
-  ),
-
-  anonJwtNonPublic: accessTierGatingCell(
-    'rejects anon-JWT caller on non-public instance',
-    async ({ task, onTestFinished, callers }) => {
-      const testData = new TestReviewsDataManager(task.id, onTestFinished);
-      await testData.createContext();
-
+  anonJwt: accessTierGatingCell(
+    'admits anon-JWT past the tier gate',
+    async ({ callers }) => {
       const caller = await callers.anonJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.listProposalRevisionRequests({
           proposalId: crypto.randomUUID(),
         }),
-        'anon',
       );
     },
   ),
 
-  userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
-    async ({ task, onTestFinished, callers }) => {
-      const testData = new TestReviewsDataManager(task.id, onTestFinished);
-      await testData.createContext();
-
+  userJwt: accessTierGatingCell(
+    'admits out-of-network user-JWT past the tier gate',
+    async ({ callers }) => {
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.listProposalRevisionRequests({
           proposalId: crypto.randomUUID(),
         }),
-        'user',
       );
     },
   ),
 
-  networkJwtNonPublic: accessTierGatingCell(
-    'admits network-JWT caller on non-public instance',
-    async ({ task, onTestFinished, callers }) => {
-      const testData = new TestReviewsDataManager(task.id, onTestFinished);
-      const context = await testData.createContext();
+  networkJwt: accessTierGatingCell(
+    'admits network-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.networkJwt();
 
-      const caller = await callers.networkJwt(context.defaultReviewer.email);
-
-      await expect(
+      await expectPassesAccessTierGate(
         caller.decision.listProposalRevisionRequests({
           proposalId: crypto.randomUUID(),
         }),
-      ).rejects.not.toMatchObject({
-        cause: { name: 'UnauthorizedError' },
-      });
+      );
     },
   ),
 });

--- a/services/api/src/routers/decision/reviews/listProposalRevisionRequests.ts
+++ b/services/api/src/routers/decision/reviews/listProposalRevisionRequests.ts
@@ -6,10 +6,10 @@ import {
 import { ProposalReviewRequestState } from '@op/db/schema';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+import { authenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listProposalRevisionRequestsRouter = router({
-  listProposalRevisionRequests: networkAuthenticatedProcedure()
+  listProposalRevisionRequests: authenticatedProcedure()
     .input(
       z.object({
         proposalId: z.uuid(),

--- a/services/api/src/routers/posts/getPosts.test.ts
+++ b/services/api/src/routers/posts/getPosts.test.ts
@@ -1,34 +1,36 @@
 import {
   accessTierGatingCell,
   describeAccessTierGating,
-  expectFailsAccessTierGate,
   expectPassesAccessTierGate,
 } from '../../test/helpers/gating';
 
 describeAccessTierGating('posts.getPosts', {
-  noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {
-    const caller = await callers.noJwt();
-    await expectFailsAccessTierGate(caller.posts.getPosts({}), 'none');
-  }),
+  noJwt: accessTierGatingCell(
+    'admits no-JWT past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.noJwt();
+      await expectPassesAccessTierGate(caller.posts.getPosts({}));
+    },
+  ),
 
   anonJwt: accessTierGatingCell(
-    'rejects anon-JWT caller',
+    'admits anon-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.anonJwt();
-      await expectFailsAccessTierGate(caller.posts.getPosts({}), 'anon');
+      await expectPassesAccessTierGate(caller.posts.getPosts({}));
     },
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits out-of-network user-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(caller.posts.getPosts({}), 'user');
+      await expectPassesAccessTierGate(caller.posts.getPosts({}));
     },
   ),
 
   networkJwt: accessTierGatingCell(
-    'admits network-JWT caller',
+    'admits network-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.networkJwt();
       await expectPassesAccessTierGate(caller.posts.getPosts({}));

--- a/services/api/src/routers/posts/getPosts.ts
+++ b/services/api/src/routers/posts/getPosts.ts
@@ -4,18 +4,18 @@ import { getPostsSchema } from '@op/types';
 import { z } from 'zod';
 
 import { postsEncoder } from '../../encoders';
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { openProcedure, router } from '../../trpcFactory';
 
 const outputSchema = z.array(postsEncoder);
 
 export const getPosts = router({
-  getPosts: networkAuthenticatedProcedure()
+  getPosts: openProcedure()
     .input(getPostsSchema)
     .output(outputSchema)
     .query(async ({ input, ctx }) => {
       const posts = await getPostsService({
         ...input,
-        authUserId: ctx.user.id,
+        authUserId: ctx.user?.id,
       });
 
       const channels: ChannelName[] = [];

--- a/services/api/src/routers/profile/relationships.test.ts
+++ b/services/api/src/routers/profile/relationships.test.ts
@@ -114,32 +114,32 @@ describeAccessTierGating('profile.removeRelationship', {
 });
 
 describeAccessTierGating('profile.getRelationships', {
-  noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {
-    const caller = await callers.noJwt();
-    await expectFailsAccessTierGate(
-      caller.profile.getRelationships({ types: ['following'] }),
-      'none',
-    );
-  }),
+  noJwt: accessTierGatingCell(
+    'admits no-JWT past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.noJwt();
+      await expectPassesAccessTierGate(
+        caller.profile.getRelationships({ types: ['following'] }),
+      );
+    },
+  ),
 
   anonJwt: accessTierGatingCell(
-    'rejects anon-JWT caller',
+    'admits anon-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.anonJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.profile.getRelationships({ types: ['following'] }),
-        'anon',
       );
     },
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits out-of-network user-JWT past the tier gate',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.profile.getRelationships({ types: ['following'] }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/profile/relationships.ts
+++ b/services/api/src/routers/profile/relationships.ts
@@ -8,7 +8,11 @@ import { ProfileRelationshipType, proposals } from '@op/db/schema';
 import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import {
+  networkAuthenticatedProcedure,
+  openProcedure,
+  router,
+} from '../../trpcFactory';
 import {
   trackProposalFollowed,
   trackProposalLiked,
@@ -118,7 +122,7 @@ export const profileRelationshipRouter = router({
       });
     }),
 
-  getRelationships: networkAuthenticatedProcedure({
+  getRelationships: openProcedure({
     rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(getRelationshipsInputSchema)
@@ -181,7 +185,7 @@ export const profileRelationshipRouter = router({
         sourceProfileId,
         relationshipTypes: types,
         profileType,
-        authUserId: ctx.user.id,
+        authUserId: ctx.user?.id,
       });
 
       for (const relationship of allRelationships) {

--- a/services/api/src/trpcFactory.ts
+++ b/services/api/src/trpcFactory.ts
@@ -130,7 +130,7 @@ export function authenticatedProcedure(opts?: RateLimitedProcedureOptions) {
 /**
  * Public-capable procedure: resolves an optional `ctx.user` but never rejects
  * at the middleware layer — authorization is fully the service layer's job.
- * Not used yet. Default rate limit is 10 requests per 10 seconds.
+ * Default rate limit is 10 requests per 10 seconds.
  */
 export function openProcedure(opts?: RateLimitedProcedureOptions) {
   const rateLimit = opts?.rateLimit ?? DEFAULT_RATE_LIMIT;


### PR DESCRIPTION
Comments, like/follower data, and editor revision requests still required network auth, so they failed for anonymous participants on public decision/proposal pages. Opening these reads lets the existing service-layer authorization decide access and restores legitimate anonymous flows.

fix(api): open posts.getPosts to anonymous callers
fix(api): open profile.getRelationships to anonymous callers
fix(api): open account.getUserProfiles to anonymous callers
fix(api): open decision.listProposalRevisionRequests to anonymous callers