### PR TITLE
refactor(decisions): rename ProposalHtmlContent to HtmlContentRenderer

### DIFF
--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -10,7 +10,7 @@ import { LuTriangleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
-import { ProposalHtmlContent } from './ProposalHtmlContent';
+import { HtmlContentRenderer } from './HtmlContentRenderer';
 import { decisionOverviewMock } from './decisionOverviewMock';
 
 interface DecisionOverviewProps {
@@ -179,7 +179,7 @@ const OverviewAbout = ({
     <section className="flex flex-col gap-4">
       <Header2 className="font-serif">{t('About the process')}</Header2>
       {html ? (
-        <ProposalHtmlContent html={html} />
+        <HtmlContentRenderer html={html} />
       ) : fallbackText ? (
         // The description is plain text (entity-encoded for some orgs, same as
         // DecisionActionBar) — decode and render as text, not HTML.

--- a/apps/app/src/components/decisions/HtmlContentRenderer.tsx
+++ b/apps/app/src/components/decisions/HtmlContentRenderer.tsx
@@ -6,8 +6,8 @@ import { useMemo } from 'react';
 import { LinkPreview } from '../LinkPreview';
 
 /**
- * Renders pre-generated HTML content for a proposal, replacing the read-only
- * TipTap editor with zero JS overhead for the prose content.
+ * Renders pre-generated HTML content (proposals, overview, etc.), replacing the
+ * read-only TipTap editor with zero JS overhead for the prose content.
  *
  * Typography styles are shared with the TipTap editor via `viewerProseStyles`.
  *
@@ -15,7 +15,7 @@ import { LinkPreview } from '../LinkPreview';
  * replaced with `LinkPreview` components rendered within the same React tree,
  * preserving access to tRPC and other providers.
  */
-export function ProposalHtmlContent({ html }: { html: string }) {
+export function HtmlContentRenderer({ html }: { html: string }) {
   const segments = useMemo(() => splitHtmlSegments(html), [html]);
 
   const hasEmbeds = segments.some((s) => s.type === 'embed');

--- a/apps/app/src/components/decisions/ProposalContentRenderer.tsx
+++ b/apps/app/src/components/decisions/ProposalContentRenderer.tsx
@@ -4,7 +4,7 @@ import type { ProposalTemplateSchema } from '@op/common/client';
 import { viewerProseStyles } from '@op/ui/RichTextEditor';
 import { useMemo } from 'react';
 
-import { ProposalHtmlContent } from './ProposalHtmlContent';
+import { HtmlContentRenderer } from './HtmlContentRenderer';
 import { compileProposalSchema } from './forms/proposal';
 import type { FieldDescriptor } from './forms/types';
 
@@ -100,7 +100,7 @@ function ViewField({
         </div>
       )}
       {html ? (
-        <ProposalHtmlContent html={html} />
+        <HtmlContentRenderer html={html} />
       ) : (
         <div className={viewerProseStyles}>
           <p className="text-neutral-gray3 italic">—</p>

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -28,9 +28,9 @@ import { Link as NavLink } from '@/lib/i18n/routing';
 import { ProfileAvatar } from '../ProfileAvatar';
 import { BudgetDisplay, formatBudget } from './BudgetDisplay';
 import { DocumentNotAvailable } from './DocumentNotAvailable';
+import { HtmlContentRenderer } from './HtmlContentRenderer';
 import { ProposalAttachmentViewList } from './ProposalAttachmentViewList';
 import { ProposalContentRenderer } from './ProposalContentRenderer';
-import { ProposalHtmlContent } from './ProposalHtmlContent';
 import { resolveProposalSystemFields } from './proposalContentUtils';
 
 export type ProposalTranslation = {
@@ -245,7 +245,7 @@ export function ProposalPreview({
 
       {/* Proposal Content */}
       {legacyHtml ? (
-        <ProposalHtmlContent html={legacyHtml} />
+        <HtmlContentRenderer html={legacyHtml} />
       ) : htmlContent && proposalTemplate ? (
         <ProposalContentRenderer
           proposalTemplate={proposalTemplate}


### PR DESCRIPTION
Follow-up to #1288 review: rename `ProposalHtmlContent` → `HtmlContentRenderer` for a name that reflects its broader use (proposals, overview, etc.).

- Renames the file + component, updates the two callers (`ProposalPreview`, `ProposalContentRenderer`).
- Based on the current default branch; the overview stack (#1288/#1291) adds a third caller in `DecisionOverview` and will pick up the new name when it rebases (or this rebases over it, whichever lands second).
