### PR TITLE
feat(decisions): let anonymous visitors upgrade to a full account

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { DecisionHeader } from '@/components/decisions/DecisionHeader';
 import { DecisionSidePanel } from '@/components/decisions/DecisionSidePanel';
 import { DecisionStateRouter } from '@/components/decisions/DecisionStateRouter';
 import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
+import { PromoteAccountModal } from '@/components/decisions/PromoteAccountModal';
 import { DecisionContentSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
 import { loadDecision } from './(decision-view)/loadDecision';
@@ -71,6 +72,7 @@ const DecisionPageContent = async ({ slug }: { slug: string }) => {
             decisionProfileId={decisionProfile.id}
             access={decisionProfile.processInstance.access}
           />
+          <PromoteAccountModal />
         </DecisionTranslationProvider>
       </div>
     </HydrationBoundary>

--- a/apps/app/src/app/[locale]/start/layout.tsx
+++ b/apps/app/src/app/[locale]/start/layout.tsx
@@ -1,5 +1,6 @@
 import { getUser } from '@/utils/getUser';
 import { assertWalledGardenAccess } from '@/utils/walledGarden';
+import { headers } from 'next/headers';
 
 import { Link } from '@/lib/i18n/routing';
 
@@ -9,8 +10,15 @@ import { TranslatedText } from '@/components/TranslatedText';
 const StartLayout = async ({ children }: { children: React.ReactNode }) => {
   const user = await getUser();
 
+  // Layouts don't receive searchParams, so read the query string the proxy
+  // exposes via x-search to detect the promote (anon-upgrade) onboarding. That
+  // flow is run by intentionally non-member accounts, so admit them past the
+  // membership gate while still redirecting any no-session/anonymous visitor.
+  const search = (await headers()).get('x-search') ?? '';
+  const isPromoteFlow = new URLSearchParams(search).get('promote') === '1';
+
   // Onboarding is inside the walled garden.
-  await assertWalledGardenAccess(user);
+  await assertWalledGardenAccess(user, { allowNonMembers: isPromoteFlow });
 
   return (
     <div className="relative flex h-svh w-full flex-col items-center justify-center font-sans">

--- a/apps/app/src/app/[locale]/start/layout.tsx
+++ b/apps/app/src/app/[locale]/start/layout.tsx
@@ -10,10 +10,8 @@ import { TranslatedText } from '@/components/TranslatedText';
 const StartLayout = async ({ children }: { children: React.ReactNode }) => {
   const user = await getUser();
 
-  // Layouts don't receive searchParams, so read the query string the proxy
-  // exposes via x-search to detect the promote (anon-upgrade) onboarding. That
-  // flow is run by intentionally non-member accounts, so admit them past the
-  // membership gate while still redirecting any no-session/anonymous visitor.
+  // Layouts don't get searchParams; read the query string the proxy exposes via
+  // x-search. The promote flow runs as non-members, so admit them past the gate.
   const search = (await headers()).get('x-search') ?? '';
   const isPromoteFlow = new URLSearchParams(search).get('promote') === '1';
 

--- a/apps/app/src/app/login/page.tsx
+++ b/apps/app/src/app/login/page.tsx
@@ -4,15 +4,26 @@ import { getSafeRedirectPath } from '@op/common/client';
 import { useAuthUser } from '@op/hooks';
 import { useSearchParams } from 'next/navigation';
 
+import { LinkAccountPanel } from '@/components/LinkAccountPanel';
 import { LoginPanel } from '@/components/LoginPanel';
 
 const LoginPage = () => {
   const user = useAuthUser();
   const searchParams = useSearchParams();
   const redirectParam = getSafeRedirectPath(searchParams.get('redirect'));
+  const isLinkMode = searchParams.get('link') === '1';
 
   if (!user || user.isFetching || user.isPending) {
     return null;
+  }
+
+  // Link mode: an anonymous visitor upgrading to a full account. They already
+  // have a session, so the walled-garden / signed-in paths below would bounce
+  // them. The dedicated panel links the new identity onto the anon user rather
+  // than creating a separate account. This must come before the walled-garden
+  // check below, which would otherwise send the upgrading visitor to LoginPanel.
+  if (isLinkMode && user.data?.user?.is_anonymous) {
+    return <LinkAccountPanel />;
   }
 
   // An anonymous session is not "signed in" for our purposes: the walled-garden

--- a/apps/app/src/app/login/page.tsx
+++ b/apps/app/src/app/login/page.tsx
@@ -17,11 +17,9 @@ const LoginPage = () => {
     return null;
   }
 
-  // Link mode: an anonymous visitor upgrading to a full account. They already
-  // have a session, so the walled-garden / signed-in paths below would bounce
-  // them. The dedicated panel links the new identity onto the anon user rather
-  // than creating a separate account. This must come before the walled-garden
-  // check below, which would otherwise send the upgrading visitor to LoginPanel.
+  // Link mode: an anonymous visitor upgrading to a full account. Must come
+  // before the checks below, which would otherwise bounce them to LoginPanel.
+  // LinkAccountPanel links the email onto the existing anon user.
   if (isLinkMode && user.data?.user?.is_anonymous) {
     return <LinkAccountPanel />;
   }

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -14,9 +14,7 @@ import { useTranslations } from '@/lib/i18n';
 
 import {
   AuthCodeField,
-  AuthDivider,
   AuthEmailField,
-  AuthGoogleButton,
   AuthPanelShell,
   isValidOtpLength,
   useAuthPanelStore,
@@ -27,10 +25,12 @@ import {
  *
  * Reached via `/login?link=1` (see PromoteAccountModal). The visitor already
  * has an anonymous Supabase session; instead of signing into a brand-new
- * account we *link* the chosen identity (Google or email OTP) onto that
- * existing anon user, so any data they created while anonymous (e.g. a
- * just-submitted idea) stays theirs.
- * See https://supabase.com/docs/guides/auth/auth-anonymous.
+ * account we *link* an email identity (via OTP) onto that existing anon user,
+ * so any data they created while anonymous (e.g. a just-submitted idea) stays
+ * theirs. See https://supabase.com/docs/guides/auth/auth-anonymous.
+ *
+ * TODO(anon-upgrade): Google identity linking is deferred to a follow-up PR;
+ * for now the only upgrade path is email + OTP.
  *
  * Normal login/signup lives in LoginPanel; login/page.tsx routes here only when
  * the visitor is actually anonymous.
@@ -79,25 +79,6 @@ export const LinkAccountPanel = () => {
     const locale = dest.split('/')[1] || 'en';
     window.location.href = `/${locale}/start?promote=1&redirect=${encodeURIComponent(dest)}`;
   }, [redirectParam]);
-
-  // Attach Google to the existing anon user instead of starting a new one.
-  const handleGoogle = async () => {
-    const callbackUrl = new URL('/api/auth/callback', location.origin);
-    if (isSafeRedirectPath(redirectParam)) {
-      callbackUrl.searchParams.set('redirect', redirectParam);
-    }
-
-    // TODO(anon-upgrade): linkIdentity fails if this Google identity already
-    // belongs to another account; we surface the raw Supabase error for now.
-    // Productionize with a friendly "that account already exists" path.
-    const { error } = await supabase.auth.linkIdentity({
-      provider: 'google',
-      options: { redirectTo: callbackUrl.toString() },
-    });
-    if (error) {
-      setLinkError(error.message);
-    }
-  };
 
   // Request the email code. `updateUser({ email })` attaches the email to the
   // current anon user. When email confirmations are enabled it sends an
@@ -276,39 +257,32 @@ export const LinkAccountPanel = () => {
     );
   }
 
-  // Create account (email entry) — email + Continue grouped (figma: 16px), then
-  // the "or" divider, then Google last.
+  // Create account (email entry) — email + Continue grouped (figma: 16px).
   return (
     <AuthPanelShell title={title} subtitle={subtitle}>
-      <div className="flex flex-col gap-8">
-        <div className="flex flex-col gap-4">
-          <AuthEmailField
-            label={t('Email')}
-            value={email}
-            isDisabled={isSubmitting}
-            onChange={(val) => {
-              setEmailIsValid(emailParser.safeParse(val).success);
-              setEmail(val);
-            }}
-            onSubmit={() => {
-              void requestEmailCode();
-            }}
-          />
-          <Button
-            type="button"
-            className="flex w-full items-center justify-center"
-            isDisabled={isSubmitting || !emailIsValid}
-            onPress={() => {
-              void requestEmailCode();
-            }}
-          >
-            {isSubmitting ? <LoadingSpinner /> : t('Continue')}
-          </Button>
-        </div>
-
-        <AuthDivider />
-
-        <AuthGoogleButton onPress={handleGoogle} />
+      <div className="flex flex-col gap-4">
+        <AuthEmailField
+          label={t('Email')}
+          value={email}
+          isDisabled={isSubmitting}
+          onChange={(val) => {
+            setEmailIsValid(emailParser.safeParse(val).success);
+            setEmail(val);
+          }}
+          onSubmit={() => {
+            void requestEmailCode();
+          }}
+        />
+        <Button
+          type="button"
+          className="flex w-full items-center justify-center"
+          isDisabled={isSubmitting || !emailIsValid}
+          onPress={() => {
+            void requestEmailCode();
+          }}
+        >
+          {isSubmitting ? <LoadingSpinner /> : t('Continue')}
+        </Button>
       </div>
     </AuthPanelShell>
   );

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from '@/lib/i18n';
 
 import {
   AuthCodeField,
+  AuthDivider,
   AuthEmailField,
   AuthGoogleButton,
   AuthPanelShell,
@@ -221,72 +222,94 @@ export const LinkAccountPanel = () => {
     );
   })();
 
-  return (
-    <AuthPanelShell title={title} subtitle={subtitle}>
-      {!errorMessage && (
-        <div className="flex flex-col gap-8">
-          {!loginSuccess && <AuthGoogleButton onPress={handleGoogle} />}
-
-          {!loginSuccess ? (
-            <AuthEmailField
-              label={t('Email')}
-              value={email}
-              isDisabled={isSubmitting}
-              onChange={(val) => {
-                setEmailIsValid(emailParser.safeParse(val).success);
-                setEmail(val);
-              }}
-              onSubmit={() => {
-                void requestEmailCode();
-              }}
-            />
-          ) : (
-            <AuthCodeField
-              value={token}
-              isDisabled={isSubmitting}
-              onChange={setToken}
-              onSubmit={handleTokenSubmit}
-            />
-          )}
-        </div>
-      )}
-
-      <section className="flex flex-col gap-6">
+  if (errorMessage) {
+    return (
+      <AuthPanelShell title={title} subtitle={subtitle}>
         <Button
-          type="button"
           className="flex w-full items-center justify-center"
-          isDisabled={
-            isSubmitting ||
-            (!loginSuccess && !emailIsValid) ||
-            (!!token && !isValidOtpLength(token))
-          }
-          onPress={async () => {
-            if (!loginSuccess) {
-              void requestEmailCode();
-            } else if (isValidOtpLength(token)) {
-              await handleTokenSubmit();
-            }
+          onPress={() => {
+            setLinkError(undefined);
+            setTokenError(undefined);
           }}
         >
-          {isSubmitting ? (
-            <LoadingSpinner />
-          ) : loginSuccess ? (
-            t('Create profile')
-          ) : (
-            t('Continue')
-          )}
+          {t('Try again')}
         </Button>
+      </AuthPanelShell>
+    );
+  }
 
-        {loginSuccess && (
+  // OTP entry ("Email sent!") — code field, then the Create profile / Go back
+  // stack (figma: 24px between field and buttons, 12px between buttons).
+  if (loginSuccess) {
+    return (
+      <AuthPanelShell title={title} subtitle={subtitle}>
+        <div className="flex flex-col gap-6">
+          <AuthCodeField
+            value={token}
+            isDisabled={isSubmitting}
+            onChange={setToken}
+            onSubmit={handleTokenSubmit}
+          />
+          <div className="flex flex-col gap-3">
+            <Button
+              type="button"
+              className="flex w-full items-center justify-center"
+              isDisabled={isSubmitting || !isValidOtpLength(token)}
+              onPress={async () => {
+                if (isValidOtpLength(token)) {
+                  await handleTokenSubmit();
+                }
+              }}
+            >
+              {isSubmitting ? <LoadingSpinner /> : t('Create profile')}
+            </Button>
+            <Button
+              color="secondary"
+              className="flex w-full items-center justify-center"
+              onPress={goBack}
+            >
+              {t('Go back')}
+            </Button>
+          </div>
+        </div>
+      </AuthPanelShell>
+    );
+  }
+
+  // Create account (email entry) — email + Continue grouped (figma: 16px), then
+  // the "or" divider, then Google last.
+  return (
+    <AuthPanelShell title={title} subtitle={subtitle}>
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-4">
+          <AuthEmailField
+            label={t('Email')}
+            value={email}
+            isDisabled={isSubmitting}
+            onChange={(val) => {
+              setEmailIsValid(emailParser.safeParse(val).success);
+              setEmail(val);
+            }}
+            onSubmit={() => {
+              void requestEmailCode();
+            }}
+          />
           <Button
-            color="secondary"
+            type="button"
             className="flex w-full items-center justify-center"
-            onPress={goBack}
+            isDisabled={isSubmitting || !emailIsValid}
+            onPress={() => {
+              void requestEmailCode();
+            }}
           >
-            {t('Go back')}
+            {isSubmitting ? <LoadingSpinner /> : t('Continue')}
           </Button>
-        )}
-      </section>
+        </div>
+
+        <AuthDivider />
+
+        <AuthGoogleButton onPress={handleGoogle} />
+      </div>
     </AuthPanelShell>
   );
 };

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -21,19 +21,12 @@ import {
 } from './AuthPanel';
 
 /**
- * Account-upgrade panel for an anonymous visitor ("link mode").
+ * Account-upgrade panel for an anonymous visitor ("link mode"), reached via
+ * `/login?link=1` (see PromoteAccountModal). Instead of a brand-new account we
+ * *link* an email identity (via OTP) onto the existing anon user, so data they
+ * created while anonymous stays theirs. Normal login/signup lives in LoginPanel.
  *
- * Reached via `/login?link=1` (see PromoteAccountModal). The visitor already
- * has an anonymous Supabase session; instead of signing into a brand-new
- * account we *link* an email identity (via OTP) onto that existing anon user,
- * so any data they created while anonymous (e.g. a just-submitted idea) stays
- * theirs. See https://supabase.com/docs/guides/auth/auth-anonymous.
- *
- * TODO(anon-upgrade): Google identity linking is deferred to a follow-up PR;
- * for now the only upgrade path is email + OTP.
- *
- * Normal login/signup lives in LoginPanel; login/page.tsx routes here only when
- * the visitor is actually anonymous.
+ * TODO(anon-upgrade): Google identity linking is deferred; email + OTP only.
  */
 export const LinkAccountPanel = () => {
   const supabase = createSBBrowserClient();
@@ -44,9 +37,8 @@ export const LinkAccountPanel = () => {
   const redirectParam = searchParams.get('redirect');
 
   const [linkError, setLinkError] = useState<string | undefined>();
-  // Guards the async Supabase calls against double-submit and drives the
-  // button's loading state (the login query that LoginPanel leans on for this
-  // does not run in link mode).
+  // Guards against double-submit and drives the button loading state (link mode
+  // doesn't run the login query LoginPanel relies on for this).
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const {
@@ -70,21 +62,17 @@ export const LinkAccountPanel = () => {
     ? `/login?redirect=${encodeURIComponent(redirectParam)}`
     : '/login';
 
-  // After linking, route the freshly-upgraded account through onboarding (which
-  // skips org-joining for this flow) and hand it the page to return to.
-  // `redirectParam` carries the locale prefix that the locale-less /login route
-  // lacks — reuse it for the /start path.
+  // After linking, route through onboarding with the page to return to.
+  // `redirectParam` carries the locale prefix the locale-less /login route lacks.
   const goAfterLink = useCallback(() => {
     const dest = isSafeRedirectPath(redirectParam) ? redirectParam : '/';
     const locale = dest.split('/')[1] || 'en';
     window.location.href = `/${locale}/start?promote=1&redirect=${encodeURIComponent(dest)}`;
   }, [redirectParam]);
 
-  // Request the email code. `updateUser({ email })` attaches the email to the
-  // current anon user. When email confirmations are enabled it sends an
-  // email-change OTP (→ code-entry screen); when they're disabled (e.g. local
-  // dev autoconfirm) the change applies immediately with no email, so we just
-  // refresh the session and continue.
+  // `updateUser({ email })` attaches the email to the anon user. With email
+  // confirmations on it sends an OTP (→ code screen); with them off the change
+  // applies immediately, so we refresh the session and continue.
   const requestEmailCode = async () => {
     if (isSubmitting) {
       return;
@@ -104,9 +92,7 @@ export const LinkAccountPanel = () => {
       }
       // No pending change + email already set ⇒ applied immediately (no OTP).
       if (data.user?.email === email && !data.user?.new_email) {
-        // The email change applied immediately, but the current access token
-        // still carries the stale anonymous claims — refresh it so the app sees
-        // the upgraded (non-anonymous) identity before navigating.
+        // Refresh so the token drops its stale anonymous claims before we nav.
         await supabase.auth.refreshSession();
         goAfterLink();
         return;

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import { isSafeRedirectPath } from '@op/common/client';
+import { useMount } from '@op/hooks';
+import { createSBBrowserClient } from '@op/supabase/client';
+import { Button } from '@op/ui/Button';
+import { CheckIcon } from '@op/ui/CheckIcon';
+import { LoadingSpinner } from '@op/ui/LoadingSpinner';
+import { useSearchParams } from 'next/navigation';
+import React, { useCallback, useState } from 'react';
+import { z } from 'zod';
+
+import { useTranslations } from '@/lib/i18n';
+
+import {
+  AuthCodeField,
+  AuthEmailField,
+  AuthGoogleButton,
+  AuthPanelShell,
+  isValidOtpLength,
+  useAuthPanelStore,
+} from './AuthPanel';
+
+/**
+ * Account-upgrade panel for an anonymous visitor ("link mode").
+ *
+ * Reached via `/login?link=1` (see PromoteAccountModal). The visitor already
+ * has an anonymous Supabase session; instead of signing into a brand-new
+ * account we *link* the chosen identity (Google or email OTP) onto that
+ * existing anon user, so any data they created while anonymous (e.g. a
+ * just-submitted idea) stays theirs.
+ * See https://supabase.com/docs/guides/auth/auth-anonymous.
+ *
+ * Normal login/signup lives in LoginPanel; login/page.tsx routes here only when
+ * the visitor is actually anonymous.
+ */
+export const LinkAccountPanel = () => {
+  const supabase = createSBBrowserClient();
+  const t = useTranslations();
+
+  const { mounted } = useMount();
+  const searchParams = useSearchParams();
+  const redirectParam = searchParams.get('redirect');
+
+  const [linkError, setLinkError] = useState<string | undefined>();
+  // Guards the async Supabase calls against double-submit and drives the
+  // button's loading state (the login query that LoginPanel leans on for this
+  // does not run in link mode).
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    email,
+    setEmail,
+    emailIsValid,
+    setEmailIsValid,
+    token,
+    setToken,
+    tokenError,
+    setTokenError,
+    loginSuccess,
+    setLoginSuccess,
+  } = useAuthPanelStore();
+
+  const emailParser = z.email();
+
+  // "Already have an account? Log in" — a real full account can't be linked
+  // onto the anon user, so that path drops link mode and goes to normal login.
+  const regularLoginHref = isSafeRedirectPath(redirectParam)
+    ? `/login?redirect=${encodeURIComponent(redirectParam)}`
+    : '/login';
+
+  // After linking, route the freshly-upgraded account through onboarding (which
+  // skips org-joining for this flow) and hand it the page to return to.
+  // `redirectParam` carries the locale prefix that the locale-less /login route
+  // lacks — reuse it for the /start path.
+  const goAfterLink = useCallback(() => {
+    const dest = isSafeRedirectPath(redirectParam) ? redirectParam : '/';
+    const locale = dest.split('/')[1] || 'en';
+    window.location.href = `/${locale}/start?promote=1&redirect=${encodeURIComponent(dest)}`;
+  }, [redirectParam]);
+
+  // Attach Google to the existing anon user instead of starting a new one.
+  const handleGoogle = async () => {
+    const callbackUrl = new URL('/api/auth/callback', location.origin);
+    if (isSafeRedirectPath(redirectParam)) {
+      callbackUrl.searchParams.set('redirect', redirectParam);
+    }
+
+    // TODO(anon-upgrade): linkIdentity fails if this Google identity already
+    // belongs to another account; we surface the raw Supabase error for now.
+    // Productionize with a friendly "that account already exists" path.
+    const { error } = await supabase.auth.linkIdentity({
+      provider: 'google',
+      options: { redirectTo: callbackUrl.toString() },
+    });
+    if (error) {
+      setLinkError(error.message);
+    }
+  };
+
+  // Request the email code. `updateUser({ email })` attaches the email to the
+  // current anon user. When email confirmations are enabled it sends an
+  // email-change OTP (→ code-entry screen); when they're disabled (e.g. local
+  // dev autoconfirm) the change applies immediately with no email, so we just
+  // refresh the session and continue.
+  const requestEmailCode = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setLinkError(undefined);
+
+    try {
+      // TODO(anon-upgrade): updateUser fails if this email already belongs to
+      // another account; we surface the raw Supabase error for now.
+      // Productionize with a friendly "that account already exists" path.
+      const { data, error } = await supabase.auth.updateUser({ email });
+      if (error) {
+        setLinkError(error.message);
+        return;
+      }
+      // No pending change + email already set ⇒ applied immediately (no OTP).
+      if (data.user?.email === email && !data.user?.new_email) {
+        // The email change applied immediately, but the current access token
+        // still carries the stale anonymous claims — refresh it so the app sees
+        // the upgraded (non-anonymous) identity before navigating.
+        await supabase.auth.refreshSession();
+        goAfterLink();
+        return;
+      }
+      setLoginSuccess(true);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleTokenSubmit = useCallback(async () => {
+    if (!token || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      // Link mode confirms an email *change* on the anon user.
+      const { data, error } = await supabase.auth.verifyOtp({
+        email,
+        token,
+        type: 'email_change',
+      });
+
+      if (data.user && data.session && data.user.role === 'authenticated') {
+        // Freshly upgraded from anonymous — send them through onboarding.
+        goAfterLink();
+        return;
+      }
+      setTokenError(error?.message ?? t('Failed to verify code'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [email, token, isSubmitting, goAfterLink, setTokenError, supabase, t]);
+
+  // "Go back" from the code screen returns to email entry without losing the
+  // anon session (only the success/token state is cleared).
+  const goBack = () => {
+    setLoginSuccess(false);
+    setToken(undefined);
+    setTokenError(undefined);
+    setLinkError(undefined);
+  };
+
+  if (!mounted) {
+    return null;
+  }
+
+  const errorMessage = linkError || tokenError;
+
+  const title = (() => {
+    if (errorMessage) {
+      return t('Oops!');
+    }
+    if (!loginSuccess) {
+      return t('Create an account');
+    }
+    return (
+      <div className="flex flex-col items-center justify-center gap-4">
+        <CheckIcon />
+        <span className="text-title-base sm:text-title-lg">
+          {t('Email sent!')}
+        </span>
+      </div>
+    );
+  })();
+
+  const subtitle = (() => {
+    if (errorMessage) {
+      return (
+        <span className={tokenError ? 'text-functional-red' : undefined}>
+          {errorMessage}
+        </span>
+      );
+    }
+    if (!loginSuccess) {
+      return t.rich('Already have an account? <login>Log in</login>', {
+        login: (chunks: React.ReactNode) => (
+          <a href={regularLoginHref} className="text-primary-teal underline">
+            {chunks}
+          </a>
+        ),
+      });
+    }
+    return (
+      <span>
+        {t(
+          'A code was sent to {email}. Type the code below to create your profile.',
+          {
+            email,
+          },
+        )}
+      </span>
+    );
+  })();
+
+  return (
+    <AuthPanelShell title={title} subtitle={subtitle}>
+      {!errorMessage && (
+        <div className="flex flex-col gap-8">
+          {!loginSuccess && <AuthGoogleButton onPress={handleGoogle} />}
+
+          {!loginSuccess ? (
+            <AuthEmailField
+              label={t('Email')}
+              value={email}
+              isDisabled={isSubmitting}
+              onChange={(val) => {
+                setEmailIsValid(emailParser.safeParse(val).success);
+                setEmail(val);
+              }}
+              onSubmit={() => {
+                void requestEmailCode();
+              }}
+            />
+          ) : (
+            <AuthCodeField
+              value={token}
+              isDisabled={isSubmitting}
+              onChange={setToken}
+              onSubmit={handleTokenSubmit}
+            />
+          )}
+        </div>
+      )}
+
+      <section className="flex flex-col gap-6">
+        <Button
+          type="button"
+          className="flex w-full items-center justify-center"
+          isDisabled={
+            isSubmitting ||
+            (!loginSuccess && !emailIsValid) ||
+            (!!token && !isValidOtpLength(token))
+          }
+          onPress={async () => {
+            if (!loginSuccess) {
+              void requestEmailCode();
+            } else if (isValidOtpLength(token)) {
+              await handleTokenSubmit();
+            }
+          }}
+        >
+          {isSubmitting ? (
+            <LoadingSpinner />
+          ) : loginSuccess ? (
+            t('Create profile')
+          ) : (
+            t('Continue')
+          )}
+        </Button>
+
+        {loginSuccess && (
+          <Button
+            color="secondary"
+            className="flex w-full items-center justify-center"
+            onPress={goBack}
+          >
+            {t('Go back')}
+          </Button>
+        )}
+      </section>
+    </AuthPanelShell>
+  );
+};
+
+export default LinkAccountPanel;

--- a/apps/app/src/components/MultiStepForm/index.tsx
+++ b/apps/app/src/components/MultiStepForm/index.tsx
@@ -46,8 +46,7 @@ export const MultiStepForm: React.FC<{
     (targetStep: number) => {
       setStep(targetStep);
 
-      // Preserve any existing query params (e.g. the promote-flow flag and its
-      // return redirect) across step navigation — only the step changes.
+      // Preserve existing query params (e.g. promote flag + redirect) across steps.
       const params = new URLSearchParams(window.location.search);
       params.set('step', targetStep.toString());
 

--- a/apps/app/src/components/MultiStepForm/index.tsx
+++ b/apps/app/src/components/MultiStepForm/index.tsx
@@ -45,9 +45,11 @@ export const MultiStepForm: React.FC<{
   const goToStep = React.useCallback(
     (targetStep: number) => {
       setStep(targetStep);
-      const query = { step: targetStep.toString() };
 
-      const params = new URLSearchParams(query);
+      // Preserve any existing query params (e.g. the promote-flow flag and its
+      // return redirect) across step navigation — only the step changes.
+      const params = new URLSearchParams(window.location.search);
+      params.set('step', targetStep.toString());
 
       // Navigate to the new URL
       router.push(`${window.location.pathname}?${params.toString()}`);

--- a/apps/app/src/components/Onboarding/PromoteOnboardingFlow.tsx
+++ b/apps/app/src/components/Onboarding/PromoteOnboardingFlow.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { analyzeError, useConnectionStatus } from '@/utils/connectionErrors';
+import { trpc } from '@op/api/client';
+import { isSafeRedirectPath } from '@op/common/client';
+import { LoadingSpinner } from '@op/ui/LoadingSpinner';
+import { StepperProgressIndicator } from '@op/ui/Stepper';
+import { toast } from '@op/ui/Toast';
+import { useSearchParams } from 'next/navigation';
+import React, { useCallback, useMemo, useState } from 'react';
+import { z } from 'zod';
+
+import { useTranslations } from '@/lib/i18n';
+
+import {
+  MultiStepForm,
+  ProgressComponentProps,
+  StepProps,
+} from '../MultiStepForm';
+import { Portal } from '../Portal';
+import {
+  PersonalDetailsForm,
+  validator as PersonalDetailsFormValidator,
+} from './PersonalDetailsForm';
+import { ToSAcceptanceScreen } from './ToSAcceptanceScreen';
+import { useOnboardingFormStore } from './useOnboardingFormStore';
+
+// The ToS step collects no form values of its own.
+const ToSStepValidator = z.object({});
+
+const ProgressInPortal = (props: ProgressComponentProps) => (
+  <Portal id="top-slot">
+    <StepperProgressIndicator {...props} />
+  </Portal>
+);
+
+/**
+ * Onboarding journey for an anonymous visitor who just upgraded to a full
+ * account (see LinkAccountPanel / PromoteAccountModal). Reached at
+ * `/start?promote=1`.
+ *
+ * Unlike the normal flow it skips organization joining/creation entirely:
+ * personal details, accept ToS, then hard-navigate back to the decision they
+ * came from so the now-authenticated tree mounts with a fresh cache.
+ */
+export const PromoteOnboardingFlow = ({
+  hasHydrated,
+}: {
+  hasHydrated: boolean;
+}) => {
+  const t = useTranslations();
+  const isOnline = useConnectionStatus();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { personalDetails } = useOnboardingFormStore();
+  const trpcUtils = trpc.useUtils();
+  const completeOnboarding = trpc.account.completeOnboarding.useMutation();
+
+  const searchParams = useSearchParams();
+  const redirectParam = searchParams.get('redirect');
+  const promoteRedirect = isSafeRedirectPath(redirectParam)
+    ? redirectParam
+    : '/';
+
+  const getStepValues = useCallback(() => {
+    return [personalDetails, {}];
+  }, [personalDetails]);
+
+  const handleComplete = useCallback(async () => {
+    if (!isOnline) {
+      toast.error({
+        title: t('No connection'),
+        message: t('Please check your internet connection and try again.'),
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await completeOnboarding.mutateAsync({ tos: true, privacy: true });
+      await trpcUtils.account.getMyAccount.invalidate();
+      window.location.assign(promoteRedirect);
+    } catch (err) {
+      setIsSubmitting(false);
+      const errorInfo = analyzeError(err);
+      toast.error({
+        title: errorInfo.isConnectionError
+          ? t('Connection issue')
+          : t("That didn't work"),
+        message: errorInfo.isConnectionError
+          ? t('Please try submitting the form again.')
+          : errorInfo.message,
+      });
+    }
+  }, [isOnline, completeOnboarding, trpcUtils, promoteRedirect, t]);
+
+  const ToSStep = useMemo(() => {
+    const Step = (props: StepProps) => (
+      <ToSAcceptanceScreen
+        onAccept={() => {
+          void handleComplete();
+        }}
+        onGoBack={props.onBack}
+        isSubmitting={isSubmitting}
+      />
+    );
+    return Step;
+  }, [handleComplete, isSubmitting]);
+
+  if (isSubmitting) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <MultiStepForm
+      steps={[PersonalDetailsForm, ToSStep]}
+      schemas={[PersonalDetailsFormValidator, ToSStepValidator]}
+      ProgressComponent={ProgressInPortal}
+      getStepValues={getStepValues}
+      hasHydrated={hasHydrated}
+    />
+  );
+};

--- a/apps/app/src/components/Onboarding/PromoteOnboardingFlow.tsx
+++ b/apps/app/src/components/Onboarding/PromoteOnboardingFlow.tsx
@@ -35,13 +35,10 @@ const ProgressInPortal = (props: ProgressComponentProps) => (
 );
 
 /**
- * Onboarding journey for an anonymous visitor who just upgraded to a full
- * account (see LinkAccountPanel / PromoteAccountModal). Reached at
- * `/start?promote=1`.
- *
- * Unlike the normal flow it skips organization joining/creation entirely:
- * personal details, accept ToS, then hard-navigate back to the decision they
- * came from so the now-authenticated tree mounts with a fresh cache.
+ * Onboarding for an anonymous visitor who just upgraded (see LinkAccountPanel /
+ * PromoteAccountModal), reached at `/start?promote=1`. Skips org joining:
+ * personal details, accept ToS, then hard-navigate back to the decision with a
+ * fresh cache.
  */
 export const PromoteOnboardingFlow = ({
   hasHydrated,

--- a/apps/app/src/components/Onboarding/index.tsx
+++ b/apps/app/src/components/Onboarding/index.tsx
@@ -55,10 +55,8 @@ const ProgressInPortal = (props: ProgressComponentProps) => (
   </Portal>
 );
 
-// Warms the cache for the organization-search step. Rendered only on the
-// org-search branch — the promote flow skips that step entirely, so prefetching
-// there would fire a network-tier request the upgraded user never needs (and
-// can't make), surfacing a spurious 403.
+// Prefetch for the org-search step. Only on the org-search branch: the promote
+// flow skips it, and prefetching there fires a network-tier 403 for the new user.
 const PrefetchDomainOrganizations = () => {
   void trpc.account.listMatchingDomainOrganizations.usePrefetchQuery();
   return null;
@@ -91,9 +89,8 @@ export const OnboardingFlow = () => {
   const completeOnboarding = trpc.account.completeOnboarding.useMutation();
   const createOrganization = trpc.organization.create.useMutation();
 
-  // Promote flow: an anonymous visitor who just upgraded to a full account (see
-  // PromoteAccountModal/LinkAccountPanel). They skip organization joining
-  // entirely — that journey lives in PromoteOnboardingFlow.
+  // Promote flow (just-upgraded anon visitor) skips org joining; that journey
+  // lives in PromoteOnboardingFlow.
   const searchParams = useSearchParams();
   const isPromoteFlow = searchParams.get('promote') === '1';
 

--- a/apps/app/src/components/Onboarding/index.tsx
+++ b/apps/app/src/components/Onboarding/index.tsx
@@ -5,7 +5,7 @@ import { trpc } from '@op/api/client';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { StepperProgressIndicator } from '@op/ui/Stepper';
 import { toast } from '@op/ui/Toast';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useCallback, useMemo, useState } from 'react';
 import { z } from 'zod';
 
@@ -33,6 +33,7 @@ import {
   PrivacyPolicyForm,
   validator as PrivacyPolicyFormValidator,
 } from './PrivacyPolicyForm';
+import { PromoteOnboardingFlow } from './PromoteOnboardingFlow';
 import { ToSForm, validator as ToSFormValidator } from './ToSForm';
 import { organizationFormValidator as OrganizationDetailsFormValidator } from './shared/organizationValidation';
 import { useOnboardingFormStore } from './useOnboardingFormStore';
@@ -81,6 +82,12 @@ export const OnboardingFlow = () => {
   const createJoinRequest = trpc.profile.createJoinRequest.useMutation();
   const completeOnboarding = trpc.account.completeOnboarding.useMutation();
   const createOrganization = trpc.organization.create.useMutation();
+
+  // Promote flow: an anonymous visitor who just upgraded to a full account (see
+  // PromoteAccountModal/LinkAccountPanel). They skip organization joining
+  // entirely — that journey lives in PromoteOnboardingFlow.
+  const searchParams = useSearchParams();
+  const isPromoteFlow = searchParams.get('promote') === '1';
 
   // Handle hydration detection
   React.useEffect(() => {
@@ -280,6 +287,10 @@ export const OnboardingFlow = () => {
 
   if (isSubmitting) {
     return <LoadingSpinner />;
+  }
+
+  if (isPromoteFlow) {
+    return <PromoteOnboardingFlow hasHydrated={hasHydrated} />;
   }
 
   if (createOrgMode) {

--- a/apps/app/src/components/Onboarding/index.tsx
+++ b/apps/app/src/components/Onboarding/index.tsx
@@ -55,6 +55,15 @@ const ProgressInPortal = (props: ProgressComponentProps) => (
   </Portal>
 );
 
+// Warms the cache for the organization-search step. Rendered only on the
+// org-search branch — the promote flow skips that step entirely, so prefetching
+// there would fire a network-tier request the upgraded user never needs (and
+// can't make), surfacing a spurious 403.
+const PrefetchDomainOrganizations = () => {
+  void trpc.account.listMatchingDomainOrganizations.usePrefetchQuery();
+  return null;
+};
+
 const processOrgInputs = (data: OrgCreationFormValues) => ({
   ...data,
   website: data.website ?? '',
@@ -68,7 +77,6 @@ export const OnboardingFlow = () => {
   const [invitesComplete, setInvitesComplete] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [createOrgMode, setCreateOrgMode] = useState(false);
-  void trpc.account.listMatchingDomainOrganizations.usePrefetchQuery();
   const {
     personalDetails,
     organizationDetails,
@@ -317,12 +325,18 @@ export const OnboardingFlow = () => {
   }
 
   return (
-    <MultiStepForm
-      steps={[PersonalDetailsForm, OrganizationSearchStep]}
-      schemas={[PersonalDetailsFormValidator, OrganizationSearchStepValidator]}
-      ProgressComponent={ProgressInPortal}
-      getStepValues={getStepValues}
-      hasHydrated={hasHydrated}
-    />
+    <>
+      <PrefetchDomainOrganizations />
+      <MultiStepForm
+        steps={[PersonalDetailsForm, OrganizationSearchStep]}
+        schemas={[
+          PersonalDetailsFormValidator,
+          OrganizationSearchStepValidator,
+        ]}
+        ProgressComponent={ProgressInPortal}
+        getStepValues={getStepValues}
+        hasHydrated={hasHydrated}
+      />
+    </>
   );
 };

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useUser } from '@/utils/UserProvider';
+import { Button } from '@op/ui/Button';
+import { CheckIcon } from '@op/ui/CheckIcon';
+import { Checkbox } from '@op/ui/Checkbox';
+import { Header1 } from '@op/ui/Header';
+import { Modal } from '@op/ui/Modal';
+import { useQueryState } from 'nuqs';
+import { useState } from 'react';
+import { LuUser, LuUserPlus } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+/**
+ * Promote an anonymous visitor to a full account.
+ *
+ * Shown when `?promote=1` is on the URL, which ProposalEditor sets after an
+ * anonymous visitor submits their idea.
+ *
+ * "Create account" / "Log in" send the visitor to the real login page in
+ * link mode (`/login?link=1`), which reuses our existing auth methods (Google,
+ * email OTP) but *links* the chosen identity onto the current anonymous user
+ * instead of creating a separate account — so the idea they just submitted
+ * stays theirs (https://supabase.com/docs/guides/auth/auth-anonymous).
+ * See LinkAccountPanel for the linking logic.
+ */
+
+export const PromoteAccountModal = () => {
+  const { user } = useUser();
+  const [promote, setPromote] = useQueryState('promote');
+  // The just-submitted proposal's profileId, so we can return the visitor to
+  // their own idea (the proposal view) after they finish creating an account.
+  const [proposalId] = useQueryState('proposal');
+
+  // Only anonymous sign-ins can be promoted — a full account has nothing to
+  // upgrade, and a no-session visitor has no anon identity to attach an email
+  // to yet. (`isAnonymous` is the session-derived flag, same as onboarding.ts.)
+  const isAnonymous = Boolean(user?.isAnonymous);
+  const isOpen = isAnonymous && promote === '1';
+
+  const close = () => {
+    void setPromote(null);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={(open) => (open ? null : close())}>
+      <PromoteAccountModalContent
+        onContinueAsGuest={close}
+        proposalId={proposalId}
+      />
+    </Modal>
+  );
+};
+
+const PromoteAccountModalContent = ({
+  onContinueAsGuest,
+  proposalId,
+}: {
+  onContinueAsGuest: () => void;
+  proposalId: string | null;
+}) => {
+  const t = useTranslations();
+  const [agreed, setAgreed] = useState(false);
+
+  // Send them to the login page in link mode, returning to their idea once
+  // linked. The current path is the decision; appending /proposal/<id> targets
+  // the proposal view they just created (falls back to the decision page).
+  //
+  // TODO(anon-upgrade): "Create account" and "Already have an account? Log in"
+  // intentionally share this link-mode entry for now. Link mode can't attach an
+  // email/identity that already belongs to a full account, so an existing-account
+  // user routed here will hit the (raw) Supabase collision error in
+  // LinkAccountPanel. Productionize by routing "Log in" to normal /login and
+  // deciding what happens to the abandoned anonymous draft.
+  const goToLogin = () => {
+    const base = window.location.pathname;
+    const redirect = proposalId ? `${base}/proposal/${proposalId}` : base;
+    window.location.assign(
+      `/login?link=1&redirect=${encodeURIComponent(redirect)}`,
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-6 p-8">
+      <div className="flex flex-col items-center gap-3 text-center">
+        <CheckIcon />
+        <Header1 className="sm:text-title-base">
+          {t('Your idea was submitted.')}
+        </Header1>
+        <p className="text-neutral-gray4">
+          {t('Want to follow what happens next?')}
+        </p>
+      </div>
+
+      <section className="flex flex-col gap-3 rounded-lg border p-4">
+        <div className="flex items-center gap-2">
+          <LuUser className="size-5 text-neutral-charcoal" aria-hidden />
+          <span className="font-medium">{t('Continue as a guest')}</span>
+        </div>
+        <p className="text-sm text-neutral-gray4">
+          {t('Stay anonymous. React to comments with emoji.')}
+        </p>
+        {/* TODO(anon-upgrade): accepting this only gates the button — it does not
+            persist ToS/privacy acceptance for the anonymous account anywhere.
+            Either record it for the anon user or drop the checkbox on the guest
+            path. */}
+        <Checkbox isSelected={agreed} onChange={setAgreed}>
+          <span className="text-sm">
+            {t('I agree to the Terms of Service and Privacy Policy')}
+          </span>
+        </Checkbox>
+        <Button
+          color="secondary"
+          className="w-full"
+          isDisabled={!agreed}
+          onPress={onContinueAsGuest}
+        >
+          {t('Continue as guest')}
+        </Button>
+      </section>
+
+      <section className="flex flex-col gap-3 rounded-lg border p-4">
+        <div className="flex items-center gap-2">
+          <LuUserPlus className="size-5 text-neutral-charcoal" aria-hidden />
+          <span className="font-medium">{t('With an account')}</span>
+        </div>
+        <p className="text-sm text-neutral-gray4">
+          {t(
+            'Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.',
+          )}
+        </p>
+        <Button className="w-full" onPress={goToLogin}>
+          {t('Create account')}
+        </Button>
+      </section>
+
+      <p className="text-center text-sm text-neutral-gray4">
+        {t('Already have an account?')}{' '}
+        <button
+          type="button"
+          onClick={goToLogin}
+          className="text-primary-teal underline"
+        >
+          {t('Log in')}
+        </button>
+      </p>
+    </div>
+  );
+};

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -8,7 +8,7 @@ import { Header1 } from '@op/ui/Header';
 import { Modal } from '@op/ui/Modal';
 import { useQueryState } from 'nuqs';
 import { useState } from 'react';
-import { LuUser, LuUserPlus } from 'react-icons/lu';
+import { LuUserRoundMinus, LuUserRoundPlus } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -82,60 +82,74 @@ const PromoteAccountModalContent = ({
   };
 
   return (
-    <div className="flex flex-col gap-6 p-8">
-      <div className="flex flex-col items-center gap-3 text-center">
+    <div className="flex flex-col gap-6 p-8 sm:px-12 sm:pt-12">
+      <div className="flex flex-col items-center gap-4 text-center">
         <CheckIcon />
-        <Header1 className="sm:text-title-base">
-          {t('Your idea was submitted.')}
-        </Header1>
-        <p className="text-neutral-gray4">
-          {t('Want to follow what happens next?')}
-        </p>
+        <div className="flex flex-col gap-2">
+          <Header1 className="text-neutral-black">
+            {t('Your idea was submitted.')}
+          </Header1>
+          <p className="text-sm text-neutral-charcoal">
+            {t('Want to follow what happens next?')}
+          </p>
+        </div>
       </div>
 
-      <section className="flex flex-col gap-3 rounded-lg border p-4">
-        <div className="flex items-center gap-2">
-          <LuUser className="size-5 text-neutral-charcoal" aria-hidden />
-          <span className="font-medium">{t('Continue as a guest')}</span>
-        </div>
-        <p className="text-sm text-neutral-gray4">
-          {t('Stay anonymous. React to comments with emoji.')}
-        </p>
-        {/* TODO(anon-upgrade): accepting this only gates the button — it does not
-            persist ToS/privacy acceptance for the anonymous account anywhere.
-            Either record it for the anon user or drop the checkbox on the guest
-            path. */}
-        <Checkbox isSelected={agreed} onChange={setAgreed}>
-          <span className="text-sm">
-            {t('I agree to the Terms of Service and Privacy Policy')}
-          </span>
-        </Checkbox>
-        <Button
-          color="secondary"
-          className="w-full"
-          isDisabled={!agreed}
-          onPress={onContinueAsGuest}
-        >
-          {t('Continue as guest')}
-        </Button>
-      </section>
+      <div className="flex flex-col gap-4">
+        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-white p-4 text-left">
+          <div className="flex items-center gap-1">
+            <LuUserRoundMinus
+              className="size-4 text-neutral-charcoal"
+              aria-hidden
+            />
+            <span className="font-serif text-title-sm text-neutral-charcoal">
+              {t('Continue as a guest')}
+            </span>
+          </div>
+          <p className="text-sm text-neutral-charcoal">
+            {t('Stay anonymous. React to comments with emoji.')}
+          </p>
+          {/* TODO(anon-upgrade): accepting this only gates the button — it does
+              not persist ToS/privacy acceptance for the anonymous account
+              anywhere. Either record it for the anon user or drop the checkbox
+              on the guest path. */}
+          <Checkbox isSelected={agreed} onChange={setAgreed}>
+            <span className="text-sm">
+              {t('I agree to the Terms of Service and Privacy Policy')}
+            </span>
+          </Checkbox>
+          <Button
+            color="secondary"
+            className="w-full"
+            isDisabled={!agreed}
+            onPress={onContinueAsGuest}
+          >
+            {t('Continue as guest')}
+          </Button>
+        </section>
 
-      <section className="flex flex-col gap-3 rounded-lg border p-4">
-        <div className="flex items-center gap-2">
-          <LuUserPlus className="size-5 text-neutral-charcoal" aria-hidden />
-          <span className="font-medium">{t('With an account')}</span>
-        </div>
-        <p className="text-sm text-neutral-gray4">
-          {t(
-            'Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.',
-          )}
-        </p>
-        <Button className="w-full" onPress={goToLogin}>
-          {t('Create account')}
-        </Button>
-      </section>
+        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-neutral-off-white p-4 text-left">
+          <div className="flex items-center gap-1">
+            <LuUserRoundPlus
+              className="size-4 text-neutral-charcoal"
+              aria-hidden
+            />
+            <span className="font-serif text-title-sm text-neutral-charcoal">
+              {t('With an account')}
+            </span>
+          </div>
+          <p className="text-sm text-neutral-charcoal">
+            {t(
+              'Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.',
+            )}
+          </p>
+          <Button className="w-full" onPress={goToLogin}>
+            {t('Create account')}
+          </Button>
+        </section>
+      </div>
 
-      <p className="text-center text-sm text-neutral-gray4">
+      <p className="text-center text-sm text-neutral-charcoal">
         {t('Already have an account?')}{' '}
         <button
           type="button"

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -38,7 +38,11 @@ export const PromoteAccountModal = () => {
   };
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={(open) => (open ? null : close())}>
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => (open ? null : close())}
+      className="sm:max-w-[29rem]"
+    >
       <PromoteAccountModalContent
         onContinueAsGuest={close}
         proposalId={proposalId}
@@ -80,7 +84,7 @@ const PromoteAccountModalContent = ({
           <Header1 className="text-neutral-black">
             {t('Your idea was submitted.')}
           </Header1>
-          <p className="text-sm text-neutral-charcoal">
+          <p className="text-base text-neutral-charcoal">
             {t('Want to follow what happens next?')}
           </p>
         </div>
@@ -97,16 +101,16 @@ const PromoteAccountModalContent = ({
               {t('Continue as a guest')}
             </span>
           </div>
-          <p className="text-sm text-neutral-charcoal">
+          <p className="text-base text-neutral-charcoal">
             {t('Stay anonymous. React to comments with emoji.')}
           </p>
           {/* TODO(anon-upgrade): this checkbox only gates the button; ToS/privacy
               acceptance isn't persisted for the anon account. Pending team
               decision on what accepting terms means for an anonymous user. */}
-          <Checkbox isSelected={agreed} onChange={setAgreed}>
+          <Checkbox size="small" isSelected={agreed} onChange={setAgreed}>
             <span className="text-sm">
               {t.rich(
-                'I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>',
+                'I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.',
                 {
                   tos: (chunks: ReactNode) => (
                     <PolicyLink href="/info/tos">{chunks}</PolicyLink>
@@ -138,7 +142,7 @@ const PromoteAccountModalContent = ({
               {t('With an account')}
             </span>
           </div>
-          <p className="text-sm text-neutral-charcoal">
+          <p className="text-base text-neutral-charcoal">
             {t(
               'Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.',
             )}
@@ -149,16 +153,8 @@ const PromoteAccountModalContent = ({
         </section>
       </div>
 
-      <p className="text-center text-sm text-neutral-charcoal">
-        {t('Already have an account?')}{' '}
-        <button
-          type="button"
-          onClick={goToLogin}
-          className="text-primary-teal underline"
-        >
-          {t('Log in')}
-        </button>
-      </p>
+      {/* TODO(anon-upgrade): restore "Already have an account? Log in" once we
+          support linking an email that already belongs to a full account. */}
     </div>
   );
 };

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -7,23 +7,18 @@ import { Checkbox } from '@op/ui/Checkbox';
 import { Header1 } from '@op/ui/Header';
 import { Modal } from '@op/ui/Modal';
 import { useQueryState } from 'nuqs';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { LuUserRoundMinus, LuUserRoundPlus } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
 /**
- * Promote an anonymous visitor to a full account.
+ * Promote an anonymous visitor to a full account. Shown when `?promote=1` is on
+ * the URL (set by ProposalEditor after an anon visitor submits their idea).
  *
- * Shown when `?promote=1` is on the URL, which ProposalEditor sets after an
- * anonymous visitor submits their idea.
- *
- * "Create account" / "Log in" send the visitor to the real login page in
- * link mode (`/login?link=1`), which *links* an email identity (via OTP) onto
- * the current anonymous user instead of creating a separate account — so the
- * idea they just submitted stays theirs
- * (https://supabase.com/docs/guides/auth/auth-anonymous).
- * See LinkAccountPanel for the linking logic.
+ * "Create account" / "Log in" route to `/login?link=1`, which *links* an email
+ * identity onto the anon user (keeping their idea) rather than creating a new
+ * account. See LinkAccountPanel.
  */
 
 export const PromoteAccountModal = () => {
@@ -33,9 +28,8 @@ export const PromoteAccountModal = () => {
   // their own idea (the proposal view) after they finish creating an account.
   const [proposalId] = useQueryState('proposal');
 
-  // Only anonymous sign-ins can be promoted — a full account has nothing to
-  // upgrade, and a no-session visitor has no anon identity to attach an email
-  // to yet. (`isAnonymous` is the session-derived flag, same as onboarding.ts.)
+  // Only anonymous sign-ins can be promoted; a full account has nothing to
+  // upgrade. (`isAnonymous` is session-derived, same as onboarding.ts.)
   const isAnonymous = Boolean(user?.isAnonymous);
   const isOpen = isAnonymous && promote === '1';
 
@@ -63,16 +57,13 @@ const PromoteAccountModalContent = ({
   const t = useTranslations();
   const [agreed, setAgreed] = useState(false);
 
-  // Send them to the login page in link mode, returning to their idea once
-  // linked. The current path is the decision; appending /proposal/<id> targets
-  // the proposal view they just created (falls back to the decision page).
+  // Login in link mode, returning to the proposal once linked (falls back to the
+  // decision page).
   //
-  // TODO(anon-upgrade): "Create account" and "Already have an account? Log in"
-  // intentionally share this link-mode entry for now. Link mode can't attach an
-  // email/identity that already belongs to a full account, so an existing-account
-  // user routed here will hit the (raw) Supabase collision error in
-  // LinkAccountPanel. Productionize by routing "Log in" to normal /login and
-  // deciding what happens to the abandoned anonymous draft.
+  // TODO(anon-upgrade): "Create account" and "Log in" share this link-mode entry.
+  // An existing full account can't be linked, so that user hits the raw Supabase
+  // collision error in LinkAccountPanel — route "Log in" to /login and handle the
+  // abandoned anon draft.
   const goToLogin = () => {
     const base = window.location.pathname;
     const redirect = proposalId ? `${base}/proposal/${proposalId}` : base;
@@ -109,13 +100,22 @@ const PromoteAccountModalContent = ({
           <p className="text-sm text-neutral-charcoal">
             {t('Stay anonymous. React to comments with emoji.')}
           </p>
-          {/* TODO(anon-upgrade): accepting this only gates the button — it does
-              not persist ToS/privacy acceptance for the anonymous account
-              anywhere. Either record it for the anon user or drop the checkbox
-              on the guest path. */}
+          {/* TODO(anon-upgrade): this checkbox only gates the button; ToS/privacy
+              acceptance isn't persisted for the anon account. Pending team
+              decision on what accepting terms means for an anonymous user. */}
           <Checkbox isSelected={agreed} onChange={setAgreed}>
             <span className="text-sm">
-              {t('I agree to the Terms of Service and Privacy Policy')}
+              {t.rich(
+                'I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>',
+                {
+                  tos: (chunks: ReactNode) => (
+                    <PolicyLink href="/info/tos">{chunks}</PolicyLink>
+                  ),
+                  privacy: (chunks: ReactNode) => (
+                    <PolicyLink href="/info/privacy">{chunks}</PolicyLink>
+                  ),
+                },
+              )}
             </span>
           </Checkbox>
           <Button
@@ -162,3 +162,25 @@ const PromoteAccountModalContent = ({
     </div>
   );
 };
+
+// Opens a policy page in a new tab without toggling the consent checkbox it
+// sits inside (stop the press from reaching the surrounding React Aria
+// Checkbox).
+const PolicyLink = ({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noreferrer"
+    className="text-primary-teal underline"
+    onClick={(e) => e.stopPropagation()}
+    onPointerDown={(e) => e.stopPropagation()}
+  >
+    {children}
+  </a>
+);

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -19,10 +19,10 @@ import { useTranslations } from '@/lib/i18n';
  * anonymous visitor submits their idea.
  *
  * "Create account" / "Log in" send the visitor to the real login page in
- * link mode (`/login?link=1`), which reuses our existing auth methods (Google,
- * email OTP) but *links* the chosen identity onto the current anonymous user
- * instead of creating a separate account — so the idea they just submitted
- * stays theirs (https://supabase.com/docs/guides/auth/auth-anonymous).
+ * link mode (`/login?link=1`), which *links* an email identity (via OTP) onto
+ * the current anonymous user instead of creating a separate account — so the
+ * idea they just submitted stays theirs
+ * (https://supabase.com/docs/guides/auth/auth-anonymous).
  * See LinkAccountPanel for the linking logic.
  */
 

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -192,7 +192,14 @@ function ProposalEditorInner({
   const router = useRouter();
   const locale = useLocale();
   const t = useTranslations();
+  const { user } = useRequiredUser();
   const utils = trpc.useUtils();
+
+  // After an anonymous visitor submits their idea, send them back to the
+  // decision page with ?promote=1 so PromoteAccountModal offers them an upgrade.
+  // A full account has nothing to promote. `isAnonymous` is the session-derived
+  // flag (see PromoteAccountModal / onboarding.ts), not the stale DB relation.
+  const isAnonymous = Boolean(user?.isAnonymous);
   const { ydoc, provider, isSynced } = useCollaborativeDoc();
   const versionPreview = useOptionalVersionPreview();
 
@@ -338,13 +345,19 @@ function ProposalEditorInner({
         },
       });
 
+      let didSubmitDraft = false;
       if (isDraft) {
         await submitProposalMutation.mutateAsync({
           proposalId: proposal.id,
         });
+        didSubmitDraft = true;
       }
 
-      router.push(backHref);
+      router.push(
+        didSubmitDraft && isAnonymous
+          ? `${backHref}?promote=1&proposal=${proposal.profileId}`
+          : backHref,
+      );
     } catch (error) {
       console.error('Failed to update proposal:', error);
     } finally {
@@ -355,6 +368,9 @@ function ProposalEditorInner({
     collaborationDocId,
     proposal,
     isDraft,
+    isAnonymous,
+    backHref,
+    router,
     submitProposalMutation,
     updateProposalMutation,
     draftRef,

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -195,10 +195,8 @@ function ProposalEditorInner({
   const { user } = useRequiredUser();
   const utils = trpc.useUtils();
 
-  // After an anonymous visitor submits their idea, send them back to the
-  // decision page with ?promote=1 so PromoteAccountModal offers them an upgrade.
-  // A full account has nothing to promote. `isAnonymous` is the session-derived
-  // flag (see PromoteAccountModal / onboarding.ts), not the stale DB relation.
+  // Anon visitors get sent back with ?promote=1 so PromoteAccountModal offers an
+  // upgrade. `isAnonymous` is session-derived, not the stale DB relation.
   const isAnonymous = Boolean(user?.isAnonymous);
   const { ydoc, provider, isSynced } = useCollaborativeDoc();
   const versionPreview = useOptionalVersionPreview();

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1352,5 +1352,14 @@
   "Remove file": "إزالة الملف",
   "File is too large (max {size} MB)": "الملف كبير جدًا (الحد الأقصى {size} ميغابايت)",
   "Drag a file or link here to add it": "اسحب ملفًا أو رابطًا هنا لإضافته",
-  "Unsaved changes": "تغييرات غير محفوظة"
+  "Unsaved changes": "تغييرات غير محفوظة",
+  "Your idea was submitted.": "تم إرسال فكرتك.",
+  "Want to follow what happens next?": "هل تريد متابعة ما سيحدث بعد ذلك؟",
+  "Continue as a guest": "المتابعة كضيف",
+  "Stay anonymous. React to comments with emoji.": "ابقَ مجهول الهوية. تفاعل مع التعليقات باستخدام الرموز التعبيرية.",
+  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "أوافق على <tos>شروط الخدمة</tos> و<privacy>سياسة الخصوصية</privacy>.",
+  "Continue as guest": "المتابعة كضيف",
+  "With an account": "باستخدام حساب",
+  "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "عدّل فكرتك قبل بدء المراجعة، واحصل على إشعار عند انتقالها إلى المرحلة التالية، وأعجب بالأفكار الأخرى وعلّق عليها وتابعها.",
+  "Create account": "إنشاء حساب"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1355,5 +1355,14 @@
   "No more updates.": "আর কোনো আপডেট নেই।",
   "Thank you for participating. Your voice helps shape how we invest in our community.": "অংশগ্রহণের জন্য ধন্যবাদ। আপনার মতামত আমরা কীভাবে আমাদের সম্প্রদায়ে বিনিয়োগ করি তা গঠনে সহায়তা করে।",
   "HORIZONRESULTSABOUT": "&lt;p&gt;প্রক্রিয়া এবং কীভাবে সিদ্ধান্ত নেওয়া হয়েছিল সে সম্পর্কে আরও জানুন &lt;a target=&quot;_blank&quot; rel=&quot;noopener noreferrer nofollow&quot; href=&quot;https://docs.google.com/presentation/d/1umMJylcpBaMtT2OLnO4THaj2aPzJqyz_g73Wi2VCyLQ/edit?slide=id.g355b90e2c0a_0_0#slide=id.g355b90e2c0a_0_0&quot;&gt;এখানে &lt;/a&gt; &lt;/p&gt;",
-  "Unsaved changes": "অসংরক্ষিত পরিবর্তন"
+  "Unsaved changes": "অসংরক্ষিত পরিবর্তন",
+  "Your idea was submitted.": "আপনার আইডিয়া জমা দেওয়া হয়েছে।",
+  "Want to follow what happens next?": "এরপর কী ঘটে তা অনুসরণ করতে চান?",
+  "Continue as a guest": "অতিথি হিসেবে চালিয়ে যান",
+  "Stay anonymous. React to comments with emoji.": "বেনামী থাকুন। ইমোজি দিয়ে মন্তব্যে প্রতিক্রিয়া জানান।",
+  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "আমি <tos>সেবার শর্তাবলী</tos> এবং <privacy>গোপনীয়তা নীতি</privacy>তে সম্মত।",
+  "Continue as guest": "অতিথি হিসেবে চালিয়ে যান",
+  "With an account": "অ্যাকাউন্ট দিয়ে",
+  "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "পর্যালোচনা শুরু হওয়ার আগে আপনার আইডিয়া সম্পাদনা করুন, এটি পরবর্তী ধাপে গেলে বিজ্ঞপ্তি পান, এবং অন্যান্য আইডিয়া পছন্দ করুন, মন্তব্য করুন ও অনুসরণ করুন।",
+  "Create account": "অ্যাকাউন্ট তৈরি করুন"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1357,7 +1357,6 @@
   "Want to follow what happens next?": "Want to follow what happens next?",
   "Continue as a guest": "Continue as a guest",
   "Stay anonymous. React to comments with emoji.": "Stay anonymous. React to comments with emoji.",
-  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>": "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>",
   "Continue as guest": "Continue as guest",
   "With an account": "With an account",
   "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.",
@@ -1366,5 +1365,6 @@
   "Create an account": "Create an account",
   "Already have an account? <login>Log in</login>": "Already have an account? <login>Log in</login>",
   "A code was sent to {email}. Type the code below to create your profile.": "A code was sent to {email}. Type the code below to create your profile.",
-  "Create profile": "Create profile"
+  "Create profile": "Create profile",
+  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>."
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1357,7 +1357,7 @@
   "Want to follow what happens next?": "Want to follow what happens next?",
   "Continue as a guest": "Continue as a guest",
   "Stay anonymous. React to comments with emoji.": "Stay anonymous. React to comments with emoji.",
-  "I agree to the Terms of Service and Privacy Policy": "I agree to the Terms of Service and Privacy Policy",
+  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>": "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>",
   "Continue as guest": "Continue as guest",
   "With an account": "With an account",
   "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1352,5 +1352,19 @@
   "This action cannot be undone.": "This action cannot be undone.",
   "File is too large (max {size} MB)": "File is too large (max {size} MB)",
   "Drag a file or link here to add it": "Drag a file or link here to add it",
-  "Unsaved changes": "Unsaved changes"
+  "Unsaved changes": "Unsaved changes",
+  "Your idea was submitted.": "Your idea was submitted.",
+  "Want to follow what happens next?": "Want to follow what happens next?",
+  "Continue as a guest": "Continue as a guest",
+  "Stay anonymous. React to comments with emoji.": "Stay anonymous. React to comments with emoji.",
+  "I agree to the Terms of Service and Privacy Policy": "I agree to the Terms of Service and Privacy Policy",
+  "Continue as guest": "Continue as guest",
+  "With an account": "With an account",
+  "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.",
+  "Create account": "Create account",
+  "Already have an account?": "Already have an account?",
+  "Create an account": "Create an account",
+  "Already have an account? <login>Log in</login>": "Already have an account? <login>Log in</login>",
+  "A code was sent to {email}. Type the code below to create your profile.": "A code was sent to {email}. Type the code below to create your profile.",
+  "Create profile": "Create profile"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1352,5 +1352,14 @@
   "Drag a file or link here to add it": "Arrastra un archivo o enlace aquí para añadirlo",
   "Failed to load proposals": "No se pudieron cargar las propuestas",
   "Thank you for participating. Your voice helps shape how we invest in our community.": "Gracias por participar. Tu voz ayuda a definir cómo invertimos en nuestra comunidad.",
-  "Unsaved changes": "Cambios sin guardar"
+  "Unsaved changes": "Cambios sin guardar",
+  "Your idea was submitted.": "Tu idea fue enviada.",
+  "Want to follow what happens next?": "¿Quieres seguir lo que pasa después?",
+  "Continue as a guest": "Continuar como invitado",
+  "Stay anonymous. React to comments with emoji.": "Mantente anónimo. Reacciona a los comentarios con emojis.",
+  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "Acepto los <tos>Términos de servicio</tos> y la <privacy>Política de privacidad</privacy>.",
+  "Continue as guest": "Continuar como invitado",
+  "With an account": "Con una cuenta",
+  "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Edita tu idea antes de que comience la revisión, recibe notificaciones cuando pase a la siguiente fase, y dale me gusta, comenta y sigue otras ideas.",
+  "Create account": "Crear cuenta"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1352,5 +1352,14 @@
   "Drag a file or link here to add it": "Glissez un fichier ou un lien ici pour l'ajouter",
   "Failed to load proposals": "Échec du chargement des propositions",
   "Thank you for participating. Your voice helps shape how we invest in our community.": "Merci de votre participation. Votre voix contribue à façonner la manière dont nous investissons dans notre communauté.",
-  "Unsaved changes": "Modifications non enregistrées"
+  "Unsaved changes": "Modifications non enregistrées",
+  "Your idea was submitted.": "Votre idée a été soumise.",
+  "Want to follow what happens next?": "Vous voulez suivre la suite ?",
+  "Continue as a guest": "Continuer en tant qu'invité",
+  "Stay anonymous. React to comments with emoji.": "Restez anonyme. Réagissez aux commentaires avec des emojis.",
+  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "J'accepte les <tos>Conditions d'utilisation</tos> et la <privacy>Politique de confidentialité</privacy>.",
+  "Continue as guest": "Continuer en tant qu'invité",
+  "With an account": "Avec un compte",
+  "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Modifiez votre idée avant le début de l'examen, soyez notifié lorsqu'elle passe à la phase suivante, et aimez, commentez et suivez d'autres idées.",
+  "Create account": "Créer un compte"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1352,5 +1352,14 @@
   "Drag a file or link here to add it": "Arraste um arquivo ou link aqui para adicioná-lo",
   "Failed to load proposals": "Falha ao carregar as propostas",
   "Thank you for participating. Your voice helps shape how we invest in our community.": "Obrigado por participar. A sua voz ajuda a definir como investimos na nossa comunidade.",
-  "Unsaved changes": "Alterações não salvas"
+  "Unsaved changes": "Alterações não salvas",
+  "Your idea was submitted.": "Sua ideia foi enviada.",
+  "Want to follow what happens next?": "Quer acompanhar o que acontece a seguir?",
+  "Continue as a guest": "Continuar como convidado",
+  "Stay anonymous. React to comments with emoji.": "Permaneça anônimo. Reaja aos comentários com emojis.",
+  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "Concordo com os <tos>Termos de Serviço</tos> e a <privacy>Política de Privacidade</privacy>.",
+  "Continue as guest": "Continuar como convidado",
+  "With an account": "Com uma conta",
+  "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Edite sua ideia antes do início da análise, seja notificado quando ela passar para a próxima fase e curta, comente e siga outras ideias.",
+  "Create account": "Criar conta"
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1354,5 +1354,14 @@
   "Following {count, plural, =1 {# organization} other {# organizations}}": "Raacaya {count, plural, =1 {# urur} other {# ururo}}",
   "Member of {count, plural, =1 {# Organization} other {# Organizations}}": "Xubin ka ah {count, plural, =1 {# Urur} other {# Ururo}}",
   "{count, plural, =1 {1 member has submitted proposals} other {# members have submitted proposals}}": "{count, plural, =1 {1 xubin ayaa soo gudbisay soo jeedimo} other {# xubno ayaa soo gudbiyay soo jeedimo}}",
-  "Unsaved changes": "Isbedello aan la kaydin"
+  "Unsaved changes": "Isbedello aan la kaydin",
+  "Your idea was submitted.": "Fikradaada waa la gudbiyay.",
+  "Want to follow what happens next?": "Ma rabtaa inaad la socoto waxa xiga?",
+  "Continue as a guest": "Ku sii wad marti ahaan",
+  "Stay anonymous. React to comments with emoji.": "Sii ahow qarsoodi. Kaga jawaab faallooyinka adoo isticmaalaya emoji.",
+  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "Waan ogolahay <tos>Shuruudaha Adeegga</tos> iyo <privacy>Xeerka Asturnaanta</privacy>.",
+  "Continue as guest": "Ku sii wad marti ahaan",
+  "With an account": "Adoo akoon leh",
+  "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Wax ka bedel fikradaada ka hor inta aan dib u eegista la bilaabin, ogeysiis hel marka ay u guurto marxaladda xigta, oo jeclow, faallo ka bixi, oo raac fikradaha kale.",
+  "Create account": "Abuur akoon"
 }

--- a/apps/app/src/proxy.ts
+++ b/apps/app/src/proxy.ts
@@ -20,10 +20,12 @@ export async function proxy(request: NextRequest, event: NextFetchEvent) {
   // i18n ROUTING
   const pathname = request.nextUrl.pathname;
 
-  // Expose the current path to Server Components (Next doesn't surface it to
-  // layouts otherwise) so the walled-garden gate can build /login?redirect=...
+  // Expose the current path (and query string) to Server Components (Next
+  // doesn't surface them to layouts otherwise) so the walled-garden gate can
+  // build /login?redirect=... and detect the promote onboarding (?promote=1).
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-pathname', pathname);
+  requestHeaders.set('x-search', request.nextUrl.search);
 
   const pathnameIsMissingLocale = i18nConfig.locales.every(
     (locale) =>

--- a/apps/app/src/utils/walledGarden.ts
+++ b/apps/app/src/utils/walledGarden.ts
@@ -11,9 +11,15 @@ import { forbidden, redirect } from 'next/navigation';
  *   can grant access.
  * - A real account that isn't a network member → `forbidden()`: logging in as
  *   the same account won't help, so show the no-access screen.
+ *
+ * `allowNonMembers` lets a caller admit a real (non-anonymous) account that
+ * isn't a network member — used by the promote/anon-upgrade onboarding (see
+ * PromoteOnboardingFlow), which is reached by intentionally non-member accounts.
+ * The no-session/anonymous redirect still applies.
  */
 export async function assertWalledGardenAccess(
   user: CommonUser | null | undefined,
+  { allowNonMembers = false }: { allowNonMembers?: boolean } = {},
 ) {
   if (!user || user.isAnonymous) {
     const pathname = (await headers()).get('x-pathname');
@@ -25,7 +31,7 @@ export async function assertWalledGardenAccess(
     );
   }
 
-  if (!user.isNetworkMember) {
+  if (!allowNonMembers && !user.isNetworkMember) {
     forbidden();
   }
 }

--- a/apps/app/src/utils/walledGarden.ts
+++ b/apps/app/src/utils/walledGarden.ts
@@ -12,10 +12,8 @@ import { forbidden, redirect } from 'next/navigation';
  * - A real account that isn't a network member → `forbidden()`: logging in as
  *   the same account won't help, so show the no-access screen.
  *
- * `allowNonMembers` lets a caller admit a real (non-anonymous) account that
- * isn't a network member — used by the promote/anon-upgrade onboarding (see
- * PromoteOnboardingFlow), which is reached by intentionally non-member accounts.
- * The no-session/anonymous redirect still applies.
+ * `allowNonMembers` admits a real (non-anonymous) account that isn't a network
+ * member — used by the promote/anon-upgrade onboarding. Anonymous still redirects.
  */
 export async function assertWalledGardenAccess(
   user: CommonUser | null | undefined,

--- a/services/api/src/routers/taxonomy/taxonomyTerms.test.ts
+++ b/services/api/src/routers/taxonomy/taxonomyTerms.test.ts
@@ -26,12 +26,11 @@ describeAccessTierGating('taxonomy.getTerms', {
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits user-JWT caller',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.taxonomy.getTerms({ name: 'xxx' }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/taxonomy/taxonomyTerms.ts
+++ b/services/api/src/routers/taxonomy/taxonomyTerms.ts
@@ -2,10 +2,10 @@ import { getTerms } from '@op/common';
 import { z } from 'zod';
 
 import { taxonomyTermsWithChildrenEncoder } from '../../encoders/taxonomyTerms';
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../trpcFactory';
 
 export const termsRouter = router({
-  getTerms: networkAuthenticatedProcedure()
+  getTerms: authenticatedConfirmedProcedure()
     .input(z.object({ name: z.string().min(3), q: z.string().optional() }))
     .output(z.array(taxonomyTermsWithChildrenEncoder))
     .query(async ({ input }) => {

--- a/tests/e2e/tests/anon-account-upgrade.spec.ts
+++ b/tests/e2e/tests/anon-account-upgrade.spec.ts
@@ -1,0 +1,120 @@
+import {
+  createDecisionInstance,
+  getSeededTemplate,
+  makeDecisionPublic,
+} from '@op/test';
+import { randomUUID } from 'node:crypto';
+
+import {
+  authenticateAnonymously,
+  createOrganization,
+  createSupabaseAdminClient,
+  expect,
+  test,
+} from '../fixtures/index.js';
+
+/**
+ * Anonymous-account upgrade ("promote") flow.
+ *
+ * An anonymous visitor on a public decision is offered an account upgrade
+ * (PromoteAccountModal, shown via ?promote=1). Choosing "Create account" routes
+ * to /login?link=1 (LinkAccountPanel), where entering an email *links* it onto
+ * the existing anonymous user and sends them through a slimmed onboarding
+ * (PromoteOnboardingFlow at /start?promote=1: personal details + ToS) before
+ * returning them to the decision.
+ *
+ * Regression guarded: the upgraded visitor is intentionally NOT a network
+ * member, so /start's walled-garden gate used to `forbidden()` (403) right after
+ * the email step. The gate now admits the promote flow (see walledGarden.ts /
+ * start/layout.tsx).
+ *
+ * Note: the e2e Supabase has email confirmations disabled, so the email change
+ * applies immediately and the OTP entry screen is skipped — entering the email
+ * advances straight to /start, which is exactly where the 403 occurred.
+ */
+test.describe('Anonymous account upgrade (promote flow)', () => {
+  // Start with no session; the test establishes an anonymous one itself.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  const admin = createSupabaseAdminClient();
+
+  test('upgrades an anonymous visitor via email and completes onboarding', async ({
+    page,
+  }) => {
+    // A published, public decision the anonymous visitor can view (so the
+    // decision page — and the promote modal mounted on it — renders).
+    const org = await createOrganization({
+      testId: `promote-${randomUUID().slice(0, 6)}`,
+      supabaseAdmin: admin,
+      users: { admin: 1, member: 0 },
+    });
+    const template = await getSeededTemplate();
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: template.processSchema,
+    });
+    // Open the decision to the public so the anonymous visitor can view it (and
+    // the promote modal mounted on it renders).
+    await makeDecisionPublic({ profileId: instance.profileId });
+
+    // Anonymous Supabase session — the state the promote flow upgrades from.
+    await authenticateAnonymously(page);
+
+    // Land on the promote modal (we skip actually submitting a proposal and
+    // just open the decision with the flag the editor would have set).
+    await page.goto(`/en/decisions/${instance.slug}?promote=1`, {
+      waitUntil: 'networkidle',
+    });
+
+    await expect(
+      page.getByRole('heading', { name: 'Your idea was submitted.' }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // Choose "Create account" → link mode on the login page.
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await expect(page).toHaveURL(/\/login\?link=1/, { timeout: 15000 });
+
+    // LinkAccountPanel: enter an email and continue.
+    const email = `promote-${randomUUID().slice(0, 8)}@example.com`;
+    await page.getByLabel('Email').fill(email);
+
+    // Confirmations are off in e2e, so entering the email applies it
+    // immediately and navigates to onboarding. Reaching /start — instead of the
+    // walled-garden forbidden (403) screen — IS the regression check.
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await page.waitForURL(/\/start\?.*promote=1/, { timeout: 20000 });
+    await expect(
+      page.getByText('You do not have permission to view this page'),
+    ).not.toBeVisible();
+
+    // PromoteOnboardingFlow — step 1: personal details.
+    await expect(
+      page.getByRole('heading', { name: 'Set up your individual profile.' }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.getByLabel('Full Name').fill('Promo Tester');
+    await page.getByLabel('Headline').fill('Community member');
+    await page.getByLabel('Email').fill(email);
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    // Step 2: accept Terms of Service + Privacy Policy.
+    await expect(
+      page.getByRole('heading', { name: 'One last step' }),
+    ).toBeVisible({ timeout: 15000 });
+    // React Aria renders a decorative box over the input, so force the click
+    // past it rather than targeting the visually-hidden checkbox center.
+    const accept = page.getByRole('checkbox', { name: 'I accept the' });
+    await accept.nth(0).check({ force: true });
+    await accept.nth(1).check({ force: true });
+    await page.getByRole('button', { name: 'Join Common' }).click();
+
+    // Onboarding complete → returned to the decision they came from.
+    await expect(page).toHaveURL(
+      new RegExp(`/decisions/${instance.slug}`),
+      { timeout: 20000 },
+    );
+    await expect(page).not.toHaveURL(/\/start/);
+  });
+});

--- a/tests/e2e/tests/anon-account-upgrade.spec.ts
+++ b/tests/e2e/tests/anon-account-upgrade.spec.ts
@@ -14,23 +14,16 @@ import {
 } from '../fixtures/index.js';
 
 /**
- * Anonymous-account upgrade ("promote") flow.
- *
- * An anonymous visitor on a public decision is offered an account upgrade
- * (PromoteAccountModal, shown via ?promote=1). Choosing "Create account" routes
- * to /login?link=1 (LinkAccountPanel), where entering an email *links* it onto
- * the existing anonymous user and sends them through a slimmed onboarding
- * (PromoteOnboardingFlow at /start?promote=1: personal details + ToS) before
- * returning them to the decision.
+ * Anonymous-account upgrade ("promote") flow: an anon visitor on a public
+ * decision upgrades via PromoteAccountModal → /login?link=1 (email link) →
+ * slimmed onboarding (/start?promote=1) → back to the decision.
  *
  * Regression guarded: the upgraded visitor is intentionally NOT a network
- * member, so /start's walled-garden gate used to `forbidden()` (403) right after
- * the email step. The gate now admits the promote flow (see walledGarden.ts /
- * start/layout.tsx).
+ * member, so /start's walled-garden gate used to 403 right after the email step;
+ * the gate now admits the promote flow.
  *
- * Note: the e2e Supabase has email confirmations disabled, so the email change
- * applies immediately and the OTP entry screen is skipped — entering the email
- * advances straight to /start, which is exactly where the 403 occurred.
+ * Note: e2e Supabase has email confirmations off, so the OTP screen is skipped
+ * and entering the email advances straight to /start — where the 403 occurred.
  */
 test.describe('Anonymous account upgrade (promote flow)', () => {
   // Start with no session; the test establishes an anonymous one itself.

--- a/tests/e2e/tests/anon-account-upgrade.spec.ts
+++ b/tests/e2e/tests/anon-account-upgrade.spec.ts
@@ -111,10 +111,9 @@ test.describe('Anonymous account upgrade (promote flow)', () => {
     await page.getByRole('button', { name: 'Join Common' }).click();
 
     // Onboarding complete → returned to the decision they came from.
-    await expect(page).toHaveURL(
-      new RegExp(`/decisions/${instance.slug}`),
-      { timeout: 20000 },
-    );
+    await expect(page).toHaveURL(new RegExp(`/decisions/${instance.slug}`), {
+      timeout: 20000,
+    });
     await expect(page).not.toHaveURL(/\/start/);
   });
 });

--- a/tests/e2e/tests/decision-role-capabilities.spec.ts
+++ b/tests/e2e/tests/decision-role-capabilities.spec.ts
@@ -207,8 +207,9 @@ test.describe('Decision Role Capabilities', () => {
       memberPage.getByRole('heading', { name: instance.name }),
     ).toBeVisible({ timeout: 15000 });
 
-    // The voting phase description confirms VotingPage rendered (not StandardDecisionPage).
-    await expect(memberPage.getByText('Members vote.')).toBeVisible({
+    await expect(
+      memberPage.getByText('TIME TO VOTE.').filter({ visible: true }),
+    ).toBeVisible({
       timeout: 10000,
     });
   });
@@ -235,9 +236,12 @@ test.describe('Decision Role Capabilities', () => {
       authenticatedPage.getByRole('heading', { name: instance.name }),
     ).toBeVisible({ timeout: 15000 });
 
-    // Submission phase description confirms StandardDecisionPage rendered, not VotingPage
     await expect(
-      authenticatedPage.getByText('Members submit proposals.'),
-    ).toBeVisible({ timeout: 10000 });
+      authenticatedPage
+        .getByText('SHARE YOUR IDEAS.')
+        .filter({ visible: true }),
+    ).toBeVisible({
+      timeout: 10000,
+    });
   });
 });


### PR DESCRIPTION
After an anonymous visitor submits an idea, offer to create a real account that keeps it — entering an email links that identity onto the existing anonymous user instead of starting a new one, so the proposal stays theirs. Promoted accounts skip org-joining during onboarding and return to their idea once done. Google identity linking is deferred to a follow-up; this round is email + OTP only.

## Demo
<img width="1854" height="1652" alt="CleanShot 2026-06-25 at 11 54 55@2x" src="https://github.com/user-attachments/assets/9d11d400-d109-4df4-b801-3bb00f26e025" />
