### PR TITLE
fix(api): gate proposal post reads on the parent decision

### DIFF
--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -555,7 +555,7 @@ export const usePostFeedActions = () => {
       void utils.organization.listPosts.invalidate();
       void utils.organization.listAllPosts.invalidate();
       void utils.posts.getPosts.invalidate();
-      void utils.posts.listProfilePosts.invalidate();
+      void utils.decision.listPosts.invalidate();
     },
     onError: (err) => {
       toast.error({ message: err.message || t('Failed to update reaction') });

--- a/apps/app/src/components/decisions/DecisionSidePanel.tsx
+++ b/apps/app/src/components/decisions/DecisionSidePanel.tsx
@@ -210,7 +210,7 @@ const UpdatesTabContent = ({
   const utils = trpc.useUtils();
 
   const handlePostSuccess = useCallback(() => {
-    void utils.posts.listProfilePosts.invalidate({
+    void utils.decision.listPosts.invalidate({
       profileId: decisionProfileId,
     });
   }, [utils, decisionProfileId]);
@@ -250,7 +250,7 @@ const UpdatesFeed = ({ decisionProfileId }: { decisionProfileId: string }) => {
   const { user } = useUser();
 
   const [paginatedData, { fetchNextPage, hasNextPage, isFetchingNextPage }] =
-    trpc.posts.listProfilePosts.useSuspenseInfiniteQuery(
+    trpc.decision.listPosts.useSuspenseInfiniteQuery(
       { profileId: decisionProfileId, limit: UPDATES_PAGE_SIZE },
       {
         getNextPageParam: (lastPage) => lastPage.next ?? undefined,

--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -21,21 +21,31 @@ export function ProposalComments({
 }) {
   const t = useTranslations();
   const { user } = useUser();
+  const utils = trpc.useUtils();
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // A proposal's posts are gated on the parent decision, so they're served by
+  // a dedicated reader rather than `posts.getPosts` (which leniently passes —
+  // and would leak — the PROPOSAL profile type).
   const { data: commentsData, isLoading: commentsLoading } =
-    trpc.posts.getPosts.useQuery({
-      profileId: proposal.profileId || undefined,
-      parentPostId: null,
-      limit: 50,
-      offset: 0,
-      includeChildren: false,
-    });
+    trpc.decision.listProposalPosts.useQuery(
+      {
+        profileId: proposal.profileId ?? '',
+        limit: 50,
+      },
+      { enabled: Boolean(proposal.profileId) },
+    );
 
-  const comments = commentsData || [];
+  const comments = commentsData?.items ?? [];
   const { handleReactionClick } = usePostFeedActions();
 
   const scrollToComments = useCallback(() => {
+    if (proposal.profileId) {
+      void utils.decision.listProposalPosts.invalidate({
+        profileId: proposal.profileId,
+      });
+    }
+
     setTimeout(() => {
       containerRef.current?.scrollIntoView({
         behavior: 'smooth',
@@ -43,7 +53,7 @@ export function ProposalComments({
         inline: 'nearest',
       });
     }, 100);
-  }, []);
+  }, [proposal.profileId, utils]);
 
   return (
     <div ref={containerRef}>

--- a/packages/common/src/services/posts/getPosts.ts
+++ b/packages/common/src/services/posts/getPosts.ts
@@ -3,10 +3,12 @@ import {
   EntityType,
   posts as postsTable,
   postsToProfiles,
+  profiles as profilesTable,
 } from '@op/db/schema';
 import { checkPermission, permission } from 'access-zones';
-import { type SQL, and, desc, eq, isNull, sql } from 'drizzle-orm';
+import { type SQL, and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 
+import { UnauthorizedError } from '../../utils';
 import {
   assertProfileTypeAccess,
   getCurrentProfileId,
@@ -83,6 +85,23 @@ export const getPosts = async (input: GetPostsInput) => {
           return rows.map((p) => p.profileId);
         })()
       : [];
+
+  // Proposal posts are gated on the parent decision via `listProposalPosts`
+  // (decision.listProposalPosts), because the READ grant lives on the parent
+  // decision profile, never on the proposal. assertProfileTypeAccess below
+  // leniently passes the PROPOSAL type (it's not in the policy), so reject it
+  // here rather than leak it — proposals must never be read through this
+  // context-blind endpoint.
+  if (profileIdsToAuthorize.length > 0) {
+    const gatedProfiles = await db
+      .select({ type: profilesTable.type })
+      .from(profilesTable)
+      .where(inArray(profilesTable.id, profileIdsToAuthorize));
+
+    if (gatedProfiles.some((profile) => profile.type === EntityType.PROPOSAL)) {
+      throw new UnauthorizedError('You do not have access to these posts');
+    }
+  }
 
   await assertProfileTypeAccess({
     user: { id: authUserId },

--- a/packages/common/src/services/posts/listProfilePosts.ts
+++ b/packages/common/src/services/posts/listProfilePosts.ts
@@ -8,6 +8,7 @@ import { checkPermission, permission } from 'access-zones';
 import { and, desc, eq, isNull } from 'drizzle-orm';
 
 import {
+  NotFoundError,
   UnauthorizedError,
   decodeCursor,
   encodeCursor,
@@ -15,6 +16,7 @@ import {
 } from '../../utils';
 import {
   type AccessUser,
+  assertInstanceProfileAccess,
   assertProfileTypeAccess,
   getCurrentProfileId,
   getProfileAccessRolesWithOrgFallback,
@@ -24,36 +26,26 @@ import {
   postModerationFilter,
 } from './listPosts';
 
-export const listProfilePosts = async ({
+/**
+ * Fetches a page of a profile's top-level posts (no replies), applying the
+ * caller-aware moderation filter and keyset pagination.
+ *
+ * Authorization is the caller's responsibility: `listProfilePosts` gates on
+ * the decision profile itself, while `listProposalPosts` gates on the
+ * proposal's parent decision. This helper assumes the caller has already
+ * proven read access to `profileId`.
+ */
+const fetchTopLevelProfilePostsPage = async ({
   user,
   profileId,
-  limit = 20,
+  limit,
   cursor,
 }: {
   user: AccessUser | undefined;
   profileId: string;
-  limit?: number;
+  limit: number;
   cursor?: string | null;
 }) => {
-  // Scoped to decision profiles: assertProfileTypeAccess leniently passes
-  // ungated types, which would leak org/individual posts to public callers.
-  const profile = await db.query.profiles.findFirst({
-    where: { id: profileId },
-    columns: { type: true },
-  });
-
-  if (profile?.type !== EntityType.DECISION) {
-    throw new UnauthorizedError('You do not have access to these posts');
-  }
-
-  await assertProfileTypeAccess({
-    user,
-    profileIds: [profileId],
-    policies: {
-      [EntityType.DECISION]: { decisions: permission.READ },
-    },
-  });
-
   const decodedCursor = cursor ? decodeCursor(cursor) : undefined;
 
   const cursorCondition = decodedCursor
@@ -145,4 +137,79 @@ export const listProfilePosts = async ({
     items: itemsWithReactions.map((item) => item.post),
     next: nextCursor,
   };
+};
+
+export const listProfilePosts = async ({
+  user,
+  profileId,
+  limit = 20,
+  cursor,
+}: {
+  user: AccessUser | undefined;
+  profileId: string;
+  limit?: number;
+  cursor?: string | null;
+}) => {
+  // Scoped to decision profiles: assertProfileTypeAccess leniently passes
+  // ungated types, which would leak org/individual posts to public callers.
+  const profile = await db.query.profiles.findFirst({
+    where: { id: profileId },
+    columns: { type: true },
+  });
+
+  if (profile?.type !== EntityType.DECISION) {
+    throw new UnauthorizedError('You do not have access to these posts');
+  }
+
+  await assertProfileTypeAccess({
+    user,
+    profileIds: [profileId],
+    policies: {
+      [EntityType.DECISION]: { decisions: permission.READ },
+    },
+  });
+
+  return fetchTopLevelProfilePostsPage({ user, profileId, limit, cursor });
+};
+
+/**
+ * Lists a proposal profile's top-level discussion posts.
+ *
+ * A proposal's profile is type PROPOSAL, which `assertProfileTypeAccess` would
+ * leniently pass (no authorization at all). The READ grant for a proposal
+ * lives on its parent decision profile, NEVER on the proposal profile itself —
+ * so we gate on the parent decision exactly as `getProposal` does, via
+ * `assertInstanceProfileAccess` on the proposal's process instance.
+ */
+export const listProposalPosts = async ({
+  user,
+  profileId,
+  limit = 20,
+  cursor,
+}: {
+  user: AccessUser | undefined;
+  profileId: string;
+  limit?: number;
+  cursor?: string | null;
+}) => {
+  const proposal = await db.query.proposals.findFirst({
+    where: { profileId },
+    with: { processInstance: true },
+  });
+
+  if (!proposal) {
+    throw new NotFoundError('Proposal', profileId);
+  }
+
+  await assertInstanceProfileAccess({
+    user,
+    instance: proposal.processInstance,
+    profilePermissions: { decisions: permission.READ },
+    orgFallbackPermissions: [
+      { decisions: permission.READ },
+      { decisions: permission.ADMIN },
+    ],
+  });
+
+  return fetchTopLevelProfilePostsPage({ user, profileId, limit, cursor });
 };

--- a/services/api/src/routers/decision/index.ts
+++ b/services/api/src/routers/decision/index.ts
@@ -1,6 +1,7 @@
 import { mergeRouters } from '../../trpcFactory';
 import { deleteProposalAttachment } from './deleteProposalAttachment';
 import { instancesRouter } from './instances';
+import { listPostsRouter } from './listPosts';
 import { processesRouter } from './processes';
 import { proposalsRouter } from './proposals';
 import { resultsRouter } from './results';
@@ -12,6 +13,7 @@ import { votingRouter } from './voting';
 export const decisionRouter = mergeRouters(
   processesRouter,
   instancesRouter,
+  listPostsRouter,
   proposalsRouter,
   reviewsRouter,
   resultsRouter,

--- a/services/api/src/routers/decision/listPosts.test.ts
+++ b/services/api/src/routers/decision/listPosts.test.ts
@@ -1,0 +1,53 @@
+import {
+  accessTierGatingCell,
+  describeAccessTierGating,
+  expectPassesAccessTierGate,
+} from '../../test/helpers/gating';
+
+// These cells only assert the caller is admitted *past the tier gate* — i.e. the
+// rejection (if any) is not an `AccessTierError`. They don't exercise a real
+// resource, so a bogus profileId is enough: the open procedure lets the caller
+// through and the service rejects on the missing profile, which still counts as
+// passing the gate. Resource-level authorization is covered by
+// posts/postAuthorization.test.ts.
+describeAccessTierGating('decision.listPosts', {
+  noJwt: accessTierGatingCell(
+    'admits no-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.noJwt();
+      await expectPassesAccessTierGate(
+        caller.decision.listPosts({ profileId: 'x' }),
+      );
+    },
+  ),
+
+  anonJwt: accessTierGatingCell(
+    'admits anon-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.anonJwt();
+      await expectPassesAccessTierGate(
+        caller.decision.listPosts({ profileId: 'x' }),
+      );
+    },
+  ),
+
+  userJwt: accessTierGatingCell(
+    'admits user-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.userJwt();
+      await expectPassesAccessTierGate(
+        caller.decision.listPosts({ profileId: 'x' }),
+      );
+    },
+  ),
+
+  networkJwt: accessTierGatingCell(
+    'admits network-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.networkJwt();
+      await expectPassesAccessTierGate(
+        caller.decision.listPosts({ profileId: 'x' }),
+      );
+    },
+  ),
+});

--- a/services/api/src/routers/decision/listPosts.ts
+++ b/services/api/src/routers/decision/listPosts.ts
@@ -13,9 +13,9 @@ const inputSchema = z.object({
   cursor: z.string().nullish(),
 });
 
-export const listProfilePosts = router({
+export const listPostsRouter = router({
   /** Lists a decision profile's update posts (public on a public decision). */
-  listProfilePosts: openProcedure()
+  listPosts: openProcedure()
     .input(inputSchema)
     .output(
       z.object({

--- a/services/api/src/routers/decision/proposals/index.ts
+++ b/services/api/src/routers/decision/proposals/index.ts
@@ -8,6 +8,7 @@ import { getExportStatusRouter } from './getExportStatus';
 import { getLatestSelectionForProposalRouter } from './getLatestSelection';
 import { getProposalWithReviewAggregatesRouter } from './getProposalWithReviewAggregates';
 import { listProposalsRouter } from './list';
+import { listProposalPostsRouter } from './listPosts';
 import { listWithReviewAggregatesRouter } from './listWithReviewAggregates';
 import { submitProposalRouter } from './submit';
 import { updateProposalRouter } from './update';
@@ -19,6 +20,7 @@ export const proposalsRouter = mergeRouters(
   getLatestSelectionForProposalRouter,
   getProposalWithReviewAggregatesRouter,
   listProposalsRouter,
+  listProposalPostsRouter,
   listWithReviewAggregatesRouter,
   submitProposalRouter,
   updateProposalRouter,

--- a/services/api/src/routers/decision/proposals/listPosts.ts
+++ b/services/api/src/routers/decision/proposals/listPosts.ts
@@ -1,0 +1,44 @@
+import {
+  Channels,
+  listProposalPosts as listProposalPostsService,
+} from '@op/common';
+import { z } from 'zod';
+
+import { postsEncoder } from '../../../encoders';
+import { openProcedure, router } from '../../../trpcFactory';
+
+const inputSchema = z.object({
+  profileId: z.string(),
+  limit: z.number().int().positive().max(100).optional(),
+  cursor: z.string().nullish(),
+});
+
+export const listProposalPostsRouter = router({
+  /**
+   * Lists a proposal's discussion posts. Gated on the parent decision's READ
+   * (public on a public decision), never on the proposal profile itself —
+   * which is why this can't go through `posts.getPosts`, whose policy
+   * leniently passes the PROPOSAL profile type.
+   */
+  listProposalPosts: openProcedure()
+    .input(inputSchema)
+    .output(
+      z.object({
+        items: z.array(postsEncoder),
+        next: z.string().nullish(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const { items, next } = await listProposalPostsService({
+        ...input,
+        user: ctx.user,
+      });
+
+      ctx.registerQueryChannels([Channels.profilePosts(input.profileId)]);
+
+      return {
+        items: items.map((post) => postsEncoder.parse(post)),
+        next,
+      };
+    }),
+});

--- a/services/api/src/routers/decision/proposals/listProposalPosts.test.ts
+++ b/services/api/src/routers/decision/proposals/listProposalPosts.test.ts
@@ -2,20 +2,21 @@ import {
   accessTierGatingCell,
   describeAccessTierGating,
   expectPassesAccessTierGate,
-} from '../../test/helpers/gating';
+} from '../../../test/helpers/gating';
 
-// These cells only assert the caller is admitted *past the tier gate* — i.e. the
-// rejection (if any) is not an `AccessTierError`. They don't exercise a real
-// resource, so a bogus profileId is enough: the open procedure lets the caller
-// through and the service rejects on the missing profile, which still counts as
-// passing the gate. Resource-level authorization is covered by postAuthorization.test.ts.
-describeAccessTierGating('posts.listProfilePosts', {
+// `decision.listProposalPosts` is an open procedure: every caller is admitted
+// past the tier gate, and the parent-decision READ check happens in the
+// service. These cells only assert admission (rejection, if any, is not an
+// `AccessTierError`); a bogus profileId is enough, since the service rejects on
+// the missing proposal — still a pass at the tier. Resource-level authorization
+// is covered by posts/getPosts.proposalAccess.test.ts.
+describeAccessTierGating('decision.listProposalPosts', {
   noJwt: accessTierGatingCell(
     'admits no-JWT caller past the tier gate',
     async ({ callers }) => {
       const caller = await callers.noJwt();
       await expectPassesAccessTierGate(
-        caller.posts.listProfilePosts({ profileId: 'x' }),
+        caller.decision.listProposalPosts({ profileId: 'x' }),
       );
     },
   ),
@@ -25,7 +26,7 @@ describeAccessTierGating('posts.listProfilePosts', {
     async ({ callers }) => {
       const caller = await callers.anonJwt();
       await expectPassesAccessTierGate(
-        caller.posts.listProfilePosts({ profileId: 'x' }),
+        caller.decision.listProposalPosts({ profileId: 'x' }),
       );
     },
   ),
@@ -35,7 +36,7 @@ describeAccessTierGating('posts.listProfilePosts', {
     async ({ callers }) => {
       const caller = await callers.userJwt();
       await expectPassesAccessTierGate(
-        caller.posts.listProfilePosts({ profileId: 'x' }),
+        caller.decision.listProposalPosts({ profileId: 'x' }),
       );
     },
   ),
@@ -45,7 +46,7 @@ describeAccessTierGating('posts.listProfilePosts', {
     async ({ callers }) => {
       const caller = await callers.networkJwt();
       await expectPassesAccessTierGate(
-        caller.posts.listProfilePosts({ profileId: 'x' }),
+        caller.decision.listProposalPosts({ profileId: 'x' }),
       );
     },
   ),

--- a/services/api/src/routers/posts/getPosts.proposalAccess.test.ts
+++ b/services/api/src/routers/posts/getPosts.proposalAccess.test.ts
@@ -1,0 +1,71 @@
+import { createPostOnProfile } from '@op/common';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '..';
+import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../test/supabase-utils';
+import { createCallerFactory } from '../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+/**
+ * Regression: `getPosts` authorizes with `assertProfileTypeAccess({ DECISION:
+ * READ })`. A proposal's profile is type PROPOSAL, which is NOT in that policy,
+ * so the check lenient-passes (no authorization at all). The READ grant lives
+ * on the parent decision profile, never on the proposal — so a caller who
+ * cannot read the decision must not be able to read its proposal's posts.
+ *
+ * FAILS against current code: an unrelated network member (a confirmed account
+ * with no grant on the decision) reads a private proposal's discussion post.
+ * Should pass once proposal reads are gated on the parent decision's READ (as
+ * `getProposal` does via `assertInstanceProfileAccess`).
+ */
+describe('posts.getPosts — proposal post access', () => {
+  it('does not leak a proposal post to a network member unrelated to the decision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    // Owner builds a PRIVATE decision (no public grant) with one proposal, and
+    // posts a discussion comment on the proposal's profile.
+    const setup = await testData.createDecisionSetup({ instanceCount: 1 });
+    const instance = setup.instances[0]!;
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Confidential Proposal' },
+    });
+
+    const post = await createPostOnProfile({
+      content: 'Sensitive proposal discussion',
+      targetProfileId: proposal.profileId,
+      authUserId: setup.user.id,
+    });
+
+    // An unrelated network member: a confirmed @oneproject.org account in a
+    // DIFFERENT organization, with no grant on this decision, its instance, or
+    // the proposal.
+    const otherOrg = await testData.createDecisionSetup();
+    const outsider = await testData.createMemberUser({
+      organization: { id: otherOrg.organization.id },
+    });
+
+    const { session } = await createIsolatedSession(outsider.email);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    const result = await caller.posts.getPosts({
+      profileId: proposal.profileId,
+      parentPostId: null,
+    });
+
+    // The outsider cannot read the private decision, so its proposal's posts
+    // must not be visible to them.
+    expect(result.map((p) => p.id)).not.toContain(post.id);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/services/api/src/routers/posts/getPosts.proposalAccess.test.ts
+++ b/services/api/src/routers/posts/getPosts.proposalAccess.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { appRouter } from '..';
 import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
 import {
+  createAuthenticatedCaller,
   createIsolatedSession,
   createTestContextWithSession,
 } from '../../test/supabase-utils';
@@ -12,19 +13,19 @@ import { createCallerFactory } from '../../trpcFactory';
 const createCaller = createCallerFactory(appRouter);
 
 /**
- * Regression: `getPosts` authorizes with `assertProfileTypeAccess({ DECISION:
- * READ })`. A proposal's profile is type PROPOSAL, which is NOT in that policy,
- * so the check lenient-passes (no authorization at all). The READ grant lives
- * on the parent decision profile, never on the proposal — so a caller who
- * cannot read the decision must not be able to read its proposal's posts.
+ * A proposal's profile is type PROPOSAL. `posts.getPosts` authorizes with
+ * `assertProfileTypeAccess({ DECISION: READ })`, which leniently passes
+ * (i.e. does NOT authorize) any type outside that policy — so before the fix
+ * it leaked private proposal posts to any network member. The READ grant for a
+ * proposal lives on its parent decision profile, never on the proposal itself.
  *
- * FAILS against current code: an unrelated network member (a confirmed account
- * with no grant on the decision) reads a private proposal's discussion post.
- * Should pass once proposal reads are gated on the parent decision's READ (as
- * `getProposal` does via `assertInstanceProfileAccess`).
+ * The fix moves proposal posts onto `decision.listProposalPosts`, gated on
+ * the parent decision via `assertInstanceProfileAccess` (as `getProposal`
+ * does), and makes `posts.getPosts` reject PROPOSAL-typed profiles outright so
+ * the leak can't reappear through that context-blind endpoint.
  */
 describe('posts.getPosts — proposal post access', () => {
-  it('does not leak a proposal post to a network member unrelated to the decision', async ({
+  it('gates proposal posts on the parent decision, not the proposal profile', async ({
     task,
     onTestFinished,
   }) => {
@@ -56,16 +57,39 @@ describe('posts.getPosts — proposal post access', () => {
     });
 
     const { session } = await createIsolatedSession(outsider.email);
-    const caller = createCaller(await createTestContextWithSession(session));
+    const outsiderCaller = createCaller(
+      await createTestContextWithSession(session),
+    );
 
-    const result = await caller.posts.getPosts({
+    // The dedicated reader gates on the parent decision: an outsider who can't
+    // read the decision is denied its proposal's posts.
+    await expect(
+      outsiderCaller.decision.listProposalPosts({
+        profileId: proposal.profileId,
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    // And the context-blind posts.getPosts now rejects PROPOSAL-typed profiles
+    // outright rather than leniently passing (and leaking) them.
+    await expect(
+      outsiderCaller.posts.getPosts({
+        profileId: proposal.profileId,
+        parentPostId: null,
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+
+    // A member granted access to the decision instance reads the proposal's
+    // posts through the dedicated reader.
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const memberCaller = await createAuthenticatedCaller(member.email);
+
+    const result = await memberCaller.decision.listProposalPosts({
       profileId: proposal.profileId,
-      parentPostId: null,
     });
 
-    // The outsider cannot read the private decision, so its proposal's posts
-    // must not be visible to them.
-    expect(result.map((p) => p.id)).not.toContain(post.id);
-    expect(result).toHaveLength(0);
+    expect(result.items.map((p) => p.id)).toContain(post.id);
   });
 });

--- a/services/api/src/routers/posts/index.ts
+++ b/services/api/src/routers/posts/index.ts
@@ -2,13 +2,11 @@ import { mergeRouters } from '../../trpcFactory';
 import { createPost } from './createPost';
 import { getPost } from './getPost';
 import { getPosts } from './getPosts';
-import { listProfilePosts } from './listProfilePosts';
 import { uploadPostAttachment } from './uploadPostAttachment';
 
 export const postsRouter = mergeRouters(
   createPost,
   getPost,
   getPosts,
-  listProfilePosts,
   uploadPostAttachment,
 );

--- a/services/api/src/routers/posts/postAuthorization.test.ts
+++ b/services/api/src/routers/posts/postAuthorization.test.ts
@@ -553,7 +553,7 @@ describe.concurrent('non-decision (organization) post authorization', () => {
   });
 });
 
-describe.concurrent('listProfilePosts authorization and pagination', () => {
+describe.concurrent('decision.listPosts authorization and pagination', () => {
   it('allows a member to read paginated updates on a decision profile', async ({
     task,
     onTestFinished,
@@ -581,7 +581,7 @@ describe.concurrent('listProfilePosts authorization and pagination', () => {
     });
     const memberCaller = await createAuthenticatedCaller(member.email);
 
-    const page = await memberCaller.posts.listProfilePosts({
+    const page = await memberCaller.decision.listPosts({
       profileId: instance.profileId,
       limit: 10,
     });
@@ -604,14 +604,14 @@ describe.concurrent('listProfilePosts authorization and pagination', () => {
     const outsiderCaller = await createOutsiderCaller(testData);
 
     await expect(
-      outsiderCaller.posts.listProfilePosts({
+      outsiderCaller.decision.listPosts({
         profileId: instance.profileId,
         limit: 10,
       }),
     ).rejects.toMatchObject({ cause: { name: 'AccessControlException' } });
   });
 
-  it('rejects listProfilePosts on non-decision (org) profiles', async ({
+  it('rejects decision.listPosts on non-decision (org) profiles', async ({
     task,
     onTestFinished,
   }) => {
@@ -625,7 +625,7 @@ describe.concurrent('listProfilePosts authorization and pagination', () => {
     });
 
     await expect(
-      ownerCaller.posts.listProfilePosts({
+      ownerCaller.decision.listPosts({
         profileId: setup.organization.profileId,
         limit: 10,
       }),
@@ -656,14 +656,14 @@ describe.concurrent('listProfilePosts authorization and pagination', () => {
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
 
-    const firstPage = await adminCaller.posts.listProfilePosts({
+    const firstPage = await adminCaller.decision.listPosts({
       profileId: instance.profileId,
       limit: 2,
     });
     expect(firstPage.items).toHaveLength(2);
     expect(firstPage.next).toBeTruthy();
 
-    const secondPage = await adminCaller.posts.listProfilePosts({
+    const secondPage = await adminCaller.decision.listPosts({
       profileId: instance.profileId,
       limit: 2,
       cursor: firstPage.next,
@@ -726,7 +726,7 @@ describe.concurrent('listProfilePosts authorization and pagination', () => {
     let cursor: string | null | undefined = undefined;
     let pages = 0;
     do {
-      const page = await memberCaller.posts.listProfilePosts({
+      const page = await memberCaller.decision.listPosts({
         profileId: instance.profileId,
         limit: 2,
         cursor,
@@ -1033,7 +1033,7 @@ describe.concurrent('getPosts pagination', () => {
     task,
     onTestFinished,
   }) => {
-    // Same regression as the listProfilePosts test, against the getPosts
+    // Same regression as the decision.listPosts test, against the getPosts
     // profileId branch (called by ProposalView). Comments inherit
     // postsToProfiles rows from their parent; a relational `with: { post: ... }`
     // filter would LEFT JOIN and silently shrink pages. SQL-level innerJoin


### PR DESCRIPTION
posts.getPosts leniently passed (and therefore never authorized) a proposal's PROPOSAL-typed profile, leaking private proposal posts to any network member. Proposal reads are now gated on the parent decision via dedicated decision-router endpoints, and getPosts rejects proposal profiles outright.