### PR TITLE
fix(decisions): hide submitter count bubble when there are no submitter avatars

### DIFF
--- a/apps/app/src/components/decisions/MemberParticipationFacePile.tsx
+++ b/apps/app/src/components/decisions/MemberParticipationFacePile.tsx
@@ -26,11 +26,13 @@ export const MemberParticipationFacePile = ({
     return null;
   }
 
+  const hasSubmitters = submitters.length > 0;
+
   return (
     <div className="flex items-center justify-center gap-2">
       <GrowingFacePile
         maxItems={20}
-        totalCount={total}
+        totalCount={hasSubmitters ? total : undefined}
         items={submitters.map((submitter) => (
           <Link
             key={submitter.slug}


### PR DESCRIPTION
The participation count includes anonymous submitters who have no avatar, so the face pile could render a lone "+N" bubble with no faces leading it. Only show the count bubble when there are submitter avatars.