### PR TITLE
feat(decisions): hide comment box from visitors and anonymous accounts

### DIFF
--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -592,7 +592,8 @@ const PostUpdateWithUser = ({
     }
   }, [content]);
 
-  if (!user?.currentProfile) {
+  // Anonymous accounts still get a `currentProfile`, so guard it explicitly.
+  if (!user?.currentProfile || user.isAnonymous) {
     return null;
   }
 

--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -32,6 +32,9 @@ export function ProposalComments({
   const comments = commentsData?.items ?? [];
   const { handleReactionClick } = usePostFeedActions();
 
+  // Visitors and anonymous accounts can't comment — hide the input.
+  const canComment = Boolean(user?.currentProfile) && !user?.isAnonymous;
+
   const scrollToComments = useCallback(() => {
     setTimeout(() => {
       containerRef.current?.scrollIntoView({
@@ -49,7 +52,7 @@ export function ProposalComments({
           {t('Comments')} ({comments.length})
         </Header3>
 
-        {!readOnly && (
+        {!readOnly && canComment && (
           <div className="mb-8">
             <Surface className="border-0 p-0 sm:border sm:p-4">
               <PostUpdate


### PR DESCRIPTION
Anonymous accounts receive a currentProfile, so the existing profile-only check let them see a comment box the API rejects. Also gate on isAnonymous.