### PR TITLE
fix(api): match channel invalidation key to infinite query keys

### DIFF
--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -131,6 +131,9 @@ const CurrentPhaseProposalsLoader = ({
     trpc.decision.listProposals.useSuspenseInfiniteQuery(queryParams, {
       getNextPageParam: (lastPage) => lastPage.next ?? undefined,
       staleTime: 30 * 1000,
+      // Force a client-side fetch so the query registers its invalidation
+      // channel via the client link. TODO: find a cleaner way to register.
+      refetchOnMount: 'always',
     });
 
   const allProposals = useMemo(
@@ -163,6 +166,7 @@ const ResultsPhaseProposalsLoader = ({
       {
         getNextPageParam: (lastPage) => lastPage.next ?? undefined,
         staleTime: 30 * 1000,
+        refetchOnMount: 'always',
       },
     );
 

--- a/services/api/src/links.test.ts
+++ b/services/api/src/links.test.ts
@@ -1,4 +1,5 @@
 import { queryChannelRegistry } from '@op/common/realtime';
+import { QueryClient, type QueryKey } from '@tanstack/react-query';
 import { observable } from '@trpc/server/observable';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -176,5 +177,124 @@ describe('createChannelRegistrationLink', () => {
     });
 
     expect(registerQuery).not.toHaveBeenCalled();
+  });
+});
+
+// Uses a real `QueryClient` + the real registry so assertions run through React
+// Query's actual partial-match logic.
+describe('createChannelRegistrationLink — infinite query invalidation', () => {
+  // tRPC caches `useSuspenseInfiniteQuery` under `type: 'infinite'`.
+  function infiniteQueryKey(processInstanceId: string): QueryKey {
+    return [
+      ['decision', 'listProposals'],
+      {
+        input: { processInstanceId, dir: 'desc', limit: 51 },
+        type: 'infinite',
+      },
+    ];
+  }
+
+  function seedInfiniteQuery(client: QueryClient, queryKey: QueryKey) {
+    client.setQueryData(queryKey, {
+      pages: [{ proposals: [], total: 0 }],
+      pageParams: [undefined],
+    });
+  }
+
+  // Wire input carries `cursor`/`direction` (tRPC infinite) that the cached key
+  // strips — the registered key must strip them too to match.
+  function registerListProposals(processInstanceId: string) {
+    runLink({
+      isServer: false,
+      op: {
+        type: 'query',
+        path: 'decision.listProposals',
+        input: {
+          processInstanceId,
+          dir: 'desc',
+          limit: 51,
+          cursor: 'page-2-cursor',
+          direction: 'forward',
+        },
+      },
+      emitted: wrapResponseWithChannels({ proposals: [], total: 0 }, [
+        `decisionProposals:${processInstanceId}`,
+      ]),
+    });
+  }
+
+  it('invalidates a live infinite query via the local mutation path', async () => {
+    registerListProposals('inst-local');
+
+    const client = new QueryClient();
+    const key = infiniteQueryKey('inst-local');
+    seedInfiniteQuery(client, key);
+    expect(client.getQueryState(key)?.isInvalidated).toBe(false);
+
+    // What QueryInvalidationSubscriber does on a `mutation:added` event.
+    const keys = queryChannelRegistry.getQueryKeysForChannels([
+      'decisionProposals:inst-local',
+    ]);
+    await Promise.all(
+      keys.map((queryKey) => client.invalidateQueries({ queryKey })),
+    );
+
+    expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+  });
+
+  it('invalidates a live infinite query via the realtime websocket path', async () => {
+    registerListProposals('inst-ws');
+
+    const client = new QueryClient();
+    const key = infiniteQueryKey('inst-ws');
+    seedInfiniteQuery(client, key);
+
+    // The websocket handler runs the same registry lookup + invalidation.
+    const keys = queryChannelRegistry.getQueryKeysForChannels([
+      'decisionProposals:inst-ws',
+    ]);
+    await Promise.all(
+      keys.map((queryKey) => client.invalidateQueries({ queryKey })),
+    );
+
+    expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+  });
+
+  it('stays instance-scoped — does not over-invalidate other instances', async () => {
+    registerListProposals('inst-a');
+
+    const client = new QueryClient();
+    const keyA = infiniteQueryKey('inst-a');
+    const keyB = infiniteQueryKey('inst-b');
+    seedInfiniteQuery(client, keyA);
+    seedInfiniteQuery(client, keyB);
+
+    const keys = queryChannelRegistry.getQueryKeysForChannels([
+      'decisionProposals:inst-a',
+    ]);
+    await Promise.all(
+      keys.map((queryKey) => client.invalidateQueries({ queryKey })),
+    );
+
+    expect(client.getQueryState(keyA)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(keyB)?.isInvalidated).toBe(false);
+  });
+
+  it('a `type: query` key does NOT match an infinite query', async () => {
+    const client = new QueryClient();
+    const key = infiniteQueryKey('inst-typed');
+    seedInfiniteQuery(client, key);
+
+    // Same input, but the `type` discriminator alone blocks the partial match.
+    const typedKey = [
+      ['decision', 'listProposals'],
+      {
+        input: { processInstanceId: 'inst-typed', dir: 'desc', limit: 51 },
+        type: 'query',
+      },
+    ];
+    await client.invalidateQueries({ queryKey: typedKey });
+
+    expect(client.getQueryState(key)?.isInvalidated).toBe(false);
   });
 });

--- a/services/api/src/links.ts
+++ b/services/api/src/links.ts
@@ -21,6 +21,32 @@ type TRPCQueryKey = [
   { input?: unknown; type?: 'query' | 'infinite' }?,
 ];
 
+/**
+ * Build the key used to invalidate a query for a channel. `invalidateQueries`
+ * partial-matches, so this must mirror the shape tRPC caches under: drop `type`
+ * (matches both `query` and `infinite`) and strip `cursor`/`direction` (tRPC
+ * strips them from infinite keys). Remaining input stays for scoping.
+ *
+ * FIXME(interim): hand-mirroring tRPC's internal key shape is brittle and
+ * breaks silently if that shape drifts. The clean fix is to tag queries with
+ * their channels (e.g. React Query `meta`) and invalidate by predicate instead.
+ */
+function buildChannelQueryKey(path: string, input: unknown): TRPCQueryKey {
+  const splitPath = path.split('.');
+  if (input === null || typeof input !== 'object') {
+    return [splitPath];
+  }
+
+  const inputWithoutPagination: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (key !== 'cursor' && key !== 'direction') {
+      inputWithoutPagination[key] = value;
+    }
+  }
+
+  return [splitPath, { input: inputWithoutPagination }];
+}
+
 const SSR_SECRETS_KEY_VAR = 'SSR_SECRETS_KEY';
 const isServer = typeof window === 'undefined';
 
@@ -110,10 +136,7 @@ export function createChannelRegistrationLink(): TRPCLink<AppRouter> {
       return observable((observer) => {
         // Build query key manually - getQueryKey() requires typed procedures, not raw op data
         // @see https://trpc.io/docs/v11/getQueryKey
-        const queryKey: TRPCQueryKey =
-          op.type === 'query'
-            ? [op.path.split('.'), { input: op.input, type: op.type }]
-            : [op.path.split('.')];
+        const queryKey = buildChannelQueryKey(op.path, op.input);
 
         const unsubscribe = next(op).subscribe({
           next(value) {

--- a/tests/e2e/tests/proposal-listing-realtime-update.spec.ts
+++ b/tests/e2e/tests/proposal-listing-realtime-update.spec.ts
@@ -1,0 +1,66 @@
+import { createDecisionInstance, getSeededTemplate } from '@op/test';
+
+import { expect, test } from '../fixtures/index.js';
+
+/**
+ * Reproduces the "new proposal doesn't show until ~30s later" bug: the list is
+ * a `useSuspenseInfiniteQuery` with `staleTime: 30s`, so after creating a
+ * proposal it must be refreshed by channel invalidation, not served stale.
+ * The return navigation MUST stay client-side — a hard reload would refetch
+ * from the server and mask the bug.
+ */
+test.describe('Proposal Listing — update after create', () => {
+  test('a newly created proposal appears without waiting for staleTime', async ({
+    authenticatedPage,
+    org,
+  }) => {
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: template.processSchema,
+    });
+
+    // View the (empty) listing — registers the client-side listProposals query.
+    await authenticatedPage.goto(`/en/decisions/${instance.slug}?filter=all`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await expect(
+      authenticatedPage.getByRole('heading', { name: instance.name }),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(authenticatedPage.getByText('No proposals yet')).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Create via the CTA (client-side nav to the editor, fires createProposal).
+    const createProposalResponse = authenticatedPage.waitForResponse(
+      (resp) => resp.url().includes('decision.createProposal') && resp.ok(),
+      { timeout: 30_000 },
+    );
+    await authenticatedPage
+      .getByRole('button', { name: 'Start a proposal' })
+      .click();
+    await createProposalResponse;
+    await authenticatedPage.waitForURL(
+      new RegExp(`/decisions/${instance.slug}/proposal/[^/]+/edit`),
+      { timeout: 15_000 },
+    );
+
+    // Return via client-side history — NOT a reload (which would mask the bug).
+    await authenticatedPage.goBack({ waitUntil: 'commit' });
+    await expect(
+      authenticatedPage.getByRole('heading', { name: instance.name }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The new draft must appear well within the 30s staleTime.
+    await expect(authenticatedPage.getByText('No proposals yet')).toBeHidden({
+      timeout: 10_000,
+    });
+    await expect(
+      authenticatedPage.locator('a[href*="/proposal/"]').first(),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
Realtime/local channel invalidation silently no-oped for infinite queries, so a newly created proposal didn't appear in the list until the 30s staleTime lapsed. Register a type-agnostic, pagination-stripped key so invalidation matches both query and infinite caches while staying instance-scoped.