### PR TITLE
feat: slash-command affordance + per-line placeholder in overview editor

### DIFF
--- a/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
@@ -21,6 +21,7 @@ import {
   LuHeading4,
   LuItalic,
   LuLink,
+  LuLink2,
   LuList,
   LuListOrdered,
   LuQuote,
@@ -60,6 +61,7 @@ export function RichTextEditorBubbleMenu({
 }: RichTextEditorBubbleMenuProps) {
   const t = useTranslations();
   const [isEditingLink, setIsEditingLink] = useState(false);
+  const [isEditingEmbed, setIsEditingEmbed] = useState(false);
 
   // Focusing the URL input blurs the editor, which hides the native
   // selection highlight — so while the link editor is open, an inline
@@ -106,6 +108,12 @@ export function RichTextEditorBubbleMenu({
   if (!editor || !activeStates) {
     return null;
   }
+
+  // The bubble menu is shared; only offer the embed button where the editor
+  // actually registered the Iframely extension (so `setIframely` exists).
+  const hasEmbed = editor.extensionManager.extensions.some(
+    (extension) => extension.name === 'iframely',
+  );
 
   const openLinkEditor = () => {
     const { from, to } = editor.state.selection;
@@ -223,7 +231,10 @@ export function RichTextEditorBubbleMenu({
         offset: 8,
         flip: true,
         shift: true,
-        onHide: () => closeLinkEditor(),
+        onHide: () => {
+          closeLinkEditor();
+          setIsEditingEmbed(false);
+        },
       }}
       className="z-50 rounded-lg border border-border bg-popover p-2 shadow-md"
     >
@@ -255,45 +266,84 @@ export function RichTextEditorBubbleMenu({
               <Separator orientation="horizontal" className="w-full" />
             </React.Fragment>
           ))}
-          {/* Controlled by isEditingLink so every dismissal path (outside
-              click, escape, trigger toggle) also clears the selection
-              highlight decoration */}
-          <Popover
-            open={isEditingLink}
-            onOpenChange={(open, eventDetails) => {
-              if (open) {
-                openLinkEditor();
-                return;
-              }
-              closeLinkEditor();
-              // Refocus the editor so the native selection highlight takes
-              // over from the cleared decoration — unless the user
-              // deliberately moved focus elsewhere
-              if (
-                eventDetails.reason !== 'outside-press' &&
-                eventDetails.reason !== 'focus-out'
-              ) {
-                editor.commands.focus();
-              }
-            }}
-          >
-            <PopoverTrigger
-              render={
-                <Toggle
-                  size="sm"
-                  pressed={isEditingLink || activeStates.link}
-                  aria-label={t('Add Link')}
-                  title={t('Add Link')}
-                  className="h-8 aria-pressed:bg-primary aria-pressed:text-white"
-                >
-                  <LuLink className="size-4" />
-                </Toggle>
-              }
-            />
-            <PopoverContent align="center" side="top">
-              <LinkEditor editor={editor} onClose={closeLinkEditor} />
-            </PopoverContent>
-          </Popover>
+          <div className="grid grid-cols-2 gap-2">
+            {/* Controlled by isEditingLink so every dismissal path (outside
+                click, escape, trigger toggle) also clears the selection
+                highlight decoration */}
+            <Popover
+              open={isEditingLink}
+              onOpenChange={(open, eventDetails) => {
+                if (open) {
+                  openLinkEditor();
+                  return;
+                }
+                closeLinkEditor();
+                // Refocus the editor so the native selection highlight takes
+                // over from the cleared decoration — unless the user
+                // deliberately moved focus elsewhere
+                if (
+                  eventDetails.reason !== 'outside-press' &&
+                  eventDetails.reason !== 'focus-out'
+                ) {
+                  editor.commands.focus();
+                }
+              }}
+            >
+              <PopoverTrigger
+                render={
+                  <Toggle
+                    size="sm"
+                    pressed={isEditingLink || activeStates.link}
+                    aria-label={t('Add Link')}
+                    title={t('Add Link')}
+                    className="h-8 aria-pressed:bg-primary aria-pressed:text-white"
+                  >
+                    <LuLink className="size-4" />
+                  </Toggle>
+                }
+              />
+              <PopoverContent align="center" side="top">
+                <LinkEditor editor={editor} onClose={closeLinkEditor} />
+              </PopoverContent>
+            </Popover>
+            {/* Embed (Iframely) — paste/enter a URL to insert a link preview.
+                Same icon as the proposal toolbar's embed button. */}
+            {hasEmbed && (
+              <Popover
+                open={isEditingEmbed}
+                onOpenChange={(open, eventDetails) => {
+                  setIsEditingEmbed(open);
+                  if (
+                    !open &&
+                    eventDetails.reason !== 'outside-press' &&
+                    eventDetails.reason !== 'focus-out'
+                  ) {
+                    editor.commands.focus();
+                  }
+                }}
+              >
+                <PopoverTrigger
+                  render={
+                    <Toggle
+                      size="sm"
+                      pressed={isEditingEmbed}
+                      aria-label={t('Embed Link Preview')}
+                      title={t('Embed Link Preview')}
+                      className="h-8 aria-pressed:bg-primary aria-pressed:text-white"
+                    >
+                      <LuLink2 className="size-4" />
+                    </Toggle>
+                  }
+                />
+                <PopoverContent align="center" side="top">
+                  <EmbedEditor
+                    editor={editor}
+                    onClose={() => setIsEditingEmbed(false)}
+                  />
+                </PopoverContent>
+              </Popover>
+            )}
+          </div>
         </div>
       </div>
     </BubbleMenu>
@@ -457,6 +507,82 @@ function LinkEditor({
           {t('Remove')}
         </Button>
       </div>
+    </form>
+  );
+}
+
+/**
+ * Inline embed form: enter a URL and insert an Iframely link-preview node.
+ * Mirrors {@link LinkEditor}; no selection-highlight decoration since the embed
+ * inserts a block node rather than wrapping the selected text.
+ */
+function EmbedEditor({
+  editor,
+  onClose,
+}: {
+  editor: Editor;
+  onClose: () => void;
+}) {
+  const t = useTranslations();
+  const [url, setUrl] = useState('');
+  const [isInvalid, setIsInvalid] = useState(false);
+
+  const applyEmbed = () => {
+    const raw = url.trim();
+
+    if (raw === '') {
+      onClose();
+      return;
+    }
+
+    // Same URL convention as the link editor: prefix https:// when no protocol
+    // is given, validate the format before inserting.
+    const src = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+    if (!zodUrlRefine(src)) {
+      setIsInvalid(true);
+      return;
+    }
+
+    editor.chain().focus().setIframely({ src }).run();
+    onClose();
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        applyEmbed();
+      }}
+    >
+      <Input
+        autoFocus
+        type="text"
+        inputMode="url"
+        placeholder={t('URL')}
+        aria-label={t('URL')}
+        aria-invalid={isInvalid || undefined}
+        value={url}
+        onChange={(e) => {
+          setUrl(e.target.value);
+          setIsInvalid(false);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            onClose();
+            editor.commands.focus();
+          }
+        }}
+        className="h-8 w-full"
+      />
+      {isInvalid && (
+        <p className="text-sm text-destructive">{t('Enter a valid URL')}</p>
+      )}
+      <Button type="submit" size="sm" variant="outline" className="w-full">
+        <LuLink2 />
+        {t('Embed Link Preview')}
+      </Button>
     </form>
   );
 }

--- a/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/RichTextEditorBubbleMenu.tsx
@@ -462,6 +462,10 @@ function LinkEditor({
   return (
     <form
       className="flex flex-col gap-2"
+      // The popover is portaled, but React synthetic events still bubble through
+      // the React tree to the toolbar's `onMouseDown` preventDefault — which would
+      // cancel text selection/caret placement in this input. Stop it here.
+      onMouseDown={(e) => e.stopPropagation()}
       onSubmit={(e) => {
         e.preventDefault();
         applyLink();
@@ -550,6 +554,9 @@ function EmbedEditor({
   return (
     <form
       className="flex flex-col gap-2"
+      // Portaled, but synthetic mousedown still bubbles to the toolbar's
+      // preventDefault (see LinkEditor) — stop it so the input is selectable.
+      onMouseDown={(e) => e.stopPropagation()}
       onSubmit={(e) => {
         e.preventDefault();
         applyEmbed();

--- a/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from '@op/sense/Item';
+import { Popover, PopoverContent } from '@op/sense/Popover';
+import type { Editor } from '@tiptap/react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+
+import {
+  getSlashMenuController,
+  type SlashMenuSnapshot,
+} from '@/components/decisions/SlashCommands';
+
+const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
+  open: false,
+  items: [],
+  command: null,
+  clientRect: null,
+};
+
+const noopSubscribe = () => () => {};
+const getEmptySnapshot = () => EMPTY_SNAPSHOT;
+
+/**
+ * Renders the slash-command menu with the `@op/sense` Popover (base-ui), so it
+ * shares the design system and gets collision-aware positioning. The `@tiptap/
+ * suggestion` plugin owns the trigger/query/range and stays the source of truth
+ * for open/close; this component only subscribes to the per-editor controller
+ * (in `editor.storage`) and delegates keyboard nav back through it.
+ *
+ * The menu is intentionally focus-less (`initialFocus`/`finalFocus={false}`,
+ * `modal={false}`): the caret stays in the editor so the user can keep typing
+ * the query. Anchored to the caret rect via a virtual anchor element.
+ *
+ * Mount it next to the editor wherever SlashCommands is enabled; no-ops when the
+ * editor doesn't have the extension.
+ */
+export function SlashCommandMenu({ editor }: { editor: Editor | null }) {
+  const controller = getSlashMenuController(editor);
+
+  const snapshot = useSyncExternalStore(
+    controller ? controller.subscribe : noopSubscribe,
+    controller ? controller.getSnapshot : getEmptySnapshot,
+    getEmptySnapshot,
+  );
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Refs so the stable key handler / virtual anchor read current values.
+  const itemsRef = useRef(snapshot.items);
+  itemsRef.current = snapshot.items;
+  const commandRef = useRef(snapshot.command);
+  commandRef.current = snapshot.command;
+  const selectedRef = useRef(0);
+  selectedRef.current = selectedIndex;
+  const clientRectRef = useRef(snapshot.clientRect);
+  clientRectRef.current = snapshot.clientRect;
+  // The currently-highlighted row, so arrow nav can scroll it into view.
+  const selectedItemRef = useRef<HTMLButtonElement>(null);
+
+  // Virtual anchor at the caret. Stable identity; base-ui re-reads the rect as
+  // the caret moves (each keystroke updates the controller → re-render).
+  const anchor = useMemo(
+    () => ({
+      getBoundingClientRect: () => clientRectRef.current?.() ?? new DOMRect(),
+    }),
+    [],
+  );
+
+  // Reset the highlight when the filtered item set changes.
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [snapshot.items]);
+
+  // Keep the highlighted row visible as arrow keys move past the menu's edge.
+  useEffect(() => {
+    selectedItemRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  // The suggestion plugin delegates keydown here while the menu is open.
+  useEffect(() => {
+    if (!controller) {
+      return;
+    }
+
+    controller.setKeyHandler((event) => {
+      const items = itemsRef.current;
+      if (!items.length) {
+        return false;
+      }
+
+      if (event.key === 'ArrowUp') {
+        setSelectedIndex((i) => (i + items.length - 1) % items.length);
+        return true;
+      }
+
+      if (event.key === 'ArrowDown') {
+        setSelectedIndex((i) => (i + 1) % items.length);
+        return true;
+      }
+
+      if (event.key === 'Enter') {
+        const item = items[selectedRef.current];
+        if (item) {
+          commandRef.current?.(item);
+        }
+
+        return true;
+      }
+
+      return false;
+    });
+
+    return () => controller.setKeyHandler(null);
+  }, [controller]);
+
+  if (!controller) {
+    return null;
+  }
+
+  return (
+    <Popover open={snapshot.open} onOpenChange={() => {}} modal={false}>
+      <PopoverContent
+        anchor={anchor}
+        side="bottom"
+        align="start"
+        sideOffset={8}
+        initialFocus={false}
+        finalFocus={false}
+        // Keep editor focus + selection when an item is clicked (mid-query).
+        onMouseDown={(event) => event.preventDefault()}
+        className="max-h-90 w-80 max-w-screen gap-0 overflow-auto p-2"
+      >
+        {snapshot.items.length ? (
+          snapshot.items.map((item, index) => (
+            <Item
+              key={item.title}
+              render={
+                <button
+                  type="button"
+                  ref={index === selectedIndex ? selectedItemRef : null}
+                />
+              }
+              onClick={() => commandRef.current?.(item)}
+              aria-selected={index === selectedIndex}
+              // scroll-my gives scrollIntoView({block:'nearest'}) breathing room
+              // so the highlighted row doesn't sit flush against the menu edge.
+              className={`cursor-pointer scroll-my-2 transition-none ${
+                index === selectedIndex
+                  ? 'bg-neutral-gray1 text-neutral-black'
+                  : 'text-neutral-charcoal hover:bg-neutral-gray1'
+              }`}
+            >
+              <ItemMedia>
+                <item.icon className="size-4" />
+              </ItemMedia>
+              <ItemContent className="gap-0">
+                <ItemTitle className="text-base font-medium">
+                  {item.title}
+                </ItemTitle>
+                <ItemDescription className="text-base text-neutral-gray4">
+                  {item.description}
+                </ItemDescription>
+              </ItemContent>
+            </Item>
+          ))
+        ) : (
+          <div className="px-2 py-1 text-neutral-gray4">No results</div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
@@ -1,16 +1,15 @@
 'use client';
 
-import {
-  Item,
-  ItemContent,
-  ItemDescription,
-  ItemMedia,
-  ItemTitle,
-} from '@op/sense/Item';
+import { Item, ItemContent, ItemMedia, ItemTitle } from '@op/sense/Item';
+import { Popover, PopoverContent } from '@op/sense/Popover';
 import type { Editor } from '@tiptap/react';
-import type { CSSProperties } from 'react';
-import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
-import { createPortal } from 'react-dom';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -29,22 +28,17 @@ const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
 const noopSubscribe = () => () => {};
 const getEmptySnapshot = () => EMPTY_SNAPSHOT;
 
-const MENU_WIDTH = 320; // w-80
-const MENU_MAX_HEIGHT = 360; // max-h-90
-
 /**
- * Slash-command menu surface. The `@tiptap/suggestion` plugin owns the whole
- * lifecycle — trigger, query, range, keyboard, open/close, and position (via
- * `clientRect`) — so this is a plain positioned surface, NOT a Popover. It
- * mounts only while the suggestion says open and unmounts instantly on close.
+ * Slash-command menu, rendered with the `@op/sense` Popover (base-ui) so it
+ * shares the design system + gets collision-aware positioning. The `@tiptap/
+ * suggestion` plugin owns the lifecycle (trigger, query, range, keyboard,
+ * open/close, position via `clientRect`); this only subscribes to the per-editor
+ * controller and delegates keyboard nav back through it.
  *
- * (A base-ui Popover layered its own portal + enter/exit animation + dismiss +
- * focus on top; the exit animation flashed the menu to the corner when the caret
- * anchor disappeared on close. A plain surface has nothing to animate.)
- *
- * Rendered through a portal so it has app providers + i18n + design tokens and
- * isn't clipped by editor overflow. Focus-less: the caret stays in the editor so
- * the user keeps typing the query.
+ * Focus-less (`initialFocus`/`finalFocus={false}`, `modal={false}`): the caret
+ * stays in the editor so the user keeps typing the query. `noAnimation` so the
+ * Popover unmounts instantly on close — base-ui's exit animation otherwise
+ * repaints the popup at a stale position when the caret anchor disappears.
  *
  * Mount next to the editor wherever SlashCommands is enabled; no-ops otherwise.
  */
@@ -60,15 +54,35 @@ export function SlashCommandMenu({ editor }: { editor: Editor | null }) {
 
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  // Refs so the stable key handler reads current values.
+  // Refs so the stable key handler / virtual anchor read current values.
   const itemsRef = useRef(snapshot.items);
   itemsRef.current = snapshot.items;
   const commandRef = useRef(snapshot.command);
   commandRef.current = snapshot.command;
   const selectedRef = useRef(0);
   selectedRef.current = selectedIndex;
+  const clientRectRef = useRef(snapshot.clientRect);
+  clientRectRef.current = snapshot.clientRect;
   // The currently-highlighted row, so arrow nav can scroll it into view.
   const selectedItemRef = useRef<HTMLButtonElement>(null);
+
+  // Virtual anchor at the caret. Stable identity; base-ui re-reads the rect as
+  // the caret moves. Cache the last good rect so a transient null on close can't
+  // jump the popup to the corner.
+  const lastRectRef = useRef<DOMRect | null>(null);
+  const anchor = useMemo(
+    () => ({
+      getBoundingClientRect: () => {
+        const rect = clientRectRef.current?.() ?? null;
+        if (rect) {
+          lastRectRef.current = rect;
+        }
+
+        return lastRectRef.current ?? new DOMRect();
+      },
+    }),
+    [],
+  );
 
   // Reset the highlight when the filtered item set changes.
   useEffect(() => {
@@ -117,71 +131,65 @@ export function SlashCommandMenu({ editor }: { editor: Editor | null }) {
     return () => controller.setKeyHandler(null);
   }, [controller]);
 
-  if (!controller || !snapshot.open) {
+  if (!controller) {
     return null;
   }
 
-  const rect = snapshot.clientRect?.();
-  if (!rect) {
-    return null;
-  }
-
-  // Below the caret; flip above when there isn't room, clamp horizontally.
-  const spaceBelow = window.innerHeight - rect.bottom;
-  const placeAbove = spaceBelow < MENU_MAX_HEIGHT && rect.top > spaceBelow;
-  const left = Math.max(
-    8,
-    Math.min(rect.left, window.innerWidth - MENU_WIDTH - 8),
-  );
-  const style: CSSProperties = placeAbove
-    ? { bottom: window.innerHeight - rect.top + 8, left }
-    : { top: rect.bottom + 8, left };
-
-  return createPortal(
-    <div
-      // Focus-less: keep editor focus + selection (user is mid-query). Clicks on
-      // items still fire onClick — preventDefault only blocks the focus shift.
-      onMouseDown={(event) => event.preventDefault()}
-      style={style}
-      className="fixed z-50 flex max-h-90 w-80 flex-col gap-0 overflow-auto rounded-lg border border-border bg-popover p-2 text-popover-foreground shadow-md"
-    >
-      {snapshot.items.length ? (
-        snapshot.items.map((item, index) => (
-          <Item
-            key={item.title}
-            render={
-              <button
-                type="button"
-                ref={index === selectedIndex ? selectedItemRef : null}
-              />
-            }
-            onClick={() => commandRef.current?.(item)}
-            aria-selected={index === selectedIndex}
-            // scroll-my gives scrollIntoView({block:'nearest'}) breathing room
-            // so the highlighted row doesn't sit flush against the menu edge.
-            className={`cursor-pointer scroll-my-2 transition-none ${
-              index === selectedIndex
-                ? 'bg-neutral-gray1 text-neutral-black'
-                : 'text-neutral-charcoal hover:bg-neutral-gray1'
-            }`}
-          >
-            <ItemMedia>
-              <item.icon className="size-4" />
-            </ItemMedia>
-            <ItemContent className="gap-0">
-              <ItemTitle className="text-base font-medium">
-                {item.title}
-              </ItemTitle>
-              <ItemDescription className="text-base text-neutral-gray4">
-                {item.description}
-              </ItemDescription>
-            </ItemContent>
-          </Item>
-        ))
-      ) : (
-        <div className="px-2 py-1 text-neutral-gray4">{t('No results')}</div>
-      )}
-    </div>,
-    document.body,
+  return (
+    <Popover open={snapshot.open} onOpenChange={() => {}} modal={false}>
+      <PopoverContent
+        anchor={anchor}
+        noAnimation
+        initialFocus={false}
+        finalFocus={false}
+        side="bottom"
+        align="start"
+        sideOffset={8}
+        // Keep editor focus + selection when an item is clicked (mid-query).
+        onMouseDown={(event) => event.preventDefault()}
+        // Clip on the rounded container; scroll on the inner wrapper — so the
+        // scrollbar can't paint past the rounded corner.
+        className="w-auto overflow-hidden p-0"
+      >
+        <div className="flex max-h-90 flex-col gap-0 overflow-auto p-2">
+          {snapshot.items.length ? (
+            snapshot.items.map((item, index) => (
+              <Item
+                key={item.title}
+                size="xs"
+                render={
+                  <button
+                    type="button"
+                    ref={index === selectedIndex ? selectedItemRef : null}
+                  />
+                }
+                onClick={() => commandRef.current?.(item)}
+                aria-selected={index === selectedIndex}
+                // scroll-my gives scrollIntoView({block:'nearest'}) breathing room
+                // so the highlighted row doesn't sit flush against the menu edge.
+                className={`cursor-pointer scroll-my-2 transition-none ${
+                  index === selectedIndex
+                    ? 'bg-neutral-gray1 text-neutral-black'
+                    : 'text-neutral-charcoal hover:bg-neutral-gray1'
+                }`}
+              >
+                <ItemMedia>
+                  <item.icon className="size-4" />
+                </ItemMedia>
+                <ItemContent className="gap-0">
+                  <ItemTitle className="text-base font-medium">
+                    {item.title}
+                  </ItemTitle>
+                </ItemContent>
+              </Item>
+            ))
+          ) : (
+            <div className="px-2 py-1 text-neutral-gray4">
+              {t('No results')}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
@@ -16,6 +16,7 @@ import {
   getSlashMenuController,
   type SlashMenuSnapshot,
 } from '@/components/decisions/SlashCommands';
+import { useTranslations } from '@/lib/i18n';
 
 const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
   open: false,
@@ -47,6 +48,7 @@ const MENU_MAX_HEIGHT = 360; // max-h-90
  * Mount next to the editor wherever SlashCommands is enabled; no-ops otherwise.
  */
 export function SlashCommandMenu({ editor }: { editor: Editor | null }) {
+  const t = useTranslations();
   const controller = getSlashMenuController(editor);
 
   const snapshot = useSyncExternalStore(
@@ -176,7 +178,7 @@ export function SlashCommandMenu({ editor }: { editor: Editor | null }) {
           </Item>
         ))
       ) : (
-        <div className="px-2 py-1 text-neutral-gray4">No results</div>
+        <div className="px-2 py-1 text-neutral-gray4">{t('No results')}</div>
       )}
     </div>,
     document.body,

--- a/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
@@ -14,16 +14,9 @@ import {
 import { useTranslations } from '@/lib/i18n';
 
 import {
+  EMPTY_SNAPSHOT,
   getSlashMenuController,
-  type SlashMenuSnapshot,
 } from '@/components/decisions/SlashCommands';
-
-const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
-  open: false,
-  items: [],
-  command: null,
-  clientRect: null,
-};
 
 const noopSubscribe = () => () => {};
 const getEmptySnapshot = () => EMPTY_SNAPSHOT;

--- a/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
@@ -7,15 +7,10 @@ import {
   ItemMedia,
   ItemTitle,
 } from '@op/sense/Item';
-import { Popover, PopoverContent } from '@op/sense/Popover';
 import type { Editor } from '@tiptap/react';
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from 'react';
+import type { CSSProperties } from 'react';
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
 
 import {
   getSlashMenuController,
@@ -32,19 +27,24 @@ const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
 const noopSubscribe = () => () => {};
 const getEmptySnapshot = () => EMPTY_SNAPSHOT;
 
+const MENU_WIDTH = 320; // w-80
+const MENU_MAX_HEIGHT = 360; // max-h-90
+
 /**
- * Renders the slash-command menu with the `@op/sense` Popover (base-ui), so it
- * shares the design system and gets collision-aware positioning. The `@tiptap/
- * suggestion` plugin owns the trigger/query/range and stays the source of truth
- * for open/close; this component only subscribes to the per-editor controller
- * (in `editor.storage`) and delegates keyboard nav back through it.
+ * Slash-command menu surface. The `@tiptap/suggestion` plugin owns the whole
+ * lifecycle — trigger, query, range, keyboard, open/close, and position (via
+ * `clientRect`) — so this is a plain positioned surface, NOT a Popover. It
+ * mounts only while the suggestion says open and unmounts instantly on close.
  *
- * The menu is intentionally focus-less (`initialFocus`/`finalFocus={false}`,
- * `modal={false}`): the caret stays in the editor so the user can keep typing
- * the query. Anchored to the caret rect via a virtual anchor element.
+ * (A base-ui Popover layered its own portal + enter/exit animation + dismiss +
+ * focus on top; the exit animation flashed the menu to the corner when the caret
+ * anchor disappeared on close. A plain surface has nothing to animate.)
  *
- * Mount it next to the editor wherever SlashCommands is enabled; no-ops when the
- * editor doesn't have the extension.
+ * Rendered through a portal so it has app providers + i18n + design tokens and
+ * isn't clipped by editor overflow. Focus-less: the caret stays in the editor so
+ * the user keeps typing the query.
+ *
+ * Mount next to the editor wherever SlashCommands is enabled; no-ops otherwise.
  */
 export function SlashCommandMenu({ editor }: { editor: Editor | null }) {
   const controller = getSlashMenuController(editor);
@@ -57,26 +57,15 @@ export function SlashCommandMenu({ editor }: { editor: Editor | null }) {
 
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  // Refs so the stable key handler / virtual anchor read current values.
+  // Refs so the stable key handler reads current values.
   const itemsRef = useRef(snapshot.items);
   itemsRef.current = snapshot.items;
   const commandRef = useRef(snapshot.command);
   commandRef.current = snapshot.command;
   const selectedRef = useRef(0);
   selectedRef.current = selectedIndex;
-  const clientRectRef = useRef(snapshot.clientRect);
-  clientRectRef.current = snapshot.clientRect;
   // The currently-highlighted row, so arrow nav can scroll it into view.
   const selectedItemRef = useRef<HTMLButtonElement>(null);
-
-  // Virtual anchor at the caret. Stable identity; base-ui re-reads the rect as
-  // the caret moves (each keystroke updates the controller → re-render).
-  const anchor = useMemo(
-    () => ({
-      getBoundingClientRect: () => clientRectRef.current?.() ?? new DOMRect(),
-    }),
-    [],
-  );
 
   // Reset the highlight when the filtered item set changes.
   useEffect(() => {
@@ -125,60 +114,71 @@ export function SlashCommandMenu({ editor }: { editor: Editor | null }) {
     return () => controller.setKeyHandler(null);
   }, [controller]);
 
-  if (!controller) {
+  if (!controller || !snapshot.open) {
     return null;
   }
 
-  return (
-    <Popover open={snapshot.open} onOpenChange={() => {}} modal={false}>
-      <PopoverContent
-        anchor={anchor}
-        side="bottom"
-        align="start"
-        sideOffset={8}
-        initialFocus={false}
-        finalFocus={false}
-        // Keep editor focus + selection when an item is clicked (mid-query).
-        onMouseDown={(event) => event.preventDefault()}
-        className="max-h-90 w-80 max-w-screen gap-0 overflow-auto p-2"
-      >
-        {snapshot.items.length ? (
-          snapshot.items.map((item, index) => (
-            <Item
-              key={item.title}
-              render={
-                <button
-                  type="button"
-                  ref={index === selectedIndex ? selectedItemRef : null}
-                />
-              }
-              onClick={() => commandRef.current?.(item)}
-              aria-selected={index === selectedIndex}
-              // scroll-my gives scrollIntoView({block:'nearest'}) breathing room
-              // so the highlighted row doesn't sit flush against the menu edge.
-              className={`cursor-pointer scroll-my-2 transition-none ${
-                index === selectedIndex
-                  ? 'bg-neutral-gray1 text-neutral-black'
-                  : 'text-neutral-charcoal hover:bg-neutral-gray1'
-              }`}
-            >
-              <ItemMedia>
-                <item.icon className="size-4" />
-              </ItemMedia>
-              <ItemContent className="gap-0">
-                <ItemTitle className="text-base font-medium">
-                  {item.title}
-                </ItemTitle>
-                <ItemDescription className="text-base text-neutral-gray4">
-                  {item.description}
-                </ItemDescription>
-              </ItemContent>
-            </Item>
-          ))
-        ) : (
-          <div className="px-2 py-1 text-neutral-gray4">No results</div>
-        )}
-      </PopoverContent>
-    </Popover>
+  const rect = snapshot.clientRect?.();
+  if (!rect) {
+    return null;
+  }
+
+  // Below the caret; flip above when there isn't room, clamp horizontally.
+  const spaceBelow = window.innerHeight - rect.bottom;
+  const placeAbove = spaceBelow < MENU_MAX_HEIGHT && rect.top > spaceBelow;
+  const left = Math.max(
+    8,
+    Math.min(rect.left, window.innerWidth - MENU_WIDTH - 8),
+  );
+  const style: CSSProperties = placeAbove
+    ? { bottom: window.innerHeight - rect.top + 8, left }
+    : { top: rect.bottom + 8, left };
+
+  return createPortal(
+    <div
+      // Focus-less: keep editor focus + selection (user is mid-query). Clicks on
+      // items still fire onClick — preventDefault only blocks the focus shift.
+      onMouseDown={(event) => event.preventDefault()}
+      style={style}
+      className="fixed z-50 flex max-h-90 w-80 flex-col gap-0 overflow-auto rounded-lg border border-border bg-popover p-2 text-popover-foreground shadow-md"
+    >
+      {snapshot.items.length ? (
+        snapshot.items.map((item, index) => (
+          <Item
+            key={item.title}
+            render={
+              <button
+                type="button"
+                ref={index === selectedIndex ? selectedItemRef : null}
+              />
+            }
+            onClick={() => commandRef.current?.(item)}
+            aria-selected={index === selectedIndex}
+            // scroll-my gives scrollIntoView({block:'nearest'}) breathing room
+            // so the highlighted row doesn't sit flush against the menu edge.
+            className={`cursor-pointer scroll-my-2 transition-none ${
+              index === selectedIndex
+                ? 'bg-neutral-gray1 text-neutral-black'
+                : 'text-neutral-charcoal hover:bg-neutral-gray1'
+            }`}
+          >
+            <ItemMedia>
+              <item.icon className="size-4" />
+            </ItemMedia>
+            <ItemContent className="gap-0">
+              <ItemTitle className="text-base font-medium">
+                {item.title}
+              </ItemTitle>
+              <ItemDescription className="text-base text-neutral-gray4">
+                {item.description}
+              </ItemDescription>
+            </ItemContent>
+          </Item>
+        ))
+      ) : (
+        <div className="px-2 py-1 text-neutral-gray4">No results</div>
+      )}
+    </div>,
+    document.body,
   );
 }

--- a/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
@@ -12,11 +12,12 @@ import type { CSSProperties } from 'react';
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useTranslations } from '@/lib/i18n';
+
 import {
   getSlashMenuController,
   type SlashMenuSnapshot,
 } from '@/components/decisions/SlashCommands';
-import { useTranslations } from '@/lib/i18n';
 
 const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
   open: false,

--- a/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
+++ b/apps/app/src/components/RichTextEditor/SlashCommandMenu.tsx
@@ -16,7 +16,7 @@ import { useTranslations } from '@/lib/i18n';
 import {
   EMPTY_SNAPSHOT,
   getSlashMenuController,
-} from '@/components/decisions/SlashCommands';
+} from '@/components/RichTextEditor/slashMenuController';
 
 const noopSubscribe = () => () => {};
 const getEmptySnapshot = () => EMPTY_SNAPSHOT;

--- a/apps/app/src/components/RichTextEditor/editorConfig.ts
+++ b/apps/app/src/components/RichTextEditor/editorConfig.ts
@@ -25,7 +25,10 @@ export function getProposalExtensions(
   options: EditorExtensionOptions = {},
 ): AnyExtension[] {
   const {
-    slashCommands = true,
+    // Opt-in: the slash menu only renders where a <SlashCommandMenu> is mounted
+    // (currently the Overview editor). Defaulting on would activate the trigger
+    // in editors with no menu — a dead, menu-less '/'.
+    slashCommands = false,
     linkEmbeds = true,
     collaborative = false,
   } = options;

--- a/apps/app/src/components/RichTextEditor/index.ts
+++ b/apps/app/src/components/RichTextEditor/index.ts
@@ -14,6 +14,8 @@ export {
   type RichTextEditorBubbleMenuProps,
 } from './RichTextEditorBubbleMenu';
 
+export { SlashCommandMenu } from './SlashCommandMenu';
+
 // App-specific editor extensions
 export {
   getProposalExtensions,

--- a/apps/app/src/components/RichTextEditor/slashMenuController.ts
+++ b/apps/app/src/components/RichTextEditor/slashMenuController.ts
@@ -1,0 +1,79 @@
+import type { ComponentType } from 'react';
+
+export interface SlashCommandItem {
+  title: string;
+  description: string;
+  searchTerms: string[];
+  icon: ComponentType<{ className?: string }>;
+  command: ({ editor, range }: { editor: any; range: any }) => void;
+}
+
+/**
+ * The state the React menu (`SlashCommandMenu`) renders from. The `@tiptap/
+ * suggestion` plugin (see `SlashCommands`) writes to it via the controller; the
+ * menu subscribes. The menu renders in the React tree (NOT a detached
+ * `createRoot`), so it gets app providers, i18n, and design tokens.
+ *
+ * This bridge lives in the editor layer (not the decisions domain) so the
+ * generic menu component and the domain extension both depend inward on it,
+ * rather than the menu reaching across into `decisions/`.
+ */
+export interface SlashMenuSnapshot {
+  open: boolean;
+  items: SlashCommandItem[];
+  command: ((item: SlashCommandItem) => void) | null;
+  clientRect: (() => DOMRect | null) | null;
+}
+
+export interface SlashMenuController {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => SlashMenuSnapshot;
+  update: (partial: Partial<SlashMenuSnapshot>) => void;
+  /** The open menu registers its key handler; the suggestion delegates to it. */
+  setKeyHandler: (handler: ((event: KeyboardEvent) => boolean) | null) => void;
+  handleKeyDown: (event: KeyboardEvent) => boolean;
+}
+
+export const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
+  open: false,
+  items: [],
+  command: null,
+  clientRect: null,
+};
+
+export function createSlashMenuController(): SlashMenuController {
+  let snapshot = EMPTY_SNAPSHOT;
+  const listeners = new Set<() => void>();
+  let keyHandler: ((event: KeyboardEvent) => boolean) | null = null;
+
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getSnapshot: () => snapshot,
+    update: (partial) => {
+      snapshot = { ...snapshot, ...partial };
+      listeners.forEach((listener) => listener());
+    },
+    setKeyHandler: (handler) => {
+      keyHandler = handler;
+    },
+    handleKeyDown: (event) => keyHandler?.(event) ?? false,
+  };
+}
+
+/**
+ * Read the per-editor slash controller off editor storage. Returns undefined
+ * when the editor doesn't have the SlashCommands extension — `SlashCommandMenu`
+ * uses that to no-op.
+ */
+export function getSlashMenuController(
+  editor: { storage?: Record<string, any> } | null | undefined,
+): SlashMenuController | undefined {
+  return editor?.storage?.['slash-commands']?.controller as
+    | SlashMenuController
+    | undefined;
+}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -6,13 +6,14 @@ import { RichTextEditor } from '@op/ui/RichTextEditor';
 import { Skeleton } from '@op/ui/Skeleton';
 import type { JSONContent } from '@tiptap/core';
 import type { Editor } from '@tiptap/react';
-import { Suspense, useRef, useState } from 'react';
+import { Suspense, useMemo, useRef, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { ErrorMessage } from '@/components/ErrorMessage';
 import { RichTextEditorBubbleMenu } from '@/components/RichTextEditor';
+import { getProposalExtensions } from '@/components/RichTextEditor/editorConfig';
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
 import type { SectionProps } from '@/components/decisions/ProcessBuilder/contentRegistry';
@@ -73,6 +74,14 @@ function OverviewSectionContent({
   // Editor instance, captured once ready, so the bubble menu can attach.
   const [editor, setEditor] = useState<Editor | null>(null);
 
+  // Match the proposal editor's extension set so link embeds (paste a YouTube /
+  // Vimeo / etc. URL → Iframely preview) work here too. Slash commands stay off:
+  // the overview editor has no slash menu, only the bubble menu.
+  const extensions = useMemo(
+    () => getProposalExtensions({ slashCommands: false }),
+    [],
+  );
+
   const saveOverview = (patch: {
     headline?: string;
     description?: string;
@@ -126,6 +135,7 @@ function OverviewSectionContent({
         <hr className="border-neutral-gray1" />
 
         <RichTextEditor
+          extensions={extensions}
           // Sanitize stored JSON so an unknown node type can't make TipTap blank
           // the whole doc on load (and autosave the blank). HTML strings parse
           // leniently, so only JSON needs it.

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -12,7 +12,10 @@ import { useTranslations } from '@/lib/i18n';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
 import { ErrorMessage } from '@/components/ErrorMessage';
-import { RichTextEditorBubbleMenu } from '@/components/RichTextEditor';
+import {
+  RichTextEditorBubbleMenu,
+  SlashCommandMenu,
+} from '@/components/RichTextEditor';
 import { getProposalExtensions } from '@/components/RichTextEditor/editorConfig';
 import { useProcessBuilderAutosave } from '@/components/decisions/ProcessBuilder/ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '@/components/decisions/ProcessBuilder/components/SaveStatusIndicator';
@@ -158,6 +161,7 @@ function OverviewSectionContent({
         />
 
         <RichTextEditorBubbleMenu editor={editor} />
+        <SlashCommandMenu editor={editor} />
       </div>
     </div>
   );

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -74,11 +74,11 @@ function OverviewSectionContent({
   // Editor instance, captured once ready, so the bubble menu can attach.
   const [editor, setEditor] = useState<Editor | null>(null);
 
-  // Match the proposal editor's extension set so link embeds (paste a YouTube /
-  // Vimeo / etc. URL → Iframely preview) work here too. Slash commands stay off:
-  // the overview editor has no slash menu, only the bubble menu.
+  // Match the proposal editor's extension set: link embeds (paste a YouTube /
+  // Vimeo / etc. URL → Iframely preview) plus the slash command menu, so blocks
+  // and embeds can be inserted with no selection (the bubble menu needs one).
   const extensions = useMemo(
-    () => getProposalExtensions({ slashCommands: false }),
+    () => getProposalExtensions({ slashCommands: true }),
     [],
   );
 
@@ -145,6 +145,7 @@ function OverviewSectionContent({
               : sanitizeTiptapDoc(initialOverview.body)
           }
           placeholder={t('overview_body_placeholder')}
+          linePlaceholder={t("Start typing or press '/' for more commands...")}
           editorClassName="min-h-40"
           onChangeJSON={(json) => {
             // Persist the TipTap JSON doc so the overview renders via the

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -9,7 +9,6 @@ import {
   LuHeading1,
   LuHeading2,
   LuHeading3,
-  LuHeading4,
   LuLink2,
   LuList,
   LuListOrdered,

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -3,13 +3,7 @@
 import { Extension } from '@tiptap/core';
 import { PluginKey } from '@tiptap/pm/state';
 import { Suggestion, SuggestionOptions } from '@tiptap/suggestion';
-import React, {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useState,
-} from 'react';
-import { createRoot } from 'react-dom/client';
+import type { ComponentType } from 'react';
 import {
   LuCode,
   LuHeading1,
@@ -27,93 +21,75 @@ export interface SlashCommandItem {
   title: string;
   description: string;
   searchTerms: string[];
-  icon: React.ComponentType<{ className?: string }>;
+  icon: ComponentType<{ className?: string }>;
   command: ({ editor, range }: { editor: any; range: any }) => void;
 }
 
-const SlashCommandsList = forwardRef<
-  { onKeyDown: (props: { event: KeyboardEvent }) => boolean },
-  {
-    items: SlashCommandItem[];
-    command: (item: SlashCommandItem) => void;
-  }
->((props, ref) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
+/**
+ * The state the React menu (`SlashCommandMenu`) renders from. The `@tiptap/
+ * suggestion` plugin writes to it via the controller; the menu subscribes. The
+ * menu renders in the React tree (NOT a detached `createRoot`), so it gets app
+ * providers, i18n, and design tokens — the createRoot approach had none.
+ */
+export interface SlashMenuSnapshot {
+  open: boolean;
+  items: SlashCommandItem[];
+  command: ((item: SlashCommandItem) => void) | null;
+  clientRect: (() => DOMRect | null) | null;
+}
 
-  const selectItem = (index: number) => {
-    const item = props.items[index];
-    if (item) {
-      props.command(item);
-    }
-  };
+export interface SlashMenuController {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => SlashMenuSnapshot;
+  update: (partial: Partial<SlashMenuSnapshot>) => void;
+  /** The open menu registers its key handler; the suggestion delegates to it. */
+  setKeyHandler: (handler: ((event: KeyboardEvent) => boolean) | null) => void;
+  handleKeyDown: (event: KeyboardEvent) => boolean;
+}
 
-  const upHandler = () => {
-    setSelectedIndex(
-      (selectedIndex + props.items.length - 1) % props.items.length,
-    );
-  };
+const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
+  open: false,
+  items: [],
+  command: null,
+  clientRect: null,
+};
 
-  const downHandler = () => {
-    setSelectedIndex((selectedIndex + 1) % props.items.length);
-  };
+function createSlashMenuController(): SlashMenuController {
+  let snapshot = EMPTY_SNAPSHOT;
+  const listeners = new Set<() => void>();
+  let keyHandler: ((event: KeyboardEvent) => boolean) | null = null;
 
-  const enterHandler = () => {
-    selectItem(selectedIndex);
-  };
-
-  useEffect(() => setSelectedIndex(0), [props.items]);
-
-  useImperativeHandle(ref, () => ({
-    onKeyDown: ({ event }) => {
-      if (event.key === 'ArrowUp') {
-        upHandler();
-        return true;
-      }
-
-      if (event.key === 'ArrowDown') {
-        downHandler();
-        return true;
-      }
-
-      if (event.key === 'Enter') {
-        enterHandler();
-        return true;
-      }
-
-      return false;
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
     },
-  }));
+    getSnapshot: () => snapshot,
+    update: (partial) => {
+      snapshot = { ...snapshot, ...partial };
+      listeners.forEach((listener) => listener());
+    },
+    setKeyHandler: (handler) => {
+      keyHandler = handler;
+    },
+    handleKeyDown: (event) => keyHandler?.(event) ?? false,
+  };
+}
 
-  return (
-    <div className="z-[9999999] h-auto max-h-[330px] w-72 overflow-auto rounded-lg border bg-white p-1 shadow-md">
-      {props.items.length ? (
-        props.items.map((item, index) => (
-          <button
-            className={`flex w-full items-center space-x-2 rounded-md px-2 py-1 text-start hover:bg-neutral-gray1 ${
-              index === selectedIndex
-                ? 'bg-neutral-gray1 text-neutral-black'
-                : 'text-neutral-charcoal'
-            }`}
-            key={index}
-            onClick={() => selectItem(index)}
-          >
-            <div className="flex size-10 shrink-0 items-center justify-center rounded-md border bg-white">
-              <item.icon className="size-4" />
-            </div>
-            <div>
-              <p className="font-medium">{item.title}</p>
-              <p className="text-xs text-neutral-gray2">{item.description}</p>
-            </div>
-          </button>
-        ))
-      ) : (
-        <div className="item">No results</div>
-      )}
-    </div>
-  );
-});
-
-SlashCommandsList.displayName = 'SlashCommandsList';
+/**
+ * Read the per-editor slash controller off editor storage. Returns undefined
+ * when the editor doesn't have the SlashCommands extension — `SlashCommandMenu`
+ * uses that to no-op.
+ */
+export function getSlashMenuController(
+  editor: { storage?: Record<string, any> } | null | undefined,
+): SlashMenuController | undefined {
+  return editor?.storage?.['slash-commands']?.controller as
+    | SlashMenuController
+    | undefined;
+}
 
 const suggestionOptions: Partial<SuggestionOptions> = {
   items: ({ query }: { query: string }): SlashCommandItem[] => {
@@ -258,72 +234,40 @@ const suggestionOptions: Partial<SuggestionOptions> = {
     });
   },
 
+  // Render only writes to the per-editor controller; `SlashCommandMenu` (mounted
+  // in the React tree alongside the editor) subscribes and renders the menu.
+  // The controller is captured in `onStart` because `onKeyDown` props carry only
+  // `{ view, event, range }` — no `editor` to look it up from.
   render: () => {
-    let component: any;
-    let popup: any;
-    let root: any;
+    let controller: SlashMenuController | undefined;
 
     return {
       onStart: (props: any) => {
-        if (!props.clientRect) {
-          return;
-        }
-
-        popup = document.createElement('div');
-        popup.style.position = 'absolute';
-        popup.style.top = `${props.clientRect().bottom + 8}px`;
-        popup.style.left = `${props.clientRect().left}px`;
-        popup.style.zIndex = '9999999';
-        document.body.appendChild(popup);
-
-        root = createRoot(popup);
-        root.render(
-          <SlashCommandsList
-            ref={(ref) => {
-              component = ref;
-            }}
-            items={props.items}
-            command={props.command}
-          />,
-        );
+        controller = getSlashMenuController(props.editor);
+        controller?.update({
+          open: true,
+          items: props.items,
+          command: props.command,
+          clientRect: props.clientRect ?? null,
+        });
       },
 
-      onUpdate(props: any) {
-        if (!popup || !root) return;
-
-        if (props.clientRect) {
-          popup.style.top = `${props.clientRect().bottom + 8}px`;
-          popup.style.left = `${props.clientRect().left}px`;
-        }
-
-        root.render(
-          <SlashCommandsList
-            ref={(ref) => {
-              component = ref;
-            }}
-            items={props.items}
-            command={props.command}
-          />,
-        );
+      onUpdate: (props: any) => {
+        controller?.update({
+          items: props.items,
+          command: props.command,
+          clientRect: props.clientRect ?? null,
+        });
       },
 
-      onKeyDown(props: any) {
-        if (props.event.key === 'Escape') {
-          if (root) {
-            root.unmount();
-          }
-          popup?.remove();
-          return true;
-        }
+      // Delegate to the menu's key handler. Escape isn't handled there (returns
+      // false), so the suggestion plugin runs its own exit → `onExit` closes.
+      onKeyDown: (props: any) =>
+        controller?.handleKeyDown(props.event) ?? false,
 
-        return component?.onKeyDown?.(props) || false;
-      },
-
-      onExit() {
-        if (root) {
-          root.unmount();
-        }
-        popup?.remove();
+      onExit: () => {
+        controller?.update({ open: false });
+        controller = undefined;
       },
     };
   },
@@ -331,6 +275,10 @@ const suggestionOptions: Partial<SuggestionOptions> = {
 
 export const SlashCommands = Extension.create({
   name: 'slash-commands',
+
+  addStorage(): { controller: SlashMenuController } {
+    return { controller: createSlashMenuController() };
+  },
 
   addOptions() {
     return {

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -152,20 +152,6 @@ const suggestionOptions: Partial<SuggestionOptions> = {
         },
       },
       {
-        title: 'Heading 4',
-        description: 'Smaller section heading.',
-        searchTerms: ['subtitle', 'small'],
-        icon: LuHeading4,
-        command: ({ editor, range }) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .setNode('heading', { level: 4 })
-            .run();
-        },
-      },
-      {
         title: 'Bullet List',
         description: 'Create a simple bullet list.',
         searchTerms: ['unordered', 'point'],

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -23,8 +23,6 @@ import {
   LuType,
 } from 'react-icons/lu';
 
-import { useTranslations } from '@/lib/i18n';
-
 export interface SlashCommandItem {
   title: string;
   description: string;
@@ -40,7 +38,6 @@ const SlashCommandsList = forwardRef<
     command: (item: SlashCommandItem) => void;
   }
 >((props, ref) => {
-  const t = useTranslations();
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   const selectItem = (index: number) => {
@@ -110,7 +107,7 @@ const SlashCommandsList = forwardRef<
           </button>
         ))
       ) : (
-        <div className="item">{t('No result')}</div>
+        <div className="item">No results</div>
       )}
     </div>
   );

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -3,7 +3,6 @@
 import { Extension } from '@tiptap/core';
 import { PluginKey } from '@tiptap/pm/state';
 import { Suggestion, SuggestionOptions } from '@tiptap/suggestion';
-import type { ComponentType } from 'react';
 import {
   LuCode,
   LuHeading1,
@@ -17,79 +16,12 @@ import {
   LuType,
 } from 'react-icons/lu';
 
-export interface SlashCommandItem {
-  title: string;
-  description: string;
-  searchTerms: string[];
-  icon: ComponentType<{ className?: string }>;
-  command: ({ editor, range }: { editor: any; range: any }) => void;
-}
-
-/**
- * The state the React menu (`SlashCommandMenu`) renders from. The `@tiptap/
- * suggestion` plugin writes to it via the controller; the menu subscribes. The
- * menu renders in the React tree (NOT a detached `createRoot`), so it gets app
- * providers, i18n, and design tokens — the createRoot approach had none.
- */
-export interface SlashMenuSnapshot {
-  open: boolean;
-  items: SlashCommandItem[];
-  command: ((item: SlashCommandItem) => void) | null;
-  clientRect: (() => DOMRect | null) | null;
-}
-
-export interface SlashMenuController {
-  subscribe: (listener: () => void) => () => void;
-  getSnapshot: () => SlashMenuSnapshot;
-  update: (partial: Partial<SlashMenuSnapshot>) => void;
-  /** The open menu registers its key handler; the suggestion delegates to it. */
-  setKeyHandler: (handler: ((event: KeyboardEvent) => boolean) | null) => void;
-  handleKeyDown: (event: KeyboardEvent) => boolean;
-}
-
-export const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
-  open: false,
-  items: [],
-  command: null,
-  clientRect: null,
-};
-
-function createSlashMenuController(): SlashMenuController {
-  let snapshot = EMPTY_SNAPSHOT;
-  const listeners = new Set<() => void>();
-  let keyHandler: ((event: KeyboardEvent) => boolean) | null = null;
-
-  return {
-    subscribe: (listener) => {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
-      };
-    },
-    getSnapshot: () => snapshot,
-    update: (partial) => {
-      snapshot = { ...snapshot, ...partial };
-      listeners.forEach((listener) => listener());
-    },
-    setKeyHandler: (handler) => {
-      keyHandler = handler;
-    },
-    handleKeyDown: (event) => keyHandler?.(event) ?? false,
-  };
-}
-
-/**
- * Read the per-editor slash controller off editor storage. Returns undefined
- * when the editor doesn't have the SlashCommands extension — `SlashCommandMenu`
- * uses that to no-op.
- */
-export function getSlashMenuController(
-  editor: { storage?: Record<string, any> } | null | undefined,
-): SlashMenuController | undefined {
-  return editor?.storage?.['slash-commands']?.controller as
-    | SlashMenuController
-    | undefined;
-}
+import {
+  createSlashMenuController,
+  getSlashMenuController,
+  type SlashCommandItem,
+  type SlashMenuController,
+} from '@/components/RichTextEditor/slashMenuController';
 
 // Query-independent: built once at module load, not rebuilt on every keystroke.
 const SLASH_ITEMS: SlashCommandItem[] = [

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -9,6 +9,7 @@ import {
   LuHeading1,
   LuHeading2,
   LuHeading3,
+  LuHeading4,
   LuLink2,
   LuList,
   LuListOrdered,
@@ -147,6 +148,20 @@ const suggestionOptions: Partial<SuggestionOptions> = {
             .focus()
             .deleteRange(range)
             .setNode('heading', { level: 3 })
+            .run();
+        },
+      },
+      {
+        title: 'Heading 4',
+        description: 'Smaller section heading.',
+        searchTerms: ['subtitle', 'small'],
+        icon: LuHeading4,
+        command: ({ editor, range }) => {
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .setNode('heading', { level: 4 })
             .run();
         },
       },

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -47,7 +47,7 @@ export interface SlashMenuController {
   handleKeyDown: (event: KeyboardEvent) => boolean;
 }
 
-const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
+export const EMPTY_SNAPSHOT: SlashMenuSnapshot = {
   open: false,
   items: [],
   command: null,
@@ -91,136 +91,137 @@ export function getSlashMenuController(
     | undefined;
 }
 
-const suggestionOptions: Partial<SuggestionOptions> = {
-  items: ({ query }: { query: string }): SlashCommandItem[] => {
-    const items: SlashCommandItem[] = [
-      {
-        title: 'Text',
-        description: 'Just start typing with plain text.',
-        searchTerms: ['p', 'paragraph'],
-        icon: LuType,
-        command: ({ editor, range }) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .toggleNode('paragraph', 'paragraph')
-            .run();
-        },
-      },
-      {
-        title: 'Heading 1',
-        description: 'Big section heading.',
-        searchTerms: ['title', 'big', 'large'],
-        icon: LuHeading1,
-        command: ({ editor, range }) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .setNode('heading', { level: 1 })
-            .run();
-        },
-      },
-      {
-        title: 'Heading 2',
-        description: 'Medium section heading.',
-        searchTerms: ['subtitle', 'medium'],
-        icon: LuHeading2,
-        command: ({ editor, range }) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .setNode('heading', { level: 2 })
-            .run();
-        },
-      },
-      {
-        title: 'Heading 3',
-        description: 'Small section heading.',
-        searchTerms: ['subtitle', 'small'],
-        icon: LuHeading3,
-        command: ({ editor, range }) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .setNode('heading', { level: 3 })
-            .run();
-        },
-      },
-      {
-        title: 'Bullet List',
-        description: 'Create a simple bullet list.',
-        searchTerms: ['unordered', 'point'],
-        icon: LuList,
-        command: ({ editor, range }) => {
-          editor.chain().focus().deleteRange(range).toggleBulletList().run();
-        },
-      },
-      {
-        title: 'Numbered List',
-        description: 'Create a list with numbering.',
-        searchTerms: ['ordered'],
-        icon: LuListOrdered,
-        command: ({ editor, range }) => {
-          editor.chain().focus().deleteRange(range).toggleOrderedList().run();
-        },
-      },
-      {
-        title: 'Quote',
-        description: 'Capture a quote.',
-        searchTerms: ['blockquote'],
-        icon: LuQuote,
-        command: ({ editor, range }) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .toggleNode('paragraph', 'paragraph')
-            .toggleBlockquote()
-            .run();
-        },
-      },
-      {
-        title: 'Code',
-        description: 'Capture a code snippet.',
-        searchTerms: ['codeblock'],
-        icon: LuCode,
-        command: ({ editor, range }) => {
-          editor.chain().focus().deleteRange(range).toggleCodeBlock().run();
-        },
-      },
-      {
-        title: 'Divider',
-        description: 'Visually divide blocks.',
-        searchTerms: ['horizontal', 'rule', 'hr'],
-        icon: LuMinus,
-        command: ({ editor, range }) => {
-          editor.chain().focus().deleteRange(range).setHorizontalRule().run();
-        },
-      },
-      {
-        title: 'Link Embed',
-        description: 'Embed a link with preview.',
-        searchTerms: ['embed', 'preview', 'iframely', 'url'],
-        icon: LuLink2,
-        command: ({ editor, range }) => {
-          const url = window.prompt('Enter the URL to embed:');
-          if (url && url.trim()) {
-            editor
-              .chain()
-              .focus()
-              .deleteRange(range)
-              .setIframely({ src: url.trim() })
-              .run();
-          }
-        },
-      },
-    ];
+// Query-independent: built once at module load, not rebuilt on every keystroke.
+const SLASH_ITEMS: SlashCommandItem[] = [
+  {
+    title: 'Text',
+    description: 'Just start typing with plain text.',
+    searchTerms: ['p', 'paragraph'],
+    icon: LuType,
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .toggleNode('paragraph', 'paragraph')
+        .run();
+    },
+  },
+  {
+    title: 'Heading 1',
+    description: 'Big section heading.',
+    searchTerms: ['title', 'big', 'large'],
+    icon: LuHeading1,
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .setNode('heading', { level: 1 })
+        .run();
+    },
+  },
+  {
+    title: 'Heading 2',
+    description: 'Medium section heading.',
+    searchTerms: ['subtitle', 'medium'],
+    icon: LuHeading2,
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .setNode('heading', { level: 2 })
+        .run();
+    },
+  },
+  {
+    title: 'Heading 3',
+    description: 'Small section heading.',
+    searchTerms: ['subtitle', 'small'],
+    icon: LuHeading3,
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .setNode('heading', { level: 3 })
+        .run();
+    },
+  },
+  {
+    title: 'Bullet List',
+    description: 'Create a simple bullet list.',
+    searchTerms: ['unordered', 'point'],
+    icon: LuList,
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).toggleBulletList().run();
+    },
+  },
+  {
+    title: 'Numbered List',
+    description: 'Create a list with numbering.',
+    searchTerms: ['ordered'],
+    icon: LuListOrdered,
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).toggleOrderedList().run();
+    },
+  },
+  {
+    title: 'Quote',
+    description: 'Capture a quote.',
+    searchTerms: ['blockquote'],
+    icon: LuQuote,
+    command: ({ editor, range }) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .toggleNode('paragraph', 'paragraph')
+        .toggleBlockquote()
+        .run();
+    },
+  },
+  {
+    title: 'Code',
+    description: 'Capture a code snippet.',
+    searchTerms: ['codeblock'],
+    icon: LuCode,
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).toggleCodeBlock().run();
+    },
+  },
+  {
+    title: 'Divider',
+    description: 'Visually divide blocks.',
+    searchTerms: ['horizontal', 'rule', 'hr'],
+    icon: LuMinus,
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).setHorizontalRule().run();
+    },
+  },
+  {
+    title: 'Link Embed',
+    description: 'Embed a link with preview.',
+    searchTerms: ['embed', 'preview', 'iframely', 'url'],
+    icon: LuLink2,
+    command: ({ editor, range }) => {
+      const url = window.prompt('Enter the URL to embed:');
+      if (url && url.trim()) {
+        editor
+          .chain()
+          .focus()
+          .deleteRange(range)
+          .setIframely({ src: url.trim() })
+          .run();
+      }
+    },
+  },
+];
 
-    return items.filter((item) => {
+const suggestionOptions: Partial<SuggestionOptions> = {
+  items: ({ query }: { query: string }): SlashCommandItem[] =>
+    SLASH_ITEMS.filter((item) => {
       if (typeof query === 'string' && query.length > 0) {
         const search = query.toLowerCase();
         return (
@@ -231,8 +232,7 @@ const suggestionOptions: Partial<SuggestionOptions> = {
         );
       }
       return true;
-    });
-  },
+    }),
 
   // Render only writes to the per-editor controller; `SlashCommandMenu` (mounted
   // in the React tree alongside the editor) subscribes and renders the menu.

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -137,6 +137,7 @@
   "Submit a proposal": "قدّم مقترحًا",
   "Participants": "المشاركون",
   "Summary": "الملخص",
+  "Start typing or press '/' for more commands...": "ابدأ الكتابة أو اضغط '/' لمزيد من الأوامر...",
   "View Details": "عرض التفاصيل",
   "Edit Process": "تعديل العملية",
   "Participate": "شارك",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -183,6 +183,7 @@
   "Proposal options": "প্রস্তাব অপশন",
   "Participants": "অংশগ্রহণকারী",
   "Summary": "সারসংক্ষেপ",
+  "Start typing or press '/' for more commands...": "টাইপ করা শুরু করুন বা আরও কমান্ডের জন্য '/' চাপুন...",
   "View Details": "বিস্তারিত দেখুন",
   "Edit Process": "প্রক্রিয়া সম্পাদনা করুন",
   "Participate": "অংশগ্রহণ করুন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -143,6 +143,7 @@
   "Proposal options": "Proposal options",
   "Participants": "Participants",
   "Summary": "Summary",
+  "Start typing or press '/' for more commands...": "Start typing or press '/' for more commands...",
   "View Details": "View Details",
   "Edit Process": "Edit Process",
   "Participate": "Participate",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -182,6 +182,7 @@
   "Proposal options": "Opciones de propuesta",
   "Participants": "Participantes",
   "Summary": "Resumen",
+  "Start typing or press '/' for more commands...": "Empieza a escribir o pulsa '/' para ver más comandos...",
   "View Details": "Ver detalles",
   "Edit Process": "Editar proceso",
   "Participate": "Participar",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -183,6 +183,7 @@
   "Proposal options": "Options de la proposition",
   "Participants": "Participants",
   "Summary": "Résumé",
+  "Start typing or press '/' for more commands...": "Commencez à écrire ou appuyez sur '/' pour plus de commandes...",
   "View Details": "Voir les détails",
   "Edit Process": "Modifier le processus",
   "Participate": "Participer",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -183,6 +183,7 @@
   "Proposal options": "Opções de proposta",
   "Participants": "Participantes",
   "Summary": "Resumo",
+  "Start typing or press '/' for more commands...": "Comece a escrever ou pressione '/' para mais comandos...",
   "View Details": "Ver detalhes",
   "Edit Process": "Editar processo",
   "Participate": "Participar",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -137,6 +137,7 @@
   "Submit a proposal": "Gudbi soo jeedin",
   "Participants": "Ka qaybgalayaal",
   "Summary": "Kooban",
+  "Start typing or press '/' for more commands...": "Bilow qorista ama riix '/' si aad u hesho amarro dheeraad ah...",
   "View Details": "Eeg Faahfaahinta",
   "Edit Process": "Wax ka bedel Habka",
   "Participate": "Ka qaybgal",

--- a/packages/sense/src/components/ui/popover.tsx
+++ b/packages/sense/src/components/ui/popover.tsx
@@ -19,17 +19,15 @@ function PopoverContent({
   alignOffset = 0,
   side = 'bottom',
   sideOffset = 4,
-  anchor,
   ...props
 }: PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
-    'align' | 'alignOffset' | 'side' | 'sideOffset' | 'anchor'
+    'align' | 'alignOffset' | 'side' | 'sideOffset'
   >) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
-        anchor={anchor}
         align={align}
         alignOffset={alignOffset}
         side={side}

--- a/packages/sense/src/components/ui/popover.tsx
+++ b/packages/sense/src/components/ui/popover.tsx
@@ -19,15 +19,17 @@ function PopoverContent({
   alignOffset = 0,
   side = 'bottom',
   sideOffset = 4,
+  anchor,
   ...props
 }: PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
-    'align' | 'alignOffset' | 'side' | 'sideOffset'
+    'align' | 'alignOffset' | 'side' | 'sideOffset' | 'anchor'
   >) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
+        anchor={anchor}
         align={align}
         alignOffset={alignOffset}
         side={side}

--- a/packages/sense/src/components/ui/popover.tsx
+++ b/packages/sense/src/components/ui/popover.tsx
@@ -19,15 +19,26 @@ function PopoverContent({
   alignOffset = 0,
   side = 'bottom',
   sideOffset = 4,
+  anchor,
+  noAnimation = false,
   ...props
 }: PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
-    'align' | 'alignOffset' | 'side' | 'sideOffset'
-  >) {
+    'align' | 'alignOffset' | 'side' | 'sideOffset' | 'anchor'
+  > & {
+    /**
+     * Drop the open/close animation. base-ui delays unmount until the exit
+     * animation finishes — for a popup anchored to a transient element (e.g. an
+     * editor caret), that exit can repaint at a stale position before unmount.
+     * No animation → instant unmount, no flash.
+     */
+    noAnimation?: boolean;
+  }) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
+        anchor={anchor}
         align={align}
         alignOffset={alignOffset}
         side={side}
@@ -37,7 +48,9 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            'z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            'z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden',
+            !noAnimation &&
+              'duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
             className,
           )}
           {...props}

--- a/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/components/RichTextEditor/RichTextEditor.tsx
@@ -25,6 +25,8 @@ export const RichTextEditor = forwardRef<
     /** HTML string or a TipTap JSON doc (the editor seeds from either). */
     content?: Content;
     placeholder?: string;
+    /** Notion-style per-empty-line hint (see useRichTextEditor). */
+    linePlaceholder?: string;
     onUpdate?: (content: string) => void;
     onChange?: (content: string) => void;
     /** Emits the editor's JSON doc on every update (for JSON-stored content). */
@@ -39,6 +41,7 @@ export const RichTextEditor = forwardRef<
       extensions,
       content = '',
       placeholder,
+      linePlaceholder,
       onUpdate,
       onChange,
       onChangeJSON,
@@ -52,6 +55,7 @@ export const RichTextEditor = forwardRef<
       extensions,
       content,
       placeholder,
+      linePlaceholder,
       editorClassName,
       onUpdate,
       onChange,

--- a/packages/ui/src/components/RichTextEditor/editorConfig.ts
+++ b/packages/ui/src/components/RichTextEditor/editorConfig.ts
@@ -43,6 +43,22 @@ const placeholderStyles = [
 ].join(' ');
 
 /**
+ * Per-line placeholder hint (Notion-style "press / for commands…"). Targets
+ * empty blocks that are NOT the whole-editor-empty node — the `:not(.is-editor-
+ * empty)` keeps it from doubling with `placeholderStyles` on the doc-empty line.
+ * Opt-in: only added to the editor class (by `useRichTextEditor`) when a
+ * `linePlaceholder` is passed, so existing single-placeholder editors are
+ * unaffected.
+ */
+export const linePlaceholderStyles = [
+  '[&_.is-empty:not(.is-editor-empty)]:before:pointer-events-none',
+  '[&_.is-empty:not(.is-editor-empty)]:before:float-start',
+  '[&_.is-empty:not(.is-editor-empty)]:before:h-0',
+  '[&_.is-empty:not(.is-editor-empty)]:before:text-neutral-gray3',
+  '[&_.is-empty:not(.is-editor-empty)]:before:content-[attr(data-placeholder)]',
+].join(' ');
+
+/**
  * TipTap heading extension that bakes the design-system `headingClasses` onto
  * each rendered `<h1>`–`<h4>` tag, keeping editor output visually identical to
  * the `Header1/2/3/4` components in `@op/ui`. Any level without a mapped class

--- a/packages/ui/src/components/RichTextEditor/editorConfig.ts
+++ b/packages/ui/src/components/RichTextEditor/editorConfig.ts
@@ -43,19 +43,24 @@ const placeholderStyles = [
 ].join(' ');
 
 /**
- * Per-line placeholder hint (Notion-style "press / for commands…"). Targets
- * empty blocks that are NOT the whole-editor-empty node — the `:not(.is-editor-
- * empty)` keeps it from doubling with `placeholderStyles` on the doc-empty line.
+ * Per-line placeholder hint (Notion-style "press / for commands…"). Scoped to
+ * TOP-LEVEL empty paragraphs only (`& > p`): not headings, and not paragraphs
+ * nested in lists/blockquotes (a "press /" hint next to a list marker reads
+ * oddly and the float/caret interaction is janky there). `:not(.is-editor-empty)`
+ * keeps it from doubling with `placeholderStyles` on the whole-editor-empty line.
  * Opt-in: only added to the editor class (by `useRichTextEditor`) when a
  * `linePlaceholder` is passed, so existing single-placeholder editors are
  * unaffected.
  */
 export const linePlaceholderStyles = [
-  '[&_.is-empty:not(.is-editor-empty)]:before:pointer-events-none',
-  '[&_.is-empty:not(.is-editor-empty)]:before:float-start',
-  '[&_.is-empty:not(.is-editor-empty)]:before:h-0',
-  '[&_.is-empty:not(.is-editor-empty)]:before:text-neutral-gray3',
-  '[&_.is-empty:not(.is-editor-empty)]:before:content-[attr(data-placeholder)]',
+  // Absolute (not float) so the hint never displaces the caret — absolute with
+  // no offsets pins the ::before at the paragraph's text start (block made
+  // `relative`) and stays out of flow, so the caret sits at the true start.
+  '[&>p.is-empty:not(.is-editor-empty)]:relative',
+  '[&>p.is-empty:not(.is-editor-empty)]:before:pointer-events-none',
+  '[&>p.is-empty:not(.is-editor-empty)]:before:absolute',
+  '[&>p.is-empty:not(.is-editor-empty)]:before:text-neutral-gray3',
+  '[&>p.is-empty:not(.is-editor-empty)]:before:content-[attr(data-placeholder)]',
 ].join(' ');
 
 /**

--- a/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
+++ b/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
@@ -5,12 +5,17 @@ import { useEditor } from '@tiptap/react';
 import { useEffect, useMemo } from 'react';
 
 import { cn } from '../../lib/utils';
-import { baseEditorStyles, defaultEditorExtensions } from './editorConfig';
+import {
+  baseEditorStyles,
+  defaultEditorExtensions,
+  linePlaceholderStyles,
+} from './editorConfig';
 
 export function useRichTextEditor({
   extensions = defaultEditorExtensions,
   content = '',
   placeholder,
+  linePlaceholder,
   editorClassName = '',
   onUpdate,
   onChange,
@@ -22,6 +27,13 @@ export function useRichTextEditor({
   extensions?: Extensions;
   content?: Content;
   placeholder?: string;
+  /**
+   * Notion-style per-empty-line hint (e.g. "Start typing or press '/' for more
+   * commands…"). When set, the placeholder follows the cursor: the editor-level
+   * `placeholder` shows while the whole editor is empty, this shows on any other
+   * empty line. Opt-in — omit it and placeholder behavior is unchanged.
+   */
+  linePlaceholder?: string;
   editorClassName?: string;
   onUpdate?: (content: string) => void;
   onChange?: (content: string) => void;
@@ -32,16 +44,29 @@ export function useRichTextEditor({
   /** When true, sets `aria-required` on the editable region for assistive tech. */
   required?: boolean;
 }) {
-  // Append the Placeholder extension only when a placeholder is provided, so
-  // editors that don't ask for one are unaffected. Styling lives in
-  // baseEditorStyles and renders the hint once when the editor is empty.
-  const resolvedExtensions = useMemo(
-    () =>
-      placeholder
-        ? [...extensions, Placeholder.configure({ placeholder })]
-        : extensions,
-    [extensions, placeholder],
-  );
+  // Append the Placeholder extension only when a hint is asked for, so editors
+  // that don't ask for one are unaffected. With a `linePlaceholder` the config
+  // switches to the function form so the hint follows the cursor (editor-level
+  // text while empty, line-level text on any other empty line). Styling lives in
+  // baseEditorStyles (+ linePlaceholderStyles, added to the class below).
+  const resolvedExtensions = useMemo(() => {
+    if (!placeholder && !linePlaceholder) {
+      return extensions;
+    }
+
+    if (linePlaceholder) {
+      return [
+        ...extensions,
+        Placeholder.configure({
+          showOnlyCurrent: true,
+          placeholder: ({ editor }) =>
+            editor.isEmpty ? (placeholder ?? '') : linePlaceholder,
+        }),
+      ];
+    }
+
+    return [...extensions, Placeholder.configure({ placeholder })];
+  }, [extensions, placeholder, linePlaceholder]);
 
   const editor = useEditor({
     extensions: resolvedExtensions,
@@ -51,6 +76,7 @@ export function useRichTextEditor({
       attributes: {
         class: cn(
           baseEditorStyles,
+          linePlaceholder ? linePlaceholderStyles : '',
           editorClassName || (editable ? 'min-h-96' : ''),
         ),
         ...(required ? { 'aria-required': 'true' } : {}),


### PR DESCRIPTION
Adds the slash-command menu (`/`) to the Overview editor — an always-visible way to insert blocks/embeds (the bubble menu only appears on a text selection).

**Stacked on #1367** (base `overview-iframely-embeds`; retarget to `dev` once that merges).

- **Slash menu renders in the React tree.** Rewrote `SlashCommands` to write to a per-editor controller on `editor.storage`; a new `<SlashCommandMenu>` subscribes (`useSyncExternalStore`) and renders via the `@op/sense` Popover — focus-less (`initialFocus`/`finalFocus`/`modal` off), `noAnimation`, anchored to the caret rect. Replaces the old detached `createRoot` render (no app providers/i18n, and a close-time flash). Keyboard nav + scroll-into-view + click all delegate through the suggestion plugin.
- **Slash is opt-in.** `getProposalExtensions` now defaults `slashCommands: false`; only editors that mount `<SlashCommandMenu>` (Overview) turn it on — avoids a menu-less `/` in the proposal/phase editors.
- **`@op/sense` `PopoverContent`** gains `anchor` (virtual element) + `noAnimation` props (additive, backward-compatible).
- **Per-line placeholder** — opt-in `linePlaceholder` on `@op/ui` `useRichTextEditor`: empty top-level paragraphs show *"Start typing or press '/' for more commands…"* (cursor-following). Existing editors unchanged.
- New i18n keys in all 7 locales. No Notion-style "+" margin button (deferred).
