### PR TITLE
fix(realtime): invalidate infinite queries via channels

### DIFF
--- a/services/api/src/links.ts
+++ b/services/api/src/links.ts
@@ -94,6 +94,30 @@ function createFetchWithSSRCookies(encryptedCookies?: string) {
 }
 
 /**
+ * tRPC stores infinite queries under a different cache key than plain queries:
+ * `type: 'infinite'` with the `cursor`/`direction` pagination fields stripped
+ * (see getQueryKeyInternal). The link only ever sees `op.type === 'query'`, so
+ * the `type: 'query'` key it builds never matches an infinite list's cache
+ * entry. Registering this variant too lets channel invalidations reach
+ * paginated feeds (proposals, posts, …). Returns null when the input can't be
+ * an infinite key.
+ */
+function buildInfiniteQueryKey(
+  path: string,
+  input: unknown,
+): TRPCQueryKey | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+  const {
+    cursor: _cursor,
+    direction: _direction,
+    ...rest
+  } = input as Record<string, unknown>;
+  return [path.split('.'), { input: rest, type: 'infinite' }];
+}
+
+/**
  * Custom link that registers queries and mutations with the channel registry.
  *
  * Extracts channels from wrapped response body (_meta.channels) and unwraps
@@ -126,6 +150,19 @@ export function createChannelRegistrationLink(): TRPCLink<AppRouter> {
                   if (op.type === 'query') {
                     // Register query's channels for future invalidation
                     queryChannelRegistry.registerQuery({ queryKey, channels });
+                    // Infinite queries live under a `type: 'infinite'` cache key,
+                    // so also register that variant — otherwise paginated lists
+                    // never get invalidated by their channels.
+                    const infiniteQueryKey = buildInfiniteQueryKey(
+                      op.path,
+                      op.input,
+                    );
+                    if (infiniteQueryKey) {
+                      queryChannelRegistry.registerQuery({
+                        queryKey: infiniteQueryKey,
+                        channels,
+                      });
+                    }
                   } else if (op.type === 'mutation') {
                     // Get request ID from response headers, fallback to random UUID
                     const response = value.context?.response as


### PR DESCRIPTION
Realtime channel invalidation never reached infinite-query lists. The channel-registration link (`services/api/src/links.ts`) registered each query under a `type: 'query'` key, but tRPC stores infinite queries under a `type: 'infinite'` cache key with the `cursor`/`direction` fields stripped — so `invalidateQueries` (partial-match) never matched them, and paginated feeds (proposals, posts) only refreshed on remount/refocus rather than live on a mutation. This registers the infinite-query variant of the key alongside the existing one, so a mutation that broadcasts a channel now invalidates both plain and infinite subscribers. Verified against React Query's `partialDeepEqual`: the infinite key matches the infinite cache for every page, and the extra key is a no-op for plain queries (doesn't over-invalidate).