### PR TITLE
fix(api): let confirmed non-allowlisted users complete onboarding

### DIFF
--- a/services/api/src/routers/account/completeOnboarding.test.ts
+++ b/services/api/src/routers/account/completeOnboarding.test.ts
@@ -26,12 +26,11 @@ describeAccessTierGating('account.completeOnboarding', {
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits user-JWT caller',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.account.completeOnboarding({ tos: false, privacy: false }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/account/completeOnboarding.ts
+++ b/services/api/src/routers/account/completeOnboarding.ts
@@ -2,10 +2,10 @@ import { invalidate } from '@op/cache';
 import { completeOnboarding as completeOnboardingService } from '@op/common';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../trpcFactory';
 
 export const completeOnboarding = router({
-  completeOnboarding: networkAuthenticatedProcedure()
+  completeOnboarding: authenticatedConfirmedProcedure()
     .input(
       z.object({
         tos: z.boolean(),

--- a/services/api/src/routers/account/listUserInvites.test.ts
+++ b/services/api/src/routers/account/listUserInvites.test.ts
@@ -431,13 +431,10 @@ describeAccessTierGating('account.listUserInvites', {
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits user-JWT caller',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
-        caller.account.listUserInvites({}),
-        'user',
-      );
+      await expectPassesAccessTierGate(caller.account.listUserInvites({}));
     },
   ),
 

--- a/services/api/src/routers/account/listUserInvites.ts
+++ b/services/api/src/routers/account/listUserInvites.ts
@@ -2,10 +2,10 @@ import { listUserInvites } from '@op/common';
 import { EntityType } from '@op/db/schema';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../trpcFactory';
 
 export const listUserInvitesRouter = router({
-  listUserInvites: networkAuthenticatedProcedure()
+  listUserInvites: authenticatedConfirmedProcedure()
     .input(
       z.object({
         entityType: z.nativeEnum(EntityType).optional(),

--- a/services/api/src/routers/account/updateUserProfile.test.ts
+++ b/services/api/src/routers/account/updateUserProfile.test.ts
@@ -26,13 +26,10 @@ describeAccessTierGating('account.updateUserProfile', {
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits user-JWT caller',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
-        caller.account.updateUserProfile({}),
-        'user',
-      );
+      await expectPassesAccessTierGate(caller.account.updateUserProfile({}));
     },
   ),
 

--- a/services/api/src/routers/account/updateUserProfile.ts
+++ b/services/api/src/routers/account/updateUserProfile.ts
@@ -1,11 +1,11 @@
 import { updateUserProfile as updateUserProfileService } from '@op/common';
 
 import { encodeUser, userEncoder } from '../../encoders';
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../trpcFactory';
 import { updateUserProfileDataSchema } from '../shared/profile';
 
 const updateUserProfile = router({
-  updateUserProfile: networkAuthenticatedProcedure({
+  updateUserProfile: authenticatedConfirmedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 3 },
   })
     .input(updateUserProfileDataSchema)

--- a/services/api/src/routers/account/uploadAvatarImage.test.ts
+++ b/services/api/src/routers/account/uploadAvatarImage.test.ts
@@ -34,16 +34,15 @@ describeAccessTierGating('account.uploadImage', {
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits user-JWT caller',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.account.uploadImage({
           file: 'x',
           fileName: 'x',
           mimeType: 'image/png',
         }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/account/uploadAvatarImage.ts
+++ b/services/api/src/routers/account/uploadAvatarImage.ts
@@ -7,7 +7,7 @@ import { Buffer } from 'buffer';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
 
@@ -20,7 +20,7 @@ const ALLOWED_MIME_TYPES = [
 
 // TODO: This is a duplicate of organization/uploadAvatarImage. Converge these
 export const uploadAvatarImage = router({
-  uploadImage: networkAuthenticatedProcedure()
+  uploadImage: authenticatedConfirmedProcedure()
     .use(withDB)
     .input(
       z.object({

--- a/services/api/src/routers/account/uploadBannerImage.test.ts
+++ b/services/api/src/routers/account/uploadBannerImage.test.ts
@@ -34,16 +34,15 @@ describeAccessTierGating('account.uploadBannerImage', {
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits user-JWT caller',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.account.uploadBannerImage({
           file: 'x',
           fileName: 'x',
           mimeType: 'image/png',
         }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/account/uploadBannerImage.ts
+++ b/services/api/src/routers/account/uploadBannerImage.ts
@@ -7,7 +7,7 @@ import { Buffer } from 'buffer';
 import { z } from 'zod';
 
 import withDB from '../../middlewares/withDB';
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 import { trackImageUpload } from '../../utils/analytics';
 
@@ -19,7 +19,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadBannerImage = router({
-  uploadBannerImage: networkAuthenticatedProcedure()
+  uploadBannerImage: authenticatedConfirmedProcedure()
     .use(withDB)
     .input(
       z.object({

--- a/services/api/src/routers/individual/getIndividual.test.ts
+++ b/services/api/src/routers/individual/getIndividual.test.ts
@@ -26,12 +26,11 @@ describeAccessTierGating('individual.getTermsByProfile', {
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits user-JWT caller',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.individual.getTermsByProfile({ profileId: 'x' }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/individual/getIndividual.ts
+++ b/services/api/src/routers/individual/getIndividual.ts
@@ -2,10 +2,10 @@ import { getIndividualTermsByProfile } from '@op/common';
 import { z } from 'zod';
 
 import { individualsTermsEncoder } from '../../encoders/individuals';
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../trpcFactory';
 
 export const getIndividualRouter = router({
-  getTermsByProfile: networkAuthenticatedProcedure()
+  getTermsByProfile: authenticatedConfirmedProcedure()
     .input(z.object({ profileId: z.string(), termUri: z.string().optional() }))
     .output(individualsTermsEncoder)
     .query(async ({ input }) => {


### PR DESCRIPTION
Anonymous visitors who upgrade to a full account with a non-allowlisted email could not finish onboarding. Lowering the onboarding reads to the confirmed-user tier unblocks them while keeping anonymous and unauthenticated callers out.