### PR TITLE
feat(realtime): only subscribe signed-in users to realtime channels

### DIFF
--- a/apps/app/src/components/QueryInvalidationSubscriber.tsx
+++ b/apps/app/src/components/QueryInvalidationSubscriber.tsx
@@ -3,8 +3,9 @@
 import type { ChannelName, RegistryEvents } from '@op/common/realtime';
 import { queryChannelRegistry } from '@op/common/realtime';
 import { RealtimeManager } from '@op/realtime/client';
+import { createSBBrowserClient } from '@op/supabase/client';
 import { QueryClientContext } from '@tanstack/react-query';
-import { useCallback, useContext, useEffect, useRef } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 
 /**
  * Returns the QueryClient if inside a QueryClientProvider, throws a descriptive error otherwise.
@@ -20,11 +21,47 @@ function useRequiredQueryClient() {
 }
 
 /**
+ * True once a Supabase session exists (anonymous or full), read from the
+ * browser client's local storage — no network or DB — and kept live via
+ * onAuthStateChange so realtime flips on at login and off at logout.
+ */
+function useHasSession(): boolean {
+  const [hasSession, setHasSession] = useState(false);
+
+  useEffect(() => {
+    const supabase = createSBBrowserClient();
+    let active = true;
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (active) {
+        setHasSession(Boolean(data.session));
+      }
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setHasSession(Boolean(session));
+    });
+
+    return () => {
+      active = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return hasSession;
+}
+
+/**
  * Component that sets up realtime subscriptions based on mutation channel headers.
  * Must be rendered inside QueryClientProvider.
+ *
+ * Gates the WebSocket to signed-in users; others still get local cache
+ * invalidation for their own mutations.
  */
 export function QueryInvalidationSubscriber() {
-  useInvalidateQueries();
+  useInvalidateQueries(useHasSession());
   return null;
 }
 
@@ -37,7 +74,7 @@ export function QueryInvalidationSubscriber() {
  *
  * Also handles WebSocket messages for server-initiated invalidations.
  */
-function useInvalidateQueries(): void {
+function useInvalidateQueries(enabled: boolean): void {
   const queryClient = useRequiredQueryClient();
   const invalidatedMutationIds = useRef(new Set<string>());
   const unsubscribersRef = useRef<Map<ChannelName, () => void>>(new Map());
@@ -83,6 +120,10 @@ function useInvalidateQueries(): void {
    * Subscribe to WebSocket channel when a query registers interest in channels
    */
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -132,5 +173,5 @@ function useInvalidateQueries(): void {
       }
       unsubscribersRef.current.clear();
     };
-  }, [handleInvalidation]);
+  }, [handleInvalidation, enabled]);
 }

--- a/services/realtime/src/client/manager.ts
+++ b/services/realtime/src/client/manager.ts
@@ -170,23 +170,22 @@ export class RealtimeManager {
   }
 
   /**
-   * Disconnect from Supabase Realtime and clean up all channels
+   * Tear down all channel subscriptions when the last one goes away. The client
+   * is retained (not nulled) so the next subscribe() reuses it and reconnects on
+   * the same connection instead of opening a fresh socket.
    */
   private disconnect(): void {
     if (!this.supabase) {
       return;
     }
 
-    console.log('[Realtime] Disconnecting...');
+    console.log('[Realtime] Closing all channels...');
 
-    // Clean up all channels
     this.channels.forEach((realtimeChannel) => {
       this.supabase?.removeChannel(realtimeChannel);
     });
     this.channels.clear();
     this.channelListeners.clear();
-
-    this.supabase = null;
   }
 
   /**

--- a/tests/e2e/tests/realtime-channel-gating.spec.ts
+++ b/tests/e2e/tests/realtime-channel-gating.spec.ts
@@ -1,0 +1,91 @@
+import {
+  createDecisionInstance,
+  getSeededTemplate,
+  makeDecisionPublic,
+} from '@op/test';
+
+import { expect, test } from '../fixtures/index.js';
+
+/**
+ * Supabase Realtime opens a websocket at `/realtime/v1/websocket`. Matching the
+ * path (rather than the host) keeps this robust across local/preview/prod URLs.
+ */
+const isRealtimeSocket = (url: string): boolean =>
+  url.includes('/realtime/v1/');
+
+type SeedOrg = {
+  organizationProfile: { id: string };
+  adminUser: { authUserId: string; email: string };
+};
+
+async function seedDecision(org: SeedOrg) {
+  const template = await getSeededTemplate();
+  return createDecisionInstance({
+    processId: template.id,
+    ownerProfileId: org.organizationProfile.id,
+    authUserId: org.adminUser.authUserId,
+    email: org.adminUser.email,
+  });
+}
+
+test.describe('realtime channel gating', () => {
+  test('a signed-in user opens a realtime websocket on a decision page', async ({
+    authenticatedPage,
+    org,
+  }) => {
+    const { slug } = await seedDecision(org);
+
+    // Arm the listener before navigating so we don't miss the connection.
+    const socket = authenticatedPage.waitForEvent('websocket', {
+      predicate: (ws) => isRealtimeSocket(ws.url()),
+      timeout: 15_000,
+    });
+
+    await authenticatedPage.goto(`/en/decisions/${slug}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // getInstance registers the decision channel; the signed-in subscriber
+    // subscribes to it over the realtime socket.
+    await expect(socket).resolves.toBeTruthy();
+  });
+
+  test('a public visitor opens no realtime websocket', async ({
+    browser,
+    org,
+  }) => {
+    const { slug, profileId } = await seedDecision(org);
+
+    // Open the decision to no-session visitors so the page actually renders
+    // (and would otherwise register channels). This isolates the session gate
+    // as the only reason no socket opens.
+    await makeDecisionPublic({ profileId });
+
+    // A fresh context with no worker session = a true no-session visitor
+    // (the shared fixture authenticates every page via storageState).
+    const context = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    const page = await context.newPage();
+
+    let realtimeOpened = false;
+    page.on('websocket', (ws) => {
+      if (isRealtimeSocket(ws.url())) {
+        realtimeOpened = true;
+      }
+    });
+
+    try {
+      await page.goto(`/en/decisions/${slug}`, { waitUntil: 'networkidle' });
+      // Guard against a vacuous pass: the visitor must actually land on the
+      // (public) decision page, not get bounced to login — otherwise "no
+      // socket" would just mean "no page", not "gated".
+      expect(page.url()).toContain(`/decisions/${slug}`);
+      // Give the client a beat to (not) open the socket after hydration.
+      await page.waitForTimeout(3000);
+      expect(realtimeOpened).toBe(false);
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
Drop no-session visitors from realtime to stay under the Supabase connection limit. Anonymous and full accounts keep realtime; visitors still get local cache invalidation for their own mutations.