### PR TITLE
perf(decisions): cache proposal-submitter face-pile in Redis

### DIFF
--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -29,12 +29,15 @@ export const DecisionActionBar = ({
   const t = useTranslations();
   const { slug } = useParams<{ slug: string }>();
 
-  const { createProposal: handleCreateProposal, isCreating } =
-    useCreateProposal({
-      instanceId,
-      navigateTo: (proposal) =>
-        `/decisions/${slug}/proposal/${proposal.profileId}/edit`,
-    });
+  const {
+    createProposal: handleCreateProposal,
+    isCreating,
+    isReady,
+  } = useCreateProposal({
+    instanceId,
+    navigateTo: (proposal) =>
+      `/decisions/${slug}/proposal/${proposal.profileId}/edit`,
+  });
 
   return (
     <div className="flex w-full justify-center">
@@ -74,7 +77,7 @@ export const DecisionActionBar = ({
           <Button
             color="primary"
             className="w-full"
-            isDisabled={isCreating}
+            isDisabled={!isReady || isCreating}
             onPress={handleCreateProposal}
           >
             {isCreating ? <LoadingSpinner /> : null}

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -169,7 +169,7 @@ const OverviewHero = ({
 }) => {
   const t = useTranslations();
   const currentPhaseHref = `/decisions/${decisionSlug}/current`;
-  const { createProposal, isCreating } = useCreateProposal({
+  const { createProposal, isCreating, isReady } = useCreateProposal({
     instanceId,
     navigateTo: (proposal) =>
       `/decisions/${decisionSlug}/proposal/${proposal.profileId}/edit`,
@@ -202,7 +202,7 @@ const OverviewHero = ({
             <Button
               color="primary"
               className="w-auto"
-              isDisabled={isCreating}
+              isDisabled={!isReady || isCreating}
               onPress={createProposal}
             >
               {isCreating ? <LoadingSpinner /> : null}

--- a/apps/app/src/components/decisions/useCreateProposal.ts
+++ b/apps/app/src/components/decisions/useCreateProposal.ts
@@ -5,7 +5,7 @@ import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { createSBBrowserClient } from '@op/supabase/client';
 import { toast } from '@op/ui/Toast';
-import { useTransition } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 
 import { useRouter, useTranslations } from '@/lib/i18n';
 
@@ -28,12 +28,17 @@ export function useCreateProposal({
   const t = useTranslations();
   const router = useRouter();
   const { user } = useUser();
+  const [isReady, setIsReady] = useState(false);
   const [isCreating, startCreating] = useTransition();
   const supabase = createSBBrowserClient();
   const utils = trpc.useUtils();
   const anonymousSigninEnabled = useFeatureFlag('anonymous_signin');
 
   const createProposalMutation = trpc.decision.createProposal.useMutation();
+
+  useEffect(() => {
+    setIsReady(true);
+  }, []);
 
   const createProposal = () => {
     startCreating(async () => {
@@ -68,5 +73,5 @@ export function useCreateProposal({
     });
   };
 
-  return { createProposal, isCreating };
+  return { createProposal, isCreating, isReady };
 }

--- a/apps/app/src/components/decisions/useCreateProposal.ts
+++ b/apps/app/src/components/decisions/useCreateProposal.ts
@@ -3,9 +3,10 @@
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
+import { useMount } from '@op/hooks';
 import { createSBBrowserClient } from '@op/supabase/client';
 import { toast } from '@op/ui/Toast';
-import { useEffect, useState, useTransition } from 'react';
+import { useTransition } from 'react';
 
 import { useRouter, useTranslations } from '@/lib/i18n';
 
@@ -28,17 +29,14 @@ export function useCreateProposal({
   const t = useTranslations();
   const router = useRouter();
   const { user } = useUser();
-  const [isReady, setIsReady] = useState(false);
+  // Gate the CTA until mount so React Aria's onPress handler is bound.
+  const { mounted } = useMount();
   const [isCreating, startCreating] = useTransition();
   const supabase = createSBBrowserClient();
   const utils = trpc.useUtils();
   const anonymousSigninEnabled = useFeatureFlag('anonymous_signin');
 
   const createProposalMutation = trpc.decision.createProposal.useMutation();
-
-  useEffect(() => {
-    setIsReady(true);
-  }, []);
 
   const createProposal = () => {
     startCreating(async () => {
@@ -73,5 +71,5 @@ export function useCreateProposal({
     });
   };
 
-  return { createProposal, isCreating, isReady };
+  return { createProposal, isCreating, isReady: !!mounted };
 }

--- a/packages/common/src/services/decision/listProposalSubmitters.ts
+++ b/packages/common/src/services/decision/listProposalSubmitters.ts
@@ -66,12 +66,11 @@ export const listProposalSubmitters = async ({
   // The face-pile data is viewer-independent — it's the set of submitters for
   // the instance's current-phase proposals, identical for everyone who passes
   // the READ gate above. Cache it on the instance id (gate stays outside the
-  // cache so a hit can never bypass authorization). Short TTL keeps the pile
-  // fresh as people submit without needing explicit invalidation wiring.
+  // cache so a hit can never bypass authorization). Mutations that change the
+  // submitter set invalidate this key; the default TTL is a fallback.
   return cache({
     type: 'decision',
     params: [processInstanceId, 'submitters'],
-    options: { ttl: 60 * 1000 },
     fetch: async () => {
       const phaseProposalIds = await getProposalIdsForPhase({ instance });
 

--- a/packages/common/src/services/decision/listProposalSubmitters.ts
+++ b/packages/common/src/services/decision/listProposalSubmitters.ts
@@ -1,3 +1,4 @@
+import { cache } from '@op/cache';
 import { type SQL, and, db, eq, inArray, isNull, ne } from '@op/db/client';
 import {
   ProposalStatus,
@@ -62,63 +63,82 @@ export const listProposalSubmitters = async ({
     orgFallbackPermissions: { decisions: permission.READ },
   });
 
-  const phaseProposalIds = await getProposalIdsForPhase({ instance });
+  // The face-pile data is viewer-independent — it's the set of submitters for
+  // the instance's current-phase proposals, identical for everyone who passes
+  // the READ gate above. Cache it on the instance id (gate stays outside the
+  // cache so a hit can never bypass authorization). Short TTL keeps the pile
+  // fresh as people submit without needing explicit invalidation wiring.
+  return cache({
+    type: 'decision',
+    params: [processInstanceId, 'submitters'],
+    options: { ttl: 60 * 1000 },
+    fetch: async () => {
+      const phaseProposalIds = await getProposalIdsForPhase({ instance });
 
-  if (phaseProposalIds.length === 0) {
-    return { submitters: [], total: 0 };
-  }
+      if (phaseProposalIds.length === 0) {
+        return { submitters: [], total: 0 };
+      }
 
-  const scope: SQL = and(
-    eq(proposals.processInstanceId, processInstanceId),
-    ne(proposals.status, ProposalStatus.DRAFT),
-    eq(proposals.visibility, Visibility.VISIBLE),
-    isNull(proposals.deletedAt),
-    inArray(proposals.id, phaseProposalIds),
-  )!;
+      const scope: SQL = and(
+        eq(proposals.processInstanceId, processInstanceId),
+        ne(proposals.status, ProposalStatus.DRAFT),
+        eq(proposals.visibility, Visibility.VISIBLE),
+        isNull(proposals.deletedAt),
+        inArray(proposals.id, phaseProposalIds),
+      )!;
 
-  // auth.users and public.users share the table name "users"; alias the auth
-  // table so joining both in one query doesn't collide on the "users" alias.
-  const submitterAuthUser = alias(authUsers, 'submitter_auth_user');
+      // auth.users and public.users share the table name "users"; alias the
+      // auth table so joining both in one query doesn't collide on the "users"
+      // alias.
+      const submitterAuthUser = alias(authUsers, 'submitter_auth_user');
 
-  const [faceRows, totalRows] = await Promise.all([
-    // Faces: registered (non-anonymous) accounts that uploaded an avatar.
-    db
-      .selectDistinct({
-        slug: profiles.slug,
-        name: profiles.name,
-        avatarName: objectsInStorage.name,
-      })
-      .from(proposals)
-      .innerJoin(profileUsers, eq(profileUsers.profileId, proposals.profileId))
-      .innerJoin(users, eq(users.authUserId, profileUsers.authUserId))
-      .innerJoin(
-        submitterAuthUser,
-        eq(submitterAuthUser.id, profileUsers.authUserId),
-      )
-      .innerJoin(profiles, eq(profiles.id, users.profileId))
-      .innerJoin(
-        objectsInStorage,
-        eq(profiles.avatarImageId, objectsInStorage.id),
-      )
-      .where(and(scope, eq(submitterAuthUser.isAnonymous, false)))
-      .limit(MAX_FACE_PILE_AVATARS),
+      const [faceRows, totalRows] = await Promise.all([
+        // Faces: registered (non-anonymous) accounts that uploaded an avatar.
+        db
+          .selectDistinct({
+            slug: profiles.slug,
+            name: profiles.name,
+            avatarName: objectsInStorage.name,
+          })
+          .from(proposals)
+          .innerJoin(
+            profileUsers,
+            eq(profileUsers.profileId, proposals.profileId),
+          )
+          .innerJoin(users, eq(users.authUserId, profileUsers.authUserId))
+          .innerJoin(
+            submitterAuthUser,
+            eq(submitterAuthUser.id, profileUsers.authUserId),
+          )
+          .innerJoin(profiles, eq(profiles.id, users.profileId))
+          .innerJoin(
+            objectsInStorage,
+            eq(profiles.avatarImageId, objectsInStorage.id),
+          )
+          .where(and(scope, eq(submitterAuthUser.isAnonymous, false)))
+          .limit(MAX_FACE_PILE_AVATARS),
 
-    // Total: every distinct submitter in scope, including anonymous accounts.
-    // A submitter is uniquely identified by authUserId, so the count needs no
-    // join to users/profiles.
-    db
-      .select({ value: countDistinct(profileUsers.authUserId) })
-      .from(proposals)
-      .innerJoin(profileUsers, eq(profileUsers.profileId, proposals.profileId))
-      .where(scope),
-  ]);
+        // Total: every distinct submitter in scope, including anonymous
+        // accounts. A submitter is uniquely identified by authUserId, so the
+        // count needs no join to users/profiles.
+        db
+          .select({ value: countDistinct(profileUsers.authUserId) })
+          .from(proposals)
+          .innerJoin(
+            profileUsers,
+            eq(profileUsers.profileId, proposals.profileId),
+          )
+          .where(scope),
+      ]);
 
-  return {
-    submitters: faceRows.map((row) => ({
-      slug: row.slug,
-      name: row.name ?? null,
-      avatarImage: row.avatarName ? { name: row.avatarName } : null,
-    })),
-    total: Number(totalRows[0]?.value ?? 0),
-  };
+      return {
+        submitters: faceRows.map((row) => ({
+          slug: row.slug,
+          name: row.name ?? null,
+          avatarImage: row.avatarName ? { name: row.avatarName } : null,
+        })),
+        total: Number(totalRows[0]?.value ?? 0),
+      };
+    },
+  });
 };

--- a/packages/common/src/services/decision/listProposalSubmitters.ts
+++ b/packages/common/src/services/decision/listProposalSubmitters.ts
@@ -63,11 +63,8 @@ export const listProposalSubmitters = async ({
     orgFallbackPermissions: { decisions: permission.READ },
   });
 
-  // The face-pile data is viewer-independent — it's the set of submitters for
-  // the instance's current-phase proposals, identical for everyone who passes
-  // the READ gate above. Cache it on the instance id (gate stays outside the
-  // cache so a hit can never bypass authorization). Mutations that change the
-  // submitter set invalidate this key; the default TTL is a fallback.
+  // The face-pile data is viewer-independent; the READ gate stays outside the
+  // cache so a hit can never bypass authorization.
   return cache({
     type: 'decision',
     params: [processInstanceId, 'submitters'],

--- a/services/api/src/routers/decision/proposals/delete.ts
+++ b/services/api/src/routers/decision/proposals/delete.ts
@@ -1,5 +1,6 @@
 import { invalidate } from '@op/cache';
 import { Channels, deleteProposal as deleteProposalService } from '@op/common';
+import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
 import { authenticatedProcedure, router } from '../../../trpcFactory';
@@ -26,10 +27,12 @@ export const deleteProposalRouter = router({
         user,
       });
 
-      await invalidate({
-        type: 'decision',
-        params: [result.processInstanceId, 'submitters'],
-      });
+      waitUntil(
+        invalidate({
+          type: 'decision',
+          params: [result.processInstanceId, 'submitters'],
+        }),
+      );
 
       ctx.registerMutationChannels([
         Channels.decisionProposals(result.processInstanceId),

--- a/services/api/src/routers/decision/proposals/delete.ts
+++ b/services/api/src/routers/decision/proposals/delete.ts
@@ -1,3 +1,4 @@
+import { invalidate } from '@op/cache';
 import { Channels, deleteProposal as deleteProposalService } from '@op/common';
 import { z } from 'zod';
 
@@ -23,6 +24,11 @@ export const deleteProposalRouter = router({
       const result = await deleteProposalService({
         proposalId: input.proposalId,
         user,
+      });
+
+      await invalidate({
+        type: 'decision',
+        params: [result.processInstanceId, 'submitters'],
       });
 
       ctx.registerMutationChannels([

--- a/services/api/src/routers/decision/proposals/submit.ts
+++ b/services/api/src/routers/decision/proposals/submit.ts
@@ -24,10 +24,12 @@ export const submitProposalRouter = router({
         authUserId: user.id,
       });
 
-      await invalidate({
-        type: 'decision',
-        params: [proposal.processInstanceId, 'submitters'],
-      });
+      waitUntil(
+        invalidate({
+          type: 'decision',
+          params: [proposal.processInstanceId, 'submitters'],
+        }),
+      );
 
       ctx.registerMutationChannels([
         Channels.decisionProposals(proposal.processInstanceId),

--- a/services/api/src/routers/decision/proposals/submit.ts
+++ b/services/api/src/routers/decision/proposals/submit.ts
@@ -1,3 +1,4 @@
+import { invalidate } from '@op/cache';
 import { Channels, submitProposal } from '@op/common';
 import { proposalSchema } from '@op/common/client';
 import { Events, inngest } from '@op/events';
@@ -21,6 +22,11 @@ export const submitProposalRouter = router({
       const proposal = await submitProposal({
         data: input,
         authUserId: user.id,
+      });
+
+      await invalidate({
+        type: 'decision',
+        params: [proposal.processInstanceId, 'submitters'],
       });
 
       ctx.registerMutationChannels([


### PR DESCRIPTION
The submitter face-pile is viewer-independent, computed from the instance's current-phase proposals, so cache it on the instance id to take it off the DB on every decision-page load. The access gate stays outside the cache so a hit can't bypass authorization.

Uses the standard cache TTL, with proposal submit/delete mutations invalidating the submitter cache via `waitUntil` so the mutation response is not blocked on cache cleanup. Proposal reads stay client-side for realtime updates.