### PR TITLE
refactor(access): un-export getProfileAccessUser from read paths

### DIFF
--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -230,6 +230,26 @@ export const getProfileAccessUser = memoize(
 );
 
 /**
+ * Resolve the caller's *effective* normalized roles on a profile — their own
+ * grant unioned with any public grant — without leaking the join-table identity
+ * row. This is the honest shape for an access decision: roles are an aggregate
+ * (own ∪ public), so they describe what the caller may do regardless of who
+ * they are. Empty when no grant (own or public) matched, so `roles.length > 0`
+ * is exactly the old `Boolean(getProfileAccessUser(...))` presence check.
+ *
+ * No org fallback — for org-profile lookups that should fall back to org-level
+ * grants, use {@link getProfileAccessRolesWithOrgFallback} instead.
+ */
+export const getProfileAccessRoles = async ({
+  user,
+  profileId,
+}: {
+  user?: AccessUser;
+  profileId: string;
+}): Promise<NormalizedRole[]> =>
+  (await getProfileAccessUser({ user, profileId }))?.roles ?? [];
+
+/**
  * Resolve the caller's normalized roles on a profile, falling back to their
  * org-level roles when that profile is an organization's profile. The same
  * built-in-fallback shape as `assertInstanceProfileAccess` /
@@ -283,7 +303,7 @@ export const assertInstanceProfileAccess = async ({
   instance: { profileId: string | null; ownerProfileId: string | null };
   profilePermissions: AccessZonePermissionInput;
   orgFallbackPermissions: AccessZonePermissionInput;
-}): Promise<ProfileUserWithNormalizedRoles | undefined> => {
+}): Promise<NormalizedRole[]> => {
   if (!instance.profileId) {
     throw new UnauthorizedError("You don't have access to do this");
   }
@@ -322,7 +342,10 @@ export const assertInstanceProfileAccess = async ({
     }
   }
 
-  return profileUser;
+  // The caller's profile-level roles (empty when they have no profile grant and
+  // were admitted via the org fallback above). Roles only — never the
+  // identity row, which could be the GLOBAL_USER_PUBLIC sentinel's.
+  return profileUser?.roles ?? [];
 };
 
 // Memoized per request (keyed by authUserId): the current profile is stable

--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -170,7 +170,8 @@ export const getOrgAccessUser = memoize(
   (args) => orgUserCacheKey(args).join(':'),
 );
 
-// gets a user's access for a specific profile
+// Don't import directly — use getProfileAccessRoles. Exported only so role
+// mutations can call .invalidate on the memoized cache.
 export const getProfileAccessUser = memoize(
   async ({
     user,
@@ -305,15 +306,12 @@ export const assertInstanceProfileAccess = async ({
     throw new UnauthorizedError("You don't have access to do this");
   }
 
-  const profileUser = await getProfileAccessUser({
+  const profileRoles = await getProfileAccessRoles({
     user,
     profileId: instance.profileId,
   });
 
-  const hasProfileAccess = checkPermission(
-    profilePermissions,
-    profileUser?.roles ?? [],
-  );
+  const hasProfileAccess = checkPermission(profilePermissions, profileRoles);
 
   if (!hasProfileAccess) {
     if (!instance.ownerProfileId) {
@@ -339,9 +337,8 @@ export const assertInstanceProfileAccess = async ({
     }
   }
 
-  // Profile-level roles only (empty when admitted via the org fallback) — never
-  // the identity row, which could be the GLOBAL_USER_PUBLIC sentinel's.
-  return profileUser?.roles ?? [];
+  // Profile-level roles only (empty when admitted via the org fallback).
+  return profileRoles;
 };
 
 // Memoized per request (keyed by authUserId): the current profile is stable

--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -230,15 +230,12 @@ export const getProfileAccessUser = memoize(
 );
 
 /**
- * Resolve the caller's *effective* normalized roles on a profile — their own
- * grant unioned with any public grant — without leaking the join-table identity
- * row. This is the honest shape for an access decision: roles are an aggregate
- * (own ∪ public), so they describe what the caller may do regardless of who
- * they are. Empty when no grant (own or public) matched, so `roles.length > 0`
- * is exactly the old `Boolean(getProfileAccessUser(...))` presence check.
+ * The caller's effective roles on a profile (own grant ∪ public grant), without
+ * the join-table identity row. Empty when no grant matched — so `roles.length
+ * > 0` means "has at least one effective role", slightly tighter than the old
+ * presence check, which also held for a row with zero effective roles.
  *
- * No org fallback — for org-profile lookups that should fall back to org-level
- * grants, use {@link getProfileAccessRolesWithOrgFallback} instead.
+ * No org fallback — see {@link getProfileAccessRolesWithOrgFallback} for that.
  */
 export const getProfileAccessRoles = async ({
   user,
@@ -342,9 +339,8 @@ export const assertInstanceProfileAccess = async ({
     }
   }
 
-  // The caller's profile-level roles (empty when they have no profile grant and
-  // were admitted via the org fallback above). Roles only — never the
-  // identity row, which could be the GLOBAL_USER_PUBLIC sentinel's.
+  // Profile-level roles only (empty when admitted via the org fallback) — never
+  // the identity row, which could be the GLOBAL_USER_PUBLIC sentinel's.
   return profileUser?.roles ?? [];
 };
 

--- a/packages/common/src/services/assert/assertProfileAccess.ts
+++ b/packages/common/src/services/assert/assertProfileAccess.ts
@@ -14,7 +14,9 @@ import { type AccessUser, getProfileAccessRoles } from '../access';
  *
  * Roles are the honest shape for an access decision: an anonymous caller on a
  * public process has access without any identity row to fabricate, so this
- * returns `{ roles }` rather than a synthetic profile-access user.
+ * returns the bare `NormalizedRole[]` — matching {@link
+ * assertInstanceProfileAccess} and {@link getProfileAccessRoles} — rather than a
+ * synthetic profile-access user.
  *
  * @param notMemberMessage - Optional message for the thrown exception when the
  *   caller has no role on the profile. Defaults to 'Not authorized'.
@@ -32,7 +34,7 @@ export async function assertProfileAccess({
   profileId: string;
   permissions: AccessZonePermissionInput;
   notMemberMessage?: string;
-}): Promise<{ roles: NormalizedRole[] }> {
+}): Promise<NormalizedRole[]> {
   const roles = await getProfileAccessRoles({ user, profileId });
 
   if (roles.length === 0) {
@@ -43,5 +45,5 @@ export async function assertProfileAccess({
     throw new UnauthorizedError('Not authorized');
   }
 
-  return { roles };
+  return roles;
 }

--- a/packages/common/src/services/assert/assertProfileAccess.ts
+++ b/packages/common/src/services/assert/assertProfileAccess.ts
@@ -8,21 +8,14 @@ import { UnauthorizedError } from '../../utils';
 import { type AccessUser, getProfileAccessRoles } from '../access';
 
 /**
- * Resolves the caller's *effective* roles on a profile (their own grant unioned
- * with any public grant) and asserts the given permissions, returning the
- * roles so callers can reuse them.
+ * Asserts the caller's effective roles on a profile satisfy `permissions`,
+ * returning those roles. Bare `NormalizedRole[]`, matching {@link
+ * assertInstanceProfileAccess} and {@link getProfileAccessRoles}.
  *
- * Roles are the honest shape for an access decision: an anonymous caller on a
- * public process has access without any identity row to fabricate, so this
- * returns the bare `NormalizedRole[]` — matching {@link
- * assertInstanceProfileAccess} and {@link getProfileAccessRoles} — rather than a
- * synthetic profile-access user.
- *
- * @param notMemberMessage - Optional message for the thrown exception when the
- *   caller has no role on the profile. Defaults to 'Not authorized'.
- * @throws UnauthorizedError if the caller has no role on the profile or their
- *   roles don't satisfy the permissions — every denial throws the same
- *   exception type (only the message differs when `notMemberMessage` is given).
+ * @param notMemberMessage - Message thrown when the caller has no role.
+ *   Defaults to 'Not authorized'.
+ * @throws UnauthorizedError on any denial (only the message differs when
+ *   `notMemberMessage` is given).
  */
 export async function assertProfileAccess({
   user,

--- a/packages/common/src/services/assert/assertProfileAccess.ts
+++ b/packages/common/src/services/assert/assertProfileAccess.ts
@@ -1,19 +1,24 @@
-import { type AccessZonePermissionInput, checkPermission } from 'access-zones';
+import {
+  type AccessZonePermissionInput,
+  type NormalizedRole,
+  checkPermission,
+} from 'access-zones';
 
 import { UnauthorizedError } from '../../utils';
-import {
-  type AccessUser,
-  type ProfileUserWithNormalizedRoles,
-  getProfileAccessUser,
-} from '../access';
+import { type AccessUser, getProfileAccessRoles } from '../access';
 
 /**
- * Fetches the user's roles on a profile and asserts the given permissions,
- * returning the resolved profile-access user so callers can reuse it.
+ * Resolves the caller's *effective* roles on a profile (their own grant unioned
+ * with any public grant) and asserts the given permissions, returning the
+ * roles so callers can reuse them.
+ *
+ * Roles are the honest shape for an access decision: an anonymous caller on a
+ * public process has access without any identity row to fabricate, so this
+ * returns `{ roles }` rather than a synthetic profile-access user.
  *
  * @param notMemberMessage - Optional message for the thrown exception when the
- *   user has no role on the profile. Defaults to 'Not authorized'.
- * @throws UnauthorizedError if the user is not a member of the profile or their
+ *   caller has no role on the profile. Defaults to 'Not authorized'.
+ * @throws UnauthorizedError if the caller has no role on the profile or their
  *   roles don't satisfy the permissions — every denial throws the same
  *   exception type (only the message differs when `notMemberMessage` is given).
  */
@@ -27,16 +32,16 @@ export async function assertProfileAccess({
   profileId: string;
   permissions: AccessZonePermissionInput;
   notMemberMessage?: string;
-}): Promise<ProfileUserWithNormalizedRoles> {
-  const profileUser = await getProfileAccessUser({ user, profileId });
+}): Promise<{ roles: NormalizedRole[] }> {
+  const roles = await getProfileAccessRoles({ user, profileId });
 
-  if (!profileUser) {
+  if (roles.length === 0) {
     throw new UnauthorizedError(notMemberMessage ?? 'Not authorized');
   }
 
-  if (!checkPermission(permissions, profileUser.roles)) {
+  if (!checkPermission(permissions, roles)) {
     throw new UnauthorizedError('Not authorized');
   }
 
-  return profileUser;
+  return { roles };
 }

--- a/packages/common/src/services/assert/assertProfileAdmin.ts
+++ b/packages/common/src/services/assert/assertProfileAdmin.ts
@@ -19,7 +19,7 @@ export async function assertProfileAdmin({
 }: {
   user?: AccessUser;
   profileId: string;
-}): Promise<{ roles: NormalizedRole[] }> {
+}): Promise<NormalizedRole[]> {
   return assertProfileAccess({
     user,
     profileId,

--- a/packages/common/src/services/assert/assertProfileAdmin.ts
+++ b/packages/common/src/services/assert/assertProfileAdmin.ts
@@ -1,11 +1,11 @@
-import { permission } from 'access-zones';
+import { type NormalizedRole, permission } from 'access-zones';
 
-import type { AccessUser, ProfileUserWithNormalizedRoles } from '../access';
+import type { AccessUser } from '../access';
 import { assertProfileAccess } from './assertProfileAccess';
 
 /**
  * Asserts that a user has admin permission on a profile, returning the
- * resolved profile-access user so callers can reuse it.
+ * resolved roles so callers can reuse them.
  *
  * Thin wrapper around {@link assertProfileAccess} for the common
  * `{ profile: permission.ADMIN }` check.
@@ -19,7 +19,7 @@ export async function assertProfileAdmin({
 }: {
   user?: AccessUser;
   profileId: string;
-}): Promise<ProfileUserWithNormalizedRoles> {
+}): Promise<{ roles: NormalizedRole[] }> {
   return assertProfileAccess({
     user,
     profileId,

--- a/packages/common/src/services/assert/assertProfileAdmin.ts
+++ b/packages/common/src/services/assert/assertProfileAdmin.ts
@@ -4,14 +4,10 @@ import type { AccessUser } from '../access';
 import { assertProfileAccess } from './assertProfileAccess';
 
 /**
- * Asserts that a user has admin permission on a profile, returning the
- * resolved roles so callers can reuse them.
+ * {@link assertProfileAccess} for the common `{ profile: permission.ADMIN }`
+ * check. Returns the caller's roles.
  *
- * Thin wrapper around {@link assertProfileAccess} for the common
- * `{ profile: permission.ADMIN }` check.
- *
- * @throws UnauthorizedError if the user doesn't have admin permission
- *   (including when the user is not a member of the profile)
+ * @throws UnauthorizedError if the user lacks admin permission.
  */
 export async function assertProfileAdmin({
   user,

--- a/packages/common/src/services/decision/deleteProposal.ts
+++ b/packages/common/src/services/decision/deleteProposal.ts
@@ -9,7 +9,7 @@ import {
   UnauthorizedError,
   ValidationError,
 } from '../../utils';
-import { getProfileAccessUser, getUserSession } from '../access';
+import { getProfileAccessRoles, getUserSession } from '../access';
 
 export const deleteProposal = async ({
   proposalId,
@@ -45,27 +45,27 @@ export const deleteProposal = async ({
     }
 
     // Check permissions on proposal's profile and instance's profile in parallel
-    const [proposalProfileUser, instanceProfileUser] = await Promise.all([
-      getProfileAccessUser({
+    const [proposalRoles, instanceRoles] = await Promise.all([
+      getProfileAccessRoles({
         user: { id: user.id },
         profileId: existingProposal.profileId,
       }),
       processInstance.profileId
-        ? getProfileAccessUser({
+        ? getProfileAccessRoles({
             user: { id: user.id },
             profileId: processInstance.profileId,
           })
-        : undefined,
+        : [],
     ]);
 
     const hasProposalAdmin = checkPermission(
       { profile: permission.ADMIN },
-      proposalProfileUser?.roles ?? [],
+      proposalRoles,
     );
 
     const hasInstanceAdmin = checkPermission(
       { decisions: permission.ADMIN },
-      instanceProfileUser?.roles ?? [],
+      instanceRoles,
     );
 
     // Only the submitter, proposal admin, or instance admin can delete

--- a/packages/common/src/services/decision/getInstance.ts
+++ b/packages/common/src/services/decision/getInstance.ts
@@ -9,7 +9,6 @@ import {
   type AccessUser,
   assertInstanceProfileAccess,
   getOrgAccessUser,
-  getProfileAccessUser,
 } from '../access';
 import type { DecisionRolePermissions } from './permissions';
 import { fromDecisionBitField } from './permissions';
@@ -39,14 +38,14 @@ const getRolesDecisionBits = (roles: NormalizedRole[]): number =>
 const resolveInstanceAccess = async (
   user: AccessUser | undefined,
   instance: { profileId: string; ownerProfileId: string | null },
-  profileUser: Awaited<ReturnType<typeof getProfileAccessUser>>,
+  profileRoles: NormalizedRole[],
 ): Promise<DecisionRolePermissions> => {
-  if (profileUser) {
+  if (profileRoles.length > 0) {
     // Profile admins bypass decision-zone role checks — they have full access
-    if (checkPermission({ profile: permission.ADMIN }, profileUser.roles)) {
+    if (checkPermission({ profile: permission.ADMIN }, profileRoles)) {
       return ALL_TRUE_ACCESS;
     }
-    return fromDecisionBitField(getRolesDecisionBits(profileUser.roles));
+    return fromDecisionBitField(getRolesDecisionBits(profileRoles));
   }
 
   // Fall back to org-level roles
@@ -96,8 +95,8 @@ export const getInstance = async ({ instanceId, user }: GetInstanceInput) => {
       throw new NotFoundError('Process instance', instanceId);
     }
 
-    // Assert read access and reuse the profile-access user it resolves.
-    const profileUser = await assertInstanceProfileAccess({
+    // Assert read access and reuse the profile-level roles it resolves.
+    const profileRoles = await assertInstanceProfileAccess({
       user,
       instance,
       profilePermissions: { decisions: permission.READ },
@@ -115,7 +114,7 @@ export const getInstance = async ({ instanceId, user }: GetInstanceInput) => {
         profileId: instance.profileId,
         ownerProfileId: instance.ownerProfileId,
       },
-      profileUser,
+      profileRoles,
     );
 
     // Calculate proposal and participant counts

--- a/packages/common/src/services/decision/getProposal.ts
+++ b/packages/common/src/services/decision/getProposal.ts
@@ -18,7 +18,7 @@ import { createSBServiceClient } from '@op/supabase/server';
 import { checkPermission, permission } from 'access-zones';
 
 import { NotFoundError } from '../../utils';
-import { assertInstanceProfileAccess, getProfileAccessUser } from '../access';
+import { assertInstanceProfileAccess, getProfileAccessRoles } from '../access';
 import { hasActiveModerationFlag } from '../moderation/moderationVisibility';
 import { generateProposalHtml } from './generateProposalHtml';
 import {
@@ -102,9 +102,9 @@ export const getProposal = async ({
     throw new NotFoundError('Proposal', profileId);
   }
 
-  // Reuse the resolved instance-profile user (drives the instance-admin check
-  // below) instead of re-fetching it per gate.
-  const instanceProfileUser = await assertInstanceProfileAccess({
+  // Reuse the resolved instance-profile roles (drive the instance-admin check
+  // below) instead of re-fetching them per gate.
+  const instanceRoles = await assertInstanceProfileAccess({
     user,
     instance: proposal.processInstance,
     profilePermissions: { decisions: permission.READ },
@@ -129,14 +129,14 @@ export const getProposal = async ({
     // Proposal-level access = the creator + invited collaborators (a
     // profileUsers record on the proposal's own profile). Only fetched for a
     // restricted proposal — a plain visible proposal never needs it.
-    const proposalProfileUser = await getProfileAccessUser({
+    const proposalRoles = await getProfileAccessRoles({
       user,
       profileId: proposal.profileId,
     });
-    const hasProposalAccess = Boolean(proposalProfileUser);
+    const hasProposalAccess = proposalRoles.length > 0;
     const isInstanceAdmin = checkPermission(
       { profile: permission.ADMIN },
-      instanceProfileUser?.roles ?? [],
+      instanceRoles,
     );
 
     // Drafts are visible only to proposal-level access (not instance admins);
@@ -276,12 +276,10 @@ export const getPermissionsOnProposal = async ({
   user: User | undefined;
   proposal: Proposal & { processInstance: ProcessInstance };
 }): Promise<{ access: DecisionRolePermissions }> => {
-  const profileUser = await getProfileAccessUser({
+  const roles = await getProfileAccessRoles({
     user,
     profileId: proposal.profileId,
   });
-
-  const roles = profileUser?.roles ?? [];
 
   // Compute decision access from combined role bitfields
   const combinedDecisionBits = roles.reduce(

--- a/packages/common/src/services/decision/listAllProposals.ts
+++ b/packages/common/src/services/decision/listAllProposals.ts
@@ -77,7 +77,7 @@ export const listAllProposals = async ({
     throw new UnauthorizedError('User does not have access to this process');
   }
 
-  const profileUser = await assertInstanceProfileAccess({
+  const profileRoles = await assertInstanceProfileAccess({
     user,
     instance,
     profilePermissions: [
@@ -92,7 +92,7 @@ export const listAllProposals = async ({
 
   const isAdmin = checkPermission(
     { decisions: permission.ADMIN },
-    profileUser?.roles ?? [],
+    profileRoles,
   );
 
   const proposalList = await db.query.proposals.findMany({

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -10,12 +10,11 @@ import {
   proposals,
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
-import { checkPermission, permission } from 'access-zones';
+import { type NormalizedRole, checkPermission, permission } from 'access-zones';
 import { count as countFn } from 'drizzle-orm';
 
 import { UnauthorizedError } from '../../utils';
 import {
-  type ProfileUserWithNormalizedRoles,
   assertInstanceProfileAccess,
   getCurrentProfileId,
   resolveAccessUserIds,
@@ -249,13 +248,13 @@ export const listProposals = async ({
   // only on the instance row (already fetched), so there's no ordering
   // dependency — the auth check still throws on failure, just slightly later.
   const accessPromise: Promise<{
-    profileUser: ProfileUserWithNormalizedRoles | undefined;
+    profileRoles: NormalizedRole[];
     canManageProposals: boolean;
   }> = (async () => {
     if (skipAccessCheck) {
-      return { profileUser: undefined, canManageProposals: false };
+      return { profileRoles: [], canManageProposals: false };
     }
-    const profileUser = await assertInstanceProfileAccess({
+    const profileRoles = await assertInstanceProfileAccess({
       user,
       instance,
       profilePermissions: [
@@ -268,17 +267,17 @@ export const listProposals = async ({
       ],
     });
     return {
-      profileUser,
+      profileRoles,
       canManageProposals: checkPermission(
         { profile: permission.ADMIN },
-        profileUser?.roles ?? [],
+        profileRoles,
       ),
     };
   })();
 
   const [
     { phaseProposalIds, phaseDraftIds },
-    { profileUser, canManageProposals },
+    { profileRoles, canManageProposals },
   ] = await Promise.all([phaseIdsPromise, accessPromise]);
 
   // For trusted contexts (skipAccessCheck), drafts are never returned and phase
@@ -527,7 +526,7 @@ export const listProposals = async ({
 
   const hasAdminPermission = checkPermission(
     { profile: permission.ADMIN },
-    profileUser?.roles ?? [],
+    profileRoles,
   );
 
   const proposalsWithCounts = proposalList.map((proposal: ProposalListItem) => {

--- a/packages/common/src/services/decision/processSurvey.ts
+++ b/packages/common/src/services/decision/processSurvey.ts
@@ -3,13 +3,10 @@ import {
   decisionProcessSurveyResponses,
   decisionProcessSurveySubmitters,
 } from '@op/db/schema';
-import { collapseRoles, permission } from 'access-zones';
+import { type NormalizedRole, collapseRoles, permission } from 'access-zones';
 
 import { NotFoundError, UnauthorizedError } from '../../utils';
-import {
-  type ProfileUserWithNormalizedRoles,
-  getIndividualProfileId,
-} from '../access';
+import { getIndividualProfileId } from '../access';
 import { assertProfileAccess } from '../assert';
 import { fromDecisionBitField } from './permissions';
 
@@ -48,7 +45,7 @@ async function authorizeSurveyAccess({
 }): Promise<{
   profileId: string;
   processInstance: ProcessInstanceForSurvey;
-  profileUser: ProfileUserWithNormalizedRoles;
+  profileUser: { roles: NormalizedRole[] };
 }> {
   const [profileId, processInstance] = await Promise.all([
     getIndividualProfileId(authUserId),
@@ -89,7 +86,7 @@ function getSurveyMeta({
 }: {
   processInstance: ProcessInstanceForSurvey;
   submittedByProfileId: string;
-  profileUser: ProfileUserWithNormalizedRoles;
+  profileUser: { roles: NormalizedRole[] };
   locale: string;
 }) {
   const roles = profileUser.roles.map((role) => ({

--- a/packages/common/src/services/decision/processSurvey.ts
+++ b/packages/common/src/services/decision/processSurvey.ts
@@ -45,7 +45,7 @@ async function authorizeSurveyAccess({
 }): Promise<{
   profileId: string;
   processInstance: ProcessInstanceForSurvey;
-  profileUser: { roles: NormalizedRole[] };
+  roles: NormalizedRole[];
 }> {
   const [profileId, processInstance] = await Promise.all([
     getIndividualProfileId(authUserId),
@@ -69,32 +69,32 @@ async function authorizeSurveyAccess({
     throw new UnauthorizedError("You don't have access to do this");
   }
 
-  const profileUser = await assertProfileAccess({
+  const roles = await assertProfileAccess({
     user: { id: authUserId },
     profileId: processInstance.profileId,
     permissions: { decisions: permission.READ },
   });
 
-  return { profileId, processInstance, profileUser };
+  return { profileId, processInstance, roles };
 }
 
 function getSurveyMeta({
   processInstance,
   submittedByProfileId,
-  profileUser,
+  roles: profileRoles,
   locale,
 }: {
   processInstance: ProcessInstanceForSurvey;
   submittedByProfileId: string;
-  profileUser: { roles: NormalizedRole[] };
+  roles: NormalizedRole[];
   locale: string;
 }) {
-  const roles = profileUser.roles.map((role) => ({
+  const roles = profileRoles.map((role) => ({
     id: role.id,
     name: role.name,
   }));
 
-  const decisionsBits = collapseRoles(profileUser.roles)['decisions'] ?? 0;
+  const decisionsBits = collapseRoles(profileRoles)['decisions'] ?? 0;
 
   return {
     roles,
@@ -116,16 +116,15 @@ export const submitProcessSurveyResponse = async ({
     throw new UnauthorizedError('User must be authenticated');
   }
 
-  const { profileId, processInstance, profileUser } =
-    await authorizeSurveyAccess({
-      authUserId,
-      processInstanceId,
-    });
+  const { profileId, processInstance, roles } = await authorizeSurveyAccess({
+    authUserId,
+    processInstanceId,
+  });
 
   const meta = getSurveyMeta({
     processInstance,
     submittedByProfileId: profileId,
-    profileUser,
+    roles,
     locale,
   });
 

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -18,7 +18,7 @@ import {
   UnauthorizedError,
   ValidationError,
 } from '../../utils';
-import { assertInstanceProfileAccess, getProfileAccessUser } from '../access';
+import { assertInstanceProfileAccess, getProfileAccessRoles } from '../access';
 import { assertUserByAuthId } from '../assert';
 import type {
   CheckpointVersion,
@@ -140,14 +140,14 @@ export const updateProposal = async ({
     });
   } else {
     // Data updates require profile-level update permission on the proposal's profile
-    const proposalProfileUser = await getProfileAccessUser({
+    const proposalRoles = await getProfileAccessRoles({
       user: { id: user.id },
       profileId: existingProposal.profileId,
     });
 
     const hasProposalUpdate = checkPermission(
       { profile: permission.UPDATE },
-      proposalProfileUser?.roles ?? [],
+      proposalRoles,
     );
 
     if (!hasProposalUpdate) {

--- a/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
@@ -51,7 +51,9 @@ beforeEach(() => {
   vi.mocked(hasActiveModerationFlag).mockResolvedValue(false);
   vi.mocked(getProfileAccessUser).mockResolvedValue(undefined);
   vi.mocked(assertProfileTypeAccess).mockResolvedValue(undefined);
-  vi.mocked(assertInstanceProfileAccess).mockResolvedValue(undefined as never);
+  // assertInstanceProfileAccess now returns the caller's instance roles
+  // (NormalizedRole[]) directly — no instance-admin grant by default.
+  vi.mocked(assertInstanceProfileAccess).mockResolvedValue([]);
   postsToProfilesFindMany.mockResolvedValue([] as never);
 });
 

--- a/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
@@ -51,8 +51,7 @@ beforeEach(() => {
   vi.mocked(hasActiveModerationFlag).mockResolvedValue(false);
   vi.mocked(getProfileAccessRoles).mockResolvedValue([]);
   vi.mocked(assertProfileTypeAccess).mockResolvedValue(undefined);
-  // assertInstanceProfileAccess now returns the caller's instance roles
-  // (NormalizedRole[]) directly — no instance-admin grant by default.
+  // Instance roles default to none (no instance-admin grant).
   vi.mocked(assertInstanceProfileAccess).mockResolvedValue([]);
   postsToProfilesFindMany.mockResolvedValue([] as never);
 });

--- a/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.test.ts
@@ -17,7 +17,7 @@ vi.mock('@op/db/client', () => ({
 vi.mock('../access', () => ({
   assertProfileTypeAccess: vi.fn(),
   assertInstanceProfileAccess: vi.fn(),
-  getProfileAccessUser: vi.fn(),
+  getProfileAccessRoles: vi.fn(),
   getCurrentProfileId: vi.fn(),
 }));
 
@@ -31,7 +31,7 @@ import {
   assertInstanceProfileAccess,
   assertProfileTypeAccess,
   getCurrentProfileId,
-  getProfileAccessUser,
+  getProfileAccessRoles,
 } from '../access';
 import { assertModerationItemAccess } from './assertModerationItemAccess';
 import { hasActiveModerationFlag } from './moderationVisibility';
@@ -49,7 +49,7 @@ const proposalFindFirst = vi.mocked(db.query.proposals.findFirst);
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(hasActiveModerationFlag).mockResolvedValue(false);
-  vi.mocked(getProfileAccessUser).mockResolvedValue(undefined);
+  vi.mocked(getProfileAccessRoles).mockResolvedValue([]);
   vi.mocked(assertProfileTypeAccess).mockResolvedValue(undefined);
   // assertInstanceProfileAccess now returns the caller's instance roles
   // (NormalizedRole[]) directly — no instance-admin grant by default.
@@ -111,7 +111,7 @@ describe('assertModerationItemAccess — post', () => {
     } as never);
     vi.mocked(hasActiveModerationFlag).mockResolvedValue(true);
     vi.mocked(getCurrentProfileId).mockResolvedValue('someone-else');
-    // getProfileAccessUser → undefined (no admin roles) from beforeEach.
+    // getProfileAccessRoles → [] (no admin roles) from beforeEach.
     await expect(
       assertModerationItemAccess({ itemType: 'post', itemId: POST_ID, user }),
     ).rejects.toThrow();
@@ -214,10 +214,8 @@ describe('assertModerationItemAccess — proposal', () => {
       visibility: 'hidden',
       processInstance: { profileId: 'instance-profile' },
     } as never);
-    // First getProfileAccessUser call (proposal profile) returns a member.
-    vi.mocked(getProfileAccessUser).mockResolvedValueOnce({
-      roles: [],
-    } as never);
+    // Proposal-profile lookup resolves a member (≥1 role).
+    vi.mocked(getProfileAccessRoles).mockResolvedValueOnce([{}] as never);
     await expect(
       assertModerationItemAccess({
         itemType: 'proposal',
@@ -254,10 +252,8 @@ describe('assertModerationItemAccess — proposal', () => {
       processInstance: { profileId: 'instance-profile' },
     } as never);
     vi.mocked(hasActiveModerationFlag).mockResolvedValue(true);
-    // getProfileAccessUser (proposal profile) returns a member.
-    vi.mocked(getProfileAccessUser).mockResolvedValueOnce({
-      roles: [],
-    } as never);
+    // Proposal-profile lookup resolves a member (≥1 role).
+    vi.mocked(getProfileAccessRoles).mockResolvedValueOnce([{}] as never);
     await expect(
       assertModerationItemAccess({
         itemType: 'proposal',

--- a/packages/common/src/services/moderation/assertModerationItemAccess.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.ts
@@ -8,7 +8,7 @@ import {
   assertInstanceProfileAccess,
   assertProfileTypeAccess,
   getCurrentProfileId,
-  getProfileAccessUser,
+  getProfileAccessRoles,
 } from '../access';
 import { hasActiveModerationFlag } from './moderationVisibility';
 import type { ModerationItemType } from './types';
@@ -87,16 +87,16 @@ export const assertModerationItemAccess = async ({
       const isAuthor =
         actorProfileId !== undefined && post.profileId === actorProfileId;
       if (!isAuthor) {
-        const rootProfileUser =
+        const rootProfileRoles =
           user && post.rootProfileId
-            ? await getProfileAccessUser({
+            ? await getProfileAccessRoles({
                 user,
                 profileId: post.rootProfileId,
               })
-            : undefined;
+            : [];
         const isAdmin = checkPermission(
           { profile: permission.ADMIN },
-          rootProfileUser?.roles ?? [],
+          rootProfileRoles,
         );
         if (!isAdmin) {
           throw new NotFoundError('Post', itemId);
@@ -139,7 +139,7 @@ export const assertModerationItemAccess = async ({
       proposal.visibility === Visibility.HIDDEN ||
       (await hasActiveModerationFlag('proposal', proposal.id));
     if (isRestricted) {
-      const proposalProfileUser = await getProfileAccessUser({
+      const proposalRoles = await getProfileAccessRoles({
         user,
         profileId: proposal.profileId,
       });
@@ -147,7 +147,7 @@ export const assertModerationItemAccess = async ({
         { profile: permission.ADMIN },
         instanceRoles,
       );
-      if (!proposalProfileUser && !isInstanceAdmin) {
+      if (proposalRoles.length === 0 && !isInstanceAdmin) {
         throw new NotFoundError('Proposal', itemId);
       }
     }

--- a/packages/common/src/services/moderation/assertModerationItemAccess.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.ts
@@ -115,9 +115,9 @@ export const assertModerationItemAccess = async ({
       throw new NotFoundError('Proposal', itemId);
     }
 
-    // Reuse the resolved instance-profile user for the instance-admin check
-    // below instead of re-fetching it, mirroring getProposal.
-    const instanceProfileUser = await assertInstanceProfileAccess({
+    // Reuse the resolved instance-profile roles for the instance-admin check
+    // below instead of re-fetching them, mirroring getProposal.
+    const instanceRoles = await assertInstanceProfileAccess({
       user,
       instance: proposal.processInstance,
       profilePermissions: { decisions: permission.READ },
@@ -145,7 +145,7 @@ export const assertModerationItemAccess = async ({
       });
       const isInstanceAdmin = checkPermission(
         { profile: permission.ADMIN },
-        instanceProfileUser?.roles ?? [],
+        instanceRoles,
       );
       if (!proposalProfileUser && !isInstanceAdmin) {
         throw new NotFoundError('Proposal', itemId);

--- a/packages/common/src/services/moderation/assertModerationItemAccess.ts
+++ b/packages/common/src/services/moderation/assertModerationItemAccess.ts
@@ -73,14 +73,11 @@ export const assertModerationItemAccess = async ({
       },
     });
 
-    // An already-flagged post is hidden from everyone but its author and the
-    // root-profile admins (see getPost's gate); the same audience may flag it,
-    // so a non-owner can't ship hidden content to the vendor by re-flagging.
+    // An already-flagged post is restricted to its author + root-profile admins
+    // (see getPost's gate); only that audience may flag it, so hidden content
+    // can't be shipped to the vendor by re-flagging. A sessionless caller is
+    // neither. getCurrentProfileId is memoized, sharing submitUserFlag's lookup.
     if (await hasActiveModerationFlag('post', post.id)) {
-      // Restricted to the author + root-profile admins. A sessionless caller is
-      // neither, so they're denied — hidden content can't be shipped to the
-      // vendor by flagging it. getCurrentProfileId is memoized per request, so
-      // this shares submitUserFlag's lookup.
       const actorProfileId = user
         ? await getCurrentProfileId(user.id)
         : undefined;
@@ -115,8 +112,7 @@ export const assertModerationItemAccess = async ({
       throw new NotFoundError('Proposal', itemId);
     }
 
-    // Reuse the resolved instance-profile roles for the instance-admin check
-    // below instead of re-fetching them, mirroring getProposal.
+    // Reused for the instance-admin check below, mirroring getProposal.
     const instanceRoles = await assertInstanceProfileAccess({
       user,
       instance: proposal.processInstance,
@@ -127,14 +123,10 @@ export const assertModerationItemAccess = async ({
       ],
     });
 
-    // HIDDEN proposals, and proposals with an active moderation flag, are
-    // restricted beyond plain instance read — visible only to proposal-level
-    // members (creator + invited collaborators) or instance admins. Mirror
-    // getProposal's gate so restricted text/attachments can't be shipped to the
-    // vendor by an instance member who only has read on the process, and so
-    // this gate (not submitUserFlag's idempotency shortcut) is what enforces it
-    // for an already-flagged proposal. (DRAFT is deliberately not gated here:
-    // drafts are reportable.)
+    // HIDDEN or already-flagged proposals are restricted beyond plain instance
+    // read — visible only to proposal-level members or instance admins (mirrors
+    // getProposal), so restricted content can't be shipped to the vendor by an
+    // instance member with only process read. DRAFT stays reportable.
     const isRestricted =
       proposal.visibility === Visibility.HIDDEN ||
       (await hasActiveModerationFlag('proposal', proposal.id));

--- a/packages/common/src/services/posts/deletePost.ts
+++ b/packages/common/src/services/posts/deletePost.ts
@@ -12,7 +12,7 @@ import { UnauthorizedError } from '../../utils';
 import {
   assertInstanceProfileAccess,
   getCurrentProfileId,
-  getProfileAccessUser,
+  getProfileAccessRoles,
 } from '../access';
 
 export interface DeletePostByIdOptions {
@@ -69,11 +69,11 @@ export const deletePostById = async (options: DeletePostByIdOptions) => {
   // preserving the legitimate self-delete path for individual and decision-
   // instance authors.
   if (post.profileId && post.profileId === currentProfileId) {
-    const profileUser = await getProfileAccessUser({
+    const roles = await getProfileAccessRoles({
       user,
       profileId: post.profileId,
     });
-    if (profileUser) {
+    if (roles.length > 0) {
       await db.delete(posts).where(eq(posts.id, postId));
       return;
     }

--- a/services/api/src/routers/decision/instances/getDecisionBySlug.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlug.ts
@@ -2,7 +2,7 @@ import {
   Channels,
   fromDecisionBitField,
   getDecisionBySlug,
-  getProfileAccessUser,
+  getProfileAccessRoles,
 } from '@op/common';
 import { collapseRoles } from 'access-zones';
 import { z } from 'zod';
@@ -36,13 +36,12 @@ export const getDecisionBySlugRouter = router({
         throw new Error('Decision profile ID is missing');
       }
 
-      const profileUser = await getProfileAccessUser({
+      const roles = await getProfileAccessRoles({
         user,
         profileId,
       });
 
-      const decisionsBitField =
-        collapseRoles(profileUser?.roles ?? [])['decisions'] ?? 0;
+      const decisionsBitField = collapseRoles(roles)['decisions'] ?? 0;
 
       ctx.registerQueryChannels([
         Channels.decisionInstance(parsed.processInstance.id),


### PR DESCRIPTION
Read callers only ever consumed the caller's effective roles, yet were fetching the full profile-access user — whose identity fields can fall back to the GLOBAL_USER_PUBLIC sentinel and thus describe someone other than the requester. Route reads through a roles-only getter so that substituted identity never leaves the access module; getProfileAccessUser remains for the asserts and cache invalidators.