### PR TITLE
feat(access): replace public sentinel substitution with a Public Participant role

### DIFF
--- a/packages/common/src/services/access/index.ts
+++ b/packages/common/src/services/access/index.ts
@@ -1,7 +1,14 @@
 import { cache } from '@op/cache';
 import { GLOBAL_USER_PUBLIC } from '@op/core';
-import { db, eq } from '@op/db/client';
-import { organizations, users } from '@op/db/schema';
+import { and, db, eq, isNull } from '@op/db/client';
+import {
+  accessRoles,
+  organizations,
+  profileUserToAccessRoles,
+  profileUsers,
+  users,
+} from '@op/db/schema';
+import { PUBLIC_PARTICIPANT_ROLE_NAME } from '@op/db/seedData/accessControl';
 import type { User } from '@op/supabase/lib';
 import type { AccessZonePermissionInput, NormalizedRole } from 'access-zones';
 import { checkPermission } from 'access-zones';
@@ -231,21 +238,123 @@ export const getProfileAccessUser = memoize(
 );
 
 /**
- * The caller's effective roles on a profile (own grant ∪ public grant), without
- * the join-table identity row. Empty when no grant matched — so `roles.length
- * > 0` means "has at least one effective role", slightly tighter than the old
- * presence check, which also held for a row with zero effective roles.
- *
- * No org fallback — see {@link getProfileAccessRolesWithOrgFallback} for that.
+ * The Public Participant grant on a profile, resolved as role junctions ready
+ * for {@link getNormalizedRoles}. Detected by the stable global Public
+ * Participant *role* (by name, `profileId IS NULL`) granted on the profile —
+ * not by the {@link GLOBAL_USER_PUBLIC} sentinel row the grant is currently
+ * anchored on. The cheap path (no public grant, i.e. almost every profile) is a
+ * single indexed existence check; the role's permissions are only loaded when a
+ * grant is actually present. Empty when the profile has no public grant.
  */
-export const getProfileAccessRoles = async ({
-  user,
-  profileId,
-}: {
-  user?: AccessUser;
-  profileId: string;
-}): Promise<NormalizedRole[]> =>
-  (await getProfileAccessUser({ user, profileId }))?.roles ?? [];
+const getPublicParticipantRoleJunctions = async (profileId: string) => {
+  const grant = await db
+    .select({ profileUserId: profileUserToAccessRoles.profileUserId })
+    .from(profileUserToAccessRoles)
+    .innerJoin(
+      profileUsers,
+      eq(profileUserToAccessRoles.profileUserId, profileUsers.id),
+    )
+    .innerJoin(
+      accessRoles,
+      eq(profileUserToAccessRoles.accessRoleId, accessRoles.id),
+    )
+    .where(
+      and(
+        eq(profileUsers.profileId, profileId),
+        eq(accessRoles.name, PUBLIC_PARTICIPANT_ROLE_NAME),
+        isNull(accessRoles.profileId),
+      ),
+    )
+    .limit(1);
+
+  if (grant.length === 0) {
+    return [];
+  }
+
+  const publicRole = await db.query.accessRoles.findFirst({
+    where: {
+      name: PUBLIC_PARTICIPANT_ROLE_NAME,
+      profileId: { isNull: true },
+    },
+    with: {
+      zonePermissions: {
+        where: zonePermissionsWhere(profileId),
+        with: {
+          accessZone: true,
+        },
+      },
+    },
+  });
+
+  return publicRole ? [{ accessRole: publicRole }] : [];
+};
+
+/**
+ * Resolve the caller's *effective* normalized roles on a profile — their own
+ * grant unioned with any public grant — without leaking the join-table identity
+ * row. This is the honest shape for an access decision: roles are an aggregate
+ * (own ∪ public), so they describe what the caller may do regardless of who
+ * they are. Empty when no grant (own or public) matched, so `roles.length > 0`
+ * is exactly the old `Boolean(getProfileAccessUser(...))` presence check.
+ *
+ * The caller's own grant is keyed on their own `authUserId` — identity is always
+ * the requester, so there's no sentinel substitution and no synthetic identity
+ * to fabricate for the anonymous-on-a-public-process case. The public grant is
+ * detected by the Public Participant role (see
+ * {@link getPublicParticipantRoleJunctions}), so this path doesn't go through
+ * `resolveAccessUserIds`.
+ *
+ * No org fallback — for org-profile lookups that should fall back to org-level
+ * grants, use {@link getProfileAccessRolesWithOrgFallback} instead.
+ */
+export const getProfileAccessRoles = memoize(
+  async ({
+    user,
+    profileId,
+  }: {
+    user?: AccessUser;
+    profileId: string;
+  }): Promise<NormalizedRole[]> => {
+    // Anonymous / no-JWT callers (and the public sentinel itself) have no "own"
+    // grant — they get exactly the public roles below.
+    const ownAuthUserId =
+      user?.id && user.id !== GLOBAL_USER_PUBLIC ? user.id : undefined;
+
+    const ownRow = ownAuthUserId
+      ? await db.query.profileUsers.findFirst({
+          where: {
+            profileId,
+            authUserId: ownAuthUserId,
+          },
+          with: {
+            roles: {
+              with: {
+                accessRole: {
+                  with: {
+                    zonePermissions: {
+                      where: zonePermissionsWhere(profileId),
+                      with: {
+                        accessZone: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+      : undefined;
+
+    const publicRoleJunctions =
+      await getPublicParticipantRoleJunctions(profileId);
+
+    return getNormalizedRoles(
+      [...(ownRow?.roles ?? []), ...publicRoleJunctions],
+      { profileId },
+    );
+  },
+  ({ profileId, user }) => `${profileId}:${user?.id ?? 'public'}`,
+);
 
 /**
  * Resolve the caller's normalized roles on a profile, falling back to their

--- a/services/api/src/test/publicParticipantAccess.test.ts
+++ b/services/api/src/test/publicParticipantAccess.test.ts
@@ -1,0 +1,159 @@
+import { assertProfileAccess, getProfileAccessRoles } from '@op/common';
+import { GLOBAL_USER_PUBLIC } from '@op/core';
+import { db } from '@op/db/client';
+import { profileUserToAccessRoles, profileUsers } from '@op/db/schema';
+import {
+  PUBLIC_PARTICIPANT_ROLE_NAME,
+  ROLES,
+} from '@op/db/seedData/accessControl';
+import { permission } from 'access-zones';
+import { describe, expect, it } from 'vitest';
+
+import { TestProfileUserDataManager } from './helpers/TestProfileUserDataManager';
+
+/**
+ * Grants the stable global Public Participant role on a profile, anchored on the
+ * GLOBAL_USER_PUBLIC sentinel row (the join needs a `profileUserId`). Mirrors
+ * the by-hand prod grant for the one public process. The grant cascades away
+ * when the profile is deleted, so the manager's profile cleanup covers it — no
+ * extra teardown needed.
+ */
+const grantPublicParticipant = async (profileId: string): Promise<void> => {
+  const [publicProfileUser] = await db
+    .insert(profileUsers)
+    .values({
+      authUserId: GLOBAL_USER_PUBLIC,
+      profileId,
+      name: 'Public',
+    })
+    .returning();
+
+  if (!publicProfileUser) {
+    throw new Error('Failed to create public profile user');
+  }
+
+  await db.insert(profileUserToAccessRoles).values({
+    profileUserId: publicProfileUser.id,
+    accessRoleId: ROLES.PUBLIC_PARTICIPANT.id,
+  });
+};
+
+// The profile/decision access path resolves a caller's effective roles as their
+// own grant unioned with the public grant — and detects the public grant by the
+// Public Participant *role*, not by the caller's identity or the sentinel user
+// id. These exercise that role-presence behaviour end-to-end against the DB.
+describe.concurrent('public participant access', () => {
+  it('lets a no-user caller read a public profile but not write it', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+    const { profile } = await testData.createProfile({ users: { admin: 1 } });
+    await grantPublicParticipant(profile.id);
+
+    const roles = await getProfileAccessRoles({
+      user: undefined,
+      profileId: profile.id,
+    });
+    expect(roles.map((role) => role.name)).toEqual([
+      PUBLIC_PARTICIPANT_ROLE_NAME,
+    ]);
+
+    await expect(
+      assertProfileAccess({
+        profileId: profile.id,
+        permissions: { decisions: permission.READ },
+      }),
+    ).resolves.toEqual({ roles });
+
+    // Public access is read-only — a write permission is denied.
+    await expect(
+      assertProfileAccess({
+        profileId: profile.id,
+        permissions: { decisions: permission.UPDATE },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('denies a no-user caller on a profile without a public grant', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+    const { profile } = await testData.createProfile({ users: { admin: 1 } });
+
+    expect(
+      await getProfileAccessRoles({ user: undefined, profileId: profile.id }),
+    ).toEqual([]);
+
+    await expect(
+      assertProfileAccess({
+        profileId: profile.id,
+        permissions: { decisions: permission.READ },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('grants public read to an authenticated non-member via the role, not their identity', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+    const { profile } = await testData.createProfile({ users: { admin: 1 } });
+    await grantPublicParticipant(profile.id);
+
+    // A real account with no grant on THIS profile (their own profile is
+    // elsewhere). They still get the public grant — proving detection keys on
+    // the role, not on the caller having a row of their own.
+    const outsider = await testData.createStandaloneUser('example.com');
+
+    const roles = await getProfileAccessRoles({
+      user: { id: outsider.authUserId },
+      profileId: profile.id,
+    });
+    expect(roles.map((role) => role.name)).toEqual([
+      PUBLIC_PARTICIPANT_ROLE_NAME,
+    ]);
+
+    await expect(
+      assertProfileAccess({
+        user: { id: outsider.authUserId },
+        profileId: profile.id,
+        permissions: { decisions: permission.READ },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('unions a member’s own roles with the public grant', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+    const { profile, memberUsers } = await testData.createProfile({
+      users: { admin: 1, member: 1 },
+    });
+    const member = memberUsers[0];
+    if (!member) {
+      throw new Error('Expected a seeded member user');
+    }
+    await grantPublicParticipant(profile.id);
+
+    const roles = await getProfileAccessRoles({
+      user: { id: member.authUserId },
+      profileId: profile.id,
+    });
+    const roleNames = roles.map((role) => role.name);
+    expect(roleNames).toContain('Member');
+    expect(roleNames).toContain(PUBLIC_PARTICIPANT_ROLE_NAME);
+
+    // The member keeps their own write capability — own ∪ public, not just the
+    // read-only public grant.
+    await expect(
+      assertProfileAccess({
+        user: { id: member.authUserId },
+        profileId: profile.id,
+        permissions: { decisions: permission.UPDATE },
+      }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/services/db/seedData/accessControl.ts
+++ b/services/db/seedData/accessControl.ts
@@ -27,7 +27,16 @@ const ACCESS_ZONE_IDS = {
 const ACCESS_ROLE_IDS = {
   ADMIN: '00000000-0000-4000-8000-000000000011',
   MEMBER: '00000000-0000-4000-8000-000000000012',
+  PUBLIC_PARTICIPANT: '00000000-0000-4000-8000-000000000013',
 } as const;
+
+/**
+ * Name of the stable global "Public Participant" role. Runtime code identifies
+ * global roles by name (the ids here are for seeds/tests), so this is the
+ * canonical identifier the access layer keys the public grant on. Global roles
+ * cannot be renamed via the API.
+ */
+export const PUBLIC_PARTICIPANT_ROLE_NAME = 'Public Participant';
 
 // Access zones data
 export const ACCESS_ZONES = [
@@ -60,6 +69,12 @@ export const ACCESS_ROLES = [
     name: 'Admin',
     description: null,
   },
+  {
+    id: ACCESS_ROLE_IDS.PUBLIC_PARTICIPANT,
+    name: PUBLIC_PARTICIPANT_ROLE_NAME,
+    description:
+      'Read-only public access to a profile’s decisions/proposals. Never granted by hand — anchored on the GLOBAL_USER_PUBLIC row for the one public process.',
+  },
 ];
 
 // Role name to ID mapping for convenient access (avoids string references)
@@ -71,6 +86,10 @@ export const ROLES = {
   MEMBER: {
     id: ACCESS_ROLE_IDS.MEMBER,
     name: 'Member',
+  },
+  PUBLIC_PARTICIPANT: {
+    id: ACCESS_ROLE_IDS.PUBLIC_PARTICIPANT,
+    name: PUBLIC_PARTICIPANT_ROLE_NAME,
   },
 } as const;
 
@@ -137,5 +156,12 @@ export const ACCESS_ROLE_PERMISSIONS = [
       PERMISSIONS.UPDATE |
       DECISION_BITS.SUBMIT_PROPOSALS |
       DECISION_BITS.VOTE,
+  },
+  // Public Participant gets read-only access to the decisions zone (global,
+  // profileId IS NULL) — "public = read decisions/proposals" applies uniformly.
+  {
+    accessRoleId: ACCESS_ROLE_IDS.PUBLIC_PARTICIPANT,
+    accessZoneId: ACCESS_ZONE_IDS.DECISIONS,
+    permission: PERMISSIONS.READ,
   },
 ];


### PR DESCRIPTION
Public read access on the profile/decision path is now a stable Public Participant role unioned with the caller's own grant, instead of substituting the GLOBAL_USER_PUBLIC sentinel user and fabricating a synthetic identity.