### PR TITLE
feat(app): enable link embeds in the overview editor

### DIFF
--- a/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
@@ -21,6 +21,7 @@ import {
   LuHeading4,
   LuItalic,
   LuLink,
+  LuLink2,
   LuList,
   LuListOrdered,
   LuQuote,
@@ -60,6 +61,7 @@ export function RichTextEditorBubbleMenu({
 }: RichTextEditorBubbleMenuProps) {
   const t = useTranslations();
   const [isEditingLink, setIsEditingLink] = useState(false);
+  const [isEditingEmbed, setIsEditingEmbed] = useState(false);
 
   // Focusing the URL input blurs the editor, which hides the native
   // selection highlight — so while the link editor is open, an inline
@@ -106,6 +108,12 @@ export function RichTextEditorBubbleMenu({
   if (!editor || !activeStates) {
     return null;
   }
+
+  // The bubble menu is shared; only offer the embed button where the editor
+  // actually registered the Iframely extension (so `setIframely` exists).
+  const hasEmbed = editor.extensionManager.extensions.some(
+    (extension) => extension.name === 'iframely',
+  );
 
   const openLinkEditor = () => {
     const { from, to } = editor.state.selection;
@@ -223,7 +231,10 @@ export function RichTextEditorBubbleMenu({
         offset: 8,
         flip: true,
         shift: true,
-        onHide: () => closeLinkEditor(),
+        onHide: () => {
+          closeLinkEditor();
+          setIsEditingEmbed(false);
+        },
       }}
       className="z-50 rounded-lg border border-border bg-popover p-2 shadow-md"
     >
@@ -255,45 +266,84 @@ export function RichTextEditorBubbleMenu({
               <Separator orientation="horizontal" className="w-full" />
             </React.Fragment>
           ))}
-          {/* Controlled by isEditingLink so every dismissal path (outside
-              click, escape, trigger toggle) also clears the selection
-              highlight decoration */}
-          <Popover
-            open={isEditingLink}
-            onOpenChange={(open, eventDetails) => {
-              if (open) {
-                openLinkEditor();
-                return;
-              }
-              closeLinkEditor();
-              // Refocus the editor so the native selection highlight takes
-              // over from the cleared decoration — unless the user
-              // deliberately moved focus elsewhere
-              if (
-                eventDetails.reason !== 'outside-press' &&
-                eventDetails.reason !== 'focus-out'
-              ) {
-                editor.commands.focus();
-              }
-            }}
-          >
-            <PopoverTrigger
-              render={
-                <Toggle
-                  size="sm"
-                  pressed={isEditingLink || activeStates.link}
-                  aria-label={t('Add Link')}
-                  title={t('Add Link')}
-                  className="h-8 aria-pressed:bg-primary aria-pressed:text-white"
-                >
-                  <LuLink className="size-4" />
-                </Toggle>
-              }
-            />
-            <PopoverContent align="center" side="top">
-              <LinkEditor editor={editor} onClose={closeLinkEditor} />
-            </PopoverContent>
-          </Popover>
+          <div className="grid grid-cols-2 gap-2">
+            {/* Controlled by isEditingLink so every dismissal path (outside
+                click, escape, trigger toggle) also clears the selection
+                highlight decoration */}
+            <Popover
+              open={isEditingLink}
+              onOpenChange={(open, eventDetails) => {
+                if (open) {
+                  openLinkEditor();
+                  return;
+                }
+                closeLinkEditor();
+                // Refocus the editor so the native selection highlight takes
+                // over from the cleared decoration — unless the user
+                // deliberately moved focus elsewhere
+                if (
+                  eventDetails.reason !== 'outside-press' &&
+                  eventDetails.reason !== 'focus-out'
+                ) {
+                  editor.commands.focus();
+                }
+              }}
+            >
+              <PopoverTrigger
+                render={
+                  <Toggle
+                    size="sm"
+                    pressed={isEditingLink || activeStates.link}
+                    aria-label={t('Add Link')}
+                    title={t('Add Link')}
+                    className="h-8 aria-pressed:bg-primary aria-pressed:text-white"
+                  >
+                    <LuLink className="size-4" />
+                  </Toggle>
+                }
+              />
+              <PopoverContent align="center" side="top">
+                <LinkEditor editor={editor} onClose={closeLinkEditor} />
+              </PopoverContent>
+            </Popover>
+            {/* Embed (Iframely) — paste/enter a URL to insert a link preview.
+                Same icon as the proposal toolbar's embed button. */}
+            {hasEmbed && (
+              <Popover
+                open={isEditingEmbed}
+                onOpenChange={(open, eventDetails) => {
+                  setIsEditingEmbed(open);
+                  if (
+                    !open &&
+                    eventDetails.reason !== 'outside-press' &&
+                    eventDetails.reason !== 'focus-out'
+                  ) {
+                    editor.commands.focus();
+                  }
+                }}
+              >
+                <PopoverTrigger
+                  render={
+                    <Toggle
+                      size="sm"
+                      pressed={isEditingEmbed}
+                      aria-label={t('Embed Link Preview')}
+                      title={t('Embed Link Preview')}
+                      className="h-8 aria-pressed:bg-primary aria-pressed:text-white"
+                    >
+                      <LuLink2 className="size-4" />
+                    </Toggle>
+                  }
+                />
+                <PopoverContent align="center" side="top">
+                  <EmbedEditor
+                    editor={editor}
+                    onClose={() => setIsEditingEmbed(false)}
+                  />
+                </PopoverContent>
+              </Popover>
+            )}
+          </div>
         </div>
       </div>
     </BubbleMenu>
@@ -457,6 +507,82 @@ function LinkEditor({
           {t('Remove')}
         </Button>
       </div>
+    </form>
+  );
+}
+
+/**
+ * Inline embed form: enter a URL and insert an Iframely link-preview node.
+ * Mirrors {@link LinkEditor}; no selection-highlight decoration since the embed
+ * inserts a block node rather than wrapping the selected text.
+ */
+function EmbedEditor({
+  editor,
+  onClose,
+}: {
+  editor: Editor;
+  onClose: () => void;
+}) {
+  const t = useTranslations();
+  const [url, setUrl] = useState('');
+  const [isInvalid, setIsInvalid] = useState(false);
+
+  const applyEmbed = () => {
+    const raw = url.trim();
+
+    if (raw === '') {
+      onClose();
+      return;
+    }
+
+    // Same URL convention as the link editor: prefix https:// when no protocol
+    // is given, validate the format before inserting.
+    const src = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+    if (!zodUrlRefine(src)) {
+      setIsInvalid(true);
+      return;
+    }
+
+    editor.chain().focus().setIframely({ src }).run();
+    onClose();
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        applyEmbed();
+      }}
+    >
+      <Input
+        autoFocus
+        type="text"
+        inputMode="url"
+        placeholder={t('URL')}
+        aria-label={t('URL')}
+        aria-invalid={isInvalid || undefined}
+        value={url}
+        onChange={(e) => {
+          setUrl(e.target.value);
+          setIsInvalid(false);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            onClose();
+            editor.commands.focus();
+          }
+        }}
+        className="h-8 w-full"
+      />
+      {isInvalid && (
+        <p className="text-sm text-destructive">{t('Enter a valid URL')}</p>
+      )}
+      <Button type="submit" size="sm" variant="outline" className="w-full">
+        <LuLink2 />
+        {t('Embed Link Preview')}
+      </Button>
     </form>
   );
 }

--- a/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
@@ -462,6 +462,10 @@ function LinkEditor({
   return (
     <form
       className="flex flex-col gap-2"
+      // The popover is portaled, but React synthetic events still bubble through
+      // the React tree to the toolbar's `onMouseDown` preventDefault — which would
+      // cancel text selection/caret placement in this input. Stop it here.
+      onMouseDown={(e) => e.stopPropagation()}
       onSubmit={(e) => {
         e.preventDefault();
         applyLink();
@@ -550,6 +554,9 @@ function EmbedEditor({
   return (
     <form
       className="flex flex-col gap-2"
+      // Portaled, but synthetic mousedown still bubbles to the toolbar's
+      // preventDefault (see LinkEditor) — stop it so the input is selectable.
+      onMouseDown={(e) => e.stopPropagation()}
       onSubmit={(e) => {
         e.preventDefault();
         applyEmbed();

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -6,13 +6,14 @@ import { RichTextEditor } from '@op/ui/RichTextEditor';
 import { Skeleton } from '@op/ui/Skeleton';
 import type { JSONContent } from '@tiptap/core';
 import type { Editor } from '@tiptap/react';
-import { Suspense, useRef, useState } from 'react';
+import { Suspense, useMemo, useRef, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { ErrorMessage } from '@/components/ErrorMessage';
 import { RichTextEditorBubbleMenu } from '@/components/RichTextEditor';
+import { getProposalExtensions } from '@/components/RichTextEditor/editorConfig';
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
@@ -73,6 +74,14 @@ function OverviewSectionContent({
   // Editor instance, captured once ready, so the bubble menu can attach.
   const [editor, setEditor] = useState<Editor | null>(null);
 
+  // Match the proposal editor's extension set so link embeds (paste a YouTube /
+  // Vimeo / etc. URL → Iframely preview) work here too. Slash commands stay off:
+  // the overview editor has no slash menu, only the bubble menu.
+  const extensions = useMemo(
+    () => getProposalExtensions({ slashCommands: false }),
+    [],
+  );
+
   const saveOverview = (patch: {
     headline?: string;
     description?: string;
@@ -126,6 +135,7 @@ function OverviewSectionContent({
         <hr className="border-neutral-gray1" />
 
         <RichTextEditor
+          extensions={extensions}
           // Sanitize stored JSON so an unknown node type can't make TipTap blank
           // the whole doc on load (and autosave the blank). HTML strings parse
           // leniently, so only JSON needs it.


### PR DESCRIPTION
Enables link embeds (Iframely) in the process **Overview** editor, matching the proposal body editor.

- Overview editor now uses `getProposalExtensions({ slashCommands: false })` instead of the bare `@op/ui` defaults, so it gets `IframelyExtension` + a paste-friendly `Link` config.
- **Insert two ways**: paste a YouTube / Vimeo / etc. URL → auto-embeds; or use the new **embed button in the bubble menu** (next to the link button, same `LuLink2` icon as the proposal toolbar) → enter a URL.
- Bubble-menu embed button is gated on the editor having Iframely registered, so the shared bubble menu stays safe in editors without it.
- Slash commands stay off (the overview editor has no slash menu).
- Viewer already rendered iframely nodes (`RichTextRenderer` nodeMapping → `LinkPreview`), so no viewer change needed.
