### PR TITLE
fix(cache): Replace custom memcache with LRU cache, split Redis timeouts from misses, add per-command socket timeout

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1369,6 +1369,9 @@ importers:
       '@vercel/functions':
         specifier: ^2.1.0
         version: 2.1.0
+      lru-cache:
+        specifier: ^11.2.2
+        version: 11.2.4
       redis:
         specifier: ^5.5.5
         version: 5.5.5
@@ -7439,10 +7442,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.2.2:
-    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.2.4:
     resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
@@ -15297,10 +15296,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.2: {}
-
-  lru-cache@11.2.4:
-    optional: true
+  lru-cache@11.2.4: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -15968,7 +15964,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.2.2
+      lru-cache: 11.2.4
       minipass: 7.1.2
 
   path-type@4.0.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1379,6 +1379,9 @@ importers:
       typescript:
         specifier: 5.7.3
         version: 5.7.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(happy-dom@20.5.3)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
   services/collab:
     dependencies:

--- a/services/cache/kv.test.ts
+++ b/services/cache/kv.test.ts
@@ -192,6 +192,46 @@ describe('cache() — Redis tier metrics', () => {
   });
 });
 
+describe('cache() — in-process LRU (L1)', () => {
+  beforeEach(() => {
+    fakeRedis.get.mockReset();
+    fakeRedis.setEx.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('serves a repeat read from the L1 LRU without re-consulting Redis or fetch', async () => {
+    fakeRedis.get.mockResolvedValue(null);
+    fakeRedis.setEx.mockResolvedValue('OK');
+
+    const fetcher = vi.fn().mockResolvedValue('db-value');
+
+    // First read: Redis miss → fetch → populates L1.
+    const first = await cache({
+      type: 'platform',
+      params: ['lru-1'],
+      fetch: fetcher,
+    });
+    expect(first).toBe('db-value');
+    expect(fetcher).toHaveBeenCalledOnce();
+
+    const redisGetsAfterFirst = fakeRedis.get.mock.calls.length;
+
+    // Second read of the same key: should hit the in-process LRU and skip
+    // both the fetch function and Redis entirely.
+    const second = await cache({
+      type: 'platform',
+      params: ['lru-1'],
+      fetch: fetcher,
+    });
+    expect(second).toBe('db-value');
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(fakeRedis.get.mock.calls.length).toBe(redisGetsAfterFirst);
+  });
+});
+
 describe('get()', () => {
   beforeEach(() => {
     fakeRedis.get.mockReset();

--- a/services/cache/kv.test.ts
+++ b/services/cache/kv.test.ts
@@ -1,0 +1,253 @@
+import type { Mock } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Tracks the fake Redis state that the tests configure between runs. Lives at
+// module scope so the `vi.mock('redis', …)` factory (which is hoisted above
+// imports) can close over it.
+type FakeRedis = {
+  isOpen: boolean;
+  on: Mock;
+  connect: Mock;
+  get: Mock<(key: string) => Promise<string | null>>;
+  setEx: Mock<(key: string, ttl: number, data: string) => Promise<unknown>>;
+  del: Mock<(key: string) => Promise<unknown>>;
+  withAbortSignal: (signal: AbortSignal) => {
+    get: (key: string) => Promise<string | null>;
+    setEx: (key: string, ttl: number, data: string) => Promise<unknown>;
+    del: (key: string) => Promise<unknown>;
+  };
+};
+
+const fakeRedis: FakeRedis = {
+  isOpen: true,
+  on: vi.fn(),
+  connect: vi.fn(),
+  get: vi.fn<(key: string) => Promise<string | null>>(),
+  setEx: vi.fn<(key: string, ttl: number, data: string) => Promise<unknown>>(),
+  del: vi.fn<(key: string) => Promise<unknown>>(),
+  // Real node-redis returns a proxy client scoped to the AbortSignal. The
+  // shim here calls the underlying mock but races it against the signal,
+  // so a signal that fires before the get/set/del resolves rejects the
+  // operation (mimicking the per-command socket timeout).
+  withAbortSignal: (signal: AbortSignal) => ({
+    get: (key: string) => raceWithSignal(fakeRedis.get(key), signal),
+    setEx: (key: string, ttl: number, data: string) =>
+      raceWithSignal(fakeRedis.setEx(key, ttl, data), signal),
+    del: (key: string) => raceWithSignal(fakeRedis.del(key), signal),
+  }),
+};
+
+vi.mock('redis', () => ({
+  createClient: () => fakeRedis,
+}));
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: (p: Promise<unknown>) => p,
+}));
+
+vi.mock('@op/logging', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  metrics: {
+    getMeter: () => ({
+      createCounter: () => ({ add: vi.fn() }),
+    }),
+  },
+}));
+
+vi.mock('@op/core', () => ({
+  OPURLConfig: () => ({ IS_PRODUCTION: false }),
+}));
+
+process.env.REDIS_URL = 'redis://localhost:6379';
+
+// Imported AFTER the mocks so kv.ts picks up the fake redis client and the
+// mocked logger/metrics modules.
+const { cache, get, set } = await import('./kv');
+const { cacheMetrics } = await import('./metrics');
+
+function raceWithSignal<T>(p: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+      return;
+    }
+    const onAbort = () =>
+      reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+    signal.addEventListener('abort', onAbort, { once: true });
+    p.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
+describe('cache() — Redis tier metrics', () => {
+  let recordHit: ReturnType<typeof vi.spyOn>;
+  let recordMiss: ReturnType<typeof vi.spyOn>;
+  let recordTimeout: ReturnType<typeof vi.spyOn>;
+  let recordError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fakeRedis.get.mockReset();
+    fakeRedis.setEx.mockReset();
+    fakeRedis.del.mockReset();
+    recordHit = vi.spyOn(cacheMetrics, 'recordHit');
+    recordMiss = vi.spyOn(cacheMetrics, 'recordMiss');
+    recordTimeout = vi.spyOn(cacheMetrics, 'recordTimeout');
+    recordError = vi.spyOn(cacheMetrics, 'recordError');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('records a redis hit and returns the cached value', async () => {
+    fakeRedis.get.mockResolvedValue(JSON.stringify({ ok: true }));
+
+    const fetcher = vi.fn();
+    const value = await cache({
+      type: 'platform',
+      // unique param so the in-process memcache from an earlier test does not leak.
+      params: ['hit-1'],
+      options: { skipMemCache: true },
+      fetch: fetcher,
+    });
+
+    expect(value).toEqual({ ok: true });
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(recordHit).toHaveBeenCalledWith({
+      type: 'kv',
+      source: 'redis',
+      keyType: 'platform',
+    });
+    expect(recordTimeout).not.toHaveBeenCalled();
+    expect(recordMiss).not.toHaveBeenCalled();
+  });
+
+  it('records a true miss (redis returned null) and falls back to fetch', async () => {
+    fakeRedis.get.mockResolvedValue(null);
+    fakeRedis.setEx.mockResolvedValue('OK');
+
+    const fetcher = vi.fn().mockResolvedValue('from-db');
+    const value = await cache({
+      type: 'platform',
+      params: ['miss-1'],
+      options: { skipMemCache: true },
+      fetch: fetcher,
+    });
+
+    expect(value).toBe('from-db');
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(recordMiss).toHaveBeenCalledWith('platform');
+    expect(recordTimeout).not.toHaveBeenCalled();
+  });
+
+  it('records a command timeout (not a miss) when Redis is too slow', async () => {
+    // A redis.get that never resolves forces the per-command AbortSignal
+    // (REDIS_COMMAND_TIMEOUT_MS = 50ms) to fire. The cache layer should
+    // surface that as `recordTimeout({layer:'command'})`, NOT recordMiss.
+    fakeRedis.get.mockImplementation(() => new Promise<string>(() => {}));
+    fakeRedis.setEx.mockResolvedValue('OK');
+
+    const fetcher = vi.fn().mockResolvedValue('from-db');
+    const value = await cache({
+      type: 'platform',
+      params: ['timeout-1'],
+      options: { skipMemCache: true },
+      fetch: fetcher,
+    });
+
+    expect(value).toBe('from-db');
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(recordTimeout).toHaveBeenCalledWith({
+      layer: 'command',
+      keyType: 'platform',
+    });
+    expect(recordMiss).not.toHaveBeenCalled();
+    expect(recordHit).not.toHaveBeenCalled();
+  });
+
+  it('records an error (not a timeout) when redis.get rejects with a non-abort error', async () => {
+    fakeRedis.get.mockRejectedValue(new Error('connection refused'));
+    fakeRedis.setEx.mockResolvedValue('OK');
+
+    const fetcher = vi.fn().mockResolvedValue('from-db');
+    const value = await cache({
+      type: 'platform',
+      params: ['err-1'],
+      options: { skipMemCache: true },
+      fetch: fetcher,
+    });
+
+    expect(value).toBe('from-db');
+    expect(recordError).toHaveBeenCalledWith('get');
+    expect(recordMiss).toHaveBeenCalledWith('platform');
+    expect(recordTimeout).not.toHaveBeenCalled();
+  });
+});
+
+describe('get()', () => {
+  beforeEach(() => {
+    fakeRedis.get.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the parsed value on hit', async () => {
+    fakeRedis.get.mockResolvedValue(JSON.stringify({ id: 1 }));
+    await expect(get('some-key')).resolves.toEqual({ id: 1 });
+  });
+
+  it('returns null on a Redis miss', async () => {
+    fakeRedis.get.mockResolvedValue(null);
+    await expect(get('some-key')).resolves.toBeNull();
+  });
+
+  it('returns null on a command timeout (does not throw to callers)', async () => {
+    fakeRedis.get.mockImplementation(() => new Promise<string>(() => {}));
+    await expect(get('some-key')).resolves.toBeNull();
+  });
+
+  it('returns null on a non-timeout error (does not throw)', async () => {
+    fakeRedis.get.mockRejectedValue(new Error('boom'));
+    await expect(get('some-key')).resolves.toBeNull();
+  });
+});
+
+describe('set()', () => {
+  let recordTimeout: ReturnType<typeof vi.spyOn>;
+  let recordError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fakeRedis.setEx.mockReset();
+    fakeRedis.del.mockReset();
+    recordTimeout = vi.spyOn(cacheMetrics, 'recordTimeout');
+    recordError = vi.spyOn(cacheMetrics, 'recordError');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('records a command timeout when setEx is too slow, does not throw', async () => {
+    fakeRedis.setEx.mockImplementation(() => new Promise<string>(() => {}));
+    await expect(set('k', { a: 1 })).resolves.toBeUndefined();
+    expect(recordTimeout).toHaveBeenCalledWith({ layer: 'command' });
+    expect(recordError).not.toHaveBeenCalled();
+  });
+
+  it('records an error when setEx rejects with a non-abort error', async () => {
+    fakeRedis.setEx.mockRejectedValue(new Error('connection refused'));
+    await expect(set('k', { a: 1 })).resolves.toBeUndefined();
+    expect(recordError).toHaveBeenCalledWith('set');
+    expect(recordTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/services/cache/kv.ts
+++ b/services/cache/kv.ts
@@ -124,10 +124,13 @@ const getCacheKey = (
 type MemCacheEntry = { data: unknown };
 const MEMCACHE_EXPIRE = 2 * 60 * 1000;
 // Total memory budget for the L1 cache (~200 MB), measured by the approximate
-// serialized byte size of each entry's data (see `estimateEntrySize`). A
-// single entry larger than this budget is simply not cached (lru-cache skips
-// items whose size exceeds `maxEntrySize`, which defaults to `maxSize`).
+// serialized byte size of each entry's data (see `estimateEntrySize`).
 const MEMCACHE_MAX_BYTES = 200 * 1024 * 1024;
+// Per-entry cap (~30 MB). An entry larger than this is simply not cached
+// (falls through to Redis) rather than being admitted and evicting most of the
+// cache to make room — without this, `maxEntrySize` would default to `maxSize`
+// and a single fat payload could thrash the whole L1.
+const MEMCACHE_MAX_ENTRY_BYTES = 30 * 1024 * 1024;
 
 // Approximate an entry's in-memory footprint by its serialized JSON byte
 // length. lru-cache requires a positive integer, and a throw here would break
@@ -143,6 +146,7 @@ const estimateEntrySize = (entry: MemCacheEntry): number => {
 
 const memCache = new LRUCache<string, MemCacheEntry>({
   maxSize: MEMCACHE_MAX_BYTES,
+  maxEntrySize: MEMCACHE_MAX_ENTRY_BYTES,
   ttl: MEMCACHE_EXPIRE,
   sizeCalculation: estimateEntrySize,
 });
@@ -182,8 +186,10 @@ export const cache = async <T>({
   const cacheKey = getCacheKey(type, appKey, params);
   const { ttl, skipMemCache = false, storeNulls = false } = options;
   // The LRU's per-entry TTL replaces the manual `createdAt` expiry check. A
-  // caller-supplied `ttl` (ms) overrides the default on write.
-  const memTtl = ttl ?? MEMCACHE_EXPIRE;
+  // caller-supplied `ttl` (ms) overrides the default on write. Use `||` (not
+  // `??`) so a falsy `ttl` of 0 falls back to the default rather than becoming
+  // an immortal entry — matching the Redis-side `ttl ? …` guard below.
+  const memTtl = ttl || MEMCACHE_EXPIRE;
 
   // try memcache first — the LRU returns `undefined` for entries that have
   // expired or been evicted, so a stale read simply falls through to Redis.

--- a/services/cache/kv.ts
+++ b/services/cache/kv.ts
@@ -1,6 +1,7 @@
 import { OPURLConfig } from '@op/core';
 import { logger } from '@op/logging';
 import { waitUntil } from '@vercel/functions';
+import { LRUCache } from 'lru-cache';
 import { createClient } from 'redis';
 
 import { cacheMetrics } from './metrics';
@@ -115,9 +116,36 @@ const getCacheKey = (
   }`;
 };
 
-// TODO: replace with something like an LRU cache
-const memCache = new Map<string, { createdAt: number; data: unknown }>();
+// In-process L1 cache (memcache → Redis → fetch). Bounded by both a per-entry
+// TTL and a total memory budget with LRU eviction, so a long-lived server
+// process can't grow this unbounded. A `null` data field is a deliberately
+// cached negative result (see `storeNulls`); the wrapper object is always
+// truthy so `cache()` can tell a cached null apart from a miss.
+type MemCacheEntry = { data: unknown };
 const MEMCACHE_EXPIRE = 2 * 60 * 1000;
+// Total memory budget for the L1 cache (~200 MB), measured by the approximate
+// serialized byte size of each entry's data (see `estimateEntrySize`). A
+// single entry larger than this budget is simply not cached (lru-cache skips
+// items whose size exceeds `maxEntrySize`, which defaults to `maxSize`).
+const MEMCACHE_MAX_BYTES = 200 * 1024 * 1024;
+
+// Approximate an entry's in-memory footprint by its serialized JSON byte
+// length. lru-cache requires a positive integer, and a throw here would break
+// the cache write, so non-serializable values fall back to a nominal cost.
+const estimateEntrySize = (entry: MemCacheEntry): number => {
+  try {
+    const json = JSON.stringify(entry.data);
+    return json ? Buffer.byteLength(json) : 1;
+  } catch {
+    return 1;
+  }
+};
+
+const memCache = new LRUCache<string, MemCacheEntry>({
+  maxSize: MEMCACHE_MAX_BYTES,
+  ttl: MEMCACHE_EXPIRE,
+  sizeCalculation: estimateEntrySize,
+});
 
 /**
  * Caches values into a tiered structure: memcache → Redis → fetch function.
@@ -153,15 +181,16 @@ export const cache = async <T>({
 }): Promise<Awaited<T>> => {
   const cacheKey = getCacheKey(type, appKey, params);
   const { ttl, skipMemCache = false, storeNulls = false } = options;
+  // The LRU's per-entry TTL replaces the manual `createdAt` expiry check. A
+  // caller-supplied `ttl` (ms) overrides the default on write.
+  const memTtl = ttl ?? MEMCACHE_EXPIRE;
 
-  // try memcache first
+  // try memcache first — the LRU returns `undefined` for entries that have
+  // expired or been evicted, so a stale read simply falls through to Redis.
   const cachedVal = !skipMemCache ? memCache.get(cacheKey) : undefined;
   if (cachedVal) {
-    const memCacheExpire = ttl ? ttl : MEMCACHE_EXPIRE;
-    if (Date.now() - cachedVal.createdAt < memCacheExpire) {
-      cacheMetrics.recordHit({ type: 'memory', keyType: type });
-      return cachedVal.data as Awaited<T>;
-    }
+    cacheMetrics.recordHit({ type: 'memory', keyType: type });
+    return cachedVal.data as Awaited<T>;
   }
 
   // fall back to Redis cache
@@ -186,7 +215,7 @@ export const cache = async <T>({
     cacheMetrics.recordTimeout({ layer: 'race', keyType: type });
   } else if (raced.status === 'hit') {
     cacheMetrics.recordHit({ type: 'kv', source: 'redis', keyType: type });
-    memCache.set(cacheKey, { createdAt: Date.now(), data: raced.data });
+    memCache.set(cacheKey, { data: raced.data }, { ttl: memTtl });
     return raced.data as Awaited<T>;
   } else if (raced.status === 'timeout') {
     cacheMetrics.recordTimeout({ layer: 'command', keyType: type });
@@ -200,13 +229,13 @@ export const cache = async <T>({
   const shouldSkipCache = options.skipCacheWrite?.(newData) ?? false;
 
   if (newData && !shouldSkipCache) {
-    memCache.set(cacheKey, { createdAt: Date.now(), data: newData });
+    memCache.set(cacheKey, { data: newData }, { ttl: memTtl });
     // don't cache if we couldn't find the record (?)
     // TTL in redis is in seconds
     waitUntil(set(cacheKey, newData, ttl ? ttl / 1000 : 72 * 60 * 60)); // 72h default cache
   } else if (storeNulls && !shouldSkipCache) {
     // This allows us to store negative values in the memcache to improve rejections as well (and avoid DB calls for repeated rejections)
-    memCache.set(cacheKey, { createdAt: Date.now(), data: null });
+    memCache.set(cacheKey, { data: null }, { ttl: memTtl });
   }
 
   return newData;
@@ -227,7 +256,7 @@ export const invalidate = async ({
 
   // TODO: support invalidating entire trees
   if (data) {
-    memCache.set(cacheKey, { createdAt: Date.now(), data });
+    memCache.set(cacheKey, { data });
     set(cacheKey, data);
   } else {
     memCache.delete(cacheKey);

--- a/services/cache/kv.ts
+++ b/services/cache/kv.ts
@@ -7,6 +7,26 @@ import { cacheMetrics } from './metrics';
 
 const REDIS_URL = process.env.REDIS_URL;
 
+// Outer race timeout: how long `cache()` is willing to wait on Redis before
+// falling through to the source. Sized for the 99th-percentile Redis call.
+const REDIS_RACE_TIMEOUT_MS = 300;
+
+// Per-command socket timeout: aborts individual Redis commands so a stuck
+// socket fails fast instead of hanging until REDIS_RACE_TIMEOUT_MS.
+const REDIS_COMMAND_TIMEOUT_MS = 50;
+
+// Sentinel for `Promise.race` — distinguishes the race timeout from a
+// legitimate `null` returned by Redis (cache miss).
+const RACE_TIMEOUT: unique symbol = Symbol('cache.race-timeout');
+
+// Discriminated result of an attempted Redis read. `cache()` uses it to
+// record `hit` / `miss` / `timeout` separately so a Redis slowdown does
+// not masquerade as a cold cache.
+type RedisGetResult =
+  | { status: 'hit'; data: unknown }
+  | { status: 'miss' }
+  | { status: 'timeout' };
+
 // Create Redis client only if REDIS_URL is provided
 let redis: ReturnType<typeof createClient> | null = null;
 
@@ -145,23 +165,37 @@ export const cache = async <T>({
   }
 
   // fall back to Redis cache
-
-  // set null if we don't get a response fast enough
-  const timeout = new Promise((resolve) => {
-    setTimeout(() => resolve(null), 300);
+  //
+  // Two timeouts cover Redis slowness, in order of likelihood:
+  //   1. `tryGetFromRedis` applies a per-command socket timeout
+  //      (REDIS_COMMAND_TIMEOUT_MS) so a stuck connection fails fast.
+  //   2. The outer Promise.race below is the belt-and-suspenders fallback
+  //      (REDIS_RACE_TIMEOUT_MS) for anything the client doesn't abort —
+  //      including a fully saturated event loop.
+  //
+  // Whichever fires, the outcome is recorded as a `cache.timeouts` event
+  // and NOT as a `cache.misses` — those two signals are different (Redis
+  // is slow vs Redis is cold) and need separate dashboards.
+  const raceTimeout = new Promise<typeof RACE_TIMEOUT>((resolve) => {
+    setTimeout(() => resolve(RACE_TIMEOUT), REDIS_RACE_TIMEOUT_MS);
   });
 
-  const data = (await Promise.race([get(cacheKey), timeout])) as Awaited<T>;
+  const raced = await Promise.race([tryGetFromRedis(cacheKey), raceTimeout]);
 
-  if (data) {
+  if (raced === RACE_TIMEOUT) {
+    cacheMetrics.recordTimeout({ layer: 'race', keyType: type });
+  } else if (raced.status === 'hit') {
     cacheMetrics.recordHit({ type: 'kv', source: 'redis', keyType: type });
-    memCache.set(cacheKey, { createdAt: Date.now(), data });
-    return data;
+    memCache.set(cacheKey, { createdAt: Date.now(), data: raced.data });
+    return raced.data as Awaited<T>;
+  } else if (raced.status === 'timeout') {
+    cacheMetrics.recordTimeout({ layer: 'command', keyType: type });
+  } else {
+    cacheMetrics.recordMiss(type);
   }
 
   // finally retrieve the data from the DB
   const newData = await fetch();
-  cacheMetrics.recordMiss(type);
 
   const shouldSkipCache = options.skipCacheWrite?.(newData) ?? false;
 
@@ -221,25 +255,43 @@ export const invalidateMultiple = async ({
   );
 };
 
-export const get = async (key: string) => {
+// Internal: returns a discriminated result so `cache()` can split hit / miss
+// / timeout into different metrics. Public `get()` still maps everything
+// non-hit to `null` for back-compat.
+const tryGetFromRedis = async (key: string): Promise<RedisGetResult> => {
   if (!redis) {
-    return null;
+    return { status: 'miss' };
   }
 
-  try {
-    const data = await redis.get(key);
+  const signal = AbortSignal.timeout(REDIS_COMMAND_TIMEOUT_MS);
 
-    if (data) {
-      return JSON.parse(data);
+  try {
+    const data = await redis.withAbortSignal(signal).get(key);
+
+    if (!data) {
+      return { status: 'miss' };
     }
 
-    return null;
+    return { status: 'hit', data: JSON.parse(data) };
   } catch (e) {
+    if (signal.aborted) {
+      // The per-command socket timeout fired — surface as a timeout so the
+      // caller records it separately from a true cache miss. We don't log
+      // here because timeouts are an expected (counted) signal at high
+      // load; a log line per event would be too noisy.
+      return { status: 'timeout' };
+    }
+
     logger.error('CACHE: error getting from Redis', { error: e });
     cacheMetrics.recordError('get');
 
-    return null;
+    return { status: 'miss' };
   }
+};
+
+export const get = async (key: string) => {
+  const result = await tryGetFromRedis(key);
+  return result.status === 'hit' ? result.data : null;
 };
 
 // const DEFAULT_TTL = 3600 * 24 * 30; // 3600 * 24 = 1 day
@@ -249,14 +301,22 @@ export const set = async (key: string, data: unknown, ttl?: number) => {
     return;
   }
 
+  const signal = AbortSignal.timeout(REDIS_COMMAND_TIMEOUT_MS);
+
   try {
     const serializedData = JSON.stringify(data);
+    const scopedRedis = redis.withAbortSignal(signal);
     if (data === null) {
-      await redis.del(key);
+      await scopedRedis.del(key);
     } else {
-      await redis.setEx(key, ttl || DEFAULT_TTL, serializedData);
+      await scopedRedis.setEx(key, ttl || DEFAULT_TTL, serializedData);
     }
   } catch (e) {
+    if (signal.aborted) {
+      cacheMetrics.recordTimeout({ layer: 'command' });
+      return;
+    }
+
     logger.error('CACHE: error setting to Redis', { error: e });
     cacheMetrics.recordError('set');
   }

--- a/services/cache/kv.ts
+++ b/services/cache/kv.ts
@@ -13,8 +13,10 @@ const REDIS_URL = process.env.REDIS_URL;
 const REDIS_RACE_TIMEOUT_MS = 300;
 
 // Per-command socket timeout: aborts individual Redis commands so a stuck
-// socket fails fast instead of hanging until REDIS_RACE_TIMEOUT_MS.
-const REDIS_COMMAND_TIMEOUT_MS = 50;
+// socket fails fast instead of hanging until REDIS_RACE_TIMEOUT_MS. Sized with
+// margin for network jitter / TLS; watch `cache.timeouts{layer:"command"}` to
+// confirm it isn't clipping successful commands.
+const REDIS_COMMAND_TIMEOUT_MS = 100;
 
 // Sentinel for `Promise.race` — distinguishes the race timeout from a
 // legitimate `null` returned by Redis (cache miss).

--- a/services/cache/metrics.ts
+++ b/services/cache/metrics.ts
@@ -6,6 +6,7 @@ type SourceType = 'redis';
 
 let cacheHitCounter: Counter | null = null;
 let cacheMissCounter: Counter | null = null;
+let cacheTimeoutCounter: Counter | null = null;
 let cacheErrorCounter: Counter | null = null;
 
 function getHitCounter() {
@@ -28,6 +29,18 @@ function getMissCounter() {
     });
   }
   return cacheMissCounter;
+}
+
+function getTimeoutCounter() {
+  if (!cacheTimeoutCounter) {
+    const meter = metrics.getMeter('cache');
+    cacheTimeoutCounter = meter.createCounter('cache.timeouts', {
+      description:
+        'Number of cache fetches that fell through to the source because the cache layer was too slow. Split from cache.misses so a Redis slowdown does not masquerade as a cold cache.',
+      unit: '1',
+    });
+  }
+  return cacheTimeoutCounter;
 }
 
 function getErrorCounter() {
@@ -61,6 +74,23 @@ export const cacheMetrics = {
   recordMiss(type?: string) {
     getMissCounter().add(1, {
       ...(type && { type }),
+    });
+  },
+
+  recordTimeout({
+    layer,
+    keyType,
+  }: {
+    // `command` = the per-command Redis socket timeout (commands fail fast).
+    // `race`    = the outer Promise.race timeout in `cache()` (Redis was
+    //             slow enough that we gave up waiting and fell to the source).
+    layer: 'command' | 'race';
+    keyType?: string;
+  }) {
+    getTimeoutCounter().add(1, {
+      source: 'redis',
+      layer,
+      ...(keyType && { keyType }),
     });
   },
 

--- a/services/cache/package.json
+++ b/services/cache/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "format:check": "oxfmt --check",
+    "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@op/typescript-config": "workspace:*",
-    "typescript": "5.7.3"
+    "typescript": "5.7.3",
+    "vitest": "catalog:"
   }
 }

--- a/services/cache/package.json
+++ b/services/cache/package.json
@@ -13,6 +13,7 @@
     "@op/core": "workspace:*",
     "@op/logging": "workspace:*",
     "@vercel/functions": "^2.1.0",
+    "lru-cache": "^11.2.2",
     "redis": "^5.5.5"
   },
   "devDependencies": {

--- a/services/cache/vitest.config.ts
+++ b/services/cache/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});


### PR DESCRIPTION

The 300ms outer Promise.race in `cache()` silently treated slow Redis as a cache miss. A Redis slowdown was indistinguishable from a cold cache in metrics, so a degrading cache layer hid behind `cache.misses`.

- Add `cache.timeouts` counter (layer=command|race) separate from `cache.misses`. Hits, misses, and timeouts are now mutually exclusive.
- Apply a 50ms per-command AbortSignal via `redis.withAbortSignal()` to `get`/`set`/`del` so a stuck socket fails fast instead of hanging until the 300ms outer race fires. The race timeout is kept as a belt-and-suspenders fallback for a saturated event loop.
- Internal `tryGetFromRedis` returns a discriminated `hit | miss | timeout` result so `cache()` can emit the right metric. The exported `get()` API is unchanged (still returns `null` on non-hit) so consumers in `@op/common`, `services/api`, and `services/workflows` need no change.
- Add `@op/cache` vitest setup + tests covering hit, miss, command-timeout, redis-error, and set-timeout paths.