### PR TITLE
fix(decisions): wrap overview headers and add headline character count

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -20,7 +20,7 @@ import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/st
 import { OverviewTextField } from './OverviewTextField';
 
 // Must match the server-side caps in instanceOverviewInputEncoder
-const HEADLINE_MAX_LENGTH = 200;
+const HEADLINE_MAX_LENGTH = 50;
 const DESCRIPTION_MAX_LENGTH = 500;
 
 export default function OverviewSection(props: SectionProps) {

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
@@ -13,8 +13,6 @@ interface OverviewTextFieldProps {
   maxLength: number;
 }
 
-// ponytail: document-wide focusable scan, fine for this small page. Scope to a
-// container ref if it ever grabs the wrong element.
 function focusNext(current: HTMLElement) {
   const focusables = Array.from(
     document.querySelectorAll<HTMLElement>(
@@ -74,7 +72,7 @@ export function OverviewTextField({
         className={cn(
           'shrink-0 text-sm transition-opacity',
           value.length > 0 ? 'opacity-100' : 'opacity-0',
-          value.length === maxLength
+          value.length >= maxLength
             ? 'text-functional-red'
             : 'text-neutral-charcoal',
         )}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
@@ -72,8 +72,11 @@ export function OverviewTextField({
       <span
         aria-hidden="true"
         className={cn(
-          'shrink-0 text-sm text-neutral-charcoal transition-opacity',
+          'shrink-0 text-sm transition-opacity',
           value.length > 0 ? 'opacity-100' : 'opacity-0',
+          value.length === maxLength
+            ? 'text-functional-red'
+            : 'text-neutral-charcoal',
         )}
       >
         {value.length}/{maxLength}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
@@ -13,6 +13,18 @@ interface OverviewTextFieldProps {
   maxLength: number;
 }
 
+// ponytail: document-wide focusable scan, fine for this small page. Scope to a
+// container ref if it ever grabs the wrong element.
+function focusNext(current: HTMLElement) {
+  const focusables = Array.from(
+    document.querySelectorAll<HTMLElement>(
+      'textarea, input, [contenteditable="true"]',
+    ),
+  ).filter((el) => !el.hasAttribute('disabled'));
+  const i = focusables.indexOf(current);
+  focusables[i + 1]?.focus();
+}
+
 export function OverviewTextField({
   variant,
   value,
@@ -20,19 +32,52 @@ export function OverviewTextField({
   placeholder,
   maxLength,
 }: OverviewTextFieldProps) {
-  return (
-    <input
-      type="text"
+  const showCount = variant === 'headline';
+
+  const textarea = (
+    <textarea
+      rows={1}
       value={value}
       maxLength={maxLength}
       onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => {
+        // These are single-line — block Enter (no newlines) and advance to the
+        // next field instead.
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          focusNext(e.currentTarget);
+        }
+      }}
       placeholder={placeholder}
       aria-label={placeholder}
       className={cn(
-        'w-full bg-transparent text-neutral-charcoal placeholder:text-neutral-gray3 focus:outline-none',
+        // field-sizing-content grows the textarea with its content so long
+        // headlines/descriptions wrap instead of getting cut off.
+        'field-sizing-content resize-none bg-transparent text-neutral-charcoal placeholder:text-neutral-gray3 focus:outline-none',
+        showCount ? 'min-w-0 flex-1' : 'w-full',
         variant === 'headline' && 'font-serif text-title-lg',
         variant === 'description' && 'text-base',
       )}
     />
+  );
+
+  if (!showCount) {
+    return textarea;
+  }
+
+  return (
+    <div className="flex items-end justify-between gap-2">
+      {textarea}
+      {/* Always rendered to reserve space; fades in once there's text. */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          'shrink-0 text-sm text-neutral-charcoal transition-opacity',
+          value.length > 0 ? 'opacity-100' : 'opacity-0',
+        )}
+      >
+        {value.length}/{maxLength}
+      </span>
+    </div>
   );
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
@@ -53,7 +53,7 @@ export function OverviewTextField({
       className={cn(
         // field-sizing-content grows the textarea with its content so long
         // headlines/descriptions wrap instead of getting cut off.
-        'field-sizing-content resize-none bg-transparent text-neutral-charcoal placeholder:text-neutral-gray3 focus:outline-none',
+        'field-sizing-content resize-none overflow-hidden bg-transparent text-neutral-charcoal placeholder:text-neutral-gray3 focus:outline-none',
         showCount ? 'min-w-0 flex-1' : 'w-full',
         variant === 'headline' && 'font-serif text-title-lg',
         variant === 'description' && 'text-base',

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -256,7 +256,7 @@ const instanceOverviewEncoder = z.object({
  * writes.
  */
 const instanceOverviewInputEncoder = z.object({
-  headline: z.string().max(200).optional(),
+  headline: z.string().max(50).optional(),
   description: z.string().max(500).optional(),
   body: overviewBodyInputEncoder.optional(),
 });


### PR DESCRIPTION
- Overview headline/description inputs are now auto-growing textareas, so long text wraps instead of getting cut off
- Enter is blocked on both fields and moves focus to the next field
- Headline shows a character counter that fades in once typing
- Headline cap lowered to 50 (client + server encoder)