### PR TITLE
refactor(decisions): gate anonymous sign-in on public submit access

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -46,8 +46,3 @@ NEXT_PUBLIC_MAPTILER_API_KEY=your-maptiler-key
 ## Select the active vendor and set its key; swap the key when switching vendors.
 MODERATION_PROVIDER=                 # hive | lasso | checkstep (empty = off)
 MODERATION_API_KEY=
-
-## TEMPORARY: anonymous sign-in rollout gate read by the proxy middleware.
-## Set to "true" to skip the logged-out → /login redirect so anonymous visitors
-## can reach the app. On by default in development/e2e. Remove with the flag.
-ANONYMOUS_SIGNIN_ENABLED=

--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -37,6 +37,7 @@ export const DecisionActionBar = ({
     instanceId,
     navigateTo: (proposal) =>
       `/decisions/${slug}/proposal/${proposal.profileId}/edit`,
+    canSubmitProposal: showSubmitButton,
   });
 
   return (

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -186,6 +186,7 @@ const OverviewHero = ({
     instanceId,
     navigateTo: (proposal) =>
       `/decisions/${decisionSlug}/proposal/${proposal.profileId}/edit`,
+    canSubmitProposal,
   });
 
   return (

--- a/apps/app/src/components/decisions/useCreateProposal.ts
+++ b/apps/app/src/components/decisions/useCreateProposal.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { useMount } from '@op/hooks';
@@ -15,16 +14,19 @@ import { useRouter, useTranslations } from '@/lib/i18n';
  * the caller builds from the created proposal. `isCreating` stays true through
  * the navigation so buttons can keep showing a pending state.
  *
- * Public (no-session) visitors are given an anonymous session first when the
- * `anonymous_signin` flag is on, so the draft has an account to attribute to.
+ * Public (no-session) visitors get an anonymous session first when the process
+ * grants them submit access, so the draft has an account to attribute to.
  */
 export function useCreateProposal({
   instanceId,
   navigateTo,
+  canSubmitProposal,
 }: {
   instanceId: string;
   /** Builds the post-create destination from the new draft proposal. */
   navigateTo: (proposal: { profileId: string }) => string;
+  /** Submit access for the viewer; permits anon sign-in for public visitors. */
+  canSubmitProposal: boolean;
 }) {
   const t = useTranslations();
   const router = useRouter();
@@ -34,7 +36,6 @@ export function useCreateProposal({
   const [isCreating, startCreating] = useTransition();
   const supabase = createSBBrowserClient();
   const utils = trpc.useUtils();
-  const anonymousSigninEnabled = useFeatureFlag('anonymous_signin');
 
   const createProposalMutation = trpc.decision.createProposal.useMutation();
 
@@ -44,7 +45,7 @@ export function useCreateProposal({
         // A public (no-session) visitor has no account to attribute the
         // proposal to, so give them an anonymous session before creating the
         // draft.
-        if (anonymousSigninEnabled && !user) {
+        if (canSubmitProposal && !user) {
           const { error } = await supabase.auth.signInAnonymously();
           if (error) {
             throw error;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -214,17 +214,6 @@ export const cookieDomains = [
 // PostHog config. Eventually to be moved to env vars
 export const posthogUIHost = 'https://eu.posthog.com';
 
-// TEMPORARY: env-flag gate for the anonymous sign-in rollout. The PostHog
-// `anonymous_signin` flag governs client UI (e.g. DecisionActionBar), but the
-// proxy middleware runs in the Edge runtime where PostHog flag evaluation isn't
-// viable, so the login-redirect gate there reads this env flag instead. On by
-// default in development and e2e to match useFeatureFlag/getServerFeatureFlag.
-// Remove this (and the proxy gate) once anonymous sign-in is permanently on.
-export const anonymousSigninEnabled =
-  process.env.NODE_ENV === 'development' ||
-  process.env.NEXT_PUBLIC_E2E === 'true' ||
-  process.env.ANONYMOUS_SIGNIN_ENABLED === 'true';
-
 export const allowedEmailDomains = ['oneproject.org', 'team.oneproject.org'];
 
 export const genericEmail = 'support@oneproject.org';

--- a/services/api/src/routers/decision/instances/getInstance.test.ts
+++ b/services/api/src/routers/decision/instances/getInstance.test.ts
@@ -82,6 +82,70 @@ describe.concurrent('getInstance', () => {
     expect(result.access?.vote).toBe(true);
   });
 
+  it('should grant submit access to a no-JWT visitor on a public decision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Make the decision public per the runbook: GLOBAL_USER_PUBLIC holds a
+    // Public role with a profile-scoped decisions READ+SUBMIT+VOTE override.
+    await testData.makeDecisionPublic(instance.profileId);
+
+    // No-JWT caller — substituted to GLOBAL_USER_PUBLIC by the access layer.
+    const publicCaller = createCaller(await createTestContextWithSession(null));
+    const result = await publicCaller.decision.getInstance({
+      instanceId: instance.instance.id,
+    });
+
+    // The access object reflects the public role's grant — this is what gates
+    // anonymous sign-in in useCreateProposal.
+    expect(result.access).toMatchObject({
+      submitProposals: true,
+      vote: true,
+      admin: false,
+    });
+  });
+
+  it('should deny a no-JWT visitor on a non-public decision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // No make-public grant: GLOBAL_USER_PUBLIC has no access to this profile,
+    // so a no-JWT visitor is denied (no submit access is ever surfaced).
+    const publicCaller = createCaller(await createTestContextWithSession(null));
+
+    await expect(
+      publicCaller.decision.getInstance({
+        instanceId: instance.instance.id,
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError', statusCode: 403 },
+    });
+  });
+
   it('should return NOT_FOUND for a non-existent instance', async ({
     task,
     onTestFinished,

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -4,23 +4,28 @@ import {
   advancePhase,
   createDecisionInstance,
   createInstanceDataFromTemplate,
+  assertGlobalRole,
   createOrganization as createOrganizationService,
   createProposal as createProposalService,
+  decisionPermission,
   getTemplate,
   joinOrganization,
 } from '@op/common';
+import { GLOBAL_USER_PUBLIC } from '@op/core';
 import { db } from '@op/db/client';
 import type { ProcessStatus } from '@op/db/schema';
 import {
   ProposalStatus,
+  accessRolePermissionsOnAccessZones,
   decisionProcesses,
   processInstances,
   profileUserToAccessRoles,
+  profileUsers,
   profiles,
   proposals,
   users,
 } from '@op/db/schema';
-import { ROLES } from '@op/db/seedData/accessControl';
+import { PERMISSIONS, ROLES, ZONES } from '@op/db/seedData/accessControl';
 import type { User } from '@op/supabase/lib';
 import { grantDecisionProfileAccess, testMinimalSchema } from '@op/test';
 import { eq, inArray } from 'drizzle-orm';
@@ -455,6 +460,53 @@ export class TestDecisionsDataManager {
     await db.insert(profileUserToAccessRoles).values({
       profileUserId: profileUser.id,
       accessRoleId: roleId,
+    });
+  }
+
+  /**
+   * Makes a decision profile publicly accessible to no-JWT (public) visitors,
+   * mirroring the production "make a process public" runbook: the
+   * GLOBAL_USER_PUBLIC sentinel becomes a member of the profile holding the
+   * seeded global Public role, whose grant on this profile is a profile-scoped
+   * `decisions` permission override. READ + SUBMIT_PROPOSALS + VOTE are granted
+   * by default (the Columbus public value), so a public visitor resolves the
+   * same capabilities the access object exposes for a public process.
+   *
+   * The Public role is seeded with no default permissions; the override is
+   * scoped to `profileId`, so the grant never leaks to other decisions and the
+   * membership + override cascade away when the profile is deleted in cleanup.
+   */
+  async makeDecisionPublic(
+    profileId: string,
+    permissionBits: number = PERMISSIONS.READ |
+      decisionPermission.SUBMIT_PROPOSALS |
+      decisionPermission.VOTE,
+  ): Promise<void> {
+    this.ensureCleanupRegistered();
+
+    // Resolve the seeded global Public role by name (global roles are keyed by
+    // name in runtime code; the seed id is not referenced here).
+    const publicRole = await assertGlobalRole('Public');
+
+    const [publicMember] = await db
+      .insert(profileUsers)
+      .values({ profileId, authUserId: GLOBAL_USER_PUBLIC })
+      .returning();
+
+    if (!publicMember) {
+      throw new Error('Failed to create public profileUser');
+    }
+
+    await db.insert(profileUserToAccessRoles).values({
+      profileUserId: publicMember.id,
+      accessRoleId: publicRole.id,
+    });
+
+    await db.insert(accessRolePermissionsOnAccessZones).values({
+      accessRoleId: publicRole.id,
+      accessZoneId: ZONES.DECISIONS.id,
+      permission: permissionBits,
+      profileId,
     });
   }
 

--- a/services/db/seedData/accessControl.ts
+++ b/services/db/seedData/accessControl.ts
@@ -27,6 +27,7 @@ const ACCESS_ZONE_IDS = {
 const ACCESS_ROLE_IDS = {
   ADMIN: '00000000-0000-4000-8000-000000000011',
   MEMBER: '00000000-0000-4000-8000-000000000012',
+  PUBLIC: '00000000-0000-4000-8000-000000000013',
 } as const;
 
 // Access zones data
@@ -60,6 +61,14 @@ export const ACCESS_ROLES = [
     name: 'Admin',
     description: null,
   },
+  {
+    id: ACCESS_ROLE_IDS.PUBLIC,
+    name: 'Public',
+    // Global role with no default permissions — public participation is granted
+    // per-profile via an override row (see TestDecisionsDataManager.makeDecisionPublic
+    // and the "make a process public" runbook), so it never opens every decision.
+    description: null,
+  },
 ];
 
 // Role name to ID mapping for convenient access (avoids string references)
@@ -71,6 +80,10 @@ export const ROLES = {
   MEMBER: {
     id: ACCESS_ROLE_IDS.MEMBER,
     name: 'Member',
+  },
+  PUBLIC: {
+    id: ACCESS_ROLE_IDS.PUBLIC,
+    name: 'Public',
   },
 } as const;
 


### PR DESCRIPTION
Replaces the temporary anonymous_signin PostHog flag and ANONYMOUS_SIGNIN_ENABLED env flag with the existing per-process submit-access signal, so anonymous sign-in is scoped to processes that grant the public role submit access.