### PR TITLE
ci: trigger secret-using jobs on pull_request_target for fork PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 concurrency:
@@ -41,6 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -133,6 +134,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -253,6 +255,8 @@ jobs:
     if: ${{ always() && !cancelled() }}
 
     steps:
+      # merge-reports only stitches together blob artifacts; it must not run
+      # fork code, so it stays on the base ref (no PR head checkout).
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -339,6 +343,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -467,7 +472,7 @@ jobs:
 
       - name: Detect a11y baseline deviation
         id: a11y-diff
-        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+        if: ${{ github.event_name == 'pull_request_target' && !cancelled() }}
         run: |
           if [ ! -f tests/e2e/a11y-baseline/diff.md ]; then
             echo "has-changes=false" >> "$GITHUB_OUTPUT"
@@ -487,14 +492,14 @@ jobs:
           fi
 
       - name: Post sticky PR comment
-        if: ${{ github.event_name == 'pull_request' && !cancelled() && steps.a11y-diff.outputs.has-changes == 'true' }}
+        if: ${{ github.event_name == 'pull_request_target' && !cancelled() && steps.a11y-diff.outputs.has-changes == 'true' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: a11y-baseline
           path: tests/e2e/a11y-baseline/diff.md
 
       - name: Remove sticky PR comment when no deviation
-        if: ${{ github.event_name == 'pull_request' && !cancelled() && steps.a11y-diff.outputs.has-changes == 'false' }}
+        if: ${{ github.event_name == 'pull_request_target' && !cancelled() && steps.a11y-diff.outputs.has-changes == 'false' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: a11y-baseline

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,7 +1,10 @@
 name: Checks
 
 on:
-  pull_request:
+  pull_request_target:
+
+permissions:
+  contents: read
 
 jobs:
   typecheck:
@@ -19,6 +22,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,10 @@
 name: Tests
 
 on:
-  pull_request:
+  pull_request_target:
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -28,6 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js


### PR DESCRIPTION
## Problem

PR #1309 gated the `TIPTAP_PRO_TOKEN` jobs behind the `fork-ci` environment but left them triggering on `on: pull_request`. A `pull_request` from a **fork** runs in the fork's context, where GitHub **strips all secrets** — repo-level *and* environment-scoped — regardless of the approval gate. So `${{ secrets.TIPTAP_PRO_TOKEN }}` resolved to an empty string (visible as the blank `TIPTAP_PRO_TOKEN:` propagated into the `actions/cache` step's `env`), and `pnpm install --frozen-lockfile` could not authenticate to `registry.tiptap.dev`.

The `***`-masked SUPABASE/DATABASE values in those logs are hardcoded literal local-dev values in the workflow `env:`, not `secrets.*`, which is why only the Tiptap token was blank.

## Fix

Switch the **Checks**, **Tests**, and **E2E** workflows to `pull_request_target`, which runs in the base-repo context and inherits secrets, gated by the existing `fork-ci` required-reviewer approval (the only supported way to give fork PRs secret access behind an approval gate).

- `on: pull_request` → `on: pull_request_target` (E2E keeps `workflow_dispatch`).
- Every job that builds/tests PR code checks out `github.event.pull_request.head.sha`.
- `merge-reports` stays on the base ref — it only merges artifacts and must not run fork code.
- Lock `GITHUB_TOKEN` to `contents: read` on Checks and Tests (E2E already had it); `a11y-baseline` keeps its job-level `pull-requests: write`.
- Update `a11y-baseline` `event_name` guards to `pull_request_target`.

## Security note

A maintainer (`scazan`/`valentin0h`) must approve each fork run before it executes fork code with the token in scope. **When approving a fork PR, review the diff — especially `package.json` scripts, `pnpm-lock.yaml`, and postinstall hooks** — since `pnpm install` runs with `TIPTAP_PRO_TOKEN` present. Note also that the workflow file itself comes from the base branch under `pull_request_target`, so a fork cannot alter CI.

## Verification

- [ ] Internal PR: Checks / Tests / E2E still run and pass (environment resolves to `''`, repo-level token used).
- [ ] Fork PR: gated jobs show "Waiting for approval"; after approval, `pnpm install` authenticates and the run is green; a11y sticky comment posts.
