### PR TITLE
fix: graceful-fail unknown nodes in the static rich-text renderer

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import {
-  sanitizeTiptapDoc,
-  serverExtensions,
-  tiptapDocToPlainText,
-} from '@op/common/client';
+import { sanitizeTiptapDoc } from '@op/common/client';
 import { RichTextEditor } from '@op/ui/RichTextEditor';
 import { Skeleton } from '@op/ui/Skeleton';
 import type { JSONContent } from '@tiptap/core';
@@ -130,7 +126,14 @@ function OverviewSectionContent({
         <hr className="border-neutral-gray1" />
 
         <RichTextEditor
-          content={sanitizeTipTapDoc(initialOverview.body)}
+          // Sanitize stored JSON so an unknown node type can't make TipTap blank
+          // the whole doc on load (and autosave the blank). HTML strings parse
+          // leniently, so only JSON needs it.
+          content={
+            typeof initialOverview.body === 'string'
+              ? initialOverview.body
+              : sanitizeTiptapDoc(initialOverview.body)
+          }
           placeholder={t('overview_body_placeholder')}
           editorClassName="min-h-40"
           onChangeJSON={(json) => {

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -1,6 +1,11 @@
 'use client';
 
 import { trpc } from '@op/api/client';
+import {
+  sanitizeTiptapDoc,
+  serverExtensions,
+  tiptapDocToPlainText,
+} from '@op/common/client';
 import { RichTextEditor } from '@op/ui/RichTextEditor';
 import { Skeleton } from '@op/ui/Skeleton';
 import type { JSONContent } from '@tiptap/core';
@@ -125,7 +130,7 @@ function OverviewSectionContent({
         <hr className="border-neutral-gray1" />
 
         <RichTextEditor
-          content={initialOverview.body}
+          content={sanitizeTipTapDoc(initialOverview.body)}
           placeholder={t('overview_body_placeholder')}
           editorClassName="min-h-40"
           onChangeJSON={(json) => {

--- a/apps/app/src/components/decisions/RichTextRenderer.tsx
+++ b/apps/app/src/components/decisions/RichTextRenderer.tsx
@@ -1,10 +1,12 @@
-import { serverExtensions } from '@op/common/client';
+import { serverExtensions, tiptapDocToPlainText } from '@op/common/client';
+import { logger } from '@op/logging';
 // Import from the editorConfig subpath (not the RichTextEditor barrel) so this
 // server component doesn't pull the client editor (useRichTextEditor/useEffect)
 // into the RSC graph — viewerProseStyles is a plain style string.
 import { viewerProseStyles } from '@op/ui/RichTextEditor/editorConfig';
 import type { JSONContent } from '@tiptap/core';
 import { renderToReactElement } from '@tiptap/static-renderer/pm/react';
+import type { ReactNode } from 'react';
 
 import { LinkPreview } from '../LinkPreview';
 import { ProposalHtmlContent } from './ProposalHtmlContent';
@@ -28,8 +30,9 @@ import { ProposalHtmlContent } from './ProposalHtmlContent';
  * {@link LinkPreview} embed leaf is a client island within the rendered tree.
  *
  * Extensions are shared with `generateProposalHtml`'s `serverExtensions` so the
- * recognized node set can't drift between the two render paths (an unknown node
- * is silently dropped, so this single source of truth matters).
+ * recognized node set can't drift between the two render paths. An unregistered
+ * node type THROWS during the parse (`Node.fromJSON`), so the render is wrapped
+ * and degrades to plain text — one unsupported node can't crash the whole tab.
  */
 export function RichTextRenderer({
   content,
@@ -45,15 +48,30 @@ export function RichTextRenderer({
     return <ProposalHtmlContent html={content} />;
   }
 
-  return (
-    <div className={viewerProseStyles}>
-      {renderToReactElement({
-        content,
-        extensions: serverExtensions,
-        options: { nodeMapping },
-      })}
-    </div>
-  );
+  let body: ReactNode;
+  try {
+    body = renderToReactElement({
+      content,
+      extensions: serverExtensions,
+      options: { nodeMapping },
+    });
+  } catch (error) {
+    // `renderToReactElement` parses the JSON into a ProseMirror doc eagerly
+    // (Node.fromJSON), which throws on an unregistered node type. Without this
+    // guard the throw escapes into the server render and takes down the whole
+    // surrounding tab, not just the body. Degrade to plain text so a node the
+    // server doesn't recognize yet (deploy skew / rollback / drift) stays readable.
+    logger.warn(
+      'RichTextRenderer: static render failed, falling back to text',
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    const text = tiptapDocToPlainText(content);
+    body = text ? <p>{text}</p> : null;
+  }
+
+  return <div className={viewerProseStyles}>{body}</div>;
 }
 
 /**

--- a/apps/app/src/components/decisions/RichTextRenderer.tsx
+++ b/apps/app/src/components/decisions/RichTextRenderer.tsx
@@ -67,8 +67,13 @@ export function RichTextRenderer({
         error: error instanceof Error ? error.message : String(error),
       },
     );
+    // Render each block as its own <p> so block breaks survive (a single <p>
+    // with newlines collapses them to spaces in HTML). prose spacing on the
+    // wrapper gives the blocks readable separation.
     const text = tiptapDocToPlainText(content);
-    body = text ? <p>{text}</p> : null;
+    body = text
+      ? text.split('\n').map((block, index) => <p key={index}>{block}</p>)
+      : null;
   }
 
   return <div className={viewerProseStyles}>{body}</div>;

--- a/apps/app/src/components/decisions/RichTextRenderer.tsx
+++ b/apps/app/src/components/decisions/RichTextRenderer.tsx
@@ -1,4 +1,8 @@
-import { serverExtensions, tiptapDocToPlainText } from '@op/common/client';
+import {
+  sanitizeTiptapDoc,
+  serverExtensions,
+  tiptapDocToPlainText,
+} from '@op/common/client';
 import { logger } from '@op/logging';
 // Import from the editorConfig subpath (not the RichTextEditor barrel) so this
 // server component doesn't pull the client editor (useRichTextEditor/useEffect)
@@ -31,8 +35,10 @@ import { ProposalHtmlContent } from './ProposalHtmlContent';
  *
  * Extensions are shared with `generateProposalHtml`'s `serverExtensions` so the
  * recognized node set can't drift between the two render paths. An unregistered
- * node type THROWS during the parse (`Node.fromJSON`), so the render is wrapped
- * and degrades to plain text — one unsupported node can't crash the whole tab.
+ * node type THROWS during the parse (`Node.fromJSON`), so the doc is sanitized
+ * first (`sanitizeTiptapDoc` coerces unknown nodes/marks to known ones) — known
+ * content stays rich, only the unsupported pieces degrade. A try/catch backstop
+ * still falls back to whole-doc plain text for failures sanitizing can't prevent.
  */
 export function RichTextRenderer({
   content,
@@ -50,17 +56,18 @@ export function RichTextRenderer({
 
   let body: ReactNode;
   try {
+    // Sanitize first: coerce any node/mark the server schema doesn't know into a
+    // known shape, so the parse can't throw on an unsupported type (deploy skew /
+    // rollback / drift). Known content renders rich; only unknown pieces degrade.
     body = renderToReactElement({
-      content,
+      content: sanitizeTiptapDoc(content),
       extensions: serverExtensions,
       options: { nodeMapping },
     });
   } catch (error) {
-    // `renderToReactElement` parses the JSON into a ProseMirror doc eagerly
-    // (Node.fromJSON), which throws on an unregistered node type. Without this
-    // guard the throw escapes into the server render and takes down the whole
-    // surrounding tab, not just the body. Degrade to plain text so a node the
-    // server doesn't recognize yet (deploy skew / rollback / drift) stays readable.
+    // Backstop: sanitizing can't prevent every failure (e.g. a content-model
+    // violation from the coercion). Degrade the whole body to plain text rather
+    // than let the throw crash the surrounding tab.
     logger.warn(
       'RichTextRenderer: static render failed, falling back to text',
       {

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -85,6 +85,7 @@ export {
   type SchemaValidationResult,
 } from './services/decision/schemaValidator';
 export { serverExtensions } from './services/decision/tiptapExtensions';
+export { tiptapDocToPlainText } from './services/decision/tiptapDocToPlainText';
 // Re-exported so API encoders / app consumers can type stored rich-text bodies
 // (TipTap JSON docs) without taking a direct @tiptap/core dependency.
 export type { JSONContent } from '@tiptap/core';

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -86,6 +86,7 @@ export {
 } from './services/decision/schemaValidator';
 export { serverExtensions } from './services/decision/tiptapExtensions';
 export { tiptapDocToPlainText } from './services/decision/tiptapDocToPlainText';
+export { sanitizeTiptapDoc } from './services/decision/sanitizeTiptapDoc';
 // Re-exported so API encoders / app consumers can type stored rich-text bodies
 // (TipTap JSON docs) without taking a direct @tiptap/core dependency.
 export type { JSONContent } from '@tiptap/core';

--- a/packages/common/src/services/decision/sanitizeTiptapDoc.test.ts
+++ b/packages/common/src/services/decision/sanitizeTiptapDoc.test.ts
@@ -1,0 +1,93 @@
+import type { JSONContent } from '@tiptap/core';
+import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string';
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeTiptapDoc } from './sanitizeTiptapDoc';
+import { serverExtensions } from './tiptapExtensions';
+
+/**
+ * Sanitizing coerces unknown node/mark types to known ones so the static
+ * renderer can't throw on them. The strongest assertion is that the sanitized
+ * doc renders without throwing while keeping the known content.
+ */
+describe('sanitizeTiptapDoc', () => {
+  const render = (doc: JSONContent) =>
+    renderToHTMLString({ content: doc, extensions: serverExtensions });
+
+  it('leaves a fully-known doc renderable and intact', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Title' }],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Body.' }] },
+      ],
+    };
+
+    const html = render(sanitizeTiptapDoc(doc));
+    expect(html).toContain('<h2');
+    expect(html).toContain('Title');
+    expect(html).toContain('Body.');
+  });
+
+  it('unwraps an unknown container, keeping its known inner blocks rich', () => {
+    // A details node (unknown to serverExtensions in this test) wrapping a known
+    // paragraph: the summary degrades to a paragraph, the body paragraph stays.
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'someDetails',
+          content: [
+            {
+              type: 'someSummary',
+              content: [{ type: 'text', text: 'Question?' }],
+            },
+            {
+              type: 'someContent',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Answer.' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const sanitized = sanitizeTiptapDoc(doc);
+    // Two separate paragraphs survive (summary + body), not one merged run.
+    expect(sanitized.content).toHaveLength(2);
+    // And it renders without throwing.
+    const html = render(sanitized);
+    expect(html).toContain('Question?');
+    expect(html).toContain('Answer.');
+  });
+
+  it('strips an unknown mark off a text node so it renders', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'styled',
+              marks: [{ type: 'someFutureMark' }, { type: 'bold' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const html = render(sanitizeTiptapDoc(doc));
+    expect(html).toContain('styled');
+    expect(html).toContain('<strong>');
+  });
+});

--- a/packages/common/src/services/decision/sanitizeTiptapDoc.ts
+++ b/packages/common/src/services/decision/sanitizeTiptapDoc.ts
@@ -87,7 +87,7 @@ function sanitizeBlocks(nodes: JSONContent[]): JSONContent[] {
 }
 
 export function sanitizeTiptapDoc(doc: JSONContent): JSONContent {
-  if (!doc.content) {
+  if (!doc?.content) {
     return doc;
   }
 

--- a/packages/common/src/services/decision/sanitizeTiptapDoc.ts
+++ b/packages/common/src/services/decision/sanitizeTiptapDoc.ts
@@ -86,10 +86,8 @@ function sanitizeBlocks(nodes: JSONContent[]): JSONContent[] {
   return out;
 }
 
-export function sanitizeTiptapDoc(
-  doc: string | JSONContent,
-): string | JSONContent {
-  if (typeof doc === 'string' || !doc?.content) {
+export function sanitizeTiptapDoc(doc: JSONContent): JSONContent {
+  if (!doc.content) {
     return doc;
   }
 

--- a/packages/common/src/services/decision/sanitizeTiptapDoc.ts
+++ b/packages/common/src/services/decision/sanitizeTiptapDoc.ts
@@ -1,0 +1,95 @@
+import { getSchema } from '@tiptap/core';
+import type { JSONContent } from '@tiptap/core';
+
+import { tiptapDocToPlainText } from './tiptapDocToPlainText';
+import { serverExtensions } from './tiptapExtensions';
+
+/**
+ * Coerce a stored TipTap doc so it contains only node/mark types the server
+ * schema knows. The static renderer parses JSON eagerly (`Node.fromJSON`) and
+ * THROWS on an unregistered type, which would crash the whole render. Sanitizing
+ * first lets the known content render rich and degrades only the unsupported
+ * pieces — far better than the all-or-nothing plain-text fallback (which stays
+ * as a backstop for failures sanitizing can't prevent, e.g. content-model
+ * violations from the coercion).
+ *
+ * Rules:
+ *  - unknown CONTAINER node (has block children) → unwrapped; its sanitized
+ *    children splice up in place (a details node becomes its summary + body
+ *    blocks instead of one flattened run).
+ *  - unknown LEAF/inline-only node → replaced by a paragraph of its flat text.
+ *  - unknown marks → stripped off text nodes (they throw too).
+ */
+// Built once: the registered node/mark names + which nodes are textblocks.
+const schema = getSchema(serverExtensions);
+
+const isKnownNode = (type: string | undefined): boolean =>
+  type !== undefined && type in schema.nodes;
+
+const isTextblock = (type: string): boolean =>
+  schema.nodes[type]?.isTextblock ?? false;
+
+const isKnownMark = (type: string | undefined): boolean =>
+  type !== undefined && type in schema.marks;
+
+function sanitizeTextNode(node: JSONContent): JSONContent {
+  if (!node.marks || node.marks.length === 0) {
+    return node;
+  }
+
+  const marks = node.marks.filter((mark) => isKnownMark(mark.type));
+  if (marks.length === node.marks.length) {
+    return node;
+  }
+
+  return { ...node, marks };
+}
+
+function sanitizeBlocks(nodes: JSONContent[]): JSONContent[] {
+  const out: JSONContent[] = [];
+
+  for (const node of nodes) {
+    if (typeof node.type !== 'string') {
+      continue;
+    }
+
+    if (isKnownNode(node.type)) {
+      if (isTextblock(node.type)) {
+        // Inline content — keep the block, just clean marks off its text leaves.
+        out.push({ ...node, content: node.content?.map(sanitizeTextNode) });
+      } else {
+        out.push({
+          ...node,
+          content: node.content ? sanitizeBlocks(node.content) : node.content,
+        });
+      }
+
+      continue;
+    }
+
+    // Unknown node. If it wraps block-level children, unwrap them so known
+    // inner blocks survive rich; otherwise flatten it to a single paragraph.
+    const hasBlockChildren = (node.content ?? []).some(
+      (child) => child.type !== undefined && child.type !== 'text',
+    );
+
+    if (hasBlockChildren) {
+      out.push(...sanitizeBlocks(node.content ?? []));
+    } else {
+      const text = tiptapDocToPlainText({ type: 'doc', content: [node] });
+      if (text) {
+        out.push({ type: 'paragraph', content: [{ type: 'text', text }] });
+      }
+    }
+  }
+
+  return out;
+}
+
+export function sanitizeTiptapDoc(doc: JSONContent): JSONContent {
+  if (!doc.content) {
+    return doc;
+  }
+
+  return { ...doc, content: sanitizeBlocks(doc.content) };
+}

--- a/packages/common/src/services/decision/sanitizeTiptapDoc.ts
+++ b/packages/common/src/services/decision/sanitizeTiptapDoc.ts
@@ -86,8 +86,10 @@ function sanitizeBlocks(nodes: JSONContent[]): JSONContent[] {
   return out;
 }
 
-export function sanitizeTiptapDoc(doc: JSONContent): JSONContent {
-  if (!doc.content) {
+export function sanitizeTiptapDoc(
+  doc: string | JSONContent,
+): string | JSONContent {
+  if (typeof doc === 'string' || !doc?.content) {
     return doc;
   }
 

--- a/packages/common/src/services/decision/staticRender.test.ts
+++ b/packages/common/src/services/decision/staticRender.test.ts
@@ -7,8 +7,10 @@ import { serverExtensions } from './tiptapExtensions';
 /**
  * The static renderer (`@tiptap/static-renderer`) is the foundation for SSR
  * rich-text rendering. It must recognize every node/mark in `serverExtensions`
- * — an unregistered type is silently dropped — so these assertions guard the
- * shared extension set against drift. Output is asserted structurally rather
+ * — an unregistered NODE type THROWS during the JSON→doc parse (see the last
+ * test); `RichTextRenderer` guards that with a plain-text fallback so it can't
+ * crash the whole surrounding tab. These assertions guard the shared extension
+ * set against drift. Output is asserted structurally rather
  * than byte-compared to `generateHTML`: both are "ours", but they use different
  * serializers, so exact-string parity would be brittle without adding value.
  *
@@ -113,5 +115,25 @@ describe('static renderer × serverExtensions', () => {
     // is recognized and its src round-trips, rather than being dropped).
     expect(html).toContain('data-iframely');
     expect(html).toContain('data-src="https://youtube.com/watch?v=x"');
+  });
+
+  it('throws on an unregistered node type (the failure RichTextRenderer falls back from)', () => {
+    // Node.fromJSON throws "Unknown node type" when a stored doc contains a type
+    // that isn't in serverExtensions (deploy skew / drift). RichTextRenderer
+    // wraps the render and degrades to plain text instead of letting the throw
+    // crash the whole surrounding tab.
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'someUnregisteredNode',
+          content: [{ type: 'text', text: 'x' }],
+        },
+      ],
+    };
+
+    expect(() =>
+      renderToHTMLString({ content: doc, extensions: serverExtensions }),
+    ).toThrow();
   });
 });

--- a/packages/common/src/services/decision/tiptapDocToPlainText.test.ts
+++ b/packages/common/src/services/decision/tiptapDocToPlainText.test.ts
@@ -51,4 +51,34 @@ describe('tiptapDocToPlainText', () => {
 
     expect(tiptapDocToPlainText(doc)).toBe('still readable');
   });
+
+  it('splits a container node (details) so summary and body are separate blocks', () => {
+    // Without container-aware walking, a details node collapses its summary and
+    // body into one run ("Question?Answer."); each should be its own line.
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'details',
+          content: [
+            {
+              type: 'detailsSummary',
+              content: [{ type: 'text', text: 'Question?' }],
+            },
+            {
+              type: 'detailsContent',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Answer.' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(tiptapDocToPlainText(doc)).toBe('Question?\nAnswer.');
+  });
 });

--- a/packages/common/src/services/decision/tiptapDocToPlainText.test.ts
+++ b/packages/common/src/services/decision/tiptapDocToPlainText.test.ts
@@ -1,0 +1,54 @@
+import type { JSONContent } from '@tiptap/core';
+import { describe, expect, it } from 'vitest';
+
+import { tiptapDocToPlainText } from './tiptapDocToPlainText';
+
+describe('tiptapDocToPlainText', () => {
+  it('returns an empty string for empty / nullish input', () => {
+    expect(tiptapDocToPlainText(null)).toBe('');
+    expect(tiptapDocToPlainText(undefined)).toBe('');
+    expect(tiptapDocToPlainText({ type: 'doc', content: [] })).toBe('');
+  });
+
+  it('joins block text with newlines and concatenates inline runs', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Hello ' },
+            { type: 'text', text: 'world', marks: [{ type: 'bold' }] },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Second line.' }],
+        },
+      ],
+    };
+
+    expect(tiptapDocToPlainText(doc)).toBe('Hello world\nSecond line.');
+  });
+
+  it('extracts text from nested children of UNKNOWN node types', () => {
+    // The whole point of the fallback: even when a node type isn't recognized
+    // (the case that throws in the static renderer), its text is still readable.
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'someFutureNode',
+          content: [
+            {
+              type: 'paragraph',
+              content: [{ type: 'text', text: 'still readable' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(tiptapDocToPlainText(doc)).toBe('still readable');
+  });
+});

--- a/packages/common/src/services/decision/tiptapDocToPlainText.ts
+++ b/packages/common/src/services/decision/tiptapDocToPlainText.ts
@@ -1,0 +1,41 @@
+import type { JSONContent } from '@tiptap/core';
+
+/**
+ * Flatten a TipTap JSON doc to its plain text. Used as a graceful fallback when
+ * the static renderer can't render a stored doc — e.g. an unregistered node type
+ * throws during schema parse (`Node.fromJSON`). Degrading to plain text keeps the
+ * content readable instead of crashing the whole render. Walks `text` leaves
+ * depth-first and joins block-level nodes with newlines.
+ *
+ * Distinct from `extractProposalText`, which collects strings from a flat
+ * proposalData record; this walks the nested TipTap node tree.
+ */
+export function tiptapDocToPlainText(
+  doc: JSONContent | null | undefined,
+): string {
+  if (!doc) {
+    return '';
+  }
+
+  const collectInline = (node: JSONContent, inline: string[]): void => {
+    if (typeof node.text === 'string') {
+      inline.push(node.text);
+    }
+
+    for (const child of node.content ?? []) {
+      collectInline(child, inline);
+    }
+  };
+
+  const blocks: string[] = [];
+  for (const node of doc.content ?? []) {
+    const inline: string[] = [];
+    collectInline(node, inline);
+    const text = inline.join('').trim();
+    if (text) {
+      blocks.push(text);
+    }
+  }
+
+  return blocks.join('\n');
+}

--- a/packages/common/src/services/decision/tiptapDocToPlainText.ts
+++ b/packages/common/src/services/decision/tiptapDocToPlainText.ts
@@ -1,11 +1,16 @@
 import type { JSONContent } from '@tiptap/core';
 
 /**
- * Flatten a TipTap JSON doc to its plain text. Used as a graceful fallback when
- * the static renderer can't render a stored doc — e.g. an unregistered node type
- * throws during schema parse (`Node.fromJSON`). Degrading to plain text keeps the
- * content readable instead of crashing the whole render. Walks `text` leaves
- * depth-first and joins block-level nodes with newlines.
+ * Flatten a TipTap JSON doc to plain-text blocks (newline-joined). Used as a
+ * graceful fallback when the static renderer can't render a stored doc — e.g. an
+ * unregistered node type throws during schema parse (`Node.fromJSON`). Degrading
+ * to plain text keeps the content readable instead of crashing the whole render;
+ * the caller renders one element per line.
+ *
+ * Each textblock (paragraph, heading, summary, …) becomes one block. Container
+ * nodes (details, lists, blockquote, and unknown wrappers) are walked so their
+ * inner blocks split out onto their own lines instead of collapsing into one run
+ * (e.g. a details summary and its body land on separate lines).
  *
  * Distinct from `extractProposalText`, which collects strings from a flat
  * proposalData record; this walks the nested TipTap node tree.
@@ -17,24 +22,50 @@ export function tiptapDocToPlainText(
     return '';
   }
 
-  const collectInline = (node: JSONContent, inline: string[]): void => {
+  const textOf = (node: JSONContent): string => {
     if (typeof node.text === 'string') {
-      inline.push(node.text);
+      return node.text;
+    }
+
+    return (node.content ?? []).map(textOf).join('');
+  };
+
+  // A textblock holds only inline content (text leaves / atoms like hardBreak);
+  // a container holds other block nodes. Splitting on containers is what keeps a
+  // details summary and its body — or list items — on separate lines.
+  const isTextblock = (node: JSONContent): boolean =>
+    Array.isArray(node.content) &&
+    node.content.length > 0 &&
+    node.content.every(
+      (child) => typeof child.text === 'string' || !child.content,
+    );
+
+  const blocks: string[] = [];
+  const visit = (node: JSONContent): void => {
+    if (isTextblock(node)) {
+      const text = textOf(node).trim();
+      if (text) {
+        blocks.push(text);
+      }
+
+      return;
     }
 
     for (const child of node.content ?? []) {
-      collectInline(child, inline);
+      if (typeof child.text === 'string') {
+        // Stray inline text directly under a container (rare) — keep it.
+        const text = child.text.trim();
+        if (text) {
+          blocks.push(text);
+        }
+      } else {
+        visit(child);
+      }
     }
   };
 
-  const blocks: string[] = [];
   for (const node of doc.content ?? []) {
-    const inline: string[] = [];
-    collectInline(node, inline);
-    const text = inline.join('').trim();
-    if (text) {
-      blocks.push(text);
-    }
+    visit(node);
   }
 
   return blocks.join('\n');


### PR DESCRIPTION
Hardens rich-text rendering AND editing so an unregistered node type can't crash a page or silently destroy stored content.

**Viewer (static render):** an unknown node makes `renderToReactElement` throw (`Node.fromJSON`) during the RSC render — unwrapped, that killed the whole overview tab. Now `sanitizeTiptapDoc` coerces unknown node/mark types to known ones before render (unknown containers unwrap keeping their known inner blocks; unknown leaves → a paragraph of their text; unknown marks stripped). A try/catch backstop still degrades the whole body to plain text for failures sanitizing can't prevent.

**Editor:** for JSON content, TipTap's `schema.nodeFromJSON` throws on the first unknown node and TipTap then blanks the ENTIRE doc (not just that node) — and autosave persists the blank → total loss of the field. The overview editor now sanitizes JSON before handing it to the editor, so the doc loads (degraded) instead of blanking.

- Shared helper `sanitizeTiptapDoc` + `tiptapDocToPlainText` in `@op/common`, reused by both paths.
- Audited the other `generateHTML` callers: `generateProposalHtml` already degrades per-fragment; `translateDecision` deliberately throws to avoid caching corrupt data.
- Tests for the sanitizer, the plain-text helper, and the unknown-node throw.

Lands before the details PR (#1355), which rebases on top so the first new authorable node type ships onto a resilient render + edit path.

<img width="2142" height="1147" alt="Screenshot showing two browsers, one with an editor open and a details/summary node added, and the other viewing the same document without support for the details/summary node. The unsupported node is rendered as plain paragraphs." src="https://github.com/user-attachments/assets/57f27725-93be-4a2e-b889-a0391d7e3cdb" />