### PR TITLE
feat(decisions): hide overview CTAs and view toggle until first phase begins

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -12,6 +12,7 @@ import { DecisionHeader } from '@/components/decisions/DecisionHeader';
 import { DecisionSidePanel } from '@/components/decisions/DecisionSidePanel';
 import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
 import { DecisionViewToggle } from '@/components/decisions/DecisionViewToggle';
+import { hasFirstPhaseStarted } from '@/components/decisions/hasFirstPhaseStarted';
 
 import { loadDecision } from './loadDecision';
 
@@ -43,7 +44,17 @@ const DecisionViewLayout = async ({
   const { decisionProfile, instanceId } = await loadDecision(slug);
   const { utils, queryClient } = await createServerUtils();
 
-  await utils.decision.getInstance.prefetch({ instanceId });
+  // Fetch (not prefetch) so we can read the phases server-side to gate the
+  // toggle, while still seeding the cache the client suspense reads hydrate
+  // from. The process is "active" once its first phase begins. Fail open if it
+  // throws — the child suspense reads drive the error UX.
+  let isActive = true;
+  try {
+    const instance = await utils.decision.getInstance.fetch({ instanceId });
+    isActive = hasFirstPhaseStarted(instance.instanceData?.phases);
+  } catch {
+    isActive = true;
+  }
 
   const access = decisionProfile.processInstance?.access;
 
@@ -57,7 +68,10 @@ const DecisionViewLayout = async ({
           canReadUpdates={access?.admin === true || access?.read === true}
           profileName={decisionProfile.name}
           showStepper={false}
-          centerSlot={<DecisionViewToggle decisionSlug={slug} />}
+          // Hidden until the first phase begins.
+          centerSlot={
+            isActive ? <DecisionViewToggle decisionSlug={slug} /> : undefined
+          }
         />
         {children}
         {/*

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
@@ -11,6 +11,7 @@ import { Suspense } from 'react';
 
 import { DecisionOverviewSuspense } from '@/components/decisions/DecisionOverview';
 import { RichTextRenderer } from '@/components/decisions/RichTextRenderer';
+import { hasFirstPhaseStarted } from '@/components/decisions/hasFirstPhaseStarted';
 import { DecisionContentSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
 import { loadDecision } from '../loadDecision';
@@ -60,6 +61,10 @@ const DecisionOverviewPage = async ({
   // pinned-resources seeding below. Best-effort: on failure the cache stays
   // empty, so the client refetches and its APIErrorBoundary drives the error UX.
   let aboutSlot: ReactNode = null;
+  // The process is "active" once its first phase begins; default to active so a
+  // failed fetch keeps the CTAs visible (the client suspense read drives the
+  // error UX). Same gate as the view toggle in the layout.
+  let isActive = true;
   const instance = await utils.decision.getInstance
     .fetch({ instanceId })
     .catch((error) => {
@@ -71,6 +76,7 @@ const DecisionOverviewPage = async ({
     });
 
   if (instance) {
+    isActive = hasFirstPhaseStarted(instance.instanceData?.phases);
     const body = instance.instanceData?.overview?.body;
     if (body) {
       aboutSlot = <RichTextRenderer content={body} />;
@@ -110,6 +116,7 @@ const DecisionOverviewPage = async ({
           instanceId={instanceId}
           decisionSlug={slug}
           aboutSlot={aboutSlot}
+          isActive={isActive}
         />
       </Suspense>
     </HydrationBoundary>

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -30,6 +30,12 @@ interface DecisionOverviewProps {
    * client JS. Null when there's no body (falls back to the plain description).
    */
   aboutSlot?: ReactNode;
+  /**
+   * Whether the process is active, i.e. its first phase has begun. Computed
+   * server-side (RSC) on the page; the proposal CTAs stay hidden until then.
+   * See hasFirstPhaseStarted.
+   */
+  isActive: boolean;
 }
 
 /**
@@ -46,6 +52,7 @@ export function DecisionOverviewSuspense({
   instanceId,
   decisionSlug,
   aboutSlot,
+  isActive,
 }: DecisionOverviewProps) {
   const t = useTranslations();
 
@@ -68,6 +75,7 @@ export function DecisionOverviewSuspense({
         instanceId={instanceId}
         decisionSlug={decisionSlug}
         aboutSlot={aboutSlot}
+        isActive={isActive}
       />
     </APIErrorBoundary>
   );
@@ -77,6 +85,7 @@ function DecisionOverviewContent({
   instanceId,
   decisionSlug,
   aboutSlot,
+  isActive,
 }: DecisionOverviewProps) {
   const t = useTranslations();
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
@@ -113,6 +122,8 @@ function DecisionOverviewContent({
         instanceId={instanceId}
         decisionSlug={decisionSlug}
         canSubmitProposal={canSubmitProposal}
+        // Hidden until the first phase begins (computed server-side).
+        showCtas={isActive}
       />
       {/* 12-col grid mirroring the Figma layout grid: sidebar spans 4 cols,
           body spans 7 starting at col 6. Stacks to one column below md. */}
@@ -160,12 +171,14 @@ const OverviewHero = ({
   instanceId,
   decisionSlug,
   canSubmitProposal,
+  showCtas,
 }: {
   headline: string;
   subhead?: string;
   instanceId: string;
   decisionSlug: string;
   canSubmitProposal: boolean;
+  showCtas: boolean;
 }) => {
   const t = useTranslations();
   const currentPhaseHref = `/decisions/${decisionSlug}/current`;
@@ -190,26 +203,28 @@ const OverviewHero = ({
             </p>
           ) : null}
         </div>
-        <div className="align-stretch flex w-full flex-col gap-4 md:flex-row md:justify-center">
-          <ButtonLink
-            color="secondary"
-            href={currentPhaseHref}
-            className="w-auto"
-          >
-            {t('Browse proposals')}
-          </ButtonLink>
-          {canSubmitProposal ? (
-            <Button
-              color="primary"
+        {showCtas ? (
+          <div className="align-stretch flex w-full flex-col gap-4 md:flex-row md:justify-center">
+            <ButtonLink
+              color="secondary"
+              href={currentPhaseHref}
               className="w-auto"
-              isDisabled={!isReady || isCreating}
-              onPress={createProposal}
             >
-              {isCreating ? <LoadingSpinner /> : null}
-              {t('Submit a proposal')}
-            </Button>
-          ) : null}
-        </div>
+              {t('Browse proposals')}
+            </ButtonLink>
+            {canSubmitProposal ? (
+              <Button
+                color="primary"
+                className="w-auto"
+                isDisabled={!isReady || isCreating}
+                onPress={createProposal}
+              >
+                {isCreating ? <LoadingSpinner /> : null}
+                {t('Submit a proposal')}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/app/src/components/decisions/hasFirstPhaseStarted.ts
+++ b/apps/app/src/components/decisions/hasFirstPhaseStarted.ts
@@ -1,0 +1,26 @@
+/**
+ * Whether the process's first phase has begun.
+ *
+ * Phase start/end dates are stored as absolute UTC instants (the author's local
+ * midnight on the chosen day, converted via `Date.toISOString()` — see
+ * ProcessBuilder's `formatDateValue`). The server advances phases by comparing
+ * those instants directly against `now` in UTC (see `transitionMonitor.ts`:
+ * `lte(scheduledDate, new Date().toISOString())`), so we mirror that here with a
+ * plain absolute-instant `>=` — no local-timezone reinterpretation.
+ *
+ * A missing or unparseable start date counts as started, so CTAs/toggles stay
+ * visible by default rather than being hidden by bad data.
+ */
+export function hasFirstPhaseStarted(
+  phases: { startDate?: string }[] | undefined,
+): boolean {
+  const start = phases?.[0]?.startDate;
+  if (!start) {
+    return true;
+  }
+  const parsed = new Date(start);
+  if (Number.isNaN(parsed.getTime())) {
+    return true;
+  }
+  return new Date() >= parsed;
+}


### PR DESCRIPTION
Hide the hero proposal CTAs and the Overview/Current Phase toggle when the first phase hasn't begun (today < first phase start date).

- New `hasFirstPhaseStarted` helper; missing/unparseable start date fails open (stays visible).
- `OverviewHero` CTAs gated via `showCtas`.
- `DecisionViewToggle` returns null until the first phase starts.