### PR TITLE
feat(decisions): store overview body as JSON, render via RSC

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
@@ -1,8 +1,11 @@
+import { createClient } from '@op/api/serverClient';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import type { ReactNode } from 'react';
 import { Suspense } from 'react';
 
 import { DecisionOverviewSuspense } from '@/components/decisions/DecisionOverview';
+import { RichTextRenderer } from '@/components/decisions/RichTextRenderer';
 import { DecisionContentSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
 import { loadDecision } from '../loadDecision';
@@ -46,9 +49,29 @@ const DecisionOverviewPage = async ({
   const { slug } = await params;
   const { instanceId } = await loadDecision(slug);
 
+  // Render the overview body on the server (RSC) from its TipTap JSON, so the
+  // prose ships as HTML with no client JS (only embed leaves are client
+  // islands). Best-effort: on failure the slot is null and the client query +
+  // error boundary in DecisionOverviewSuspense still drive the page.
+  let aboutSlot: ReactNode = null;
+  try {
+    const client = await createClient();
+    const instance = await client.decision.getInstance({ instanceId });
+    const body = instance.instanceData?.overview?.body;
+    if (body) {
+      aboutSlot = <RichTextRenderer content={body} />;
+    }
+  } catch {
+    aboutSlot = null;
+  }
+
   return (
     <Suspense fallback={<DecisionContentSkeleton />}>
-      <DecisionOverviewSuspense instanceId={instanceId} decisionSlug={slug} />
+      <DecisionOverviewSuspense
+        instanceId={instanceId}
+        decisionSlug={slug}
+        aboutSlot={aboutSlot}
+      />
     </Suspense>
   );
 };

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from '@op/api/serverClient';
+import { logger } from '@op/logging';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import type { ReactNode } from 'react';
@@ -61,7 +62,14 @@ const DecisionOverviewPage = async ({
     if (body) {
       aboutSlot = <RichTextRenderer content={body} />;
     }
-  } catch {
+  } catch (error) {
+    // Best-effort: log for observability, then fall back to null. The client
+    // suspense query + APIErrorBoundary in DecisionOverviewSuspense remain the
+    // safety net, so a server-side fetch hiccup degrades rather than 500s.
+    logger.warn('Failed to server-render decision overview body', {
+      instanceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
     aboutSlot = null;
   }
 

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
@@ -54,6 +54,12 @@ const DecisionOverviewPage = async ({
   // prose ships as HTML with no client JS (only embed leaves are client
   // islands). Best-effort: on failure the slot is null and the client query +
   // error boundary in DecisionOverviewSuspense still drive the page.
+  //
+  // TODO: this getInstance call duplicates the client useSuspenseQuery in
+  // DecisionOverviewContent (two fetches per load) and can diverge — if this
+  // server fetch fails while the client succeeds, the body slot is null even
+  // though the body exists. Fetch the instance once here and pass it down to
+  // DecisionOverview, dropping the client suspense query.
   let aboutSlot: ReactNode = null;
   try {
     const client = await createClient();

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
@@ -1,4 +1,8 @@
-import { createClient } from '@op/api/serverClient';
+import {
+  HydrationBoundary,
+  createServerUtils,
+  dehydrate,
+} from '@op/api/server';
 import { logger } from '@op/logging';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
@@ -49,29 +53,20 @@ const DecisionOverviewPage = async ({
 }) => {
   const { slug } = await params;
   const { instanceId } = await loadDecision(slug);
+  const { utils, queryClient } = await createServerUtils();
 
-  // Render the overview body on the server (RSC) from its TipTap JSON, so the
-  // prose ships as HTML with no client JS (only embed leaves are client
-  // islands). Best-effort: on failure the slot is null and the client query +
-  // error boundary in DecisionOverviewSuspense still drive the page.
-  //
-  // TODO: this getInstance call duplicates the client useSuspenseQuery in
-  // DecisionOverviewContent (two fetches per load) and can diverge — if this
-  // server fetch fails while the client succeeds, the body slot is null even
-  // though the body exists. Fetch the instance once here and pass it down to
-  // DecisionOverview, dropping the client suspense query.
+  // One server fetch renders the body as RSC and seeds the cache the client
+  // useSuspenseQuery hydrates from (no second fetch, no divergence). Body is
+  // best-effort: on failure the cache stays empty, so the client refetches and
+  // its APIErrorBoundary drives the error UX.
   let aboutSlot: ReactNode = null;
   try {
-    const client = await createClient();
-    const instance = await client.decision.getInstance({ instanceId });
+    const instance = await utils.decision.getInstance.fetch({ instanceId });
     const body = instance.instanceData?.overview?.body;
     if (body) {
       aboutSlot = <RichTextRenderer content={body} />;
     }
   } catch (error) {
-    // Best-effort: log for observability, then fall back to null. The client
-    // suspense query + APIErrorBoundary in DecisionOverviewSuspense remain the
-    // safety net, so a server-side fetch hiccup degrades rather than 500s.
     logger.warn('Failed to server-render decision overview body', {
       instanceId,
       error: error instanceof Error ? error.message : String(error),
@@ -80,13 +75,15 @@ const DecisionOverviewPage = async ({
   }
 
   return (
-    <Suspense fallback={<DecisionContentSkeleton />}>
-      <DecisionOverviewSuspense
-        instanceId={instanceId}
-        decisionSlug={slug}
-        aboutSlot={aboutSlot}
-      />
-    </Suspense>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<DecisionContentSkeleton />}>
+        <DecisionOverviewSuspense
+          instanceId={instanceId}
+          decisionSlug={slug}
+          aboutSlot={aboutSlot}
+        />
+      </Suspense>
+    </HydrationBoundary>
   );
 };
 

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -7,16 +7,22 @@ import { EmptyState } from '@op/ui/EmptyState';
 import { Header2, Header3 } from '@op/ui/Header';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import he from 'he';
+import type { ReactNode } from 'react';
 import { LuTriangleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
-import { ProposalHtmlContent } from './ProposalHtmlContent';
 import { useCreateProposal } from './useCreateProposal';
 
 interface DecisionOverviewProps {
   instanceId: string;
   decisionSlug: string;
+  /**
+   * The "About" body, pre-rendered on the server (RSC) from the overview's
+   * TipTap JSON via RichTextRenderer, so the prose ships as server HTML with no
+   * client JS. Null when there's no body (falls back to the plain description).
+   */
+  aboutSlot?: ReactNode;
 }
 
 /**
@@ -32,6 +38,7 @@ interface DecisionOverviewProps {
 export function DecisionOverviewSuspense({
   instanceId,
   decisionSlug,
+  aboutSlot,
 }: DecisionOverviewProps) {
   const t = useTranslations();
 
@@ -53,6 +60,7 @@ export function DecisionOverviewSuspense({
       <DecisionOverviewContent
         instanceId={instanceId}
         decisionSlug={decisionSlug}
+        aboutSlot={aboutSlot}
       />
     </APIErrorBoundary>
   );
@@ -61,6 +69,7 @@ export function DecisionOverviewSuspense({
 function DecisionOverviewContent({
   instanceId,
   decisionSlug,
+  aboutSlot,
 }: DecisionOverviewProps) {
   const t = useTranslations();
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
@@ -102,7 +111,7 @@ function DecisionOverviewContent({
         </div>
         <div className="min-w-0 md:col-span-7 md:col-start-6">
           <OverviewAbout
-            content={overview?.body}
+            bodySlot={aboutSlot}
             fallbackText={instance.description ?? undefined}
           />
         </div>
@@ -173,25 +182,25 @@ const OverviewHero = ({
 };
 
 const OverviewAbout = ({
-  content,
+  bodySlot,
   fallbackText,
 }: {
-  /** TipTap-generated HTML from the overview content. */
-  content?: string;
-  /** Plain-text process description shown when no overview content exists. */
+  /** Server-rendered overview body (RSC). Null when there's no body. */
+  bodySlot?: ReactNode;
+  /** Plain-text process description shown when no overview body exists. */
   fallbackText?: string;
 }) => {
   const t = useTranslations();
 
-  if (!content && !fallbackText) {
+  if (!bodySlot && !fallbackText) {
     return null;
   }
 
   return (
     <section className="flex flex-col gap-4">
       <Header2 className="font-serif">{t('About the process')}</Header2>
-      {content ? (
-        <ProposalHtmlContent html={content} />
+      {bodySlot ? (
+        bodySlot
       ) : fallbackText ? (
         // The description is plain text (entity-encoded for some orgs, same as
         // DecisionActionBar) — decode and render as text, not HTML.

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -192,22 +192,28 @@ const OverviewAbout = ({
 }) => {
   const t = useTranslations();
 
-  if (!bodySlot && !fallbackText) {
+  // Prefer the server-rendered body; otherwise fall back to the plain-text
+  // description (entity-encoded for some orgs, same as DecisionActionBar —
+  // decode and render as text, not HTML).
+  let body: ReactNode = null;
+  if (bodySlot) {
+    body = bodySlot;
+  } else if (fallbackText) {
+    body = (
+      <p dir="auto" className="text-base">
+        {he.decode(fallbackText)}
+      </p>
+    );
+  }
+
+  if (!body) {
     return null;
   }
 
   return (
     <section className="flex flex-col gap-4">
       <Header2 className="font-serif">{t('About the process')}</Header2>
-      {bodySlot ? (
-        bodySlot
-      ) : fallbackText ? (
-        // The description is plain text (entity-encoded for some orgs, same as
-        // DecisionActionBar) — decode and render as text, not HTML.
-        <p dir="auto" className="text-base">
-          {he.decode(fallbackText)}
-        </p>
-      ) : null}
+      {body}
     </section>
   );
 };

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -71,9 +71,6 @@ function OverviewSectionContent({
 
   // Editor instance, captured once ready, so the bubble menu can attach.
   const [editor, setEditor] = useState<Editor | null>(null);
-  // A ref to the same editor, read at call time inside onChange so we always
-  // pull the live JSON doc (the onChange closure can be captured stale).
-  const editorRef = useRef<Editor | null>(null);
 
   const saveOverview = (patch: {
     headline?: string;
@@ -131,20 +128,14 @@ function OverviewSectionContent({
           content={initialOverview.body}
           placeholder={t('overview_body_placeholder')}
           editorClassName="min-h-40"
-          onChange={() => {
-            // Persist the TipTap JSON doc (not HTML) so the overview can be
-            // rendered via the static React renderer. Read from the ref so the
-            // value is always live even if this closure was captured early.
-            const json = editorRef.current?.getJSON();
-            if (json) {
-              bodyRef.current = json;
-              saveOverview({ body: json });
-            }
+          onChangeJSON={(json) => {
+            // Persist the TipTap JSON doc so the overview renders via the
+            // static React renderer. tiptap hands us the live editor's JSON, so
+            // no stale-closure workaround is needed.
+            bodyRef.current = json;
+            saveOverview({ body: json });
           }}
-          onEditorReady={(e) => {
-            editorRef.current = e;
-            setEditor(e);
-          }}
+          onEditorReady={setEditor}
         />
 
         <RichTextEditorBubbleMenu editor={editor} />

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -3,6 +3,7 @@
 import { trpc } from '@op/api/client';
 import { RichTextEditor } from '@op/ui/RichTextEditor';
 import { Skeleton } from '@op/ui/Skeleton';
+import type { JSONContent } from '@tiptap/core';
 import type { Editor } from '@tiptap/react';
 import { Suspense, useRef, useState } from 'react';
 
@@ -64,17 +65,20 @@ function OverviewSectionContent({
 
   const [headline, setHeadline] = useState(initialOverview.headline);
   const [description, setDescription] = useState(initialOverview.description);
-  // The editor owns body state; track the latest HTML so headline/description
+  // The editor owns body state; track the latest JSON doc so headline/description
   // saves don't clobber it.
-  const bodyRef = useRef(initialOverview.body);
+  const bodyRef = useRef<string | JSONContent>(initialOverview.body);
 
   // Editor instance, captured once ready, so the bubble menu can attach.
   const [editor, setEditor] = useState<Editor | null>(null);
+  // A ref to the same editor, read at call time inside onChange so we always
+  // pull the live JSON doc (the onChange closure can be captured stale).
+  const editorRef = useRef<Editor | null>(null);
 
   const saveOverview = (patch: {
     headline?: string;
     description?: string;
-    body?: string;
+    body?: string | JSONContent;
   }) => {
     saveChanges({
       overview: {
@@ -127,11 +131,20 @@ function OverviewSectionContent({
           content={initialOverview.body}
           placeholder={t('overview_body_placeholder')}
           editorClassName="min-h-40"
-          onChange={(html) => {
-            bodyRef.current = html;
-            saveOverview({ body: html });
+          onChange={() => {
+            // Persist the TipTap JSON doc (not HTML) so the overview can be
+            // rendered via the static React renderer. Read from the ref so the
+            // value is always live even if this closure was captured early.
+            const json = editorRef.current?.getJSON();
+            if (json) {
+              bodyRef.current = json;
+              saveOverview({ body: json });
+            }
           }}
-          onEditorReady={setEditor}
+          onEditorReady={(e) => {
+            editorRef.current = e;
+            setEditor(e);
+          }}
         />
 
         <RichTextEditorBubbleMenu editor={editor} />

--- a/apps/app/src/components/decisions/ProposalHtmlContent.tsx
+++ b/apps/app/src/components/decisions/ProposalHtmlContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { viewerProseStyles } from '@op/ui/RichTextEditor';
+import { viewerProseStyles } from '@op/ui/RichTextEditor/editorConfig';
 import { useMemo } from 'react';
 
 import { LinkPreview } from '../LinkPreview';

--- a/apps/app/src/components/decisions/RichTextRenderer.tsx
+++ b/apps/app/src/components/decisions/RichTextRenderer.tsx
@@ -1,5 +1,8 @@
 import { serverExtensions } from '@op/common/client';
-import { viewerProseStyles } from '@op/ui/RichTextEditor';
+// Import from the editorConfig subpath (not the RichTextEditor barrel) so this
+// server component doesn't pull the client editor (useRichTextEditor/useEffect)
+// into the RSC graph — viewerProseStyles is a plain style string.
+import { viewerProseStyles } from '@op/ui/RichTextEditor/editorConfig';
 import type { JSONContent } from '@tiptap/core';
 import { renderToReactElement } from '@tiptap/static-renderer/pm/react';
 

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -85,6 +85,9 @@ export {
   type SchemaValidationResult,
 } from './services/decision/schemaValidator';
 export { serverExtensions } from './services/decision/tiptapExtensions';
+// Re-exported so API encoders / app consumers can type stored rich-text bodies
+// (TipTap JSON docs) without taking a direct @tiptap/core dependency.
+export type { JSONContent } from '@tiptap/core';
 export {
   getRubricScoringInfo,
   OVERALL_RECOMMENDATION_KEY,

--- a/packages/common/src/services/decision/schemas/instanceData.ts
+++ b/packages/common/src/services/decision/schemas/instanceData.ts
@@ -2,6 +2,7 @@
  * Instance data creation helpers for DecisionSchemaDefinition templates.
  */
 import type { UiSchema } from '@rjsf/utils';
+import type { JSONContent } from '@tiptap/core';
 import type { JSONSchema7 } from 'json-schema';
 
 import { CommonError, ValidationError } from '../../../utils';
@@ -47,8 +48,12 @@ export interface PhaseInstanceData {
 export interface InstanceOverview {
   headline?: string;
   description?: string;
-  /** Rich text body as an HTML string (TipTap getHTML output) */
-  body?: string;
+  /**
+   * Rich text body. New content is a TipTap JSON doc (`editor.getJSON()`),
+   * which the static renderer consumes directly. Legacy rows hold an HTML
+   * string (`editor.getHTML()`) until backfilled; both shapes are read.
+   */
+  body?: string | JSONContent;
 }
 
 /**

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,6 +56,7 @@
     "./RequiredAsterisk": "./src/components/RequiredAsterisk.tsx",
     "./StatusDot": "./src/components/StatusDot.tsx",
     "./RichTextEditor": "./src/components/RichTextEditor/index.ts",
+    "./RichTextEditor/editorConfig": "./src/components/RichTextEditor/editorConfig.ts",
     "./Sortable": "./src/components/Sortable/index.ts",
     "./SplitPane": "./src/components/SplitPane.tsx",
     "./Surface": "./src/components/Surface.tsx",

--- a/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Editor, Extensions } from '@tiptap/react';
+import type { Content, Editor, Extensions } from '@tiptap/react';
 import { forwardRef, useImperativeHandle } from 'react';
 
 import { RichTextEditorSkeleton } from './RichTextEditorSkeleton';
@@ -21,7 +21,8 @@ export const RichTextEditor = forwardRef<
   RichTextEditorRef,
   {
     extensions?: Extensions;
-    content?: string;
+    /** HTML string or a TipTap JSON doc (the editor seeds from either). */
+    content?: Content;
     placeholder?: string;
     onUpdate?: (content: string) => void;
     onChange?: (content: string) => void;

--- a/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { JSONContent } from '@tiptap/core';
 import type { Content, Editor, Extensions } from '@tiptap/react';
 import { forwardRef, useImperativeHandle } from 'react';
 
@@ -26,6 +27,8 @@ export const RichTextEditor = forwardRef<
     placeholder?: string;
     onUpdate?: (content: string) => void;
     onChange?: (content: string) => void;
+    /** Emits the editor's JSON doc on every update (for JSON-stored content). */
+    onChangeJSON?: (content: JSONContent) => void;
     onEditorReady?: (editor: Editor) => void;
     className?: string;
     editorClassName?: string;
@@ -38,6 +41,7 @@ export const RichTextEditor = forwardRef<
       placeholder,
       onUpdate,
       onChange,
+      onChangeJSON,
       onEditorReady,
       className = '',
       editorClassName = '',
@@ -51,6 +55,7 @@ export const RichTextEditor = forwardRef<
       editorClassName,
       onUpdate,
       onChange,
+      onChangeJSON,
       onEditorReady,
     });
 

--- a/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
+++ b/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
@@ -1,3 +1,4 @@
+import type { JSONContent } from '@tiptap/core';
 import Placeholder from '@tiptap/extension-placeholder';
 import type { Content, Editor, Extensions } from '@tiptap/react';
 import { useEditor } from '@tiptap/react';
@@ -13,6 +14,7 @@ export function useRichTextEditor({
   editorClassName = '',
   onUpdate,
   onChange,
+  onChangeJSON,
   onEditorReady,
   editable = true,
   required = false,
@@ -23,6 +25,8 @@ export function useRichTextEditor({
   editorClassName?: string;
   onUpdate?: (content: string) => void;
   onChange?: (content: string) => void;
+  /** Emits the editor's JSON doc on every update (for JSON-stored content). */
+  onChangeJSON?: (content: JSONContent) => void;
   onEditorReady?: (editor: Editor) => void;
   editable?: boolean;
   /** When true, sets `aria-required` on the editable region for assistive tech. */
@@ -56,6 +60,7 @@ export function useRichTextEditor({
       const html = editor.getHTML();
       onUpdate?.(html);
       onChange?.(html);
+      onChangeJSON?.(editor.getJSON());
     },
     immediatelyRender: false,
   });

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -195,12 +195,13 @@ export const instancePhaseDataEncoder = z.object({
 });
 
 /**
- * Generous byte budget for the overview body, applied on writes only. Large
+ * Generous size budget (string length / serialized JSON length) for the
+ * overview body, applied on writes only. Large
  * because images are currently inlined as base64 (editor feature behind a flag,
  * internal testing only) — a single image easily exceeds tens of KB. Tighten it
  * once images move to the app-wide upload→URL flow.
  */
-const MAX_OVERVIEW_BODY_BYTES = 5_000_000;
+const MAX_OVERVIEW_BODY_SIZE = 5_000_000;
 
 /**
  * A stored TipTap JSON doc — a `doc`-rooted object (what `editor.getJSON()`
@@ -225,11 +226,11 @@ const overviewBodyEncoder = z.union([
 ]);
 
 const overviewBodyInputEncoder = z.union([
-  z.string().max(MAX_OVERVIEW_BODY_BYTES),
+  z.string().max(MAX_OVERVIEW_BODY_SIZE),
   z
     .custom<JSONContent>(isRichTextDoc)
     .refine(
-      (doc) => JSON.stringify(doc).length <= MAX_OVERVIEW_BODY_BYTES,
+      (doc) => JSON.stringify(doc).length <= MAX_OVERVIEW_BODY_SIZE,
       'Overview body is too large',
     ),
 ]);

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -4,6 +4,7 @@ import {
   proposalSchema,
   rubricTemplateSchema,
 } from '@op/common/client';
+import type { JSONContent } from '@op/common/client';
 import type { PhaseRules as CommonPhaseRules } from '@op/common/src/services/decision';
 import {
   ProcessStatus,
@@ -194,6 +195,37 @@ export const instancePhaseDataEncoder = z.object({
 });
 
 /**
+ * Generous byte budget for the overview body, applied on writes only. Large
+ * because images are currently inlined as base64 (editor feature behind a flag,
+ * internal testing only) — a single image easily exceeds tens of KB. Tighten it
+ * once images move to the app-wide upload→URL flow.
+ */
+const MAX_OVERVIEW_BODY_BYTES = 5_000_000;
+
+/** A stored TipTap JSON doc — a plain object (not a string or array). */
+const isRichTextDoc = (val: unknown): val is JSONContent =>
+  typeof val === 'object' && val !== null && !Array.isArray(val);
+
+/**
+ * Rich text body. New content is a TipTap JSON doc; legacy rows hold an HTML
+ * string until backfilled. Both shapes are accepted on read and write.
+ */
+const overviewBodyEncoder = z.union([
+  z.string(),
+  z.custom<JSONContent>(isRichTextDoc),
+]);
+
+const overviewBodyInputEncoder = z.union([
+  z.string().max(MAX_OVERVIEW_BODY_BYTES),
+  z
+    .custom<JSONContent>(isRichTextDoc)
+    .refine(
+      (doc) => JSON.stringify(doc).length <= MAX_OVERVIEW_BODY_BYTES,
+      'Overview body is too large',
+    ),
+]);
+
+/**
  * Public-facing overview content (headline, short description, rich text body).
  *
  * Output encoder: permissive (no length caps) so already-stored rows always
@@ -204,21 +236,17 @@ export const instancePhaseDataEncoder = z.object({
 const instanceOverviewEncoder = z.object({
   headline: z.string().optional(),
   description: z.string().optional(),
-  /** Rich text body as an HTML string (TipTap getHTML output) */
-  body: z.string().optional(),
+  body: overviewBodyEncoder.optional(),
 });
 
 /**
  * Input encoder: enforces length caps as an abuse/runaway-storage guard on
- * writes. The body cap is generous because images are currently inlined as
- * base64 (editor feature behind a flag, internal testing only) — a single
- * image easily exceeds tens of KB. Tighten it once images move to the
- * app-wide upload→URL flow, which keeps stored HTML small.
+ * writes.
  */
 const instanceOverviewInputEncoder = z.object({
   headline: z.string().max(200).optional(),
   description: z.string().max(500).optional(),
-  body: z.string().max(5_000_000).optional(),
+  body: overviewBodyInputEncoder.optional(),
 });
 
 /** Instance data encoder for new schema format */

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -202,9 +202,18 @@ export const instancePhaseDataEncoder = z.object({
  */
 const MAX_OVERVIEW_BODY_BYTES = 5_000_000;
 
-/** A stored TipTap JSON doc — a plain object (not a string or array). */
+/**
+ * A stored TipTap JSON doc — a `doc`-rooted object (what `editor.getJSON()`
+ * always produces). Requiring `type === 'doc'` rejects arbitrary objects at the
+ * write boundary, so a misrouted value can't silently store and then render
+ * blank; on read, a non-doc object degrades via the body's `.catch(undefined)`.
+ */
 const isRichTextDoc = (val: unknown): val is JSONContent =>
-  typeof val === 'object' && val !== null && !Array.isArray(val);
+  typeof val === 'object' &&
+  val !== null &&
+  !Array.isArray(val) &&
+  'type' in val &&
+  val.type === 'doc';
 
 /**
  * Rich text body. New content is a TipTap JSON doc; legacy rows hold an HTML
@@ -236,7 +245,9 @@ const overviewBodyInputEncoder = z.union([
 const instanceOverviewEncoder = z.object({
   headline: z.string().optional(),
   description: z.string().optional(),
-  body: overviewBodyEncoder.optional(),
+  // Scope the read-path degradation to `body` alone: a malformed stored body
+  // becomes undefined without taking headline/description down with it.
+  body: overviewBodyEncoder.optional().catch(undefined),
 });
 
 /**

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -265,7 +265,16 @@ describe.concurrent('updateDecisionInstance', () => {
     const overview = {
       headline: `Overview headline ${task.id}`,
       description: 'A short description for the overview page',
-      body: '<p>Overview body text</p>',
+      // New bodies are TipTap JSON docs (editor.getJSON()).
+      body: {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Overview body text' }],
+          },
+        ],
+      },
     };
 
     await caller.decision.updateDecisionInstance({
@@ -276,6 +285,43 @@ describe.concurrent('updateDecisionInstance', () => {
     // Round-trip through getInstance — this also guards the encoder: if
     // `overview` were dropped from instanceDataWithSchemaEncoder, zod would
     // strip it from the response and the editor would initialize empty.
+    const fetched = await caller.decision.getInstance({
+      instanceId: instance.instance.id,
+    });
+
+    expect(fetched.instanceData?.overview).toEqual(overview);
+  });
+
+  it('should round-trip a legacy HTML string overview body', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // Bodies written before the JSON migration are HTML strings; they must
+    // still read and write unchanged (the renderer falls back to HTML).
+    const overview = {
+      headline: `Legacy body ${task.id}`,
+      body: '<p>Overview body text</p>',
+    };
+
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      overview,
+    });
+
     const fetched = await caller.decision.getInstance({
       instanceId: instance.instance.id,
     });
@@ -370,7 +416,7 @@ describe.concurrent('updateDecisionInstance', () => {
     expect(instanceData.overview?.description).toBe('');
   });
 
-  it('should tolerate legacy-shaped stored overview when reading an instance', async ({
+  it('should degrade a malformed stored overview body to undefined when reading', async ({
     task,
     onTestFinished,
   }) => {
@@ -386,22 +432,23 @@ describe.concurrent('updateDecisionInstance', () => {
       throw new Error('No instance created');
     }
 
-    // Plant an overview shape written by an older build (body as a TipTap JSON
-    // doc instead of the current HTML string) directly in the database
+    // Plant a corrupt overview shape (body is neither an HTML string nor a
+    // JSON doc — here a number) directly in the database. Both string and
+    // object bodies are valid now, so this is the genuinely-malformed case.
     const dbInstance = await db.query.processInstances.findFirst({
       where: { id: instance.instance.id },
     });
-    const legacyInstanceData = {
+    const corruptInstanceData = {
       ...(dbInstance!.instanceData as DecisionInstanceData),
       overview: {
-        headline: 'Legacy headline',
-        body: { type: 'doc', content: [{ type: 'paragraph' }] },
+        headline: 'Corrupt body',
+        body: 12345,
       },
     };
     await db
       .update(processInstances)
       .set({
-        instanceData: legacyInstanceData as unknown as DecisionInstanceData,
+        instanceData: corruptInstanceData as unknown as DecisionInstanceData,
       })
       .where(eq(processInstances.id, instance.instance.id));
 

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -416,7 +416,7 @@ describe.concurrent('updateDecisionInstance', () => {
     expect(instanceData.overview?.description).toBe('');
   });
 
-  it('should degrade a malformed stored overview body to undefined when reading', async ({
+  it('should degrade a malformed stored overview body without dropping sibling fields', async ({
     task,
     onTestFinished,
   }) => {
@@ -454,14 +454,16 @@ describe.concurrent('updateDecisionInstance', () => {
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
-    // The read must not fail — the malformed overview degrades to undefined
-    // instead of breaking the whole instance (and any list containing it)
+    // The read must not fail. The malformed body degrades to undefined, but the
+    // body-scoped `.catch` keeps headline/description intact (and the whole
+    // instance, and any list containing it, still reads).
     const fetched = await caller.decision.getInstance({
       instanceId: instance.instance.id,
     });
 
     expect(fetched.id).toBe(instance.instance.id);
-    expect(fetched.instanceData?.overview).toBeUndefined();
+    expect(fetched.instanceData?.overview?.headline).toBe('Corrupt body');
+    expect(fetched.instanceData?.overview?.body).toBeUndefined();
   });
 
   it('should update phase settings', async ({ task, onTestFinished }) => {


### PR DESCRIPTION
Stacked on #1331. Combines the planned storage + render-wire steps — storing JSON requires the JSON-capable renderer to ship at the same time, or the overview page can't display newly-saved bodies.

- Overview editor persists `editor.getJSON()` (read via an editor ref to dodge stale-closure capture) instead of `getHTML()`.
- `InstanceOverview.body` + the API encoders accept `string | JSONContent`, so legacy HTML rows and new JSON rows both read/write during rollout; the input encoder keeps a size cap.
- The overview page renders the body on the **server (RSC)** via `RichTextRenderer` and threads it into `DecisionOverview` as an `aboutSlot` — prose ships as server HTML with no client JS; only embed leaves stay client islands.
- `@op/ui` `RichTextEditor` `content` widened to `Content` so it seeds from a JSON doc.
- `JSONContent` re-exported from `@op/common/client` for typing stored bodies (no new runtime dep).
- Overview round-trip tests updated: JSON body is valid, legacy HTML string still round-trips, genuinely-malformed body degrades to undefined.