### PR TITLE
fix(common): exclude GLOBAL_USER_PUBLIC sentinel from listProfileUsers

### DIFF
--- a/packages/common/src/services/platform/listAllUsers.ts
+++ b/packages/common/src/services/platform/listAllUsers.ts
@@ -1,5 +1,4 @@
-import { GLOBAL_USER_IDS } from '@op/core';
-import { and, count, db, ilike, notInArray } from '@op/db/client';
+import { and, count, db, ilike } from '@op/db/client';
 import { users } from '@op/db/schema';
 import type { SQL } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
@@ -8,6 +7,7 @@ import {
   type SortDir,
   decodeCursor,
   encodeCursor,
+  excludeGlobalUsers,
   getGenericCursorCondition,
 } from '../../utils/db';
 
@@ -29,7 +29,6 @@ export const listAllUsers = async ({
 }) => {
   const decodedCursor = cursor ? decodeCursor(cursor) : undefined;
   const hasSearch = !!(query && query.length >= 2);
-  const sentinelIds = [...GLOBAL_USER_IDS];
 
   // Filter shared by the paginated query and the total count: exclude the
   // sentinel users and, when searching, match the email. The cursor condition
@@ -38,7 +37,7 @@ export const listAllUsers = async ({
     authUserId: AnyPgColumn;
     email: AnyPgColumn;
   }): SQL[] => {
-    const conds: SQL[] = [notInArray(table.authUserId, sentinelIds)];
+    const conds: SQL[] = [excludeGlobalUsers(table.authUserId)];
     if (hasSearch) {
       conds.push(ilike(table.email, `%${query}%`));
     }

--- a/packages/common/src/services/profile/listProfileUsers.ts
+++ b/packages/common/src/services/profile/listProfileUsers.ts
@@ -7,6 +7,7 @@ import {
   type SortDir,
   decodeCursor,
   encodeCursor,
+  excludeGlobalUsers,
 } from '../../utils/db';
 import { assertProfile, assertProfileAdmin } from '../assert';
 import type {
@@ -125,7 +126,10 @@ export const listProfileUsers = async ({
   const cursorCondition = buildCursorCondition();
 
   // Combine all conditions
-  const baseCondition = eq(profileUsers.profileId, profileId);
+  const baseCondition = and(
+    eq(profileUsers.profileId, profileId),
+    excludeGlobalUsers(profileUsers.authUserId),
+  );
   const conditions = [baseCondition, searchFilter, cursorCondition].filter(
     Boolean,
   );

--- a/packages/common/src/utils/db.ts
+++ b/packages/common/src/utils/db.ts
@@ -1,10 +1,21 @@
-import { SQL, and, eq, gt, lt, or, sql } from 'drizzle-orm';
-import { PgColumn } from 'drizzle-orm/pg-core';
+import { GLOBAL_USER_IDS } from '@op/core';
+import { SQL, and, eq, gt, lt, notInArray, or, sql } from 'drizzle-orm';
+import { AnyPgColumn, PgColumn } from 'drizzle-orm/pg-core';
 
 import { CommonError } from './error';
 
 /** Standard sort direction type for database queries */
 export type SortDir = 'asc' | 'desc';
+
+/**
+ * Excludes the global access-control sentinel users (e.g. GLOBAL_USER_PUBLIC)
+ * from a user/member listing. The public-access grant is anchored on real
+ * `users` / `profile_users` rows for these sentinels, so any query that
+ * surfaces those rows to people (or counts them) must drop them or they leak
+ * as ghost participants. Pass the query's `authUserId` column.
+ */
+export const excludeGlobalUsers = (authUserIdColumn: AnyPgColumn): SQL =>
+  notInArray(authUserIdColumn, [...GLOBAL_USER_IDS]);
 
 /** Generic paginated result type for cursor-based pagination */
 export type PaginatedResult<T> = {

--- a/services/api/src/routers/profile/users/listUsers.test.ts
+++ b/services/api/src/routers/profile/users/listUsers.test.ts
@@ -1,3 +1,6 @@
+import { GLOBAL_USER_PUBLIC } from '@op/core';
+import { db, eq } from '@op/db/client';
+import { profileUsers } from '@op/db/schema';
 import { ROLES } from '@op/db/seedData/accessControl';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -211,6 +214,52 @@ describe.concurrent('profile.users.listUsers', () => {
       expect(resultDesc.items[resultDesc.items.length - 1]?.email).toBe(
         adminUser.email,
       );
+    });
+  });
+
+  describe('global sentinel exclusion', () => {
+    it('should exclude the GLOBAL_USER_PUBLIC sentinel participant', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+      const { profile, adminUser, memberUsers } = await testData.createProfile({
+        users: { admin: 1, member: 1 },
+      });
+
+      // Simulate the public-access grant: a real profile_users row anchored on
+      // the GLOBAL_USER_PUBLIC sentinel (its auth.users + public.users rows are
+      // seeded by seedGlobalUsers). Without the notInArray filter this leaks as
+      // a ghost "Unknown" participant on the Manage Participants screen.
+      const [sentinelRow] = await db
+        .insert(profileUsers)
+        .values({
+          authUserId: GLOBAL_USER_PUBLIC,
+          profileId: profile.id,
+        })
+        .returning();
+
+      // Explicit cleanup in case the profile-cascade ordering changes.
+      onTestFinished(async () => {
+        if (sentinelRow) {
+          await db
+            .delete(profileUsers)
+            .where(eq(profileUsers.id, sentinelRow.id));
+        }
+      });
+
+      const { session } = await createIsolatedSession(adminUser.email);
+      const caller = createCaller(await createTestContextWithSession(session));
+
+      const result = await caller.listUsers({
+        profileId: profile.id,
+      });
+
+      // Only the two real members are returned; the sentinel is filtered out.
+      expect(result.items).toHaveLength(2);
+      const emails = result.items.map((u) => u.email);
+      expect(emails).toContain(adminUser.email);
+      expect(emails).toContain(memberUsers[0]?.email);
     });
   });
 


### PR DESCRIPTION
Keeps the public-access sentinel's profile_users row from leaking into Manage Participants as a ghost participant.