### PR TITLE
feat(moderation): user-initiated content reports (flagItem)

### DIFF
--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -325,39 +325,46 @@ export const assertInstanceProfileAccess = async ({
   return profileUser;
 };
 
-export const getCurrentProfileId = async (authUserId: string) => {
-  const validatedAuthUserId = validateAuthUserId(authUserId);
-  const { user } =
-    (await getUserSession({ authUserId: validatedAuthUserId })) ?? {};
+// Memoized per request (keyed by authUserId): the current profile is stable
+// within a request, so callers that each resolve it independently — e.g.
+// submitUserFlag and the assertModerationItemAccess gate it invokes — share a
+// single lookup instead of re-hitting getUserSession + the org fallback.
+export const getCurrentProfileId = memoize(
+  async (authUserId: string) => {
+    const validatedAuthUserId = validateAuthUserId(authUserId);
+    const { user } =
+      (await getUserSession({ authUserId: validatedAuthUserId })) ?? {};
 
-  if (!user) {
-    throw new UnauthorizedError("You don't have access to do this");
-  }
-
-  // Primary: use currentProfileId if available
-  if (user.currentProfileId) {
-    return user.currentProfileId;
-  }
-
-  // Fallback: if lastOrgId exists but currentProfileId doesn't, convert it
-  if (user.lastOrgId) {
-    try {
-      const [org] = await db
-        .select({ profileId: organizations.profileId })
-        .from(organizations)
-        .where(eq(organizations.id, user.lastOrgId))
-        .limit(1);
-
-      if (org) {
-        return org.profileId;
-      }
-    } catch (error) {
-      console.error('Error converting lastOrgId to profileId:', error);
+    if (!user) {
+      throw new UnauthorizedError("You don't have access to do this");
     }
-  }
 
-  throw new UnauthorizedError("You don't have access to do this");
-};
+    // Primary: use currentProfileId if available
+    if (user.currentProfileId) {
+      return user.currentProfileId;
+    }
+
+    // Fallback: if lastOrgId exists but currentProfileId doesn't, convert it
+    if (user.lastOrgId) {
+      try {
+        const [org] = await db
+          .select({ profileId: organizations.profileId })
+          .from(organizations)
+          .where(eq(organizations.id, user.lastOrgId))
+          .limit(1);
+
+        if (org) {
+          return org.profileId;
+        }
+      } catch (error) {
+        console.error('Error converting lastOrgId to profileId:', error);
+      }
+    }
+
+    throw new UnauthorizedError("You don't have access to do this");
+  },
+  (authUserId) => authUserId,
+);
 
 export const getIndividualProfileId = async (authUserId: string) => {
   const validatedAuthUserId = validateAuthUserId(authUserId);

--- a/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Boundary mocks: this gate is pure orchestration over the DB + access
+// helpers, so we drive those and assert the allow/deny decisions. @op/db/schema
+// is left real (EntityType.DECISION / Visibility.HIDDEN are value comparisons).
+const selectChain = { resolve: vi.fn() };
+
+vi.mock('@op/db/client', () => ({
+  db: {
+    // db.select({...}).from(t).where(c).limit(n) → Promise<rows>
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => selectChain.resolve(),
+        }),
+      }),
+    }),
+    query: { proposals: { findFirst: vi.fn() } },
+  },
+  eq: vi.fn(),
+}));
+
+vi.mock('../access', () => ({
+  assertProfileTypeAccess: vi.fn(),
+  assertInstanceProfileAccess: vi.fn(),
+  getProfileAccessUser: vi.fn(),
+  getCurrentProfileId: vi.fn(),
+}));
+
+vi.mock('./moderationVisibility', () => ({
+  hasActiveModerationFlag: vi.fn(),
+}));
+
+import { db } from '@op/db/client';
+
+import {
+  assertInstanceProfileAccess,
+  assertProfileTypeAccess,
+  getCurrentProfileId,
+  getProfileAccessUser,
+} from '../access';
+import { assertModerationItemAccess } from './assertModerationItemAccess';
+import { hasActiveModerationFlag } from './moderationVisibility';
+
+const user = { id: 'auth-1' } as never;
+const POST_ID = '11111111-1111-4111-8111-111111111111';
+const PROPOSAL_ID = '22222222-2222-4222-8222-222222222222';
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+
+const proposalFindFirst = vi.mocked(db.query.proposals.findFirst);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(hasActiveModerationFlag).mockResolvedValue(false);
+  vi.mocked(getProfileAccessUser).mockResolvedValue(undefined);
+  vi.mocked(assertProfileTypeAccess).mockResolvedValue(undefined);
+  vi.mocked(assertInstanceProfileAccess).mockResolvedValue(undefined as never);
+});
+
+describe('assertModerationItemAccess — post', () => {
+  it('throws NotFound when the post does not exist', async () => {
+    selectChain.resolve.mockResolvedValue([]);
+    await expect(
+      assertModerationItemAccess({ itemType: 'post', itemId: POST_ID, user }),
+    ).rejects.toThrow();
+  });
+
+  it('passes a readable, unflagged post', async () => {
+    selectChain.resolve.mockResolvedValue([
+      { id: POST_ID, profileId: 'author', rootProfileId: 'root' },
+    ]);
+    await expect(
+      assertModerationItemAccess({ itemType: 'post', itemId: POST_ID, user }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('propagates a read-access denial (assertProfileTypeAccess throws)', async () => {
+    selectChain.resolve.mockResolvedValue([
+      { id: POST_ID, profileId: 'author', rootProfileId: 'root' },
+    ]);
+    vi.mocked(assertProfileTypeAccess).mockRejectedValue(
+      new Error('Unauthorized'),
+    );
+    await expect(
+      assertModerationItemAccess({ itemType: 'post', itemId: POST_ID, user }),
+    ).rejects.toThrow('Unauthorized');
+  });
+
+  it('lets the author flag their own already-flagged post', async () => {
+    selectChain.resolve.mockResolvedValue([
+      { id: POST_ID, profileId: 'author-profile', rootProfileId: 'root' },
+    ]);
+    vi.mocked(hasActiveModerationFlag).mockResolvedValue(true);
+    vi.mocked(getCurrentProfileId).mockResolvedValue('author-profile');
+    await expect(
+      assertModerationItemAccess({ itemType: 'post', itemId: POST_ID, user }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('hides an already-flagged post from a non-author non-admin', async () => {
+    selectChain.resolve.mockResolvedValue([
+      { id: POST_ID, profileId: 'author-profile', rootProfileId: 'root' },
+    ]);
+    vi.mocked(hasActiveModerationFlag).mockResolvedValue(true);
+    vi.mocked(getCurrentProfileId).mockResolvedValue('someone-else');
+    // getProfileAccessUser → undefined (no admin roles) from beforeEach.
+    await expect(
+      assertModerationItemAccess({ itemType: 'post', itemId: POST_ID, user }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('assertModerationItemAccess — proposal', () => {
+  it('throws NotFound when the proposal does not exist', async () => {
+    proposalFindFirst.mockResolvedValue(undefined as never);
+    await expect(
+      assertModerationItemAccess({
+        itemType: 'proposal',
+        itemId: PROPOSAL_ID,
+        user,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('passes a readable VISIBLE proposal', async () => {
+    proposalFindFirst.mockResolvedValue({
+      id: PROPOSAL_ID,
+      profileId: 'prop-profile',
+      visibility: 'public',
+      processInstance: { profileId: 'instance-profile' },
+    } as never);
+    await expect(
+      assertModerationItemAccess({
+        itemType: 'proposal',
+        itemId: PROPOSAL_ID,
+        user,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('allows flagging a DRAFT proposal (drafts are reportable, not gated)', async () => {
+    proposalFindFirst.mockResolvedValue({
+      id: PROPOSAL_ID,
+      profileId: 'prop-profile',
+      status: 'draft',
+      visibility: 'public',
+      processInstance: { profileId: 'instance-profile' },
+    } as never);
+    await expect(
+      assertModerationItemAccess({
+        itemType: 'proposal',
+        itemId: PROPOSAL_ID,
+        user,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('hides a HIDDEN proposal from a non-member non-admin', async () => {
+    proposalFindFirst.mockResolvedValue({
+      id: PROPOSAL_ID,
+      profileId: 'prop-profile',
+      visibility: 'hidden',
+      processInstance: { profileId: 'instance-profile' },
+    } as never);
+    // No proposal-level access, no instance-admin roles (beforeEach default).
+    await expect(
+      assertModerationItemAccess({
+        itemType: 'proposal',
+        itemId: PROPOSAL_ID,
+        user,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('lets a proposal-level member flag a HIDDEN proposal', async () => {
+    proposalFindFirst.mockResolvedValue({
+      id: PROPOSAL_ID,
+      profileId: 'prop-profile',
+      visibility: 'hidden',
+      processInstance: { profileId: 'instance-profile' },
+    } as never);
+    // First getProfileAccessUser call (proposal profile) returns a member.
+    vi.mocked(getProfileAccessUser).mockResolvedValueOnce({
+      roles: [],
+    } as never);
+    await expect(
+      assertModerationItemAccess({
+        itemType: 'proposal',
+        itemId: PROPOSAL_ID,
+        user,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('hides an already-flagged VISIBLE proposal from a non-member non-admin', async () => {
+    proposalFindFirst.mockResolvedValue({
+      id: PROPOSAL_ID,
+      profileId: 'prop-profile',
+      visibility: 'public',
+      processInstance: { profileId: 'instance-profile' },
+    } as never);
+    // Visible, but an active flag restricts it like getProposal does — no
+    // proposal-level access, no instance-admin roles (beforeEach default).
+    vi.mocked(hasActiveModerationFlag).mockResolvedValue(true);
+    await expect(
+      assertModerationItemAccess({
+        itemType: 'proposal',
+        itemId: PROPOSAL_ID,
+        user,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('lets a proposal-level member flag an already-flagged VISIBLE proposal', async () => {
+    proposalFindFirst.mockResolvedValue({
+      id: PROPOSAL_ID,
+      profileId: 'prop-profile',
+      visibility: 'public',
+      processInstance: { profileId: 'instance-profile' },
+    } as never);
+    vi.mocked(hasActiveModerationFlag).mockResolvedValue(true);
+    // getProfileAccessUser (proposal profile) returns a member.
+    vi.mocked(getProfileAccessUser).mockResolvedValueOnce({
+      roles: [],
+    } as never);
+    await expect(
+      assertModerationItemAccess({
+        itemType: 'proposal',
+        itemId: PROPOSAL_ID,
+        user,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('assertModerationItemAccess — user', () => {
+  it('passes when the user exists', async () => {
+    selectChain.resolve.mockResolvedValue([{ id: USER_ID }]);
+    await expect(
+      assertModerationItemAccess({ itemType: 'user', itemId: USER_ID, user }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws NotFound when the user does not exist', async () => {
+    selectChain.resolve.mockResolvedValue([]);
+    await expect(
+      assertModerationItemAccess({ itemType: 'user', itemId: USER_ID, user }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
@@ -3,21 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Boundary mocks: this gate is pure orchestration over the DB + access
 // helpers, so we drive those and assert the allow/deny decisions. @op/db/schema
 // is left real (EntityType.DECISION / Visibility.HIDDEN are value comparisons).
-const selectChain = { resolve: vi.fn() };
-
 vi.mock('@op/db/client', () => ({
   db: {
-    // db.select({...}).from(t).where(c).limit(n) → Promise<rows>
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: () => selectChain.resolve(),
-        }),
-      }),
-    }),
-    query: { proposals: { findFirst: vi.fn() } },
+    query: {
+      posts: { findFirst: vi.fn() },
+      postsToProfiles: { findMany: vi.fn() },
+      users: { findFirst: vi.fn() },
+      proposals: { findFirst: vi.fn() },
+    },
   },
-  eq: vi.fn(),
 }));
 
 vi.mock('../access', () => ({
@@ -47,6 +41,9 @@ const POST_ID = '11111111-1111-4111-8111-111111111111';
 const PROPOSAL_ID = '22222222-2222-4222-8222-222222222222';
 const USER_ID = '33333333-3333-4333-8333-333333333333';
 
+const postsFindFirst = vi.mocked(db.query.posts.findFirst);
+const postsToProfilesFindMany = vi.mocked(db.query.postsToProfiles.findMany);
+const usersFindFirst = vi.mocked(db.query.users.findFirst);
 const proposalFindFirst = vi.mocked(db.query.proposals.findFirst);
 
 beforeEach(() => {
@@ -55,29 +52,34 @@ beforeEach(() => {
   vi.mocked(getProfileAccessUser).mockResolvedValue(undefined);
   vi.mocked(assertProfileTypeAccess).mockResolvedValue(undefined);
   vi.mocked(assertInstanceProfileAccess).mockResolvedValue(undefined as never);
+  postsToProfilesFindMany.mockResolvedValue([] as never);
 });
 
 describe('assertModerationItemAccess — post', () => {
   it('throws NotFound when the post does not exist', async () => {
-    selectChain.resolve.mockResolvedValue([]);
+    postsFindFirst.mockResolvedValue(undefined as never);
     await expect(
       assertModerationItemAccess({ itemType: 'post', itemId: POST_ID, user }),
     ).rejects.toThrow();
   });
 
   it('passes a readable, unflagged post', async () => {
-    selectChain.resolve.mockResolvedValue([
-      { id: POST_ID, profileId: 'author', rootProfileId: 'root' },
-    ]);
+    postsFindFirst.mockResolvedValue({
+      id: POST_ID,
+      profileId: 'author',
+      rootProfileId: 'root',
+    } as never);
     await expect(
       assertModerationItemAccess({ itemType: 'post', itemId: POST_ID, user }),
     ).resolves.toBeUndefined();
   });
 
   it('propagates a read-access denial (assertProfileTypeAccess throws)', async () => {
-    selectChain.resolve.mockResolvedValue([
-      { id: POST_ID, profileId: 'author', rootProfileId: 'root' },
-    ]);
+    postsFindFirst.mockResolvedValue({
+      id: POST_ID,
+      profileId: 'author',
+      rootProfileId: 'root',
+    } as never);
     vi.mocked(assertProfileTypeAccess).mockRejectedValue(
       new Error('Unauthorized'),
     );
@@ -87,9 +89,11 @@ describe('assertModerationItemAccess — post', () => {
   });
 
   it('lets the author flag their own already-flagged post', async () => {
-    selectChain.resolve.mockResolvedValue([
-      { id: POST_ID, profileId: 'author-profile', rootProfileId: 'root' },
-    ]);
+    postsFindFirst.mockResolvedValue({
+      id: POST_ID,
+      profileId: 'author-profile',
+      rootProfileId: 'root',
+    } as never);
     vi.mocked(hasActiveModerationFlag).mockResolvedValue(true);
     vi.mocked(getCurrentProfileId).mockResolvedValue('author-profile');
     await expect(
@@ -98,15 +102,44 @@ describe('assertModerationItemAccess — post', () => {
   });
 
   it('hides an already-flagged post from a non-author non-admin', async () => {
-    selectChain.resolve.mockResolvedValue([
-      { id: POST_ID, profileId: 'author-profile', rootProfileId: 'root' },
-    ]);
+    postsFindFirst.mockResolvedValue({
+      id: POST_ID,
+      profileId: 'author-profile',
+      rootProfileId: 'root',
+    } as never);
     vi.mocked(hasActiveModerationFlag).mockResolvedValue(true);
     vi.mocked(getCurrentProfileId).mockResolvedValue('someone-else');
     // getProfileAccessUser → undefined (no admin roles) from beforeEach.
     await expect(
       assertModerationItemAccess({ itemType: 'post', itemId: POST_ID, user }),
     ).rejects.toThrow();
+  });
+
+  it('lets a sessionless caller flag a publicly readable post', async () => {
+    postsFindFirst.mockResolvedValue({
+      id: POST_ID,
+      profileId: 'author',
+      rootProfileId: 'root',
+    } as never);
+    // assertProfileTypeAccess resolves (public READ) from beforeEach.
+    await expect(
+      assertModerationItemAccess({ itemType: 'post', itemId: POST_ID }),
+    ).resolves.toBeUndefined();
+    // No session → no author/profile lookup.
+    expect(getCurrentProfileId).not.toHaveBeenCalled();
+  });
+
+  it('hides an already-flagged post from a sessionless caller', async () => {
+    postsFindFirst.mockResolvedValue({
+      id: POST_ID,
+      profileId: 'author-profile',
+      rootProfileId: 'root',
+    } as never);
+    vi.mocked(hasActiveModerationFlag).mockResolvedValue(true);
+    await expect(
+      assertModerationItemAccess({ itemType: 'post', itemId: POST_ID }),
+    ).rejects.toThrow();
+    expect(getCurrentProfileId).not.toHaveBeenCalled();
   });
 });
 
@@ -235,16 +268,23 @@ describe('assertModerationItemAccess — proposal', () => {
 
 describe('assertModerationItemAccess — user', () => {
   it('passes when the user exists', async () => {
-    selectChain.resolve.mockResolvedValue([{ id: USER_ID }]);
+    usersFindFirst.mockResolvedValue({ id: USER_ID } as never);
     await expect(
       assertModerationItemAccess({ itemType: 'user', itemId: USER_ID, user }),
     ).resolves.toBeUndefined();
   });
 
   it('throws NotFound when the user does not exist', async () => {
-    selectChain.resolve.mockResolvedValue([]);
+    usersFindFirst.mockResolvedValue(undefined as never);
     await expect(
       assertModerationItemAccess({ itemType: 'user', itemId: USER_ID, user }),
     ).rejects.toThrow();
+  });
+
+  it('lets a sessionless caller flag an existing user (platform-visible)', async () => {
+    usersFindFirst.mockResolvedValue({ id: USER_ID } as never);
+    await expect(
+      assertModerationItemAccess({ itemType: 'user', itemId: USER_ID }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/common/src/services/moderation/assertModerationItemAccess.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.ts
@@ -1,11 +1,5 @@
-import { db, eq } from '@op/db/client';
-import {
-  EntityType,
-  Visibility,
-  posts,
-  postsToProfiles,
-  users,
-} from '@op/db/schema';
+import { db } from '@op/db/client';
+import { EntityType, Visibility } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 import { checkPermission, permission } from 'access-zones';
 
@@ -20,13 +14,18 @@ import { hasActiveModerationFlag } from './moderationVisibility';
 import type { ModerationItemType } from './types';
 
 /**
- * Asserts the reporter can actually see the item they're flagging, and that it
+ * Asserts the caller can actually see the item they're flagging, and that it
  * exists. Flagging ships the item's text and signed attachment URLs to the
  * external moderation provider, so it must be gated like reading the item —
- * otherwise an authenticated session could exfiltrate restricted content (or
- * probe for ids) by flagging it. Mirrors the read-path checks: posts gate like
- * `getPost`, proposals like `getProposal`; user profiles are platform-visible,
- * so a user item only needs to exist.
+ * otherwise a caller could exfiltrate restricted content (or probe for ids) by
+ * flagging it. Mirrors the read-path checks: posts gate like `getPost`,
+ * proposals like `getProposal`; user profiles are platform-visible, so a user
+ * item only needs to exist.
+ *
+ * `user` is optional: a sessionless caller resolves to public grants only (via
+ * the `GLOBAL_USER_PUBLIC` fallback in the access helpers), so they can flag a
+ * publicly readable item but are denied anything restricted — exactly the read
+ * path's behavior for an anonymous visitor.
  *
  * Two intentional carve-outs from the read path:
  *  - DRAFT proposals are NOT gated here — drafts are reportable.
@@ -40,18 +39,17 @@ export const assertModerationItemAccess = async ({
 }: {
   itemType: ModerationItemType;
   itemId: string;
-  user: User;
+  user?: User;
 }): Promise<void> => {
   if (itemType === 'post') {
-    const [post] = await db
-      .select({
-        id: posts.id,
-        profileId: posts.profileId,
-        rootProfileId: posts.rootProfileId,
-      })
-      .from(posts)
-      .where(eq(posts.id, itemId))
-      .limit(1);
+    const post = await db.query.posts.findFirst({
+      where: { id: itemId },
+      columns: {
+        id: true,
+        profileId: true,
+        rootProfileId: true,
+      },
+    });
     if (!post) {
       throw new NotFoundError('Post', itemId);
     }
@@ -61,10 +59,10 @@ export const assertModerationItemAccess = async ({
     const profileIds = post.rootProfileId
       ? [post.rootProfileId]
       : (
-          await db
-            .select({ profileId: postsToProfiles.profileId })
-            .from(postsToProfiles)
-            .where(eq(postsToProfiles.postId, itemId))
+          await db.query.postsToProfiles.findMany({
+            where: { postId: itemId },
+            columns: { profileId: true },
+          })
         ).map((row) => row.profileId);
 
     await assertProfileTypeAccess({
@@ -79,12 +77,23 @@ export const assertModerationItemAccess = async ({
     // root-profile admins (see getPost's gate); the same audience may flag it,
     // so a non-owner can't ship hidden content to the vendor by re-flagging.
     if (await hasActiveModerationFlag('post', post.id)) {
-      const actorProfileId = await getCurrentProfileId(user.id);
-      const isAuthor = post.profileId === actorProfileId;
+      // Restricted to the author + root-profile admins. A sessionless caller is
+      // neither, so they're denied — hidden content can't be shipped to the
+      // vendor by flagging it. getCurrentProfileId is memoized per request, so
+      // this shares submitUserFlag's lookup.
+      const actorProfileId = user
+        ? await getCurrentProfileId(user.id)
+        : undefined;
+      const isAuthor =
+        actorProfileId !== undefined && post.profileId === actorProfileId;
       if (!isAuthor) {
-        const rootProfileUser = post.rootProfileId
-          ? await getProfileAccessUser({ user, profileId: post.rootProfileId })
-          : undefined;
+        const rootProfileUser =
+          user && post.rootProfileId
+            ? await getProfileAccessUser({
+                user,
+                profileId: post.rootProfileId,
+              })
+            : undefined;
         const isAdmin = checkPermission(
           { profile: permission.ADMIN },
           rootProfileUser?.roles ?? [],
@@ -147,11 +156,10 @@ export const assertModerationItemAccess = async ({
 
   // itemType === 'user': profiles are platform-visible, so existence is the
   // only gate — a nonexistent id must not create a queue entry or an email.
-  const [row] = await db
-    .select({ id: users.id })
-    .from(users)
-    .where(eq(users.id, itemId))
-    .limit(1);
+  const row = await db.query.users.findFirst({
+    where: { id: itemId },
+    columns: { id: true },
+  });
   if (!row) {
     throw new NotFoundError('User', itemId);
   }

--- a/packages/common/src/services/moderation/assertModerationItemAccess.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.ts
@@ -1,0 +1,158 @@
+import { db, eq } from '@op/db/client';
+import {
+  EntityType,
+  Visibility,
+  posts,
+  postsToProfiles,
+  users,
+} from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+import { checkPermission, permission } from 'access-zones';
+
+import { NotFoundError } from '../../utils';
+import {
+  assertInstanceProfileAccess,
+  assertProfileTypeAccess,
+  getCurrentProfileId,
+  getProfileAccessUser,
+} from '../access';
+import { hasActiveModerationFlag } from './moderationVisibility';
+import type { ModerationItemType } from './types';
+
+/**
+ * Asserts the reporter can actually see the item they're flagging, and that it
+ * exists. Flagging ships the item's text and signed attachment URLs to the
+ * external moderation provider, so it must be gated like reading the item —
+ * otherwise an authenticated session could exfiltrate restricted content (or
+ * probe for ids) by flagging it. Mirrors the read-path checks: posts gate like
+ * `getPost`, proposals like `getProposal`; user profiles are platform-visible,
+ * so a user item only needs to exist.
+ *
+ * Two intentional carve-outs from the read path:
+ *  - DRAFT proposals are NOT gated here — drafts are reportable.
+ *  - HIDDEN proposals and already-flagged posts ARE gated, so content that's
+ *    restricted from a reader can't be shipped to the vendor by flagging it.
+ */
+export const assertModerationItemAccess = async ({
+  itemType,
+  itemId,
+  user,
+}: {
+  itemType: ModerationItemType;
+  itemId: string;
+  user: User;
+}): Promise<void> => {
+  if (itemType === 'post') {
+    const [post] = await db
+      .select({
+        id: posts.id,
+        profileId: posts.profileId,
+        rootProfileId: posts.rootProfileId,
+      })
+      .from(posts)
+      .where(eq(posts.id, itemId))
+      .limit(1);
+    if (!post) {
+      throw new NotFoundError('Post', itemId);
+    }
+
+    // Prefer the pinned rootProfileId gate when present; legacy posts written
+    // before the gate fall back to the postsToProfiles index (same as getPost).
+    const profileIds = post.rootProfileId
+      ? [post.rootProfileId]
+      : (
+          await db
+            .select({ profileId: postsToProfiles.profileId })
+            .from(postsToProfiles)
+            .where(eq(postsToProfiles.postId, itemId))
+        ).map((row) => row.profileId);
+
+    await assertProfileTypeAccess({
+      user,
+      profileIds,
+      policies: {
+        [EntityType.DECISION]: { decisions: permission.READ },
+      },
+    });
+
+    // An already-flagged post is hidden from everyone but its author and the
+    // root-profile admins (see getPost's gate); the same audience may flag it,
+    // so a non-owner can't ship hidden content to the vendor by re-flagging.
+    if (await hasActiveModerationFlag('post', post.id)) {
+      const actorProfileId = await getCurrentProfileId(user.id);
+      const isAuthor = post.profileId === actorProfileId;
+      if (!isAuthor) {
+        const rootProfileUser = post.rootProfileId
+          ? await getProfileAccessUser({ user, profileId: post.rootProfileId })
+          : undefined;
+        const isAdmin = checkPermission(
+          { profile: permission.ADMIN },
+          rootProfileUser?.roles ?? [],
+        );
+        if (!isAdmin) {
+          throw new NotFoundError('Post', itemId);
+        }
+      }
+    }
+    return;
+  }
+
+  if (itemType === 'proposal') {
+    const proposal = await db.query.proposals.findFirst({
+      where: { id: itemId },
+      with: { processInstance: true },
+    });
+    if (!proposal) {
+      throw new NotFoundError('Proposal', itemId);
+    }
+
+    // Reuse the resolved instance-profile user for the instance-admin check
+    // below instead of re-fetching it, mirroring getProposal.
+    const instanceProfileUser = await assertInstanceProfileAccess({
+      user,
+      instance: proposal.processInstance,
+      profilePermissions: { decisions: permission.READ },
+      orgFallbackPermissions: [
+        { decisions: permission.READ },
+        { decisions: permission.ADMIN },
+      ],
+    });
+
+    // HIDDEN proposals, and proposals with an active moderation flag, are
+    // restricted beyond plain instance read — visible only to proposal-level
+    // members (creator + invited collaborators) or instance admins. Mirror
+    // getProposal's gate so restricted text/attachments can't be shipped to the
+    // vendor by an instance member who only has read on the process, and so
+    // this gate (not submitUserFlag's idempotency shortcut) is what enforces it
+    // for an already-flagged proposal. (DRAFT is deliberately not gated here:
+    // drafts are reportable.)
+    const isRestricted =
+      proposal.visibility === Visibility.HIDDEN ||
+      (await hasActiveModerationFlag('proposal', proposal.id));
+    if (isRestricted) {
+      const proposalProfileUser = await getProfileAccessUser({
+        user,
+        profileId: proposal.profileId,
+      });
+      const isInstanceAdmin = checkPermission(
+        { profile: permission.ADMIN },
+        instanceProfileUser?.roles ?? [],
+      );
+      if (!proposalProfileUser && !isInstanceAdmin) {
+        throw new NotFoundError('Proposal', itemId);
+      }
+    }
+    return;
+  }
+
+  // itemType === 'user': profiles are platform-visible, so existence is the
+  // only gate — a nonexistent id must not create a queue entry or an email.
+  const [row] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, itemId))
+    .limit(1);
+  if (!row) {
+    throw new NotFoundError('User', itemId);
+  }
+};

--- a/packages/common/src/services/moderation/flagItem.test.ts
+++ b/packages/common/src/services/moderation/flagItem.test.ts
@@ -1,0 +1,128 @@
+import type { ModerationFlag } from '@op/db/schema';
+import { describe, expect, it, vi } from 'vitest';
+
+import { flagItem } from './flagItem';
+
+const pendingRow = { id: 'flag-1', status: 'pending' } as ModerationFlag;
+
+const ROUND_ID = '99999999-9999-4999-8999-999999999999';
+
+const input = {
+  itemType: 'post' as const,
+  itemId: 'p1',
+  roundId: ROUND_ID,
+  flaggedByProfileId: 'profile-9',
+  content: 'report me',
+  media: [{ url: 'https://cdn/a.png', kind: 'image' as const }],
+  callbackUrl: 'https://us/webhook',
+};
+
+const plannedRefs = [`post:p1:${ROUND_ID}`, `post:p1:${ROUND_ID}:0`];
+
+const fullDeps = () => ({
+  findOpenFlag: vi.fn().mockResolvedValue(undefined),
+  createPendingFlag: vi
+    .fn()
+    .mockResolvedValue({ flag: pendingRow, created: true }),
+  submitForReview: vi.fn().mockResolvedValue({
+    providerRecordId: 'r1',
+    submittedRefs: plannedRefs,
+  }),
+  planRefs: vi.fn().mockReturnValue(plannedRefs),
+  recordRound: vi.fn().mockResolvedValue(undefined),
+  rollback: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('flagItem', () => {
+  it('creates a pending flag, records the planned round, then submits', async () => {
+    const deps = fullDeps();
+
+    const result = await flagItem(input, deps);
+
+    expect(deps.createPendingFlag).toHaveBeenCalledWith({
+      itemType: 'post',
+      itemId: 'p1',
+      flaggedByProfileId: 'profile-9',
+      reason: undefined,
+    });
+    expect(deps.recordRound).toHaveBeenCalledWith(
+      'post',
+      'p1',
+      ROUND_ID,
+      plannedRefs,
+    );
+    expect(deps.submitForReview).toHaveBeenCalledWith({
+      itemType: 'post',
+      itemId: 'p1',
+      roundId: ROUND_ID,
+      content: 'report me',
+      media: [{ url: 'https://cdn/a.png', kind: 'image' }],
+      callbackUrl: 'https://us/webhook',
+    });
+    // The round must be on record before the provider can possibly call back.
+    expect(deps.recordRound.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.submitForReview.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(result).toEqual({ flag: pendingRow, created: true });
+  });
+
+  it('is idempotent: returns the existing open flag without creating or submitting', async () => {
+    const deps = fullDeps();
+    deps.findOpenFlag.mockResolvedValue(pendingRow);
+
+    const result = await flagItem(input, deps);
+
+    expect(deps.createPendingFlag).not.toHaveBeenCalled();
+    expect(deps.submitForReview).not.toHaveBeenCalled();
+    expect(deps.recordRound).not.toHaveBeenCalled();
+    expect(result).toEqual({ flag: pendingRow, created: false });
+  });
+
+  it('does not submit or roll back when a concurrent report won the insert race', async () => {
+    const deps = fullDeps();
+    deps.createPendingFlag.mockResolvedValue({
+      flag: pendingRow,
+      created: false,
+    });
+
+    const result = await flagItem(input, deps);
+
+    // The winner owns the round (and any rollback); the loser just reports
+    // the existing flag.
+    expect(deps.recordRound).not.toHaveBeenCalled();
+    expect(deps.submitForReview).not.toHaveBeenCalled();
+    expect(result).toEqual({ flag: pendingRow, created: false });
+  });
+
+  it('rolls back the pending flag and rethrows when the provider submit fails', async () => {
+    const deps = fullDeps();
+    deps.submitForReview.mockRejectedValue(new Error('provider down'));
+
+    await expect(flagItem(input, deps)).rejects.toThrow('provider down');
+
+    // Without the rollback the flag would sit pending forever and the
+    // open-flag idempotency check would swallow every retry.
+    expect(deps.rollback).toHaveBeenCalledWith(pendingRow);
+  });
+
+  it('keeps the flag pending without submitting when nothing is reviewable', async () => {
+    const deps = fullDeps();
+    deps.planRefs.mockReturnValue([]);
+
+    const result = await flagItem({ ...input, content: '', media: [] }, deps);
+
+    expect(deps.recordRound).not.toHaveBeenCalled();
+    expect(deps.submitForReview).not.toHaveBeenCalled();
+    expect(result).toEqual({ flag: pendingRow, created: true });
+  });
+
+  it('skips the provider entirely when async review is not configured', async () => {
+    const deps = fullDeps();
+    const result = await flagItem(input, {
+      findOpenFlag: deps.findOpenFlag,
+      createPendingFlag: deps.createPendingFlag,
+    });
+
+    expect(result).toEqual({ flag: pendingRow, created: true });
+  });
+});

--- a/packages/common/src/services/moderation/flagItem.test.ts
+++ b/packages/common/src/services/moderation/flagItem.test.ts
@@ -63,7 +63,7 @@ describe('flagItem', () => {
     expect(deps.recordRound.mock.invocationCallOrder[0]).toBeLessThan(
       deps.submitForReview.mock.invocationCallOrder[0] ?? 0,
     );
-    expect(result).toEqual({ flag: pendingRow, created: true });
+    expect(result).toEqual({ flag: pendingRow });
   });
 
   it('is idempotent: returns the existing open flag without creating or submitting', async () => {
@@ -75,7 +75,7 @@ describe('flagItem', () => {
     expect(deps.createPendingFlag).not.toHaveBeenCalled();
     expect(deps.submitForReview).not.toHaveBeenCalled();
     expect(deps.recordRound).not.toHaveBeenCalled();
-    expect(result).toEqual({ flag: pendingRow, created: false });
+    expect(result).toEqual({ flag: pendingRow });
   });
 
   it('does not submit or roll back when a concurrent report won the insert race', async () => {
@@ -91,7 +91,7 @@ describe('flagItem', () => {
     // the existing flag.
     expect(deps.recordRound).not.toHaveBeenCalled();
     expect(deps.submitForReview).not.toHaveBeenCalled();
-    expect(result).toEqual({ flag: pendingRow, created: false });
+    expect(result).toEqual({ flag: pendingRow });
   });
 
   it('rolls back the pending flag and rethrows when the provider submit fails', async () => {
@@ -113,7 +113,7 @@ describe('flagItem', () => {
 
     expect(deps.recordRound).not.toHaveBeenCalled();
     expect(deps.submitForReview).not.toHaveBeenCalled();
-    expect(result).toEqual({ flag: pendingRow, created: true });
+    expect(result).toEqual({ flag: pendingRow });
   });
 
   it('skips the provider entirely when async review is not configured', async () => {
@@ -123,6 +123,6 @@ describe('flagItem', () => {
       createPendingFlag: deps.createPendingFlag,
     });
 
-    expect(result).toEqual({ flag: pendingRow, created: true });
+    expect(result).toEqual({ flag: pendingRow });
   });
 });

--- a/packages/common/src/services/moderation/flagItem.ts
+++ b/packages/common/src/services/moderation/flagItem.ts
@@ -1,0 +1,130 @@
+import type { ModerationFlag } from '@op/db/schema';
+
+import type {
+  ModerationItemType,
+  ModerationMediaItem,
+  ModerationProviderReference,
+  ModerationSubmission,
+} from './types';
+
+export interface FlagItemInput {
+  itemType: ModerationItemType;
+  itemId: string;
+  /** Identifies this submission round; encoded into every ref sent to the
+   *  provider, and verdicts must match it. */
+  roundId: string;
+  /** The profile raising the report. */
+  flaggedByProfileId: string;
+  reason?: string;
+  /** Content shipped to the provider for the async verdict. */
+  content: string;
+  media?: ModerationMediaItem[];
+  callbackUrl: string;
+}
+
+export interface FlagItemDeps {
+  findOpenFlag: (
+    itemType: ModerationItemType,
+    itemId: string,
+  ) => Promise<ModerationFlag | undefined>;
+  /** `created: false` means a concurrent report won the insert race; the
+   *  caller returns that flag without submitting a second round. */
+  createPendingFlag: (input: {
+    itemType: ModerationItemType;
+    itemId: string;
+    flaggedByProfileId: string;
+    reason?: string;
+  }) => Promise<{ flag: ModerationFlag; created: boolean }>;
+  submitForReview?: (
+    input: ModerationSubmission,
+  ) => Promise<ModerationProviderReference>;
+  /** The refs `submitForReview` will create, known before the provider is
+   *  called. Required alongside `submitForReview`. */
+  planRefs?: (
+    input: Pick<
+      ModerationSubmission,
+      'itemType' | 'itemId' | 'roundId' | 'content' | 'media'
+    >,
+  ) => string[];
+  /** Persists the round of tasks about to be submitted (one per ref). Called
+   *  *before* `submitForReview` so a verdict can't arrive for an unrecorded
+   *  task. */
+  recordRound?: (
+    itemType: ModerationItemType,
+    itemId: string,
+    roundId: string,
+    submittedRefs: string[],
+  ) => Promise<void>;
+  /** Undoes the pending flag + round when the provider submit fails, so the
+   *  user's retry isn't swallowed by the open-flag idempotency check. */
+  rollback?: (flag: ModerationFlag) => Promise<void>;
+}
+
+/**
+ * User-initiated flag. Records a `pending` flag (manual source), records the
+ * round of tasks the submission fans out into, then submits the content to the
+ * provider; the provider's webhook later confirms it (→ flagged) or clears it
+ * (→ dismissed). Idempotent: if the item already has an open flag, returns it
+ * without a second record or submission. If the provider submit fails, the
+ * pending flag and round are rolled back and the error propagates — otherwise
+ * the flag would sit `pending` forever (nothing left to resolve it) and the
+ * idempotency check would swallow every retry.
+ */
+export const flagItem = async (
+  input: FlagItemInput,
+  deps: FlagItemDeps,
+): Promise<{ flag: ModerationFlag; created: boolean }> => {
+  const existing = await deps.findOpenFlag(input.itemType, input.itemId);
+  if (existing) {
+    return { flag: existing, created: false };
+  }
+
+  const { flag, created } = await deps.createPendingFlag({
+    itemType: input.itemType,
+    itemId: input.itemId,
+    flaggedByProfileId: input.flaggedByProfileId,
+    reason: input.reason,
+  });
+
+  // Lost the insert race to a concurrent report: that report owns the round
+  // (and the rollback if its submit fails) — don't submit a duplicate.
+  if (!created) {
+    return { flag, created: false };
+  }
+
+  if (deps.submitForReview && deps.planRefs) {
+    const planned = deps.planRefs({
+      itemType: input.itemType,
+      itemId: input.itemId,
+      roundId: input.roundId,
+      content: input.content,
+      media: input.media,
+    });
+
+    // Nothing the provider would review (no text, no media): keep the flag
+    // pending for manual/admin handling rather than submitting an empty round.
+    if (planned.length > 0) {
+      try {
+        await deps.recordRound?.(
+          input.itemType,
+          input.itemId,
+          input.roundId,
+          planned,
+        );
+        await deps.submitForReview({
+          itemType: input.itemType,
+          itemId: input.itemId,
+          roundId: input.roundId,
+          content: input.content,
+          media: input.media,
+          callbackUrl: input.callbackUrl,
+        });
+      } catch (error) {
+        await deps.rollback?.(flag);
+        throw error;
+      }
+    }
+  }
+
+  return { flag, created: true };
+};

--- a/packages/common/src/services/moderation/flagItem.ts
+++ b/packages/common/src/services/moderation/flagItem.ts
@@ -13,8 +13,9 @@ export interface FlagItemInput {
   /** Identifies this submission round; encoded into every ref sent to the
    *  provider, and verdicts must match it. */
   roundId: string;
-  /** The profile raising the report. */
-  flaggedByProfileId: string;
+  /** The profile raising the report, or `null` for an anonymous (sessionless)
+   *  report. */
+  flaggedByProfileId: string | null;
   reason?: string;
   /** Content shipped to the provider for the async verdict. */
   content: string;
@@ -32,7 +33,7 @@ export interface FlagItemDeps {
   createPendingFlag: (input: {
     itemType: ModerationItemType;
     itemId: string;
-    flaggedByProfileId: string;
+    flaggedByProfileId: string | null;
     reason?: string;
   }) => Promise<{ flag: ModerationFlag; created: boolean }>;
   submitForReview?: (

--- a/packages/common/src/services/moderation/flagItem.ts
+++ b/packages/common/src/services/moderation/flagItem.ts
@@ -73,10 +73,10 @@ export interface FlagItemDeps {
 export const flagItem = async (
   input: FlagItemInput,
   deps: FlagItemDeps,
-): Promise<{ flag: ModerationFlag; created: boolean }> => {
+): Promise<{ flag: ModerationFlag }> => {
   const existing = await deps.findOpenFlag(input.itemType, input.itemId);
   if (existing) {
-    return { flag: existing, created: false };
+    return { flag: existing };
   }
 
   const { flag, created } = await deps.createPendingFlag({
@@ -89,7 +89,7 @@ export const flagItem = async (
   // Lost the insert race to a concurrent report: that report owns the round
   // (and the rollback if its submit fails) — don't submit a duplicate.
   if (!created) {
-    return { flag, created: false };
+    return { flag };
   }
 
   if (deps.submitForReview && deps.planRefs) {
@@ -126,5 +126,5 @@ export const flagItem = async (
     }
   }
 
-  return { flag, created: true };
+  return { flag };
 };

--- a/packages/common/src/services/moderation/index.ts
+++ b/packages/common/src/services/moderation/index.ts
@@ -1,6 +1,8 @@
 export * from './applyModerationVerdict';
+export * from './assertModerationItemAccess';
 export * from './assertTextContentModerated';
 export * from './contentRef';
+export * from './flagItem';
 export * from './handleModerationWebhook';
 export * from './moderateTextContent';
 export * from './moderationCallback';
@@ -15,5 +17,6 @@ export * from './resolveModerationItemText';
 export * from './resolveModerationMedia';
 export * from './reviewContentAsync';
 export * from './submissionAggregate';
+export * from './submitUserFlag';
 export * from './types';
 export * from './utils';

--- a/packages/common/src/services/moderation/moderationFlagStore.ts
+++ b/packages/common/src/services/moderation/moderationFlagStore.ts
@@ -86,7 +86,7 @@ export const createPendingFlag = async ({
 }: {
   itemType: ModerationItemType;
   itemId: string;
-  flaggedByProfileId: string;
+  flaggedByProfileId: string | null;
   reason?: string;
 }): Promise<{ flag: ModerationFlag; created: boolean }> => {
   const [inserted] = await db

--- a/packages/common/src/services/moderation/submitUserFlag.ts
+++ b/packages/common/src/services/moderation/submitUserFlag.ts
@@ -1,0 +1,108 @@
+import { db } from '@op/db/client';
+import type { ModerationFlag } from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+
+import { assertModerationItemAccess } from './assertModerationItemAccess';
+import { flagItem } from './flagItem';
+import { getModerationCallbackUrl } from './moderationCallback';
+import {
+  createPendingFlag,
+  deletePendingFlag,
+  findOpenModerationFlag,
+} from './moderationFlagStore';
+import {
+  clearSubmissions,
+  recordSubmissionRound,
+  submissionMediaIdsFromRefs,
+} from './moderationSubmissionStore';
+import { getModerationProvider } from './provider';
+import { resolveModerationItemText } from './resolveModerationItemText';
+import { resolveModerationMedia } from './resolveModerationMedia';
+import type { ModerationItemType } from './types';
+
+export interface SubmitUserFlagInput {
+  itemType: ModerationItemType;
+  itemId: string;
+  flaggedByProfileId: string;
+  reason?: string;
+  /** The reporting user; must be able to read the item they're flagging. */
+  user: User;
+}
+
+/**
+ * User-initiated report. Verifies the reporter can read the item (flagging
+ * ships its content to the external provider), records a `pending` flag and,
+ * when a provider + webhook secret are configured, submits the item (text +
+ * media) for an async verdict. Idempotent on an item's open flag.
+ */
+export const submitUserFlag = async (
+  input: SubmitUserFlagInput,
+): Promise<{ flag: ModerationFlag; created: boolean }> => {
+  await assertModerationItemAccess({
+    itemType: input.itemType,
+    itemId: input.itemId,
+    user: input.user,
+  });
+
+  // Idempotency shortcut: if the item already has an open flag, return it
+  // before resolving content. Resolving means a TipTap fetch + signing one URL
+  // per attachment — wasted work on the hot case (many users reporting the
+  // same already-flagged item). `flagItem` still does its own authoritative
+  // open-flag check, so this is a fast path, not the correctness boundary.
+  const existing = await findOpenModerationFlag(input.itemType, input.itemId);
+  if (existing) {
+    return { flag: existing, created: false };
+  }
+
+  const provider = getModerationProvider();
+  const callbackUrl = getModerationCallbackUrl();
+  // Fresh round per report: encoded into the provider refs, so only this
+  // round's verdicts can land on the rows recorded below.
+  const roundId = crypto.randomUUID();
+  const [content, media] = await Promise.all([
+    resolveModerationItemText(input.itemType, input.itemId),
+    resolveModerationMedia(input.itemType, input.itemId),
+  ]);
+
+  return flagItem(
+    {
+      itemType: input.itemType,
+      itemId: input.itemId,
+      roundId,
+      flaggedByProfileId: input.flaggedByProfileId,
+      reason: input.reason,
+      content,
+      media,
+      callbackUrl: callbackUrl ?? '',
+    },
+    {
+      findOpenFlag: findOpenModerationFlag,
+      createPendingFlag,
+      // Submit only when a provider with the full async surface and a callback
+      // URL are configured; otherwise the flag stays pending for manual/admin
+      // handling.
+      submitForReview:
+        provider?.submitForReview && provider.planReviewRefs && callbackUrl
+          ? provider.submitForReview
+          : undefined,
+      planRefs: provider?.planReviewRefs,
+      recordRound: (itemType, itemId, round, refs) =>
+        recordSubmissionRound(
+          itemType,
+          itemId,
+          round,
+          submissionMediaIdsFromRefs(refs),
+        ),
+      rollback: async (flag) => {
+        // One transaction so the undo can't half-apply: either the pending
+        // flag and its submission rows both go, or neither does and the
+        // original error propagates for retry. A partial rollback would either
+        // strand the flag `pending` forever or leave orphan submission rows.
+        await db.transaction(async (tx) => {
+          await deletePendingFlag(flag.id, tx);
+          await clearSubmissions(input.itemType, input.itemId, tx);
+        });
+      },
+    },
+  );
+};

--- a/packages/common/src/services/moderation/submitUserFlag.ts
+++ b/packages/common/src/services/moderation/submitUserFlag.ts
@@ -37,7 +37,7 @@ export interface SubmitUserFlagInput {
  */
 export const submitUserFlag = async (
   input: SubmitUserFlagInput,
-): Promise<{ flag: ModerationFlag; created: boolean }> => {
+): Promise<{ flag: ModerationFlag }> => {
   await assertModerationItemAccess({
     itemType: input.itemType,
     itemId: input.itemId,
@@ -51,7 +51,7 @@ export const submitUserFlag = async (
   // open-flag check, so this is a fast path, not the correctness boundary.
   const existing = await findOpenModerationFlag(input.itemType, input.itemId);
   if (existing) {
-    return { flag: existing, created: false };
+    return { flag: existing };
   }
 
   const provider = getModerationProvider();

--- a/packages/common/src/services/moderation/submitUserFlag.ts
+++ b/packages/common/src/services/moderation/submitUserFlag.ts
@@ -2,6 +2,7 @@ import { db } from '@op/db/client';
 import type { ModerationFlag } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 
+import { getCurrentProfileId } from '../access';
 import { assertModerationItemAccess } from './assertModerationItemAccess';
 import { flagItem } from './flagItem';
 import { getModerationCallbackUrl } from './moderationCallback';
@@ -23,10 +24,14 @@ import type { ModerationItemType } from './types';
 export interface SubmitUserFlagInput {
   itemType: ModerationItemType;
   itemId: string;
-  flaggedByProfileId: string;
   reason?: string;
-  /** The reporting user; must be able to read the item they're flagging. */
-  user: User;
+  /**
+   * The reporting user, or `undefined` for a sessionless caller. Either way the
+   * caller must be able to *read* the item they're flagging — a sessionless
+   * caller is held to public visibility (see {@link assertModerationItemAccess}).
+   * A sessionless report records a `null` reporter.
+   */
+  user?: User;
 }
 
 /**
@@ -38,6 +43,15 @@ export interface SubmitUserFlagInput {
 export const submitUserFlag = async (
   input: SubmitUserFlagInput,
 ): Promise<{ flag: ModerationFlag }> => {
+  // Resolve the reporter's profile (memoized per request, so the access gate's
+  // own getCurrentProfileId call reuses it) alongside the open-flag lookup —
+  // they're independent, and the open flag is the idempotency shortcut below. A
+  // sessionless report has no reporter profile.
+  const [flaggedByProfileId, existing] = await Promise.all([
+    input.user ? getCurrentProfileId(input.user.id) : Promise.resolve(null),
+    findOpenModerationFlag(input.itemType, input.itemId),
+  ]);
+
   await assertModerationItemAccess({
     itemType: input.itemType,
     itemId: input.itemId,
@@ -49,7 +63,6 @@ export const submitUserFlag = async (
   // per attachment — wasted work on the hot case (many users reporting the
   // same already-flagged item). `flagItem` still does its own authoritative
   // open-flag check, so this is a fast path, not the correctness boundary.
-  const existing = await findOpenModerationFlag(input.itemType, input.itemId);
   if (existing) {
     return { flag: existing };
   }
@@ -69,7 +82,7 @@ export const submitUserFlag = async (
       itemType: input.itemType,
       itemId: input.itemId,
       roundId,
-      flaggedByProfileId: input.flaggedByProfileId,
+      flaggedByProfileId,
       reason: input.reason,
       content,
       media,

--- a/services/api/src/routers/index.ts
+++ b/services/api/src/routers/index.ts
@@ -3,6 +3,7 @@ import accountRouter from './account';
 import { contentRouter } from './content';
 import { decisionRouter } from './decision';
 import individualRouter from './individual';
+import { moderationRouter } from './moderation';
 import { organizationRouter } from './organization';
 import { platformRouter } from './platform';
 import { postsRouter } from './posts';
@@ -20,6 +21,7 @@ export const appRouter = router({
   content: contentRouter,
   posts: postsRouter,
   decision: decisionRouter,
+  moderation: moderationRouter,
   platform: platformRouter,
   resources: resourcesRouter,
   translation: translationRouter,

--- a/services/api/src/routers/moderation/flagItem.gating.test.ts
+++ b/services/api/src/routers/moderation/flagItem.gating.test.ts
@@ -1,14 +1,17 @@
 import {
   accessTierGatingCell,
   describeAccessTierGating,
-  expectFailsAccessTierGate,
   expectPassesAccessTierGate,
 } from '../../test/helpers/gating';
 
-// A syntactically valid uuid that exists nowhere: the authenticated tiers get
-// past the gate and the service then 404s on the missing item, which still
-// counts as passing. Item-level authorization (existence + read access before
-// anything ships to the provider) is the service layer's job — see
+// flagItem is an `openProcedure`: the tier gate admits every caller (including
+// no-JWT) and authorization is fully the service/handler layer's job. A
+// syntactically valid uuid that exists nowhere lets the authenticated tiers get
+// past the gate and 404 at the service, which counts as passing; the no-JWT
+// caller also passes the gate and is then failed closed by the handler with an
+// `UnauthorizedError` (not an `AccessTierError`), which still counts as passing
+// the gate. Item-level authorization (existence + read access before anything
+// ships to the provider) is the service layer's job — see
 // assertModerationItemAccess.
 const input = {
   itemType: 'post' as const,
@@ -16,10 +19,13 @@ const input = {
 };
 
 describeAccessTierGating('moderation.flagItem', {
-  noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {
-    const caller = await callers.noJwt();
-    await expectFailsAccessTierGate(caller.moderation.flagItem(input), 'none');
-  }),
+  noJwt: accessTierGatingCell(
+    'admits no-JWT caller past the tier gate (handler fails it closed)',
+    async ({ callers }) => {
+      const caller = await callers.noJwt();
+      await expectPassesAccessTierGate(caller.moderation.flagItem(input));
+    },
+  ),
 
   anonJwt: accessTierGatingCell(
     'admits anon-JWT caller past the tier gate',

--- a/services/api/src/routers/moderation/flagItem.gating.test.ts
+++ b/services/api/src/routers/moderation/flagItem.gating.test.ts
@@ -1,0 +1,47 @@
+import {
+  accessTierGatingCell,
+  describeAccessTierGating,
+  expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
+} from '../../test/helpers/gating';
+
+// A syntactically valid uuid that exists nowhere: the authenticated tiers get
+// past the gate and the service then 404s on the missing item, which still
+// counts as passing. Item-level authorization (existence + read access before
+// anything ships to the provider) is the service layer's job — see
+// assertModerationItemAccess.
+const input = {
+  itemType: 'post' as const,
+  itemId: '11111111-1111-4111-8111-111111111111',
+};
+
+describeAccessTierGating('moderation.flagItem', {
+  noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {
+    const caller = await callers.noJwt();
+    await expectFailsAccessTierGate(caller.moderation.flagItem(input), 'none');
+  }),
+
+  anonJwt: accessTierGatingCell(
+    'admits anon-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.anonJwt();
+      await expectPassesAccessTierGate(caller.moderation.flagItem(input));
+    },
+  ),
+
+  userJwt: accessTierGatingCell(
+    'admits user-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.userJwt();
+      await expectPassesAccessTierGate(caller.moderation.flagItem(input));
+    },
+  ),
+
+  networkJwt: accessTierGatingCell(
+    'admits network-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.networkJwt();
+      await expectPassesAccessTierGate(caller.moderation.flagItem(input));
+    },
+  ),
+});

--- a/services/api/src/routers/moderation/flagItem.test.ts
+++ b/services/api/src/routers/moderation/flagItem.test.ts
@@ -5,14 +5,12 @@ import {
 } from '../../test/helpers/gating';
 
 // flagItem is an `openProcedure`: the tier gate admits every caller (including
-// no-JWT) and authorization is fully the service/handler layer's job. A
-// syntactically valid uuid that exists nowhere lets the authenticated tiers get
-// past the gate and 404 at the service, which counts as passing; the no-JWT
-// caller also passes the gate and is then failed closed by the handler with an
-// `UnauthorizedError` (not an `AccessTierError`), which still counts as passing
-// the gate. Item-level authorization (existence + read access before anything
-// ships to the provider) is the service layer's job — see
-// assertModerationItemAccess.
+// no-JWT) and authorization is fully the service layer's job — a sessionless
+// caller is held to public visibility and may flag a publicly readable item. A
+// syntactically valid uuid that exists nowhere lets every tier (no-JWT
+// included) get past the gate and 404 at the service, which counts as passing.
+// Item-level authorization (existence + read access before anything ships to
+// the provider) is the service layer's job — see assertModerationItemAccess.
 const input = {
   itemType: 'post' as const,
   itemId: '11111111-1111-4111-8111-111111111111',

--- a/services/api/src/routers/moderation/index.ts
+++ b/services/api/src/routers/moderation/index.ts
@@ -1,8 +1,4 @@
-import {
-  UnauthorizedError,
-  getCurrentProfileId,
-  submitUserFlag,
-} from '@op/common';
+import { submitUserFlag } from '@op/common';
 import { z } from 'zod';
 
 import { openProcedure, router } from '../../trpcFactory';
@@ -18,30 +14,15 @@ const flagItemOutputSchema = z.object({
 });
 
 export const moderationRouter = router({
-  // A signed-in user reports an item. Records a pending flag and submits it for
-  // async provider review; the provider's webhook confirms or clears it.
-  // Tighter than the default rate limit: each call signs attachment URLs and
-  // makes outbound provider submissions, and nobody legitimately reports five
-  // items in a minute.
   flagItem: openProcedure({
     rateLimit: { windowSize: 60, maxRequests: 5 },
   })
     .input(flagItemInputSchema)
     .output(flagItemOutputSchema)
     .mutation(async ({ ctx, input }) => {
-      // openProcedure resolves an optional user; reporting records the reporter
-      // and ships the item's content to the provider, so fail closed without a
-      // session rather than letting an anonymous caller flag content.
-      if (!ctx.user) {
-        throw new UnauthorizedError('Must be signed in to report content');
-      }
-
-      const flaggedByProfileId = await getCurrentProfileId(ctx.user.id);
-
       const { flag } = await submitUserFlag({
         itemType: input.itemType,
         itemId: input.itemId,
-        flaggedByProfileId,
         reason: input.reason,
         user: ctx.user,
       });

--- a/services/api/src/routers/moderation/index.ts
+++ b/services/api/src/routers/moderation/index.ts
@@ -1,7 +1,11 @@
-import { getCurrentProfileId, submitUserFlag } from '@op/common';
+import {
+  UnauthorizedError,
+  getCurrentProfileId,
+  submitUserFlag,
+} from '@op/common';
 import { z } from 'zod';
 
-import { authenticatedProcedure, router } from '../../trpcFactory';
+import { openProcedure, router } from '../../trpcFactory';
 
 const flagItemInputSchema = z.object({
   itemType: z.enum(['proposal', 'post', 'user']),
@@ -11,7 +15,6 @@ const flagItemInputSchema = z.object({
 
 const flagItemOutputSchema = z.object({
   flagId: z.uuid(),
-  created: z.boolean(),
 });
 
 export const moderationRouter = router({
@@ -20,15 +23,22 @@ export const moderationRouter = router({
   // Tighter than the default rate limit: each call signs attachment URLs and
   // makes outbound provider submissions, and nobody legitimately reports five
   // items in a minute.
-  flagItem: authenticatedProcedure({
+  flagItem: openProcedure({
     rateLimit: { windowSize: 60, maxRequests: 5 },
   })
     .input(flagItemInputSchema)
     .output(flagItemOutputSchema)
     .mutation(async ({ ctx, input }) => {
+      // openProcedure resolves an optional user; reporting records the reporter
+      // and ships the item's content to the provider, so fail closed without a
+      // session rather than letting an anonymous caller flag content.
+      if (!ctx.user) {
+        throw new UnauthorizedError('Must be signed in to report content');
+      }
+
       const flaggedByProfileId = await getCurrentProfileId(ctx.user.id);
 
-      const { flag, created } = await submitUserFlag({
+      const { flag } = await submitUserFlag({
         itemType: input.itemType,
         itemId: input.itemId,
         flaggedByProfileId,
@@ -36,6 +46,6 @@ export const moderationRouter = router({
         user: ctx.user,
       });
 
-      return { flagId: flag.id, created };
+      return { flagId: flag.id };
     }),
 });

--- a/services/api/src/routers/moderation/index.ts
+++ b/services/api/src/routers/moderation/index.ts
@@ -1,0 +1,41 @@
+import { getCurrentProfileId, submitUserFlag } from '@op/common';
+import { z } from 'zod';
+
+import { authenticatedProcedure, router } from '../../trpcFactory';
+
+const flagItemInputSchema = z.object({
+  itemType: z.enum(['proposal', 'post', 'user']),
+  itemId: z.uuid(),
+  reason: z.string().max(1000).optional(),
+});
+
+const flagItemOutputSchema = z.object({
+  flagId: z.uuid(),
+  created: z.boolean(),
+});
+
+export const moderationRouter = router({
+  // A signed-in user reports an item. Records a pending flag and submits it for
+  // async provider review; the provider's webhook confirms or clears it.
+  // Tighter than the default rate limit: each call signs attachment URLs and
+  // makes outbound provider submissions, and nobody legitimately reports five
+  // items in a minute.
+  flagItem: authenticatedProcedure({
+    rateLimit: { windowSize: 60, maxRequests: 5 },
+  })
+    .input(flagItemInputSchema)
+    .output(flagItemOutputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const flaggedByProfileId = await getCurrentProfileId(ctx.user.id);
+
+      const { flag, created } = await submitUserFlag({
+        itemType: input.itemType,
+        itemId: input.itemId,
+        flaggedByProfileId,
+        reason: input.reason,
+        user: ctx.user,
+      });
+
+      return { flagId: flag.id, created };
+    }),
+});


### PR DESCRIPTION
Stacked on #1269.

The user-initiated report path, split out of #1269 so the automated-moderation flow can be reviewed on its own. Adds the `flagItem` / `submitUserFlag` services, the `assertModerationItemAccess` read-gate (flagging ships an item's text + signed attachment URLs to the external provider, so it's gated exactly like reading the item — posts like `getPost`, proposals like `getProposal`, user profiles existence-only), and the rate-limited `moderation.flagItem` tRPC route. A report records a `pending` flag and submits a fresh round to the provider; the verdict (handled in #1269) later confirms or clears it.

Depends on the shared stores, provider integration, and verdict pipeline in #1269.
