### PR TITLE
feat(ui): add static SSR rich-text renderer engine

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -77,6 +77,7 @@
     "@tiptap/pm": "catalog:",
     "@tiptap/react": "catalog:",
     "@tiptap/starter-kit": "catalog:",
+    "@tiptap/static-renderer": "catalog:",
     "@tiptap/suggestion": "catalog:",
     "@vercel/otel": "^2.1.0",
     "access-zones": "catalog:",

--- a/apps/app/src/components/decisions/RichTextRenderer.tsx
+++ b/apps/app/src/components/decisions/RichTextRenderer.tsx
@@ -1,0 +1,68 @@
+import { serverExtensions } from '@op/common/client';
+import { viewerProseStyles } from '@op/ui/RichTextEditor';
+import type { JSONContent } from '@tiptap/core';
+import { renderToReactElement } from '@tiptap/static-renderer/pm/react';
+
+import { LinkPreview } from '../LinkPreview';
+import { ProposalHtmlContent } from './ProposalHtmlContent';
+
+/**
+ * Static (SSR-friendly) renderer for stored TipTap rich-text content.
+ *
+ * This is the principled replacement for {@link ProposalHtmlContent}'s
+ * `dangerouslySetInnerHTML` + Iframely regex path. `renderToReactElement` is
+ * pure JS (no DOM), so it runs in a React Server Component — the rendered prose
+ * ships as server HTML with zero client JS, and custom nodes render as real
+ * React components (e.g. embeds, and — once authored — Details/summary).
+ *
+ * Input is dual-read:
+ *  - a TipTap JSON doc (object) → static React render via the `nodeMapping`.
+ *  - a legacy HTML string → delegates to {@link ProposalHtmlContent} so existing
+ *    HTML-stored bodies (and their Iframely placeholders) still render until the
+ *    content is migrated/backfilled to JSON.
+ *
+ * The module itself is server-capable (no `'use client'`); only the
+ * {@link LinkPreview} embed leaf is a client island within the rendered tree.
+ *
+ * Extensions are shared with `generateProposalHtml`'s `serverExtensions` so the
+ * recognized node set can't drift between the two render paths (an unknown node
+ * is silently dropped, so this single source of truth matters).
+ */
+export function RichTextRenderer({
+  content,
+}: {
+  content: JSONContent | string | null | undefined;
+}) {
+  if (!content) {
+    return null;
+  }
+
+  // Legacy HTML string → existing innerHTML + Iframely path. JSON is an object.
+  if (typeof content === 'string') {
+    return <ProposalHtmlContent html={content} />;
+  }
+
+  return (
+    <div className={viewerProseStyles}>
+      {renderToReactElement({
+        content,
+        extensions: serverExtensions,
+        options: { nodeMapping },
+      })}
+    </div>
+  );
+}
+
+/**
+ * Custom-node renderers. Standard nodes/marks render automatically from
+ * `serverExtensions`; only nodes whose static markup differs from a plain
+ * `renderHTML` need an entry here.
+ */
+const nodeMapping = {
+  // `iframely` is a schema-only atom (a `<div data-iframely data-src>`
+  // placeholder); render the live embed in-tree instead, preserving tRPC access.
+  iframely: ({ node }: { node: { attrs?: { src?: string } } }) => {
+    const src = node.attrs?.src;
+    return src ? <LinkPreview url={src} className="my-4" /> : null;
+  },
+};

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -39,6 +39,7 @@
     "@tiptap/extension-underline": "catalog:",
     "@tiptap/html": "catalog:",
     "@tiptap/starter-kit": "catalog:",
+    "@tiptap/static-renderer": "catalog:",
     "@vercel/functions": "^2.1.0",
     "access-zones": "catalog:",
     "ajv": "^8.17.1",

--- a/packages/common/src/services/decision/staticRender.test.ts
+++ b/packages/common/src/services/decision/staticRender.test.ts
@@ -72,6 +72,29 @@ describe('static renderer × serverExtensions', () => {
     expect(html).toContain('src="https://img.test/a.png"');
   });
 
+  it('renders an h4 as <h4>, not falling back to <h1>', () => {
+    // The editor allows heading levels 1-4; serverExtensions must too, or
+    // TipTap's renderHTML falls back to levels[0] and an H4 renders as H1.
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 4 },
+          content: [{ type: 'text', text: 'Sub-subheading' }],
+        },
+      ],
+    };
+
+    const html = renderToHTMLString({
+      content: doc,
+      extensions: serverExtensions,
+    });
+
+    expect(html).toContain('<h4');
+    expect(html).not.toContain('<h1');
+  });
+
   it('renders the iframely node as its placeholder div (carrying the src)', () => {
     const doc: JSONContent = {
       type: 'doc',

--- a/packages/common/src/services/decision/staticRender.test.ts
+++ b/packages/common/src/services/decision/staticRender.test.ts
@@ -1,0 +1,94 @@
+import type { JSONContent } from '@tiptap/core';
+import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string';
+import { describe, expect, it } from 'vitest';
+
+import { serverExtensions } from './tiptapExtensions';
+
+/**
+ * The static renderer (`@tiptap/static-renderer`) is the foundation for SSR
+ * rich-text rendering. It must recognize every node/mark in `serverExtensions`
+ * — an unregistered type is silently dropped — so these assertions guard the
+ * shared extension set against drift. Output is asserted structurally rather
+ * than byte-compared to `generateHTML`: both are "ours", but they use different
+ * serializers, so exact-string parity would be brittle without adding value.
+ *
+ * The React entry (`renderToReactElement`) used by the app shares this same
+ * node/mark coverage; html-string is used here to keep the test free of a
+ * react-dom dependency in this package.
+ */
+describe('static renderer × serverExtensions', () => {
+  it('renders standard nodes and marks', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Title' }],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'b', marks: [{ type: 'bold' }] },
+            { type: 'text', text: 'i', marks: [{ type: 'italic' }] },
+            { type: 'text', text: 'u', marks: [{ type: 'underline' }] },
+            {
+              type: 'text',
+              text: 'link',
+              marks: [{ type: 'link', attrs: { href: 'https://example.com' } }],
+            },
+          ],
+        },
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'one' }] },
+              ],
+            },
+          ],
+        },
+        { type: 'image', attrs: { src: 'https://img.test/a.png' } },
+      ],
+    };
+
+    const html = renderToHTMLString({
+      content: doc,
+      extensions: serverExtensions,
+    });
+
+    expect(html).toContain('<h2');
+    expect(html).toContain('Title');
+    expect(html).toContain('<strong>b</strong>');
+    expect(html).toContain('<em>i</em>');
+    expect(html).toContain('<u>u</u>');
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('<ul');
+    expect(html).toContain('<li');
+    expect(html).toContain('one');
+    expect(html).toContain('<img');
+    expect(html).toContain('src="https://img.test/a.png"');
+  });
+
+  it('renders the iframely node as its placeholder div (carrying the src)', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        { type: 'iframely', attrs: { src: 'https://youtube.com/watch?v=x' } },
+      ],
+    };
+
+    const html = renderToHTMLString({
+      content: doc,
+      extensions: serverExtensions,
+    });
+
+    // The iframely node must survive the static render (the app's nodeMapping
+    // later swaps this placeholder for a <LinkPreview>; here we assert the node
+    // is recognized and its src round-trips, rather than being dropped).
+    expect(html).toContain('data-iframely');
+    expect(html).toContain('data-src="https://youtube.com/watch?v=x"');
+  });
+});

--- a/packages/common/src/services/decision/tiptapExtensions.ts
+++ b/packages/common/src/services/decision/tiptapExtensions.ts
@@ -91,8 +91,11 @@ export const serverExtensions = [
   StarterKit.configure({
     heading: false,
   }),
+  // Must match the editor (@op/ui editorConfig allows 1-4). TipTap's
+  // Heading.renderHTML falls back to levels[0] for any out-of-range level, so a
+  // narrower list here silently renders a stored H4 as H1.
   StyledHeading.configure({
-    levels: [1, 2, 3],
+    levels: [1, 2, 3, 4],
   }),
   TextAlign.configure({
     types: ['heading', 'paragraph'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ catalogs:
     '@tiptap/starter-kit':
       specifier: ^3.15.3
       version: 3.17.1
+    '@tiptap/static-renderer':
+      specifier: 3.17.1
+      version: 3.17.1
     '@tiptap/suggestion':
       specifier: ^3.15.3
       version: 3.17.1
@@ -601,6 +604,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: 'catalog:'
         version: 3.17.1
+      '@tiptap/static-renderer':
+        specifier: 'catalog:'
+        version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@tiptap/suggestion':
         specifier: 'catalog:'
         version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1)
@@ -794,6 +800,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: 'catalog:'
         version: 3.17.1
+      '@tiptap/static-renderer':
+        specifier: 'catalog:'
+        version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@vercel/functions':
         specifier: ^2.1.0
         version: 2.1.0
@@ -4983,6 +4992,14 @@ packages:
 
   '@tiptap/starter-kit@3.17.1':
     resolution: {integrity: sha512-3vBGqag9mwuQoWTrfQlULtHeoFs7k/2Q8CREf3Y79hv2fqAXTvTOKlWYPSgZhiGVMp6Dti7BDiE9Y1QpvAat2g==}
+
+  '@tiptap/static-renderer@3.17.1':
+    resolution: {integrity: sha512-Nf/+zIXmheALFnlzQKG4Lgdr+O4L/M4RlCJl06djFFsilGrM4RYi4BkEOCynesSRPhMa/8UJ8Q2CMSxQWceMnQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.17.1
+      '@tiptap/pm': ^3.17.1
+      react: ^19.0.1
+      react-dom: ^19.0.1
 
   '@tiptap/suggestion@3.17.1':
     resolution: {integrity: sha512-a188uVYjlLsUiwK3Ki7KsaWVWC0u28KsqGEAqCk9ECYmtVY99Hrb+rcAwGpMjA7tn8WAwThOxiLISoMdpuqXwg==}
@@ -12952,6 +12969,13 @@ snapshots:
       '@tiptap/extension-underline': 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))
       '@tiptap/extensions': 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1)
       '@tiptap/pm': 3.17.1
+
+  '@tiptap/static-renderer@3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@tiptap/core': 3.17.1(@tiptap/pm@3.17.1)
+      '@tiptap/pm': 3.17.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   '@tiptap/suggestion@3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,10 @@ catalog:
   '@tiptap/pm': ^3.15.3
   '@tiptap/react': ^3.15.3
   '@tiptap/starter-kit': ^3.15.3
+  # Pinned exact to match the resolved tiptap suite (3.17.1): static-renderer's
+  # peerDeps demand an exact core/pm match, and a caret floats it to a newer
+  # major-minor that skews against the suite. Bump in lockstep with the suite.
+  '@tiptap/static-renderer': 3.17.1
   '@tiptap/extension-blockquote': ^3.15.3
   '@tiptap/extension-bubble-menu': ^3.15.3
   '@tiptap/extension-bullet-list': ^3.15.3


### PR DESCRIPTION
Foundation of the static rich-text renderer work. The static renderer is the only render path that is **both** SSR-able and able to render real React components for custom nodes (`dangerouslySetInnerHTML` is SSR but markup-only; the live `RichTextViewer` mounts an editor and isn't true SSR).

- `RichTextRenderer` renders a TipTap JSON doc via `@tiptap/static-renderer` (`renderToReactElement`) with an `iframely`→`LinkPreview` nodeMapping; legacy HTML strings fall back to `ProposalHtmlContent`. Server-capable (no `'use client'`) — only the `LinkPreview` embed leaf is a client island.
- Reuses `@op/common` `serverExtensions` so the recognized node set can't drift from the `generateProposalHtml` HTML path.
- Pins `@tiptap/static-renderer` to `3.17.1` to match the tiptap suite (a caret floats it to a skewed major that demands an exact, mismatched core).
- Parity coverage in `@op/common` guards against silent node drops.

Structured so future custom nodes (Details/summary, callouts) drop in via `serverExtensions` + a `nodeMapping` entry.

Stack:
- this PR — renderer engine
- #1332 — overview body → JSON storage + RSC render (wires this renderer), stacked on this
- follow-up — backfill existing HTML overview rows → JSON