### PR TITLE
fix(decisions): add headline character count

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -20,7 +20,7 @@ import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/st
 import { OverviewTextField } from './OverviewTextField';
 
 // Must match the server-side caps in instanceOverviewInputEncoder
-const HEADLINE_MAX_LENGTH = 200;
+const HEADLINE_MAX_LENGTH = 50;
 const DESCRIPTION_MAX_LENGTH = 500;
 
 export default function OverviewSection(props: SectionProps) {

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
@@ -30,7 +30,9 @@ export function OverviewTextField({
   placeholder,
   maxLength,
 }: OverviewTextFieldProps) {
-  return (
+  const showCount = variant === 'headline';
+
+  const textarea = (
     <textarea
       rows={1}
       value={value}
@@ -49,10 +51,34 @@ export function OverviewTextField({
       className={cn(
         // field-sizing-content grows the textarea with its content so long
         // headlines/descriptions wrap instead of getting cut off.
-        'field-sizing-content w-full resize-none overflow-hidden bg-transparent text-neutral-charcoal placeholder:text-neutral-gray3 focus:outline-none',
+        'field-sizing-content resize-none overflow-hidden bg-transparent text-neutral-charcoal placeholder:text-neutral-gray3 focus:outline-none',
+        showCount ? 'min-w-0 flex-1' : 'w-full',
         variant === 'headline' && 'font-serif text-title-lg',
         variant === 'description' && 'text-base',
       )}
     />
+  );
+
+  if (!showCount) {
+    return textarea;
+  }
+
+  return (
+    <div className="flex items-end justify-between gap-2">
+      {textarea}
+      {/* Always rendered to reserve space; fades in once there's text. */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          'shrink-0 text-sm transition-opacity',
+          value.length > 0 ? 'opacity-100' : 'opacity-0',
+          value.length >= maxLength
+            ? 'text-functional-red'
+            : 'text-neutral-charcoal',
+        )}
+      >
+        {value.length}/{maxLength}
+      </span>
+    </div>
   );
 }

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -256,7 +256,7 @@ const instanceOverviewEncoder = z.object({
  * writes.
  */
 const instanceOverviewInputEncoder = z.object({
-  headline: z.string().max(200).optional(),
+  headline: z.string().max(50).optional(),
   description: z.string().max(500).optional(),
   body: overviewBodyInputEncoder.optional(),
 });


### PR DESCRIPTION
- Character counter beside the headline that fades in once typing, turns red at or over the cap
- Headline cap lowered to 50 (client constant + server input encoder)

Stacked on #1364 (wrap fields). Split from #1354.