### PR TITLE
feat(decisions): don't link anonymous proposal authors to their profile

### DIFF
--- a/apps/app/src/components/decisions/MemberParticipationFacePile.tsx
+++ b/apps/app/src/components/decisions/MemberParticipationFacePile.tsx
@@ -15,12 +15,14 @@ type Submitter = {
 
 export const MemberParticipationFacePile = ({
   submitters,
+  total,
 }: {
   submitters: Submitter[];
+  total: number;
 }) => {
   const t = useTranslations();
 
-  if (submitters.length === 0) {
+  if (total === 0) {
     return null;
   }
 
@@ -28,6 +30,7 @@ export const MemberParticipationFacePile = ({
     <div className="flex items-center justify-center gap-2">
       <GrowingFacePile
         maxItems={20}
+        totalCount={total}
         items={submitters.map((submitter) => (
           <Link
             key={submitter.slug}
@@ -52,7 +55,7 @@ export const MemberParticipationFacePile = ({
         <span className="w-fit text-sm text-neutral-charcoal">
           {t(
             '{count, plural, =1 {1 member has submitted proposals} other {# members have submitted proposals}}',
-            { count: submitters.length },
+            { count: total },
           )}
         </span>
       </GrowingFacePile>

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -232,6 +232,8 @@ export function ProposalCardAuthor({
     return null;
   }
 
+  const linkToProfile = withLink && !proposal.submittedBy.isAnonymous;
+
   return (
     <>
       <Avatar
@@ -247,7 +249,7 @@ export function ProposalCardAuthor({
           />
         ) : null}
       </Avatar>
-      {withLink ? (
+      {linkToProfile ? (
         <Link
           href={`/profile/${proposal.submittedBy.slug}`}
           className="max-w-32 truncate text-base text-nowrap text-neutral-charcoal"

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -184,15 +184,22 @@ export function ProposalPreview({
               <>
                 <ProfileAvatar
                   profile={proposal.submittedBy}
+                  withLink={!proposal.submittedBy.isAnonymous}
                   className="size-8"
                 />
                 <div className="flex flex-col">
-                  <NavLink
-                    href={`/profile/${proposal.submittedBy.slug}`}
-                    className="text-base text-neutral-black hover:no-underline"
-                  >
-                    {proposal.submittedBy.name || proposal.submittedBy.slug}
-                  </NavLink>
+                  {proposal.submittedBy.isAnonymous ? (
+                    <span className="text-base text-neutral-black">
+                      {proposal.submittedBy.name || proposal.submittedBy.slug}
+                    </span>
+                  ) : (
+                    <NavLink
+                      href={`/profile/${proposal.submittedBy.slug}`}
+                      className="text-base text-neutral-black hover:no-underline"
+                    >
+                      {proposal.submittedBy.name || proposal.submittedBy.slug}
+                    </NavLink>
+                  )}
                   {!isDraft && (
                     <div className="flex flex-wrap items-center gap-2 text-sm text-neutral-charcoal">
                       <span>

--- a/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
+++ b/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
@@ -35,7 +35,7 @@ export function StandardDecisionPage({
   const t = useTranslations();
   const translation = useDecisionTranslation();
 
-  const [[instance, { submitters }]] = trpc.useSuspenseQueries((t) => [
+  const [[instance, { submitters, total }]] = trpc.useSuspenseQueries((t) => [
     t.decision.getInstance({ instanceId }),
     t.decision.listProposalSubmitters({ processInstanceId: instanceId }),
   ]);
@@ -82,7 +82,7 @@ export function StandardDecisionPage({
           variant="standard"
         />
 
-        <MemberParticipationFacePile submitters={submitters} />
+        <MemberParticipationFacePile submitters={submitters} total={total} />
 
         <DecisionActionBar
           instanceId={instanceId}

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -28,13 +28,12 @@ export function VotingPage({
   const locale = useLocale();
   const translation = useDecisionTranslation();
 
-  const [[instance, voteStatus, { submitters }]] = trpc.useSuspenseQueries(
-    (t) => [
+  const [[instance, voteStatus, { submitters, total }]] =
+    trpc.useSuspenseQueries((t) => [
       t.decision.getInstance({ instanceId }),
       t.decision.getVotingStatus({ processInstanceId: instanceId }),
       t.decision.listProposalSubmitters({ processInstanceId: instanceId }),
-    ],
-  );
+    ]);
 
   const phases = instance.instanceData?.phases ?? [];
   const currentPhaseId = instance.currentStateId;
@@ -87,7 +86,7 @@ export function VotingPage({
           variant="standard"
         />
 
-        <MemberParticipationFacePile submitters={submitters} />
+        <MemberParticipationFacePile submitters={submitters} total={total} />
 
         <DecisionActionBar
           instanceId={instanceId}

--- a/packages/common/src/services/decision/getProposal.ts
+++ b/packages/common/src/services/decision/getProposal.ts
@@ -61,7 +61,10 @@ export const getProposal = async ({
 }): Promise<
   Omit<Proposal, 'proposalData'> & {
     proposalData: ProposalData;
-    submittedBy: Profile & { avatarImage: ObjectsInStorage | null };
+    submittedBy: Profile & {
+      avatarImage: ObjectsInStorage | null;
+      isAnonymous: boolean;
+    };
     processInstance: ProcessInstance;
     profile: Profile;
     commentsCount: number;
@@ -83,6 +86,10 @@ export const getProposal = async ({
       submittedBy: {
         with: {
           avatarImage: true,
+          profileUsers: {
+            columns: {},
+            with: { authUser: { columns: { isAnonymous: true } } },
+          },
         },
       },
       profile: true,
@@ -205,7 +212,11 @@ export const getProposal = async ({
           likesCount: Number(likes[0]?.count || 0),
           followersCount: Number(followers[0]?.count || 0),
         }))
-      : Promise.resolve({ commentsCount: 0, likesCount: 0, followersCount: 0 }),
+      : Promise.resolve({
+          commentsCount: 0,
+          likesCount: 0,
+          followersCount: 0,
+        }),
 
     // Fetch document content
     getProposalDocumentsContent([
@@ -257,8 +268,16 @@ export const getProposal = async ({
     };
   }
 
+  const { profileUsers, ...submittedByProfile } = proposal.submittedBy;
+
   return {
     ...proposal,
+    submittedBy: {
+      ...submittedByProfile,
+      isAnonymous: Boolean(
+        profileUsers?.some((pu) => pu.authUser?.isAnonymous),
+      ),
+    },
     proposalData: parsedProposalData,
     proposalTemplate,
     ...engagementCounts,

--- a/packages/common/src/services/decision/listAllProposals.ts
+++ b/packages/common/src/services/decision/listAllProposals.ts
@@ -200,6 +200,10 @@ export const listAllProposals = async ({
         submittedBy: {
           with: {
             avatarImage: true,
+            profileUsers: {
+              columns: {},
+              with: { authUser: { columns: { isAnonymous: true } } },
+            },
           },
         },
         profile: true,
@@ -250,9 +254,23 @@ export const listAllProposals = async ({
     ]);
 
   const items = pageItems.map((proposal) => {
-    const submittedBy = Array.isArray(proposal.submittedBy)
+    const rawSubmittedBy = Array.isArray(proposal.submittedBy)
       ? proposal.submittedBy[0]
       : proposal.submittedBy;
+    const submittedBy = rawSubmittedBy
+      ? (() => {
+          const { profileUsers, ...author } = rawSubmittedBy;
+          return {
+            ...author,
+            isAnonymous: Boolean(
+              profileUsers?.some(
+                (pu: { authUser: { isAnonymous: boolean } | null }) =>
+                  pu.authUser?.isAnonymous,
+              ),
+            ),
+          };
+        })()
+      : rawSubmittedBy;
     const profile = Array.isArray(proposal.profile)
       ? proposal.profile[0]
       : proposal.profile;

--- a/packages/common/src/services/decision/listProposalSubmitters.ts
+++ b/packages/common/src/services/decision/listProposalSubmitters.ts
@@ -1,7 +1,8 @@
-import { and, db, eq, inArray, isNull, ne } from '@op/db/client';
+import { type SQL, and, db, eq, inArray, isNull, ne } from '@op/db/client';
 import {
   ProposalStatus,
   Visibility,
+  authUsers,
   objectsInStorage,
   profileUsers,
   profiles,
@@ -10,6 +11,8 @@ import {
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 import { permission } from 'access-zones';
+import { countDistinct } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 
 import { UnauthorizedError } from '../../utils';
 import { assertInstanceProfileAccess } from '../access';
@@ -18,6 +21,8 @@ import { getProposalIdsForPhase } from './getProposalsForPhase';
 export interface ListProposalSubmittersInput {
   processInstanceId: string;
 }
+
+const MAX_FACE_PILE_AVATARS = 20;
 
 /**
  * Returns unique submitter profiles for non-draft, visible proposals
@@ -60,35 +65,60 @@ export const listProposalSubmitters = async ({
   const phaseProposalIds = await getProposalIdsForPhase({ instance });
 
   if (phaseProposalIds.length === 0) {
-    return { submitters: [] };
+    return { submitters: [], total: 0 };
   }
 
-  const rows = await db
-    .selectDistinct({
-      slug: profiles.slug,
-      name: profiles.name,
-      avatarName: objectsInStorage.name,
-    })
-    .from(proposals)
-    .innerJoin(profileUsers, eq(profileUsers.profileId, proposals.profileId))
-    .innerJoin(users, eq(users.authUserId, profileUsers.authUserId))
-    .innerJoin(profiles, eq(profiles.id, users.profileId))
-    .leftJoin(objectsInStorage, eq(profiles.avatarImageId, objectsInStorage.id))
-    .where(
-      and(
-        eq(proposals.processInstanceId, processInstanceId),
-        ne(proposals.status, ProposalStatus.DRAFT),
-        eq(proposals.visibility, Visibility.VISIBLE),
-        isNull(proposals.deletedAt),
-        inArray(proposals.id, phaseProposalIds),
-      ),
-    );
+  const scope: SQL = and(
+    eq(proposals.processInstanceId, processInstanceId),
+    ne(proposals.status, ProposalStatus.DRAFT),
+    eq(proposals.visibility, Visibility.VISIBLE),
+    isNull(proposals.deletedAt),
+    inArray(proposals.id, phaseProposalIds),
+  )!;
+
+  // auth.users and public.users share the table name "users"; alias the auth
+  // table so joining both in one query doesn't collide on the "users" alias.
+  const submitterAuthUser = alias(authUsers, 'submitter_auth_user');
+
+  const [faceRows, totalRows] = await Promise.all([
+    // Faces: registered (non-anonymous) accounts that uploaded an avatar.
+    db
+      .selectDistinct({
+        slug: profiles.slug,
+        name: profiles.name,
+        avatarName: objectsInStorage.name,
+      })
+      .from(proposals)
+      .innerJoin(profileUsers, eq(profileUsers.profileId, proposals.profileId))
+      .innerJoin(users, eq(users.authUserId, profileUsers.authUserId))
+      .innerJoin(
+        submitterAuthUser,
+        eq(submitterAuthUser.id, profileUsers.authUserId),
+      )
+      .innerJoin(profiles, eq(profiles.id, users.profileId))
+      .innerJoin(
+        objectsInStorage,
+        eq(profiles.avatarImageId, objectsInStorage.id),
+      )
+      .where(and(scope, eq(submitterAuthUser.isAnonymous, false)))
+      .limit(MAX_FACE_PILE_AVATARS),
+
+    // Total: every distinct submitter in scope, including anonymous accounts.
+    // A submitter is uniquely identified by authUserId, so the count needs no
+    // join to users/profiles.
+    db
+      .select({ value: countDistinct(profileUsers.authUserId) })
+      .from(proposals)
+      .innerJoin(profileUsers, eq(profileUsers.profileId, proposals.profileId))
+      .where(scope),
+  ]);
 
   return {
-    submitters: rows.map((row) => ({
+    submitters: faceRows.map((row) => ({
       slug: row.slug,
       name: row.name ?? null,
       avatarImage: row.avatarName ? { name: row.avatarName } : null,
     })),
+    total: Number(totalRows[0]?.value ?? 0),
   };
 };

--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -473,6 +473,10 @@ export const listProposals = async ({
         submittedBy: {
           with: {
             avatarImage: true,
+            profileUsers: {
+              columns: {},
+              with: { authUser: { columns: { isAnonymous: true } } },
+            },
           },
         },
         profile: true,
@@ -561,9 +565,23 @@ export const listProposals = async ({
   );
 
   const proposalsWithCounts = proposalList.map((proposal: ProposalListItem) => {
-    const submittedBy = Array.isArray(proposal.submittedBy)
+    const rawSubmittedBy = Array.isArray(proposal.submittedBy)
       ? proposal.submittedBy[0]
       : proposal.submittedBy;
+    const submittedBy = rawSubmittedBy
+      ? (() => {
+          const { profileUsers, ...author } = rawSubmittedBy;
+          return {
+            ...author,
+            isAnonymous: Boolean(
+              profileUsers?.some(
+                (pu: { authUser: { isAnonymous: boolean } | null }) =>
+                  pu.authUser?.isAnonymous,
+              ),
+            ),
+          };
+        })()
+      : rawSubmittedBy;
     const profile = Array.isArray(proposal.profile)
       ? proposal.profile[0]
       : proposal.profile;

--- a/packages/common/src/services/decision/schemas/proposal.ts
+++ b/packages/common/src/services/decision/schemas/proposal.ts
@@ -108,7 +108,9 @@ export const proposalSchema = z.object({
   createdAt: z.string().nullish(),
   updatedAt: z.string().nullish(),
   profileId: z.string().uuid(),
-  submittedBy: proposalProfileSchema.optional(),
+  submittedBy: proposalProfileSchema
+    .extend({ isAnonymous: z.boolean().optional() })
+    .optional(),
   profile: proposalProfileSchema,
   decisionCount: z.number().optional(),
   likesCount: z.number().optional(),
@@ -205,6 +207,7 @@ export type ProposalSubmitter = z.infer<typeof proposalSubmitterSchema>;
 
 export const proposalSubmittersListSchema = z.object({
   submitters: z.array(proposalSubmitterSchema),
+  total: z.number(),
 });
 
 export type ProposalSubmittersList = z.infer<

--- a/packages/ui/src/components/GrowingFacePile/index.tsx
+++ b/packages/ui/src/components/GrowingFacePile/index.tsx
@@ -7,10 +7,14 @@ export const GrowingFacePile = ({
   children,
   items,
   maxItems = 20,
+  totalCount,
 }: {
   children?: ReactNode;
   items: Array<ReactNode>;
   maxItems?: number;
+  // When set, the "+N" bubble counts everyone beyond the rendered faces
+  // (totalCount - rendered), so a few avatars can still convey a large total.
+  totalCount?: number;
 }) => {
   const facePileRef = useRef<HTMLDivElement>(null);
   const [numItems, setNumItems] = useState(maxItems);
@@ -39,11 +43,16 @@ export const GrowingFacePile = ({
 
   const renderedItems = items.slice(0, numItems);
 
-  if (items.length > numItems) {
+  const overflowCount =
+    totalCount !== undefined
+      ? totalCount - renderedItems.length
+      : items.length - numItems;
+
+  if (overflowCount > 0) {
     renderedItems.push(
       <Avatar className="bg-neutral-charcoal text-sm text-neutral-offWhite">
         <span className="align-super">+</span>
-        {items.length - numItems}
+        {overflowCount}
       </Avatar>,
     );
   }

--- a/services/api/src/routers/decision/instances/listProposalSubmitters.test.ts
+++ b/services/api/src/routers/decision/instances/listProposalSubmitters.test.ts
@@ -2,7 +2,9 @@ import { db, eq } from '@op/db/client';
 import {
   ProcessStatus,
   ProposalStatus,
+  objectsInStorage,
   profileUsers,
+  profiles,
   users,
 } from '@op/db/schema';
 import { randomUUID } from 'node:crypto';
@@ -17,8 +19,39 @@ import {
 import { schemaWithoutPipeline } from '../../../test/helpers/pipelineSchemas';
 import {
   createAuthenticatedCaller,
+  createIsolatedTestClient,
   createTestUser,
 } from '../../../test/supabase-utils';
+
+/** Gives a profile an avatar so it qualifies for the face pile. */
+async function giveProfileAvatar(profileId: string): Promise<void> {
+  const [storageObject] = await db
+    .insert(objectsInStorage)
+    .values({ bucketId: 'assets', name: `face-pile-test/${profileId}` })
+    .returning();
+
+  await db
+    .update(profiles)
+    .set({ avatarImageId: storageObject!.id })
+    .where(eq(profiles.id, profileId));
+}
+
+/** Looks up the individual profile a submitter is displayed as. */
+async function profileForAuthUser(
+  authUserId: string,
+): Promise<{ id: string; slug: string }> {
+  const [row] = await db
+    .select({ id: profiles.id, slug: profiles.slug })
+    .from(users)
+    .innerJoin(profiles, eq(profiles.id, users.profileId))
+    .where(eq(users.authUserId, authUserId));
+
+  if (!row) {
+    throw new Error(`No individual profile for auth user ${authUserId}`);
+  }
+
+  return row;
+}
 
 describe.concurrent('listProposalSubmitters', () => {
   it('deduplicates submitters across multiple proposals by the same author', async ({
@@ -55,7 +88,7 @@ describe.concurrent('listProposalSubmitters', () => {
       processInstanceId: instanceId,
     });
 
-    expect(result.submitters).toHaveLength(1);
+    expect(result.total).toBe(1);
   });
 
   it('excludes submitters whose only proposal is a draft', async ({
@@ -89,7 +122,7 @@ describe.concurrent('listProposalSubmitters', () => {
       processInstanceId: instanceId,
     });
 
-    expect(result.submitters).toHaveLength(0);
+    expect(result.total).toBe(0);
   });
 
   it('includes invited collaborators on the same proposal', async ({
@@ -150,7 +183,118 @@ describe.concurrent('listProposalSubmitters', () => {
       processInstanceId: instanceId,
     });
 
-    expect(result.submitters).toHaveLength(2);
+    expect(result.total).toBe(2);
+  });
+
+  it('counts anonymous submitters in the total but keeps them out of the face pile', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      processSchema: schemaWithoutPipeline,
+      instanceCount: 1,
+      status: ProcessStatus.PUBLISHED,
+    });
+    const instanceId = setup.instances[0]!.instance.id;
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instanceId,
+      proposalData: { title: `Proposal ${task.id}` },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    // An anonymous account collaborates on the proposal. Give it an avatar so
+    // the only reason it stays out of the pile is its anonymity.
+    const anonClient = createIsolatedTestClient();
+    const { data: anon, error } = await anonClient.auth.signInAnonymously();
+    if (error || !anon.user) {
+      throw new Error(`Failed to sign in anonymously: ${error?.message}`);
+    }
+    testData.trackAuthUserForCleanup(anon.user.id);
+    const anonProfile = await profileForAuthUser(anon.user.id);
+    testData.trackProfileForCleanup(anonProfile.id);
+    await giveProfileAvatar(anonProfile.id);
+
+    await db.insert(profileUsers).values({
+      profileId: proposal.profileId,
+      authUserId: anon.user.id,
+    });
+
+    await testData.advancePhase({
+      instanceId,
+      fromPhaseId: 'submission',
+      toPhaseId: 'review',
+    });
+
+    const result = await caller.decision.listProposalSubmitters({
+      processInstanceId: instanceId,
+    });
+
+    // Owner + anonymous collaborator both count toward the total.
+    expect(result.total).toBe(2);
+    // ...but the anonymous account is never a face, even with an avatar.
+    expect(result.submitters.some((s) => s.slug === anonProfile.slug)).toBe(
+      false,
+    );
+  });
+
+  it('shows registered submitters with an avatar as faces and omits those without', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      processSchema: schemaWithoutPipeline,
+      instanceCount: 1,
+      status: ProcessStatus.PUBLISHED,
+    });
+    const instanceId = setup.instances[0]!.instance.id;
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // Owner submits but has no avatar → counted, never a face.
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instanceId,
+      proposalData: { title: `Proposal ${task.id}` },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    // A registered collaborator with an avatar → the one face shown.
+    const collaboratorEmail = `${task.id}-collab-${randomUUID()}@oneproject.org`;
+    const collabAuth = await createTestUser(collaboratorEmail).then(
+      (res) => res.user,
+    );
+    if (!collabAuth) {
+      throw new Error('Failed to create collaborator auth user');
+    }
+    testData.trackAuthUserForCleanup(collabAuth.id);
+    const collabProfile = await profileForAuthUser(collabAuth.id);
+    testData.trackProfileForCleanup(collabProfile.id);
+    await giveProfileAvatar(collabProfile.id);
+
+    await db.insert(profileUsers).values({
+      profileId: proposal.profileId,
+      authUserId: collabAuth.id,
+      email: collaboratorEmail,
+    });
+
+    await testData.advancePhase({
+      instanceId,
+      fromPhaseId: 'submission',
+      toPhaseId: 'review',
+    });
+
+    const result = await caller.decision.listProposalSubmitters({
+      processInstanceId: instanceId,
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.submitters).toHaveLength(1);
+    expect(result.submitters[0]?.slug).toBe(collabProfile.slug);
+    expect(result.submitters[0]?.avatarImage).not.toBeNull();
   });
 });
 

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -492,6 +492,11 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.profileUsers.id,
       to: r.profileUserToAccessRoles.profileUserId,
     }),
+    authUser: r.one.authUsers({
+      from: r.profileUsers.authUserId,
+      to: r.authUsers.id,
+      optional: false,
+    }),
   },
 
   /**


### PR DESCRIPTION
Anonymous (accountless) proposal authors have no public profile page, so linking their name/avatar led to a 404. Render them as plain text in the proposal list and detail view instead.