### PR TITLE
feat: collapsible details/summary in rich text editor

### DIFF
--- a/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
@@ -22,6 +22,7 @@ import {
   LuItalic,
   LuLink,
   LuList,
+  LuListCollapse,
   LuListOrdered,
   LuQuote,
   LuSave,
@@ -98,6 +99,7 @@ export function RichTextEditorBubbleMenu({
             bulletList: e.isActive('bulletList'),
             orderedList: e.isActive('orderedList'),
             blockquote: e.isActive('blockquote'),
+            details: e.isActive('details'),
             link: e.isActive('link'),
           }
         : null,
@@ -209,6 +211,40 @@ export function RichTextEditorBubbleMenu({
         icon: LuCode,
         isActive: activeStates.code,
         toggle: () => editor.chain().focus().toggleCode().run(),
+      },
+      {
+        key: 'details',
+        label: t('Toggle'),
+        icon: LuListCollapse,
+        isActive: activeStates.details,
+        // The Details extension has no toggleDetails — branch on active state
+        toggle: () => {
+          if (activeStates.details) {
+            editor.chain().focus().unsetDetails().run();
+            return;
+          }
+
+          editor.chain().focus().setDetails().run();
+
+          // Details is `isolating` with no gap cursor, so a details at the end
+          // of the doc traps the caret. Insert a trailing paragraph right after
+          // it (when nothing follows) so the user can type below it.
+          const { state } = editor;
+          const { $from } = state.selection;
+          for (let depth = $from.depth; depth > 0; depth--) {
+            if ($from.node(depth).type.name === 'details') {
+              const after = $from.after(depth);
+              if (!state.doc.nodeAt(after)) {
+                editor
+                  .chain()
+                  .insertContentAt(after, { type: 'paragraph' })
+                  .run();
+              }
+
+              break;
+            }
+          }
+        },
       },
     ],
   ];

--- a/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
@@ -214,7 +214,7 @@ export function RichTextEditorBubbleMenu({
       },
       {
         key: 'details',
-        label: t('Toggle'),
+        label: t('Collapsible'),
         icon: LuListCollapse,
         isActive: activeStates.details,
         // The Details extension has no toggleDetails — branch on active state

--- a/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
@@ -22,7 +22,7 @@ import {
   LuItalic,
   LuLink,
   LuList,
-  LuListCollapse,
+  LuChevronRight,
   LuListOrdered,
   LuQuote,
   LuSave,
@@ -215,7 +215,7 @@ export function RichTextEditorBubbleMenu({
       {
         key: 'details',
         label: t('Collapsible'),
-        icon: LuListCollapse,
+        icon: LuChevronRight,
         isActive: activeStates.details,
         // The Details extension has no toggleDetails — branch on active state
         toggle: () => {

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -135,6 +135,7 @@ function OverviewSectionContent({
               : sanitizeTiptapDoc(initialOverview.body)
           }
           placeholder={t('overview_body_placeholder')}
+          summaryPlaceholder={t('Write something...')}
           editorClassName="min-h-40"
           onChangeJSON={(json) => {
             // Persist the TipTap JSON doc so the overview renders via the

--- a/apps/app/src/components/decisions/RichTextRenderer.tsx
+++ b/apps/app/src/components/decisions/RichTextRenderer.tsx
@@ -98,4 +98,7 @@ const nodeMapping = {
     const src = node.attrs?.src;
     return src ? <LinkPreview url={src} className="my-4" /> : null;
   },
+  // Details/summary need no entry: they render via their renderHTML to a native
+  // `<details><summary>…` (collapsible with zero JS), styled by the shared
+  // `.details` CSS in @op/styles — the same block that styles the editor.
 };

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1361,5 +1361,6 @@
   "Continue as guest": "المتابعة كضيف",
   "With an account": "باستخدام حساب",
   "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "عدّل فكرتك قبل بدء المراجعة، واحصل على إشعار عند انتقالها إلى المرحلة التالية، وأعجب بالأفكار الأخرى وعلّق عليها وتابعها.",
-  "Create account": "إنشاء حساب"
+  "Create account": "إنشاء حساب",
+  "Collapsible": "قابل للطي"
 }

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -137,6 +137,7 @@
   "Submit a proposal": "قدّم مقترحًا",
   "Participants": "المشاركون",
   "Summary": "الملخص",
+  "Write something...": "اكتب شيئًا...",
   "View Details": "عرض التفاصيل",
   "Edit Process": "تعديل العملية",
   "Participate": "شارك",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1364,5 +1364,6 @@
   "Continue as guest": "অতিথি হিসেবে চালিয়ে যান",
   "With an account": "অ্যাকাউন্ট দিয়ে",
   "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "পর্যালোচনা শুরু হওয়ার আগে আপনার আইডিয়া সম্পাদনা করুন, এটি পরবর্তী ধাপে গেলে বিজ্ঞপ্তি পান, এবং অন্যান্য আইডিয়া পছন্দ করুন, মন্তব্য করুন ও অনুসরণ করুন।",
-  "Create account": "অ্যাকাউন্ট তৈরি করুন"
+  "Create account": "অ্যাকাউন্ট তৈরি করুন",
+  "Collapsible": "সংকোচনযোগ্য"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -183,6 +183,7 @@
   "Proposal options": "প্রস্তাব অপশন",
   "Participants": "অংশগ্রহণকারী",
   "Summary": "সারসংক্ষেপ",
+  "Write something...": "কিছু লিখুন...",
   "View Details": "বিস্তারিত দেখুন",
   "Edit Process": "প্রক্রিয়া সম্পাদনা করুন",
   "Participate": "অংশগ্রহণ করুন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -414,6 +414,7 @@
   "Bullet List": "Bullet List",
   "Numbered List": "Numbered List",
   "Blockquote": "Blockquote",
+  "Toggle": "Toggle",
   "Align Left": "Align Left",
   "Align Center": "Align Center",
   "Align Right": "Align Right",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -414,7 +414,7 @@
   "Bullet List": "Bullet List",
   "Numbered List": "Numbered List",
   "Blockquote": "Blockquote",
-  "Toggle": "Toggle",
+  "Collapsible": "Collapsible",
   "Align Left": "Align Left",
   "Align Center": "Align Center",
   "Align Right": "Align Right",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -143,6 +143,7 @@
   "Proposal options": "Proposal options",
   "Participants": "Participants",
   "Summary": "Summary",
+  "Write something...": "Write something...",
   "View Details": "View Details",
   "Edit Process": "Edit Process",
   "Participate": "Participate",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -182,6 +182,7 @@
   "Proposal options": "Opciones de propuesta",
   "Participants": "Participantes",
   "Summary": "Resumen",
+  "Write something...": "Escribe algo...",
   "View Details": "Ver detalles",
   "Edit Process": "Editar proceso",
   "Participate": "Participar",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1361,5 +1361,6 @@
   "Continue as guest": "Continuar como invitado",
   "With an account": "Con una cuenta",
   "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Edita tu idea antes de que comience la revisión, recibe notificaciones cuando pase a la siguiente fase, y dale me gusta, comenta y sigue otras ideas.",
-  "Create account": "Crear cuenta"
+  "Create account": "Crear cuenta",
+  "Collapsible": "Plegable"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1361,5 +1361,6 @@
   "Continue as guest": "Continuer en tant qu'invité",
   "With an account": "Avec un compte",
   "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Modifiez votre idée avant le début de l'examen, soyez notifié lorsqu'elle passe à la phase suivante, et aimez, commentez et suivez d'autres idées.",
-  "Create account": "Créer un compte"
+  "Create account": "Créer un compte",
+  "Collapsible": "Dépliable"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -183,6 +183,7 @@
   "Proposal options": "Options de la proposition",
   "Participants": "Participants",
   "Summary": "Résumé",
+  "Write something...": "Écrivez quelque chose...",
   "View Details": "Voir les détails",
   "Edit Process": "Modifier le processus",
   "Participate": "Participer",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1361,5 +1361,6 @@
   "Continue as guest": "Continuar como convidado",
   "With an account": "Com uma conta",
   "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Edite sua ideia antes do início da análise, seja notificado quando ela passar para a próxima fase e curta, comente e siga outras ideias.",
-  "Create account": "Criar conta"
+  "Create account": "Criar conta",
+  "Collapsible": "Recolhível"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -183,6 +183,7 @@
   "Proposal options": "Opções de proposta",
   "Participants": "Participantes",
   "Summary": "Resumo",
+  "Write something...": "Escreva algo...",
   "View Details": "Ver detalhes",
   "Edit Process": "Editar processo",
   "Participate": "Participar",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -137,6 +137,7 @@
   "Submit a proposal": "Gudbi soo jeedin",
   "Participants": "Ka qaybgalayaal",
   "Summary": "Kooban",
+  "Write something...": "Wax qor...",
   "View Details": "Eeg Faahfaahinta",
   "Edit Process": "Wax ka bedel Habka",
   "Participate": "Ka qaybgal",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1363,5 +1363,6 @@
   "Continue as guest": "Ku sii wad marti ahaan",
   "With an account": "Adoo akoon leh",
   "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Wax ka bedel fikradaada ka hor inta aan dib u eegista la bilaabin, ogeysiis hel marka ay u guurto marxaladda xigta, oo jeclow, faallo ka bixi, oo raac fikradaha kale.",
-  "Create account": "Abuur akoon"
+  "Create account": "Abuur akoon",
+  "Collapsible": "La laalaabi karo"
 }

--- a/packages/common/src/services/decision/staticRender.test.ts
+++ b/packages/common/src/services/decision/staticRender.test.ts
@@ -168,10 +168,53 @@ describe('static renderer × serverExtensions', () => {
       extensions: serverExtensions,
     });
 
-    // Assert the whole details subtree survives (recognized, not dropped). The
-    // app's nodeMapping swaps these for a design-system Collapsible; html-string
-    // here just guards schema coverage, like the iframely case above.
+    // Text survives (recognized, not dropped).
     expect(html).toContain('Question?');
     expect(html).toContain('Answer.');
+    // The native collapsible shape IS the feature — guard the structure the
+    // viewer CSS hooks onto, not just the text. `class="details"` styles it,
+    // `data-type="detailsContent"` is the body wrapper, `open` reflects attrs.
+    expect(html).toContain('<details');
+    expect(html).toContain('class="details"');
+    expect(html).toMatch(/<details[^>]*\sopen/);
+    expect(html).toContain('data-type="detailsContent"');
+    expect(html).toContain('<summary>Question?</summary>');
+  });
+
+  it('omits the `open` attribute when details is collapsed (open: false)', () => {
+    // The only custom attr with a renderHTML mapping: open ? { open: '' } : {}.
+    // Assert the false branch so a regression in either direction is caught.
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'details',
+          attrs: { open: false },
+          content: [
+            {
+              type: 'detailsSummary',
+              content: [{ type: 'text', text: 'Question?' }],
+            },
+            {
+              type: 'detailsContent',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Answer.' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const html = renderToHTMLString({
+      content: doc,
+      extensions: serverExtensions,
+    });
+
+    expect(html).toContain('<details');
+    expect(html).not.toMatch(/<details[^>]*\sopen/);
   });
 });

--- a/packages/common/src/services/decision/staticRender.test.ts
+++ b/packages/common/src/services/decision/staticRender.test.ts
@@ -137,7 +137,7 @@ describe('static renderer × serverExtensions', () => {
     ).toThrow();
   });
 
-  it('renders details/summary/content (the app maps these to a Collapsible)', () => {
+  it('renders details/summary/content as a native <details> (recognized, not dropped)', () => {
     const doc: JSONContent = {
       type: 'doc',
       content: [

--- a/packages/common/src/services/decision/staticRender.test.ts
+++ b/packages/common/src/services/decision/staticRender.test.ts
@@ -136,4 +136,42 @@ describe('static renderer × serverExtensions', () => {
       renderToHTMLString({ content: doc, extensions: serverExtensions }),
     ).toThrow();
   });
+
+  it('renders details/summary/content (the app maps these to a Collapsible)', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'details',
+          attrs: { open: true },
+          content: [
+            {
+              type: 'detailsSummary',
+              content: [{ type: 'text', text: 'Question?' }],
+            },
+            {
+              type: 'detailsContent',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Answer.' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const html = renderToHTMLString({
+      content: doc,
+      extensions: serverExtensions,
+    });
+
+    // Assert the whole details subtree survives (recognized, not dropped). The
+    // app's nodeMapping swaps these for a design-system Collapsible; html-string
+    // here just guards schema coverage, like the iframely case above.
+    expect(html).toContain('Question?');
+    expect(html).toContain('Answer.');
+  });
 });

--- a/packages/common/src/services/decision/tiptapExtensions.ts
+++ b/packages/common/src/services/decision/tiptapExtensions.ts
@@ -78,6 +78,76 @@ const IframelyServerNode = Node.create({
 });
 
 /**
+ * Server-safe schema for the Details (collapsible) nodes — schema only, no React
+ * node view (mirrors `IframelyServerNode`). The static renderer uses this
+ * `renderHTML` directly (no nodeMapping override), emitting a native
+ * `<details class="details"><summary>…` that toggles with zero JS and is styled
+ * by the shared `.details` CSS in `@op/styles`. Content models mirror
+ * `@tiptap/extension-details`; `open` mirrors the editor's `persist: true` attr.
+ */
+const DetailsServerNode = Node.create({
+  name: 'details',
+  group: 'block',
+  content: 'detailsSummary detailsContent',
+  defining: true,
+  isolating: true,
+
+  addAttributes() {
+    return {
+      open: {
+        default: false,
+        parseHTML: (element) => element.hasAttribute('open'),
+        renderHTML: ({ open }) => (open ? { open: '' } : {}),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'details' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    // `class: 'details'` so the shared `.details` CSS (in @op/styles) styles the
+    // native viewer <details> the same way it styles the editor node view.
+    return [
+      'details',
+      mergeAttributes(HTMLAttributes, { class: 'details' }),
+      0,
+    ];
+  },
+});
+
+const DetailsSummaryServerNode = Node.create({
+  name: 'detailsSummary',
+  content: 'text*',
+
+  parseHTML() {
+    return [{ tag: 'summary' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['summary', mergeAttributes(HTMLAttributes), 0];
+  },
+});
+
+const DetailsContentServerNode = Node.create({
+  name: 'detailsContent',
+  content: 'block+',
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="detailsContent"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, { 'data-type': 'detailsContent' }),
+      0,
+    ];
+  },
+});
+
+/**
  * Server-side TipTap extensions for `generateHTML()`.
  *
  * These must match the editor/viewer extensions exactly (minus React-specific parts)
@@ -109,4 +179,7 @@ export const serverExtensions = [
     openOnClick: false,
   }),
   IframelyServerNode,
+  DetailsServerNode,
+  DetailsSummaryServerNode,
+  DetailsContentServerNode,
 ];

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -760,29 +760,4 @@
   details.details > [data-type='detailsContent'] {
     @apply ps-6 pb-3;
   }
-
-  /* Animate open/close on the viewer's native <details>. `display`/`hidden`
-   * isn't transitionable, so we animate `::details-content` height 0 -> auto
-   * (`interpolate-size` enables the auto keyframe) plus a discrete
-   * content-visibility transition. Gated on `@supports` for the pseudo-element
-   * (Chrome 131+, Safari 18.2+); degrades to instant elsewhere (e.g. Firefox).
-   * Editor-only `div.details` is intentionally left instant. */
-  @supports selector(::details-content) {
-    /* Must be on :root — `height: auto` only interpolates when interpolate-size
-     * is in effect via inheritance from the root, not when set on the element. */
-    :root {
-      interpolate-size: allow-keywords;
-    }
-    details.details::details-content {
-      height: 0;
-      overflow: hidden;
-      transition:
-        height 0.2s ease,
-        content-visibility 0.2s;
-      transition-behavior: allow-discrete;
-    }
-    details.details[open]::details-content {
-      height: auto;
-    }
-  }
 }

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -682,3 +682,80 @@
     @apply absolute -top-5 -start-px rounded-t rounded-ee px-1.5 py-0.5 text-xs font-semibold whitespace-nowrap text-white select-none;
   }
 }
+
+/* ============================================
+ * Details / summary (collapsible "FAQ" disclosure)
+ * One source of truth for BOTH render paths:
+ *  - Editor: @tiptap/extension-details' built-in node view renders
+ *    `div.details(.is-open) > button + div > (summary, div[data-type=detailsContent])`,
+ *    toggling `is-open` on the root and `hidden` on the content (collapse is automatic).
+ *  - Viewer: the static renderer emits a native `details.details[open] > summary +
+ *    div[data-type=detailsContent]` (collapsible with zero JS).
+ * The chevron lives on the editor's toggle <button> and the native <summary>::before.
+ * ============================================ */
+@layer components {
+  /* Shared, non-conflicting bits only. No `display` here: the editor sets it on
+   * `div.details`; the native viewer <details> is `block` by default. */
+  .details {
+    --rt-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m9 18 6-6-6-6'/%3E%3C/svg%3E");
+  }
+  .details summary {
+    @apply py-2 font-serif text-lg text-neutral-black tracking-[-0.0125em];
+    list-style: none;
+  }
+  .details summary::-webkit-details-marker {
+    display: none;
+  }
+
+  /* The chevron glyph — the editor's toggle <button>, the viewer's native
+   * <summary>::before. (`content` is inert on the real <button>.) */
+  div.details > button,
+  details.details > summary::before {
+    @apply size-4 flex-none bg-neutral-gray3 transition-transform;
+    content: '';
+    -webkit-mask: var(--rt-chevron) center / contain no-repeat;
+    mask: var(--rt-chevron) center / contain no-repeat;
+  }
+  div.details.is-open > button,
+  details.details[open] > summary::before {
+    @apply rotate-90;
+  }
+
+  /* Editor (div.details): chevron in a left gutter, content in the column. */
+  div.details {
+    @apply flex items-start gap-2;
+  }
+  /* Highlight the details the caret is in. ProseMirror is one contentEditable
+   * host, so DOM :focus can't target an inner node — the `detailsFocus` plugin
+   * tags it with `is-focused`; gate on `.ProseMirror-focused` so it only paints
+   * while the editor is focused. */
+  div.details.is-focused {
+    @apply bg-neutral-gray1/60 shadow-[12px_0_0_2px_hsla(180,2.9%,93.1%,0.6),-8px_0_0_2px_hsla(180,2.9%,93.1%,0.6)];
+  }
+  div.details > button {
+    @apply mt-3 cursor-pointer border-0 p-0;
+  }
+  div.details > div {
+    @apply min-w-0 flex-1;
+  }
+  /* Drop the first child's top margin inside the body. `!` is required: prose's
+   * paragraph margins live in @layer utilities (later than components), so they
+   * win on layer order over a plain rule here regardless of specificity. */
+  .details [data-type='detailsContent'] > :first-child {
+    @apply mt-2!;
+  }
+
+  /* Viewer (native details.details): the chevron is an inline ::before so the
+   * summary's own inline content (text + <strong>/<em> spans) flows normally.
+   * (A flex summary turns every inline node into a flex item and the gap pushes
+   * the words apart.) */
+  details.details > summary {
+    @apply cursor-pointer;
+  }
+  details.details > summary::before {
+    @apply mr-2 inline-block align-middle;
+  }
+  details.details > [data-type='detailsContent'] {
+    @apply ps-6 pb-3;
+  }
+}

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -768,7 +768,9 @@
    * (Chrome 131+, Safari 18.2+); degrades to instant elsewhere (e.g. Firefox).
    * Editor-only `div.details` is intentionally left instant. */
   @supports selector(::details-content) {
-    details.details {
+    /* Must be on :root — `height: auto` only interpolates when interpolate-size
+     * is in effect via inheritance from the root, not when set on the element. */
+    :root {
       interpolate-size: allow-keywords;
     }
     details.details::details-content {

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -748,12 +748,14 @@
   /* Viewer (native details.details): the chevron is an inline ::before so the
    * summary's own inline content (text + <strong>/<em> spans) flows normally.
    * (A flex summary turns every inline node into a flex item and the gap pushes
-   * the words apart.) */
+   * the words apart.) Hanging indent: pad the summary `ps-6` and pull the
+   * chevron back into that gutter with `-ms-6`, so wrapped lines align under the
+   * first line's text instead of under the chevron. */
   details.details > summary {
-    @apply cursor-pointer;
+    @apply cursor-pointer ps-6;
   }
   details.details > summary::before {
-    @apply mr-2 inline-block align-middle;
+    @apply -ms-6 me-2 inline-block align-middle;
   }
   details.details > [data-type='detailsContent'] {
     @apply ps-6 pb-3;

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -760,4 +760,27 @@
   details.details > [data-type='detailsContent'] {
     @apply ps-6 pb-3;
   }
+
+  /* Animate open/close on the viewer's native <details>. `display`/`hidden`
+   * isn't transitionable, so we animate `::details-content` height 0 -> auto
+   * (`interpolate-size` enables the auto keyframe) plus a discrete
+   * content-visibility transition. Gated on `@supports` for the pseudo-element
+   * (Chrome 131+, Safari 18.2+); degrades to instant elsewhere (e.g. Firefox).
+   * Editor-only `div.details` is intentionally left instant. */
+  @supports selector(::details-content) {
+    details.details {
+      interpolate-size: allow-keywords;
+    }
+    details.details::details-content {
+      height: 0;
+      overflow: hidden;
+      transition:
+        height 0.2s ease,
+        content-visibility 0.2s;
+      transition-behavior: allow-discrete;
+    }
+    details.details[open]::details-content {
+      height: auto;
+    }
+  }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "SEE LICENSE in /LICENSE",
   "type": "module",
+  "module": "./src/index.ts",
   "exports": {
     "./Accordion": "./src/components/ui/accordion.tsx",
     "./AutoSizeInput": "./src/components/AutoSizeInput.tsx",
@@ -87,7 +88,6 @@
     "./AlertBanner": "./src/components/AlertBanner.tsx",
     "./ui/table": "./src/components/ui/table.tsx"
   },
-  "module": "./src/index.ts",
   "scripts": {
     "build": "storybook build",
     "dev": "storybook dev -p 3600 --no-open",
@@ -105,6 +105,7 @@
     "@tiptap/core": "catalog:",
     "@tiptap/extension-blockquote": "catalog:",
     "@tiptap/extension-bubble-menu": "catalog:",
+    "@tiptap/extension-details": "catalog:",
     "@tiptap/extension-heading": "catalog:",
     "@tiptap/extension-horizontal-rule": "catalog:",
     "@tiptap/extension-image": "catalog:",

--- a/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
@@ -25,6 +25,8 @@ export const RichTextEditor = forwardRef<
     /** HTML string or a TipTap JSON doc (the editor seeds from either). */
     content?: Content;
     placeholder?: string;
+    /** Translated hint for an empty Details summary (see useRichTextEditor). */
+    summaryPlaceholder?: string;
     onUpdate?: (content: string) => void;
     onChange?: (content: string) => void;
     /** Emits the editor's JSON doc on every update (for JSON-stored content). */
@@ -39,6 +41,7 @@ export const RichTextEditor = forwardRef<
       extensions,
       content = '',
       placeholder,
+      summaryPlaceholder,
       onUpdate,
       onChange,
       onChangeJSON,
@@ -52,6 +55,7 @@ export const RichTextEditor = forwardRef<
       extensions,
       content,
       placeholder,
+      summaryPlaceholder,
       editorClassName,
       onUpdate,
       onChange,

--- a/packages/ui/src/components/RichTextEditor/editorConfig.ts
+++ b/packages/ui/src/components/RichTextEditor/editorConfig.ts
@@ -1,6 +1,11 @@
 import { headingClasses } from '@op/styles/constants';
-import { mergeAttributes } from '@tiptap/core';
+import { Extension, mergeAttributes } from '@tiptap/core';
 import Blockquote from '@tiptap/extension-blockquote';
+import {
+  Details,
+  DetailsContent,
+  DetailsSummary,
+} from '@tiptap/extension-details';
 import Heading from '@tiptap/extension-heading';
 import HorizontalRule from '@tiptap/extension-horizontal-rule';
 import Image from '@tiptap/extension-image';
@@ -8,6 +13,8 @@ import Link from '@tiptap/extension-link';
 import Strike from '@tiptap/extension-strike';
 import TextAlign from '@tiptap/extension-text-align';
 import Underline from '@tiptap/extension-underline';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import StarterKit from '@tiptap/starter-kit';
 
 /**
@@ -26,6 +33,9 @@ export const viewerProseStyles = [
   '[&_blockquote]:font-normal',
   '[&_:is(h1,h2,h3)]:my-4',
   'leading-5 max-w-none break-words overflow-wrap-anywhere',
+  // Details/Summary (collapsible) chrome lives in one raw-CSS block in
+  // `@op/styles` (`.details` in shared-styles.css), shared by the editor's
+  // built-in node view AND the viewer's native <details>. Nothing here.
 ].join(' ');
 
 /**
@@ -40,6 +50,23 @@ const placeholderStyles = [
   '[&_.is-editor-empty:first-child]:before:h-0',
   '[&_.is-editor-empty:first-child]:before:text-neutral-gray3',
   '[&_.is-editor-empty:first-child]:before:content-[attr(data-placeholder)]',
+].join(' ');
+
+/**
+ * Per-node placeholder for an empty Details summary. Scoped to `summary.is-empty`
+ * (not the global `.is-empty`) so only the Details summary gets a hint — other
+ * empty blocks are unaffected. Requires `Placeholder.configure({ includeChildren:
+ * true })`, which `useRichTextEditor` wires when the Details extension is present.
+ */
+const detailsSummaryPlaceholderStyles = [
+  '[&_summary.is-empty]:before:pointer-events-none',
+  // float-start + h-0 pull the ::before out of the text flow so the caret sits
+  // at the start of the summary, not after the placeholder text.
+  '[&_summary.is-empty]:before:float-start',
+  '[&_summary.is-empty]:before:h-0',
+  '[&_summary.is-empty]:before:text-neutral-gray3',
+  '[&_summary.is-empty]:before:content-[attr(data-placeholder)]',
+  '[&_summary.is-empty]:before:font-serif',
 ].join(' ');
 
 /**
@@ -68,13 +95,49 @@ export const StyledHeading = Heading.extend({
 /**
  * Styles applied to the editor element
  */
-export const baseEditorStyles = `${viewerProseStyles} outline-hidden placeholder:text-neutral-gray2 ${placeholderStyles}`;
+export const baseEditorStyles = `${viewerProseStyles} outline-hidden placeholder:text-neutral-gray2 ${placeholderStyles} ${detailsSummaryPlaceholderStyles}`;
+
+/**
+ * Adds an `is-focused` class to the `details` node that currently contains the
+ * selection. ProseMirror is a single contentEditable host, so DOM `:focus`
+ * never lands inside an individual node — `:focus`/`:focus-within`/`:has(:focus)`
+ * can't target "the details the caret is in". This node decoration can. It's
+ * painted only while the editor is focused (CSS gates on `.ProseMirror-focused`).
+ */
+const DetailsFocus = Extension.create({
+  name: 'detailsFocus',
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('detailsFocus'),
+        props: {
+          decorations(state) {
+            const { $from } = state.selection;
+            for (let depth = $from.depth; depth > 0; depth--) {
+              if ($from.node(depth).type.name === 'details') {
+                const pos = $from.before(depth);
+                return DecorationSet.create(state.doc, [
+                  Decoration.node(pos, pos + $from.node(depth).nodeSize, {
+                    class: 'is-focused',
+                  }),
+                ]);
+              }
+            }
+
+            return DecorationSet.empty;
+          },
+        },
+      }),
+    ];
+  },
+});
 
 /**
  * Base extensions shared by both editor and viewer
  */
 const baseExtensions = [
   StarterKit,
+  DetailsFocus,
   TextAlign.configure({
     types: ['heading', 'paragraph'],
   }),
@@ -89,6 +152,12 @@ const baseExtensions = [
   Strike,
   Blockquote,
   HorizontalRule,
+  // Vanilla Details extension — its built-in node view provides the toggle
+  // button + `is-open` class; all chrome is styled via `.details` CSS in
+  // @op/styles. `persist` stores the open state in the doc.
+  Details.configure({ persist: true, HTMLAttributes: { class: 'details' } }),
+  DetailsSummary,
+  DetailsContent,
 ];
 
 /**

--- a/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
+++ b/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
@@ -11,6 +11,7 @@ export function useRichTextEditor({
   extensions = defaultEditorExtensions,
   content = '',
   placeholder,
+  summaryPlaceholder = 'Write something...',
   editorClassName = '',
   onUpdate,
   onChange,
@@ -22,6 +23,12 @@ export function useRichTextEditor({
   extensions?: Extensions;
   content?: Content;
   placeholder?: string;
+  /**
+   * Hint shown inside an empty Details summary. Only takes effect when the
+   * Details extension is present. Defaults to 'Summary'; pass a translated
+   * string from the app to localize it.
+   */
+  summaryPlaceholder?: string;
   editorClassName?: string;
   onUpdate?: (content: string) => void;
   onChange?: (content: string) => void;
@@ -32,16 +39,38 @@ export function useRichTextEditor({
   /** When true, sets `aria-required` on the editable region for assistive tech. */
   required?: boolean;
 }) {
-  // Append the Placeholder extension only when a placeholder is provided, so
-  // editors that don't ask for one are unaffected. Styling lives in
-  // baseEditorStyles and renders the hint once when the editor is empty.
-  const resolvedExtensions = useMemo(
-    () =>
-      placeholder
-        ? [...extensions, Placeholder.configure({ placeholder })]
-        : extensions,
-    [extensions, placeholder],
-  );
+  // Append a single Placeholder extension when a top-level placeholder is asked
+  // for OR the Details extension is present (it needs a per-node 'Summary' hint).
+  // There can only be one Placeholder extension — tiptap dedupes by name — so it
+  // serves both cases via the function form: the editor-empty hint comes from
+  // `placeholder`, the empty Details summary from `summaryPlaceholder`. Styling
+  // lives in baseEditorStyles (`placeholderStyles` + `detailsSummaryPlaceholderStyles`).
+  const resolvedExtensions = useMemo(() => {
+    const hasDetails = extensions.some((ext) => ext.name === 'detailsSummary');
+
+    if (!placeholder && !hasDetails) {
+      return extensions;
+    }
+
+    return [
+      ...extensions,
+      Placeholder.configure({
+        includeChildren: true,
+        // Show empty-node placeholders even when the caret isn't in the node, so
+        // the Details summary's "Summary" hint stays visible while unfocused.
+        // Safe: only `summary.is-empty` and `.is-editor-empty:first-child` are
+        // painted in CSS, so other empty blocks don't get a per-block hint.
+        showOnlyCurrent: false,
+        placeholder: ({ node }) => {
+          if (node.type.name === 'detailsSummary') {
+            return summaryPlaceholder;
+          }
+
+          return placeholder ?? '';
+        },
+      }),
+    ];
+  }, [extensions, placeholder, summaryPlaceholder]);
 
   const editor = useEditor({
     extensions: resolvedExtensions,

--- a/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
+++ b/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
@@ -25,8 +25,10 @@ export function useRichTextEditor({
   placeholder?: string;
   /**
    * Hint shown inside an empty Details summary. Only takes effect when the
-   * Details extension is present. Defaults to 'Summary'; pass a translated
-   * string from the app to localize it.
+   * Details extension is present. Defaults to 'Write something...' rather than
+   * 'Summary': "Summary" reads as jargon to writers who don't know the
+   * underlying <summary> HTML tag. Pass a translated string from the app to
+   * localize it.
    */
   summaryPlaceholder?: string;
   editorClassName?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,9 +785,6 @@ importers:
       '@tiptap/core':
         specifier: 'catalog:'
         version: 3.17.1(@tiptap/pm@3.17.1)
-      '@tiptap/extension-details':
-        specifier: 'catalog:'
-        version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/extension-text-style@3.27.0(@tiptap/core@3.17.1(@tiptap/pm@3.17.1)))(@tiptap/pm@3.17.1)
       '@tiptap/extension-heading':
         specifier: 'catalog:'
         version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     '@tiptap/extension-collaboration-caret':
       specifier: ^3.15.3
       version: 3.17.1
+    '@tiptap/extension-details':
+      specifier: 3.17.1
+      version: 3.17.1
     '@tiptap/extension-document':
       specifier: ^3.15.3
       version: 3.17.1
@@ -782,6 +785,9 @@ importers:
       '@tiptap/core':
         specifier: 'catalog:'
         version: 3.17.1(@tiptap/pm@3.17.1)
+      '@tiptap/extension-details':
+        specifier: 'catalog:'
+        version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/extension-text-style@3.27.0(@tiptap/core@3.17.1(@tiptap/pm@3.17.1)))(@tiptap/pm@3.17.1)
       '@tiptap/extension-heading':
         specifier: 'catalog:'
         version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))
@@ -1100,6 +1106,9 @@ importers:
       '@tiptap/extension-bubble-menu':
         specifier: 'catalog:'
         version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/pm@3.17.1)
+      '@tiptap/extension-details':
+        specifier: 'catalog:'
+        version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/extension-text-style@3.27.0(@tiptap/core@3.17.1(@tiptap/pm@3.17.1)))(@tiptap/pm@3.17.1)
       '@tiptap/extension-heading':
         specifier: 'catalog:'
         version: 3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))
@@ -4882,6 +4891,13 @@ packages:
       '@tiptap/y-tiptap': ^3.0.2
       yjs: ^13
 
+  '@tiptap/extension-details@3.17.1':
+    resolution: {integrity: sha512-HcVEGBkpezuTAJ7TBE1g4/4kq+wuSgelvnYBSgo2rmM6xXlziGrnoFmjgTywEf16Pt+q/T3RQ+paV9jpP1WLxg==}
+    peerDependencies:
+      '@tiptap/core': ^3.17.1
+      '@tiptap/extension-text-style': ^3.17.1
+      '@tiptap/pm': ^3.17.1
+
   '@tiptap/extension-document@3.17.1':
     resolution: {integrity: sha512-F7Q5HoAU383HWFa6AXZQ5N6t6lTJzVjYM8z93XrtH/2GzDFwy1UmDSrsXqvgznedBLAOgCNVTNh9PjXpLoOUbg==}
     peerDependencies:
@@ -4976,6 +4992,11 @@ packages:
     resolution: {integrity: sha512-CyJbZf823dqPZ/1zwRsza5pk/NQwFZwILdFYLVkV88I4+Ua9YVztI9kmwTB6dJyuKT4kTc7nhQHdaa957alGZQ==}
     peerDependencies:
       '@tiptap/core': ^3.17.1
+
+  '@tiptap/extension-text-style@3.27.0':
+    resolution: {integrity: sha512-R4Paicrf8vG46RvSi5RljacJjNClwj280Xei81QyEAJYNE2Vfxmw+pvdg8XMBFPUhGwNJiBQhcdPhhH81mBcng==}
+    peerDependencies:
+      '@tiptap/core': 3.27.0
 
   '@tiptap/extension-text@3.17.1':
     resolution: {integrity: sha512-rGml96vokQbvPB+w6L3+WKyYJWwqELaLdFUr1WMgg+py5uNYGJYAExYNAbDb5biWJBrX9GgMlCaNeiJj849L1w==}
@@ -12838,6 +12859,12 @@ snapshots:
       '@tiptap/y-tiptap': 3.0.2(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.40.1)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)
       yjs: 13.6.29
 
+  '@tiptap/extension-details@3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))(@tiptap/extension-text-style@3.27.0(@tiptap/core@3.17.1(@tiptap/pm@3.17.1)))(@tiptap/pm@3.17.1)':
+    dependencies:
+      '@tiptap/core': 3.17.1(@tiptap/pm@3.17.1)
+      '@tiptap/extension-text-style': 3.27.0(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))
+      '@tiptap/pm': 3.17.1
+
   '@tiptap/extension-document@3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))':
     dependencies:
       '@tiptap/core': 3.17.1(@tiptap/pm@3.17.1)
@@ -12914,6 +12941,10 @@ snapshots:
       '@tiptap/core': 3.17.1(@tiptap/pm@3.17.1)
 
   '@tiptap/extension-text-align@3.17.1(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))':
+    dependencies:
+      '@tiptap/core': 3.17.1(@tiptap/pm@3.17.1)
+
+  '@tiptap/extension-text-style@3.27.0(@tiptap/core@3.17.1(@tiptap/pm@3.17.1))':
     dependencies:
       '@tiptap/core': 3.17.1(@tiptap/pm@3.17.1)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ catalog:
   '@tiptap/extension-bullet-list': ^3.15.3
   '@tiptap/extension-collaboration': ^3.15.3
   '@tiptap/extension-collaboration-caret': ^3.15.3
+  '@tiptap/extension-details': 3.17.1
   '@tiptap/extension-document': ^3.15.3
   '@tiptap/extension-heading': ^3.15.3
   '@tiptap/html': ^3.15.3


### PR DESCRIPTION
Adds a collapsible details/summary ("FAQ toggle") to the rich text editor and renders it on the decision overview.

- **Editor**: vanilla `@tiptap/extension-details` with a built-in toggle; bubble-menu insert (adds a trailing paragraph so the caret can escape); an empty summary shows a translated placeholder that stays visible when unfocused; a ProseMirror plugin highlights the details the caret is in.
- **Viewer**: static renderer emits a native `<details>` (zero JS); server schema registered so nodes aren't dropped.
- **Styling**: one `.details` block in `@op/styles` (via `@apply`) shared by both the editor node view and the native viewer.

<img width="921" height="795" alt="Screenshot of editor showing new node in various states" src="https://github.com/user-attachments/assets/9ad28aac-325a-4f09-8541-1ba8a1d3d427" />
