### PR TITLE
feat(decisions): render phase timeline in the overview sidebar

### DIFF
--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -2,6 +2,7 @@
 
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { trpc } from '@op/api/client';
+import { type ProcessPhase } from '@op/api/encoders';
 import { Button, ButtonLink } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header2, Header3 } from '@op/ui/Header';
@@ -12,6 +13,7 @@ import { LuTriangleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
+import { DecisionPhaseTimeline } from './DecisionPhaseTimeline';
 import { useCreateProposal } from './useCreateProposal';
 
 interface DecisionOverviewProps {
@@ -86,6 +88,17 @@ function DecisionOverviewContent({
     currentPhase?.rules?.proposals?.submit === true &&
     instance.access?.submitProposals === true;
 
+  const phases: ProcessPhase[] = (instance.instanceData?.phases ?? []).map(
+    (p) => ({
+      id: p.phaseId,
+      name: p.name || '',
+      description: p.description,
+      phase: { startDate: p.startDate, endDate: p.endDate },
+      advancementMethod: p.rules?.advancement?.method,
+      config: { allowProposals: p.rules?.proposals?.submit },
+    }),
+  );
+
   return (
     <div className="flex w-full flex-col">
       <OverviewHero
@@ -98,16 +111,17 @@ function DecisionOverviewContent({
       {/* 12-col grid mirroring the Figma layout grid: sidebar spans 4 cols,
           body spans 7 starting at col 6. Stacks to one column below md. */}
       <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-4 py-6 md:grid-cols-12 md:gap-x-6 md:px-6 md:py-12">
-        {/* TODO: phases timeline lands here in a follow-up PR */}
         <div className="flex flex-col gap-4 md:col-span-4">
           <Header3 className="text-sm text-neutral-gray4">
             {t('Process Overview')}
           </Header3>
-          <div className="flex flex-col gap-6">
-            <div className="h-24 rounded border bg-neutral-offWhite" />
-            <div className="h-24 rounded border bg-neutral-offWhite" />
-            <div className="h-24 rounded border bg-neutral-offWhite" />
-          </div>
+          <DecisionPhaseTimeline
+            phases={phases}
+            currentStateId={instance.currentStateId ?? ''}
+            instanceId={instanceId}
+            isAdmin={instance.access?.admin}
+            decisionSlug={decisionSlug}
+          />
         </div>
         <div className="min-w-0 md:col-span-7 md:col-start-6">
           <OverviewAbout

--- a/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
+++ b/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
@@ -55,7 +55,7 @@ export function DecisionPhaseTimeline({
 
   const { requestAdvance, advanceConfirm } = useAdvancePhase({
     instanceId,
-    currentStateId,
+    currentPhaseId: currentStateId,
     nextPhaseId,
     currentPhaseName: currentPhase ? phaseName(currentPhase) : '',
     nextPhaseName: nextPhase ? phaseName(nextPhase) : '',

--- a/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
+++ b/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
@@ -1,22 +1,23 @@
 'use client';
 
 import { type ProcessPhase } from '@op/api/encoders';
-import { type Phase } from '@op/ui/PhaseStepper';
-import { PhaseTimeline } from '@op/ui/PhaseTimeline';
+import { PhaseCard, type PhaseCardState } from '@op/ui/PhaseCard';
+import { cn } from '@op/ui/utils';
 import { useLocale } from 'next-intl';
 import { useMemo } from 'react';
 
-import { useRouter, useTranslations } from '@/lib/i18n';
+import { useTranslations } from '@/lib/i18n';
 
 import { useDecisionTranslation } from './DecisionTranslationContext';
 import { useAdvancePhase } from './useAdvancePhase';
 
 /**
- * Vertical phase timeline for the decision Overview sidebar. App-side wrapper
- * around the presentational @op/ui PhaseTimeline (cf. DecisionProcessStepper →
- * PhaseStepper): resolves translated phase names, derives the "Now open!" and
- * admin-advanceable phases, wires the arrow to the current-phase view, and
- * reuses useAdvancePhase for the advance flow.
+ * Vertical phase timeline for the decision Overview sidebar. App-side
+ * composition over the presentational @op/ui PhaseCard (cf. DecisionProcessStepper
+ * → PhaseStepper): owns the <ol> and the completed/current/upcoming derivation,
+ * resolves translated phase names, flags the "Now open!" and admin-advanceable
+ * phases, links the current card to its phase view, and reuses useAdvancePhase
+ * for the advance flow.
  */
 export function DecisionPhaseTimeline({
   phases,
@@ -35,7 +36,6 @@ export function DecisionPhaseTimeline({
 }) {
   const locale = useLocale();
   const t = useTranslations();
-  const router = useRouter();
   const translation = useDecisionTranslation();
   const translatedPhaseNames = useMemo(
     () =>
@@ -45,67 +45,57 @@ export function DecisionPhaseTimeline({
     [translation],
   );
 
-  const {
-    nextPhaseId,
-    currentPhaseName,
-    nextPhaseName,
-    currentPhaseEndDate,
-    nowOpenPhaseId,
-  } = useMemo(() => {
-    const idx = phases.findIndex((p) => p.id === currentStateId);
-    const currentPhase = idx >= 0 ? phases[idx] : undefined;
-    const nextPhase = idx >= 0 ? phases[idx + 1] : undefined;
-    return {
-      nextPhaseId: nextPhase?.id,
-      currentPhaseName: currentPhase
-        ? (translatedPhaseNames?.get(currentPhase.id) ?? currentPhase.name)
-        : '',
-      nextPhaseName: nextPhase
-        ? (translatedPhaseNames?.get(nextPhase.id) ?? nextPhase.name)
-        : '',
-      currentPhaseEndDate: currentPhase?.phase?.endDate,
-      nowOpenPhaseId: currentPhase?.config?.allowProposals
-        ? currentPhase.id
-        : undefined,
-    };
-  }, [phases, currentStateId, translatedPhaseNames]);
+  const phaseName = (phase: ProcessPhase) =>
+    translatedPhaseNames?.get(phase.id) ?? phase.name;
+
+  const currentIndex = phases.findIndex((p) => p.id === currentStateId);
+  const currentPhase = currentIndex >= 0 ? phases[currentIndex] : undefined;
+  const nextPhase = currentIndex >= 0 ? phases[currentIndex + 1] : undefined;
+  const nextPhaseId = nextPhase?.id;
 
   const { requestAdvance, advanceConfirm } = useAdvancePhase({
     instanceId,
     currentStateId,
     nextPhaseId,
-    currentPhaseName,
-    nextPhaseName,
-    currentPhaseEndDate,
+    currentPhaseName: currentPhase ? phaseName(currentPhase) : '',
+    nextPhaseName: nextPhase ? phaseName(nextPhase) : '',
+    currentPhaseEndDate: currentPhase?.phase?.endDate,
   });
 
-  const transformedPhases: Phase[] = useMemo(
-    () =>
-      phases.map((phase) => ({
-        id: phase.id,
-        name: translatedPhaseNames?.get(phase.id) ?? phase.name,
-        description: phase.description,
-        startDate: phase.phase?.startDate,
-        endDate: phase.phase?.endDate,
-      })),
-    [phases, translatedPhaseNames],
-  );
+  const currentHref = `/decisions/${decisionSlug}/current`;
 
   return (
     <>
-      <PhaseTimeline
-        phases={transformedPhases}
-        currentPhaseId={currentStateId}
-        className={className}
-        locale={locale}
-        nowOpenPhaseId={nowOpenPhaseId}
-        nowOpenLabel={t('Now open!')}
-        advanceablePhaseId={isAdmin ? nextPhaseId : undefined}
-        advanceLabel={t('Advance')}
-        onAdvance={isAdmin ? requestAdvance : undefined}
-        onNavigate={() => router.push(`/decisions/${decisionSlug}/current`)}
-        navigateAriaLabel={t('Go to the current phase')}
-      />
+      <ol className={cn('flex flex-col gap-6', className)}>
+        {phases.map((phase, index) => {
+          const state: PhaseCardState =
+            index < currentIndex
+              ? 'completed'
+              : index === currentIndex
+                ? 'current'
+                : 'upcoming';
+          const isAdvanceable = isAdmin === true && phase.id === nextPhaseId;
+
+          return (
+            <PhaseCard
+              key={phase.id}
+              state={state}
+              name={phaseName(phase)}
+              startDate={phase.phase?.startDate}
+              endDate={phase.phase?.endDate}
+              locale={locale}
+              isNowOpen={
+                state === 'current' && phase.config?.allowProposals === true
+              }
+              nowOpenLabel={t('Now open!')}
+              isAdvanceable={isAdvanceable}
+              advanceLabel={t('Advance')}
+              onAdvance={isAdvanceable ? requestAdvance : undefined}
+              href={state === 'current' ? currentHref : undefined}
+            />
+          );
+        })}
+      </ol>
       {advanceConfirm}
     </>
   );

--- a/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
+++ b/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { type ProcessPhase } from '@op/api/encoders';
+import { type Phase } from '@op/ui/PhaseStepper';
+import { PhaseTimeline } from '@op/ui/PhaseTimeline';
+import { useLocale } from 'next-intl';
+import { useMemo } from 'react';
+
+import { useRouter, useTranslations } from '@/lib/i18n';
+
+import { useDecisionTranslation } from './DecisionTranslationContext';
+import { useAdvancePhase } from './useAdvancePhase';
+
+/**
+ * Vertical phase timeline for the decision Overview sidebar. App-side wrapper
+ * around the presentational @op/ui PhaseTimeline (cf. DecisionProcessStepper →
+ * PhaseStepper): resolves translated phase names, derives the "Now open!" and
+ * admin-advanceable phases, wires the arrow to the current-phase view, and
+ * reuses useAdvancePhase for the advance flow.
+ */
+export function DecisionPhaseTimeline({
+  phases,
+  currentStateId,
+  instanceId,
+  isAdmin,
+  decisionSlug,
+  className,
+}: {
+  phases: ProcessPhase[];
+  currentStateId: string;
+  instanceId?: string;
+  isAdmin?: boolean;
+  decisionSlug: string;
+  className?: string;
+}) {
+  const locale = useLocale();
+  const t = useTranslations();
+  const router = useRouter();
+  const translation = useDecisionTranslation();
+  const translatedPhaseNames = useMemo(
+    () =>
+      translation
+        ? new Map(translation.phases.map((p) => [p.id, p.name]))
+        : null,
+    [translation],
+  );
+
+  const {
+    nextPhaseId,
+    currentPhaseName,
+    nextPhaseName,
+    currentPhaseEndDate,
+    nowOpenPhaseId,
+  } = useMemo(() => {
+    const idx = phases.findIndex((p) => p.id === currentStateId);
+    const currentPhase = idx >= 0 ? phases[idx] : undefined;
+    const nextPhase = idx >= 0 ? phases[idx + 1] : undefined;
+    return {
+      nextPhaseId: nextPhase?.id,
+      currentPhaseName: currentPhase
+        ? (translatedPhaseNames?.get(currentPhase.id) ?? currentPhase.name)
+        : '',
+      nextPhaseName: nextPhase
+        ? (translatedPhaseNames?.get(nextPhase.id) ?? nextPhase.name)
+        : '',
+      currentPhaseEndDate: currentPhase?.phase?.endDate,
+      nowOpenPhaseId: currentPhase?.config?.allowProposals
+        ? currentPhase.id
+        : undefined,
+    };
+  }, [phases, currentStateId, translatedPhaseNames]);
+
+  const { requestAdvance, advanceConfirm } = useAdvancePhase({
+    instanceId,
+    currentStateId,
+    nextPhaseId,
+    currentPhaseName,
+    nextPhaseName,
+    currentPhaseEndDate,
+  });
+
+  const transformedPhases: Phase[] = useMemo(
+    () =>
+      phases.map((phase) => ({
+        id: phase.id,
+        name: translatedPhaseNames?.get(phase.id) ?? phase.name,
+        description: phase.description,
+        startDate: phase.phase?.startDate,
+        endDate: phase.phase?.endDate,
+      })),
+    [phases, translatedPhaseNames],
+  );
+
+  return (
+    <>
+      <PhaseTimeline
+        phases={transformedPhases}
+        currentPhaseId={currentStateId}
+        className={className}
+        locale={locale}
+        nowOpenPhaseId={nowOpenPhaseId}
+        nowOpenLabel={t('Now open!')}
+        advanceablePhaseId={isAdmin ? nextPhaseId : undefined}
+        advanceLabel={t('Advance')}
+        onAdvance={isAdmin ? requestAdvance : undefined}
+        onNavigate={() => router.push(`/decisions/${decisionSlug}/current`)}
+        navigateAriaLabel={t('Go to the current phase')}
+      />
+      {advanceConfirm}
+    </>
+  );
+}

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1175,6 +1175,7 @@
   "The previous phase did not leave any eligible proposals.": "لم تترك المرحلة السابقة أي مقترحات مؤهلة.",
   "Publish": "نشر",
   "Advance": "تقدم",
+  "Now open!": "مفتوح الآن!",
   "Advancing": "جارٍ التقدم",
   "Confirm decisions": "تأكيد القرارات",
   "{count} proposals advancing": "{count, plural, one {# مقترح متقدم} other {# مقترحات متقدمة}}",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1260,6 +1260,7 @@
   "These {numProposals} proposals will move on to the {phaseName} phase": "{numProposals, plural, one {এই #টি প্রস্তাব {phaseName} পর্যায়ে অগ্রসর হবে} other {এই #টি প্রস্তাব {phaseName} পর্যায়ে অগ্রসর হবে}}",
   "PROPOSALS TO ADVANCE": "অগ্রসর করার প্রস্তাব",
   "Advance": "অগ্রসর",
+  "Now open!": "এখন খোলা!",
   "Advancing": "অগ্রসর হচ্ছে",
   "Advance proposal": "প্রস্তাব অগ্রসর করুন",
   "Advancing proposal": "প্রস্তাব অগ্রসর হচ্ছে",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1336,7 +1336,6 @@
   "It feels like it's built for a different type of organization than mine": "It feels like it's built for a different type of organization than mine",
   "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!": "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!",
   "Go to the platform": "Go to the platform",
-  "Go to the current phase": "Go to the current phase",
   "Now open!": "Now open!",
   "{count, plural, =1 {1 follower} other {# followers}}": "{count, plural, =1 {1 follower} other {# followers}}",
   "{count, plural, =1 {1 relationship} other {# relationships}}": "{count, plural, =1 {1 relationship} other {# relationships}}",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1336,6 +1336,8 @@
   "It feels like it's built for a different type of organization than mine": "It feels like it's built for a different type of organization than mine",
   "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!": "Any specific features we should fix, improve or keep? Any features we should add? We actually read these!",
   "Go to the platform": "Go to the platform",
+  "Go to the current phase": "Go to the current phase",
+  "Now open!": "Now open!",
   "{count, plural, =1 {1 follower} other {# followers}}": "{count, plural, =1 {1 follower} other {# followers}}",
   "{count, plural, =1 {1 relationship} other {# relationships}}": "{count, plural, =1 {1 relationship} other {# relationships}}",
   "{count, plural, =1 {1 organization} other {# organizations}}": "{count, plural, =1 {1 organization} other {# organizations}}",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1259,6 +1259,7 @@
   "These {numProposals} proposals will move on to the {phaseName} phase": "{numProposals, plural, one {Esta # propuesta avanzará a la fase {phaseName}} other {Estas # propuestas avanzarán a la fase {phaseName}}}",
   "PROPOSALS TO ADVANCE": "PROPUESTAS A AVANZAR",
   "Advance": "Avanzar",
+  "Now open!": "¡Abierto ahora!",
   "Advancing": "Avanzando",
   "Advance proposal": "Avanzar propuesta",
   "Advancing proposal": "Propuesta avanzando",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1259,6 +1259,7 @@
   "These {numProposals} proposals will move on to the {phaseName} phase": "{numProposals, plural, one {Cette # proposition passera à la phase {phaseName}} other {Ces # propositions passeront à la phase {phaseName}}}",
   "PROPOSALS TO ADVANCE": "PROPOSITIONS À FAIRE AVANCER",
   "Advance": "Avancer",
+  "Now open!": "Ouvert maintenant !",
   "Advancing": "En cours",
   "Advance proposal": "Faire avancer la proposition",
   "Advancing proposal": "Proposition en cours",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1259,6 +1259,7 @@
   "These {numProposals} proposals will move on to the {phaseName} phase": "{numProposals, plural, one {Esta # proposta avançará para a fase {phaseName}} other {Estas # propostas avançarão para a fase {phaseName}}}",
   "PROPOSALS TO ADVANCE": "PROPOSTAS A AVANÇAR",
   "Advance": "Avançar",
+  "Now open!": "Aberto agora!",
   "Advancing": "Avançando",
   "Advance proposal": "Avançar proposta",
   "Advancing proposal": "Proposta avançando",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1194,6 +1194,7 @@
   "The previous phase did not leave any eligible proposals.": "Marxaladda hore ma reebin soo jeedimo qalma.",
   "Publish": "Daabac",
   "Advance": "Horey u qaad",
+  "Now open!": "Hadda furan!",
   "Advancing": "Waa la horey u qaadayaa",
   "Confirm decisions": "Xaqiiji go'aamada",
   "Confirm winning proposals": "Xaqiiji soo jeedimaha guulaystay",


### PR DESCRIPTION
Third of a 3-PR stack. Stacked on #1318.

- Replace the overview sidebar placeholder with `DecisionPhaseTimeline`, an app-side wrapper around `@op/ui` `PhaseTimeline`.
- Resolves translated phase names, flags the current proposal-open phase with "Now open!", exposes the admin Advance affordance via `useAdvancePhase`, and links the current phase to its view.

Note: touches `DecisionOverview.tsx`, which #1316 also edits (real overview data wiring). Independent regions; will reconcile on rebase once #1316 lands.