### PR TITLE
EXPERIMENT: isolate decision-page double-render (do not merge)

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/page.tsx
@@ -11,7 +11,6 @@ import { DecisionHeader } from '@/components/decisions/DecisionHeader';
 import { DecisionSidePanel } from '@/components/decisions/DecisionSidePanel';
 import { DecisionStateRouter } from '@/components/decisions/DecisionStateRouter';
 import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
-import { PromoteAccountModal } from '@/components/decisions/PromoteAccountModal';
 import { DecisionContentSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
 import { loadDecision } from './(decision-view)/loadDecision';
@@ -72,7 +71,6 @@ const DecisionPageContent = async ({ slug }: { slug: string }) => {
             decisionProfileId={decisionProfile.id}
             access={decisionProfile.processInstance.access}
           />
-          <PromoteAccountModal />
         </DecisionTranslationProvider>
       </div>
     </HydrationBoundary>

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/page.tsx
@@ -11,6 +11,7 @@ import { DecisionHeader } from '@/components/decisions/DecisionHeader';
 import { DecisionSidePanel } from '@/components/decisions/DecisionSidePanel';
 import { DecisionStateRouter } from '@/components/decisions/DecisionStateRouter';
 import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
+import { PromoteAccountModal } from '@/components/decisions/PromoteAccountModal';
 import { DecisionContentSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
 import { loadDecision } from './(decision-view)/loadDecision';
@@ -71,6 +72,7 @@ const DecisionPageContent = async ({ slug }: { slug: string }) => {
             decisionProfileId={decisionProfile.id}
             access={decisionProfile.processInstance.access}
           />
+          <PromoteAccountModal />
         </DecisionTranslationProvider>
       </div>
     </HydrationBoundary>

--- a/apps/app/src/app/login/page.tsx
+++ b/apps/app/src/app/login/page.tsx
@@ -4,15 +4,26 @@ import { getSafeRedirectPath } from '@op/common/client';
 import { useAuthUser } from '@op/hooks';
 import { useSearchParams } from 'next/navigation';
 
+import { LinkAccountPanel } from '@/components/LinkAccountPanel';
 import { LoginPanel } from '@/components/LoginPanel';
 
 const LoginPage = () => {
   const user = useAuthUser();
   const searchParams = useSearchParams();
   const redirectParam = getSafeRedirectPath(searchParams.get('redirect'));
+  const isLinkMode = searchParams.get('link') === '1';
 
   if (!user || user.isFetching || user.isPending) {
     return null;
+  }
+
+  // Link mode: an anonymous visitor upgrading to a full account. They already
+  // have a session, so the walled-garden / signed-in paths below would bounce
+  // them. The dedicated panel links the new identity onto the anon user rather
+  // than creating a separate account. This must come before the walled-garden
+  // check below, which would otherwise send the upgrading visitor to LoginPanel.
+  if (isLinkMode && user.data?.user?.is_anonymous) {
+    return <LinkAccountPanel />;
   }
 
   // An anonymous session is not "signed in" for our purposes: the walled-garden

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -14,6 +14,7 @@ import { useTranslations } from '@/lib/i18n';
 
 import {
   AuthCodeField,
+  AuthDivider,
   AuthEmailField,
   AuthGoogleButton,
   AuthPanelShell,
@@ -221,72 +222,94 @@ export const LinkAccountPanel = () => {
     );
   })();
 
-  return (
-    <AuthPanelShell title={title} subtitle={subtitle}>
-      {!errorMessage && (
-        <div className="flex flex-col gap-8">
-          {!loginSuccess && <AuthGoogleButton onPress={handleGoogle} />}
-
-          {!loginSuccess ? (
-            <AuthEmailField
-              label={t('Email')}
-              value={email}
-              isDisabled={isSubmitting}
-              onChange={(val) => {
-                setEmailIsValid(emailParser.safeParse(val).success);
-                setEmail(val);
-              }}
-              onSubmit={() => {
-                void requestEmailCode();
-              }}
-            />
-          ) : (
-            <AuthCodeField
-              value={token}
-              isDisabled={isSubmitting}
-              onChange={setToken}
-              onSubmit={handleTokenSubmit}
-            />
-          )}
-        </div>
-      )}
-
-      <section className="flex flex-col gap-6">
+  if (errorMessage) {
+    return (
+      <AuthPanelShell title={title} subtitle={subtitle}>
         <Button
-          type="button"
           className="flex w-full items-center justify-center"
-          isDisabled={
-            isSubmitting ||
-            (!loginSuccess && !emailIsValid) ||
-            (!!token && !isValidOtpLength(token))
-          }
-          onPress={async () => {
-            if (!loginSuccess) {
-              void requestEmailCode();
-            } else if (isValidOtpLength(token)) {
-              await handleTokenSubmit();
-            }
+          onPress={() => {
+            setLinkError(undefined);
+            setTokenError(undefined);
           }}
         >
-          {isSubmitting ? (
-            <LoadingSpinner />
-          ) : loginSuccess ? (
-            t('Create profile')
-          ) : (
-            t('Continue')
-          )}
+          {t('Try again')}
         </Button>
+      </AuthPanelShell>
+    );
+  }
 
-        {loginSuccess && (
+  // OTP entry ("Email sent!") — code field, then the Create profile / Go back
+  // stack (figma: 24px between field and buttons, 12px between buttons).
+  if (loginSuccess) {
+    return (
+      <AuthPanelShell title={title} subtitle={subtitle}>
+        <div className="flex flex-col gap-6">
+          <AuthCodeField
+            value={token}
+            isDisabled={isSubmitting}
+            onChange={setToken}
+            onSubmit={handleTokenSubmit}
+          />
+          <div className="flex flex-col gap-3">
+            <Button
+              type="button"
+              className="flex w-full items-center justify-center"
+              isDisabled={isSubmitting || !isValidOtpLength(token)}
+              onPress={async () => {
+                if (isValidOtpLength(token)) {
+                  await handleTokenSubmit();
+                }
+              }}
+            >
+              {isSubmitting ? <LoadingSpinner /> : t('Create profile')}
+            </Button>
+            <Button
+              color="secondary"
+              className="flex w-full items-center justify-center"
+              onPress={goBack}
+            >
+              {t('Go back')}
+            </Button>
+          </div>
+        </div>
+      </AuthPanelShell>
+    );
+  }
+
+  // Create account (email entry) — email + Continue grouped (figma: 16px), then
+  // the "or" divider, then Google last.
+  return (
+    <AuthPanelShell title={title} subtitle={subtitle}>
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-4">
+          <AuthEmailField
+            label={t('Email')}
+            value={email}
+            isDisabled={isSubmitting}
+            onChange={(val) => {
+              setEmailIsValid(emailParser.safeParse(val).success);
+              setEmail(val);
+            }}
+            onSubmit={() => {
+              void requestEmailCode();
+            }}
+          />
           <Button
-            color="secondary"
+            type="button"
             className="flex w-full items-center justify-center"
-            onPress={goBack}
+            isDisabled={isSubmitting || !emailIsValid}
+            onPress={() => {
+              void requestEmailCode();
+            }}
           >
-            {t('Go back')}
+            {isSubmitting ? <LoadingSpinner /> : t('Continue')}
           </Button>
-        )}
-      </section>
+        </div>
+
+        <AuthDivider />
+
+        <AuthGoogleButton onPress={handleGoogle} />
+      </div>
     </AuthPanelShell>
   );
 };

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+import { isSafeRedirectPath } from '@op/common/client';
+import { useMount } from '@op/hooks';
+import { createSBBrowserClient } from '@op/supabase/client';
+import { Button } from '@op/ui/Button';
+import { CheckIcon } from '@op/ui/CheckIcon';
+import { LoadingSpinner } from '@op/ui/LoadingSpinner';
+import { useSearchParams } from 'next/navigation';
+import React, { useCallback, useState } from 'react';
+import { z } from 'zod';
+
+import { useTranslations } from '@/lib/i18n';
+
+import {
+  AuthCodeField,
+  AuthEmailField,
+  AuthGoogleButton,
+  AuthPanelShell,
+  isValidOtpLength,
+  useAuthPanelStore,
+} from './AuthPanel';
+
+/**
+ * Account-upgrade panel for an anonymous visitor ("link mode").
+ *
+ * Reached via `/login?link=1` (see PromoteAccountModal). The visitor already
+ * has an anonymous Supabase session; instead of signing into a brand-new
+ * account we *link* the chosen identity (Google or email OTP) onto that
+ * existing anon user, so any data they created while anonymous (e.g. a
+ * just-submitted idea) stays theirs.
+ * See https://supabase.com/docs/guides/auth/auth-anonymous.
+ *
+ * Normal login/signup lives in LoginPanel; login/page.tsx routes here only when
+ * the visitor is actually anonymous.
+ */
+export const LinkAccountPanel = () => {
+  const supabase = createSBBrowserClient();
+  const t = useTranslations();
+
+  const { mounted } = useMount();
+  const searchParams = useSearchParams();
+  const redirectParam = searchParams.get('redirect');
+
+  const [linkError, setLinkError] = useState<string | undefined>();
+  // Guards the async Supabase calls against double-submit and drives the
+  // button's loading state (the login query that LoginPanel leans on for this
+  // does not run in link mode).
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    email,
+    setEmail,
+    emailIsValid,
+    setEmailIsValid,
+    token,
+    setToken,
+    tokenError,
+    setTokenError,
+    loginSuccess,
+    setLoginSuccess,
+  } = useAuthPanelStore();
+
+  const emailParser = z.email();
+
+  // "Already have an account? Log in" — a real full account can't be linked
+  // onto the anon user, so that path drops link mode and goes to normal login.
+  const regularLoginHref = isSafeRedirectPath(redirectParam)
+    ? `/login?redirect=${encodeURIComponent(redirectParam)}`
+    : '/login';
+
+  // After linking, route the freshly-upgraded account through onboarding (which
+  // skips org-joining for this flow) and hand it the page to return to.
+  // `redirectParam` carries the locale prefix that the locale-less /login route
+  // lacks — reuse it for the /start path.
+  const goAfterLink = useCallback(() => {
+    const dest = isSafeRedirectPath(redirectParam) ? redirectParam : '/';
+    const locale = dest.split('/')[1] || 'en';
+    window.location.href = `/${locale}/start?promote=1&redirect=${encodeURIComponent(dest)}`;
+  }, [redirectParam]);
+
+  // Attach Google to the existing anon user instead of starting a new one.
+  const handleGoogle = async () => {
+    const callbackUrl = new URL('/api/auth/callback', location.origin);
+    if (isSafeRedirectPath(redirectParam)) {
+      callbackUrl.searchParams.set('redirect', redirectParam);
+    }
+
+    // TODO(anon-upgrade): linkIdentity fails if this Google identity already
+    // belongs to another account; we surface the raw Supabase error for now.
+    // Productionize with a friendly "that account already exists" path.
+    const { error } = await supabase.auth.linkIdentity({
+      provider: 'google',
+      options: { redirectTo: callbackUrl.toString() },
+    });
+    if (error) {
+      setLinkError(error.message);
+    }
+  };
+
+  // Request the email code. `updateUser({ email })` attaches the email to the
+  // current anon user. When email confirmations are enabled it sends an
+  // email-change OTP (→ code-entry screen); when they're disabled (e.g. local
+  // dev autoconfirm) the change applies immediately with no email, so we just
+  // refresh the session and continue.
+  const requestEmailCode = async () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setLinkError(undefined);
+
+    try {
+      // TODO(anon-upgrade): updateUser fails if this email already belongs to
+      // another account; we surface the raw Supabase error for now.
+      // Productionize with a friendly "that account already exists" path.
+      const { data, error } = await supabase.auth.updateUser({ email });
+      if (error) {
+        setLinkError(error.message);
+        return;
+      }
+      // No pending change + email already set ⇒ applied immediately (no OTP).
+      if (data.user?.email === email && !data.user?.new_email) {
+        // The email change applied immediately, but the current access token
+        // still carries the stale anonymous claims — refresh it so the app sees
+        // the upgraded (non-anonymous) identity before navigating.
+        await supabase.auth.refreshSession();
+        goAfterLink();
+        return;
+      }
+      setLoginSuccess(true);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleTokenSubmit = useCallback(async () => {
+    if (!token || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      // Link mode confirms an email *change* on the anon user.
+      const { data, error } = await supabase.auth.verifyOtp({
+        email,
+        token,
+        type: 'email_change',
+      });
+
+      if (data.user && data.session && data.user.role === 'authenticated') {
+        // Freshly upgraded from anonymous — send them through onboarding.
+        goAfterLink();
+        return;
+      }
+      setTokenError(error?.message ?? t('Failed to verify code'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [email, token, isSubmitting, goAfterLink, setTokenError, supabase, t]);
+
+  // "Go back" from the code screen returns to email entry without losing the
+  // anon session (only the success/token state is cleared).
+  const goBack = () => {
+    setLoginSuccess(false);
+    setToken(undefined);
+    setTokenError(undefined);
+    setLinkError(undefined);
+  };
+
+  if (!mounted) {
+    return null;
+  }
+
+  const errorMessage = linkError || tokenError;
+
+  const title = (() => {
+    if (errorMessage) {
+      return t('Oops!');
+    }
+    if (!loginSuccess) {
+      return t('Create an account');
+    }
+    return (
+      <div className="flex flex-col items-center justify-center gap-4">
+        <CheckIcon />
+        <span className="text-title-base sm:text-title-lg">
+          {t('Email sent!')}
+        </span>
+      </div>
+    );
+  })();
+
+  const subtitle = (() => {
+    if (errorMessage) {
+      return (
+        <span className={tokenError ? 'text-functional-red' : undefined}>
+          {errorMessage}
+        </span>
+      );
+    }
+    if (!loginSuccess) {
+      return t.rich('Already have an account? <login>Log in</login>', {
+        login: (chunks: React.ReactNode) => (
+          <a href={regularLoginHref} className="text-primary-teal underline">
+            {chunks}
+          </a>
+        ),
+      });
+    }
+    return (
+      <span>
+        {t(
+          'A code was sent to {email}. Type the code below to create your profile.',
+          {
+            email,
+          },
+        )}
+      </span>
+    );
+  })();
+
+  return (
+    <AuthPanelShell title={title} subtitle={subtitle}>
+      {!errorMessage && (
+        <div className="flex flex-col gap-8">
+          {!loginSuccess && <AuthGoogleButton onPress={handleGoogle} />}
+
+          {!loginSuccess ? (
+            <AuthEmailField
+              label={t('Email')}
+              value={email}
+              isDisabled={isSubmitting}
+              onChange={(val) => {
+                setEmailIsValid(emailParser.safeParse(val).success);
+                setEmail(val);
+              }}
+              onSubmit={() => {
+                void requestEmailCode();
+              }}
+            />
+          ) : (
+            <AuthCodeField
+              value={token}
+              isDisabled={isSubmitting}
+              onChange={setToken}
+              onSubmit={handleTokenSubmit}
+            />
+          )}
+        </div>
+      )}
+
+      <section className="flex flex-col gap-6">
+        <Button
+          type="button"
+          className="flex w-full items-center justify-center"
+          isDisabled={
+            isSubmitting ||
+            (!loginSuccess && !emailIsValid) ||
+            (!!token && !isValidOtpLength(token))
+          }
+          onPress={async () => {
+            if (!loginSuccess) {
+              void requestEmailCode();
+            } else if (isValidOtpLength(token)) {
+              await handleTokenSubmit();
+            }
+          }}
+        >
+          {isSubmitting ? (
+            <LoadingSpinner />
+          ) : loginSuccess ? (
+            t('Create profile')
+          ) : (
+            t('Continue')
+          )}
+        </Button>
+
+        {loginSuccess && (
+          <Button
+            color="secondary"
+            className="flex w-full items-center justify-center"
+            onPress={goBack}
+          >
+            {t('Go back')}
+          </Button>
+        )}
+      </section>
+    </AuthPanelShell>
+  );
+};
+
+export default LinkAccountPanel;

--- a/apps/app/src/components/MultiStepForm/index.tsx
+++ b/apps/app/src/components/MultiStepForm/index.tsx
@@ -45,9 +45,11 @@ export const MultiStepForm: React.FC<{
   const goToStep = React.useCallback(
     (targetStep: number) => {
       setStep(targetStep);
-      const query = { step: targetStep.toString() };
 
-      const params = new URLSearchParams(query);
+      // Preserve any existing query params (e.g. the promote-flow flag and its
+      // return redirect) across step navigation — only the step changes.
+      const params = new URLSearchParams(window.location.search);
+      params.set('step', targetStep.toString());
 
       // Navigate to the new URL
       router.push(`${window.location.pathname}?${params.toString()}`);

--- a/apps/app/src/components/Onboarding/PromoteOnboardingFlow.tsx
+++ b/apps/app/src/components/Onboarding/PromoteOnboardingFlow.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { analyzeError, useConnectionStatus } from '@/utils/connectionErrors';
+import { trpc } from '@op/api/client';
+import { isSafeRedirectPath } from '@op/common/client';
+import { LoadingSpinner } from '@op/ui/LoadingSpinner';
+import { StepperProgressIndicator } from '@op/ui/Stepper';
+import { toast } from '@op/ui/Toast';
+import { useSearchParams } from 'next/navigation';
+import React, { useCallback, useMemo, useState } from 'react';
+import { z } from 'zod';
+
+import { useTranslations } from '@/lib/i18n';
+
+import {
+  MultiStepForm,
+  ProgressComponentProps,
+  StepProps,
+} from '../MultiStepForm';
+import { Portal } from '../Portal';
+import {
+  PersonalDetailsForm,
+  validator as PersonalDetailsFormValidator,
+} from './PersonalDetailsForm';
+import { ToSAcceptanceScreen } from './ToSAcceptanceScreen';
+import { useOnboardingFormStore } from './useOnboardingFormStore';
+
+// The ToS step collects no form values of its own.
+const ToSStepValidator = z.object({});
+
+const ProgressInPortal = (props: ProgressComponentProps) => (
+  <Portal id="top-slot">
+    <StepperProgressIndicator {...props} />
+  </Portal>
+);
+
+/**
+ * Onboarding journey for an anonymous visitor who just upgraded to a full
+ * account (see LinkAccountPanel / PromoteAccountModal). Reached at
+ * `/start?promote=1`.
+ *
+ * Unlike the normal flow it skips organization joining/creation entirely:
+ * personal details, accept ToS, then hard-navigate back to the decision they
+ * came from so the now-authenticated tree mounts with a fresh cache.
+ */
+export const PromoteOnboardingFlow = ({
+  hasHydrated,
+}: {
+  hasHydrated: boolean;
+}) => {
+  const t = useTranslations();
+  const isOnline = useConnectionStatus();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { personalDetails } = useOnboardingFormStore();
+  const trpcUtils = trpc.useUtils();
+  const completeOnboarding = trpc.account.completeOnboarding.useMutation();
+
+  const searchParams = useSearchParams();
+  const redirectParam = searchParams.get('redirect');
+  const promoteRedirect = isSafeRedirectPath(redirectParam)
+    ? redirectParam
+    : '/';
+
+  const getStepValues = useCallback(() => {
+    return [personalDetails, {}];
+  }, [personalDetails]);
+
+  const handleComplete = useCallback(async () => {
+    if (!isOnline) {
+      toast.error({
+        title: t('No connection'),
+        message: t('Please check your internet connection and try again.'),
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await completeOnboarding.mutateAsync({ tos: true, privacy: true });
+      await trpcUtils.account.getMyAccount.invalidate();
+      window.location.assign(promoteRedirect);
+    } catch (err) {
+      setIsSubmitting(false);
+      const errorInfo = analyzeError(err);
+      toast.error({
+        title: errorInfo.isConnectionError
+          ? t('Connection issue')
+          : t("That didn't work"),
+        message: errorInfo.isConnectionError
+          ? t('Please try submitting the form again.')
+          : errorInfo.message,
+      });
+    }
+  }, [isOnline, completeOnboarding, trpcUtils, promoteRedirect, t]);
+
+  const ToSStep = useMemo(() => {
+    const Step = (props: StepProps) => (
+      <ToSAcceptanceScreen
+        onAccept={() => {
+          void handleComplete();
+        }}
+        onGoBack={props.onBack}
+        isSubmitting={isSubmitting}
+      />
+    );
+    return Step;
+  }, [handleComplete, isSubmitting]);
+
+  if (isSubmitting) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <MultiStepForm
+      steps={[PersonalDetailsForm, ToSStep]}
+      schemas={[PersonalDetailsFormValidator, ToSStepValidator]}
+      ProgressComponent={ProgressInPortal}
+      getStepValues={getStepValues}
+      hasHydrated={hasHydrated}
+    />
+  );
+};

--- a/apps/app/src/components/Onboarding/index.tsx
+++ b/apps/app/src/components/Onboarding/index.tsx
@@ -5,7 +5,7 @@ import { trpc } from '@op/api/client';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { StepperProgressIndicator } from '@op/ui/Stepper';
 import { toast } from '@op/ui/Toast';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import React, { useCallback, useMemo, useState } from 'react';
 import { z } from 'zod';
 
@@ -33,6 +33,7 @@ import {
   PrivacyPolicyForm,
   validator as PrivacyPolicyFormValidator,
 } from './PrivacyPolicyForm';
+import { PromoteOnboardingFlow } from './PromoteOnboardingFlow';
 import { ToSForm, validator as ToSFormValidator } from './ToSForm';
 import { organizationFormValidator as OrganizationDetailsFormValidator } from './shared/organizationValidation';
 import { useOnboardingFormStore } from './useOnboardingFormStore';
@@ -81,6 +82,12 @@ export const OnboardingFlow = () => {
   const createJoinRequest = trpc.profile.createJoinRequest.useMutation();
   const completeOnboarding = trpc.account.completeOnboarding.useMutation();
   const createOrganization = trpc.organization.create.useMutation();
+
+  // Promote flow: an anonymous visitor who just upgraded to a full account (see
+  // PromoteAccountModal/LinkAccountPanel). They skip organization joining
+  // entirely — that journey lives in PromoteOnboardingFlow.
+  const searchParams = useSearchParams();
+  const isPromoteFlow = searchParams.get('promote') === '1';
 
   // Handle hydration detection
   React.useEffect(() => {
@@ -280,6 +287,10 @@ export const OnboardingFlow = () => {
 
   if (isSubmitting) {
     return <LoadingSpinner />;
+  }
+
+  if (isPromoteFlow) {
+    return <PromoteOnboardingFlow hasHydrated={hasHydrated} />;
   }
 
   if (createOrgMode) {

--- a/apps/app/src/components/Onboarding/index.tsx
+++ b/apps/app/src/components/Onboarding/index.tsx
@@ -55,6 +55,15 @@ const ProgressInPortal = (props: ProgressComponentProps) => (
   </Portal>
 );
 
+// Warms the cache for the organization-search step. Rendered only on the
+// org-search branch — the promote flow skips that step entirely, so prefetching
+// there would fire a network-tier request the upgraded user never needs (and
+// can't make), surfacing a spurious 403.
+const PrefetchDomainOrganizations = () => {
+  void trpc.account.listMatchingDomainOrganizations.usePrefetchQuery();
+  return null;
+};
+
 const processOrgInputs = (data: OrgCreationFormValues) => ({
   ...data,
   website: data.website ?? '',
@@ -68,7 +77,6 @@ export const OnboardingFlow = () => {
   const [invitesComplete, setInvitesComplete] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [createOrgMode, setCreateOrgMode] = useState(false);
-  void trpc.account.listMatchingDomainOrganizations.usePrefetchQuery();
   const {
     personalDetails,
     organizationDetails,
@@ -317,12 +325,18 @@ export const OnboardingFlow = () => {
   }
 
   return (
-    <MultiStepForm
-      steps={[PersonalDetailsForm, OrganizationSearchStep]}
-      schemas={[PersonalDetailsFormValidator, OrganizationSearchStepValidator]}
-      ProgressComponent={ProgressInPortal}
-      getStepValues={getStepValues}
-      hasHydrated={hasHydrated}
-    />
+    <>
+      <PrefetchDomainOrganizations />
+      <MultiStepForm
+        steps={[PersonalDetailsForm, OrganizationSearchStep]}
+        schemas={[
+          PersonalDetailsFormValidator,
+          OrganizationSearchStepValidator,
+        ]}
+        ProgressComponent={ProgressInPortal}
+        getStepValues={getStepValues}
+        hasHydrated={hasHydrated}
+      />
+    </>
   );
 };

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useUser } from '@/utils/UserProvider';
+import { Button } from '@op/ui/Button';
+import { CheckIcon } from '@op/ui/CheckIcon';
+import { Checkbox } from '@op/ui/Checkbox';
+import { Header1 } from '@op/ui/Header';
+import { Modal } from '@op/ui/Modal';
+import { useQueryState } from 'nuqs';
+import { useState } from 'react';
+import { LuUser, LuUserPlus } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+/**
+ * Promote an anonymous visitor to a full account.
+ *
+ * Shown when `?promote=1` is on the URL, which ProposalEditor sets after an
+ * anonymous visitor submits their idea.
+ *
+ * "Create account" / "Log in" send the visitor to the real login page in
+ * link mode (`/login?link=1`), which reuses our existing auth methods (Google,
+ * email OTP) but *links* the chosen identity onto the current anonymous user
+ * instead of creating a separate account — so the idea they just submitted
+ * stays theirs (https://supabase.com/docs/guides/auth/auth-anonymous).
+ * See LinkAccountPanel for the linking logic.
+ */
+
+export const PromoteAccountModal = () => {
+  const { user } = useUser();
+  const [promote, setPromote] = useQueryState('promote');
+  // The just-submitted proposal's profileId, so we can return the visitor to
+  // their own idea (the proposal view) after they finish creating an account.
+  const [proposalId] = useQueryState('proposal');
+
+  // Only anonymous sign-ins can be promoted — a full account has nothing to
+  // upgrade, and a no-session visitor has no anon identity to attach an email
+  // to yet. (`isAnonymous` is the session-derived flag, same as onboarding.ts.)
+  const isAnonymous = Boolean(user?.isAnonymous);
+  const isOpen = isAnonymous && promote === '1';
+
+  const close = () => {
+    void setPromote(null);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onOpenChange={(open) => (open ? null : close())}>
+      <PromoteAccountModalContent
+        onContinueAsGuest={close}
+        proposalId={proposalId}
+      />
+    </Modal>
+  );
+};
+
+const PromoteAccountModalContent = ({
+  onContinueAsGuest,
+  proposalId,
+}: {
+  onContinueAsGuest: () => void;
+  proposalId: string | null;
+}) => {
+  const t = useTranslations();
+  const [agreed, setAgreed] = useState(false);
+
+  // Send them to the login page in link mode, returning to their idea once
+  // linked. The current path is the decision; appending /proposal/<id> targets
+  // the proposal view they just created (falls back to the decision page).
+  //
+  // TODO(anon-upgrade): "Create account" and "Already have an account? Log in"
+  // intentionally share this link-mode entry for now. Link mode can't attach an
+  // email/identity that already belongs to a full account, so an existing-account
+  // user routed here will hit the (raw) Supabase collision error in
+  // LinkAccountPanel. Productionize by routing "Log in" to normal /login and
+  // deciding what happens to the abandoned anonymous draft.
+  const goToLogin = () => {
+    const base = window.location.pathname;
+    const redirect = proposalId ? `${base}/proposal/${proposalId}` : base;
+    window.location.assign(
+      `/login?link=1&redirect=${encodeURIComponent(redirect)}`,
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-6 p-8">
+      <div className="flex flex-col items-center gap-3 text-center">
+        <CheckIcon />
+        <Header1 className="sm:text-title-base">
+          {t('Your idea was submitted.')}
+        </Header1>
+        <p className="text-neutral-gray4">
+          {t('Want to follow what happens next?')}
+        </p>
+      </div>
+
+      <section className="flex flex-col gap-3 rounded-lg border p-4">
+        <div className="flex items-center gap-2">
+          <LuUser className="size-5 text-neutral-charcoal" aria-hidden />
+          <span className="font-medium">{t('Continue as a guest')}</span>
+        </div>
+        <p className="text-sm text-neutral-gray4">
+          {t('Stay anonymous. React to comments with emoji.')}
+        </p>
+        {/* TODO(anon-upgrade): accepting this only gates the button — it does not
+            persist ToS/privacy acceptance for the anonymous account anywhere.
+            Either record it for the anon user or drop the checkbox on the guest
+            path. */}
+        <Checkbox isSelected={agreed} onChange={setAgreed}>
+          <span className="text-sm">
+            {t('I agree to the Terms of Service and Privacy Policy')}
+          </span>
+        </Checkbox>
+        <Button
+          color="secondary"
+          className="w-full"
+          isDisabled={!agreed}
+          onPress={onContinueAsGuest}
+        >
+          {t('Continue as guest')}
+        </Button>
+      </section>
+
+      <section className="flex flex-col gap-3 rounded-lg border p-4">
+        <div className="flex items-center gap-2">
+          <LuUserPlus className="size-5 text-neutral-charcoal" aria-hidden />
+          <span className="font-medium">{t('With an account')}</span>
+        </div>
+        <p className="text-sm text-neutral-gray4">
+          {t(
+            'Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.',
+          )}
+        </p>
+        <Button className="w-full" onPress={goToLogin}>
+          {t('Create account')}
+        </Button>
+      </section>
+
+      <p className="text-center text-sm text-neutral-gray4">
+        {t('Already have an account?')}{' '}
+        <button
+          type="button"
+          onClick={goToLogin}
+          className="text-primary-teal underline"
+        >
+          {t('Log in')}
+        </button>
+      </p>
+    </div>
+  );
+};

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -8,7 +8,7 @@ import { Header1 } from '@op/ui/Header';
 import { Modal } from '@op/ui/Modal';
 import { useQueryState } from 'nuqs';
 import { useState } from 'react';
-import { LuUser, LuUserPlus } from 'react-icons/lu';
+import { LuUserRoundMinus, LuUserRoundPlus } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -82,60 +82,74 @@ const PromoteAccountModalContent = ({
   };
 
   return (
-    <div className="flex flex-col gap-6 p-8">
-      <div className="flex flex-col items-center gap-3 text-center">
+    <div className="flex flex-col gap-6 p-8 sm:px-12 sm:pt-12">
+      <div className="flex flex-col items-center gap-4 text-center">
         <CheckIcon />
-        <Header1 className="sm:text-title-base">
-          {t('Your idea was submitted.')}
-        </Header1>
-        <p className="text-neutral-gray4">
-          {t('Want to follow what happens next?')}
-        </p>
+        <div className="flex flex-col gap-2">
+          <Header1 className="text-neutral-black">
+            {t('Your idea was submitted.')}
+          </Header1>
+          <p className="text-sm text-neutral-charcoal">
+            {t('Want to follow what happens next?')}
+          </p>
+        </div>
       </div>
 
-      <section className="flex flex-col gap-3 rounded-lg border p-4">
-        <div className="flex items-center gap-2">
-          <LuUser className="size-5 text-neutral-charcoal" aria-hidden />
-          <span className="font-medium">{t('Continue as a guest')}</span>
-        </div>
-        <p className="text-sm text-neutral-gray4">
-          {t('Stay anonymous. React to comments with emoji.')}
-        </p>
-        {/* TODO(anon-upgrade): accepting this only gates the button — it does not
-            persist ToS/privacy acceptance for the anonymous account anywhere.
-            Either record it for the anon user or drop the checkbox on the guest
-            path. */}
-        <Checkbox isSelected={agreed} onChange={setAgreed}>
-          <span className="text-sm">
-            {t('I agree to the Terms of Service and Privacy Policy')}
-          </span>
-        </Checkbox>
-        <Button
-          color="secondary"
-          className="w-full"
-          isDisabled={!agreed}
-          onPress={onContinueAsGuest}
-        >
-          {t('Continue as guest')}
-        </Button>
-      </section>
+      <div className="flex flex-col gap-4">
+        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-white p-4 text-left">
+          <div className="flex items-center gap-1">
+            <LuUserRoundMinus
+              className="size-4 text-neutral-charcoal"
+              aria-hidden
+            />
+            <span className="font-serif text-title-sm text-neutral-charcoal">
+              {t('Continue as a guest')}
+            </span>
+          </div>
+          <p className="text-sm text-neutral-charcoal">
+            {t('Stay anonymous. React to comments with emoji.')}
+          </p>
+          {/* TODO(anon-upgrade): accepting this only gates the button — it does
+              not persist ToS/privacy acceptance for the anonymous account
+              anywhere. Either record it for the anon user or drop the checkbox
+              on the guest path. */}
+          <Checkbox isSelected={agreed} onChange={setAgreed}>
+            <span className="text-sm">
+              {t('I agree to the Terms of Service and Privacy Policy')}
+            </span>
+          </Checkbox>
+          <Button
+            color="secondary"
+            className="w-full"
+            isDisabled={!agreed}
+            onPress={onContinueAsGuest}
+          >
+            {t('Continue as guest')}
+          </Button>
+        </section>
 
-      <section className="flex flex-col gap-3 rounded-lg border p-4">
-        <div className="flex items-center gap-2">
-          <LuUserPlus className="size-5 text-neutral-charcoal" aria-hidden />
-          <span className="font-medium">{t('With an account')}</span>
-        </div>
-        <p className="text-sm text-neutral-gray4">
-          {t(
-            'Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.',
-          )}
-        </p>
-        <Button className="w-full" onPress={goToLogin}>
-          {t('Create account')}
-        </Button>
-      </section>
+        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-neutral-off-white p-4 text-left">
+          <div className="flex items-center gap-1">
+            <LuUserRoundPlus
+              className="size-4 text-neutral-charcoal"
+              aria-hidden
+            />
+            <span className="font-serif text-title-sm text-neutral-charcoal">
+              {t('With an account')}
+            </span>
+          </div>
+          <p className="text-sm text-neutral-charcoal">
+            {t(
+              'Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.',
+            )}
+          </p>
+          <Button className="w-full" onPress={goToLogin}>
+            {t('Create account')}
+          </Button>
+        </section>
+      </div>
 
-      <p className="text-center text-sm text-neutral-gray4">
+      <p className="text-center text-sm text-neutral-charcoal">
         {t('Already have an account?')}{' '}
         <button
           type="button"

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -192,7 +192,14 @@ function ProposalEditorInner({
   const router = useRouter();
   const locale = useLocale();
   const t = useTranslations();
+  const { user } = useRequiredUser();
   const utils = trpc.useUtils();
+
+  // After an anonymous visitor submits their idea, send them back to the
+  // decision page with ?promote=1 so PromoteAccountModal offers them an upgrade.
+  // A full account has nothing to promote. `isAnonymous` is the session-derived
+  // flag (see PromoteAccountModal / onboarding.ts), not the stale DB relation.
+  const isAnonymous = Boolean(user?.isAnonymous);
   const { ydoc, provider, isSynced } = useCollaborativeDoc();
   const versionPreview = useOptionalVersionPreview();
 
@@ -338,13 +345,19 @@ function ProposalEditorInner({
         },
       });
 
+      let didSubmitDraft = false;
       if (isDraft) {
         await submitProposalMutation.mutateAsync({
           proposalId: proposal.id,
         });
+        didSubmitDraft = true;
       }
 
-      router.push(backHref);
+      router.push(
+        didSubmitDraft && isAnonymous
+          ? `${backHref}?promote=1&proposal=${proposal.profileId}`
+          : backHref,
+      );
     } catch (error) {
       console.error('Failed to update proposal:', error);
     } finally {
@@ -355,6 +368,9 @@ function ProposalEditorInner({
     collaborationDocId,
     proposal,
     isDraft,
+    isAnonymous,
+    backHref,
+    router,
     submitProposalMutation,
     updateProposalMutation,
     draftRef,

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1352,5 +1352,19 @@
   "This action cannot be undone.": "This action cannot be undone.",
   "File is too large (max {size} MB)": "File is too large (max {size} MB)",
   "Drag a file or link here to add it": "Drag a file or link here to add it",
-  "Unsaved changes": "Unsaved changes"
+  "Unsaved changes": "Unsaved changes",
+  "Your idea was submitted.": "Your idea was submitted.",
+  "Want to follow what happens next?": "Want to follow what happens next?",
+  "Continue as a guest": "Continue as a guest",
+  "Stay anonymous. React to comments with emoji.": "Stay anonymous. React to comments with emoji.",
+  "I agree to the Terms of Service and Privacy Policy": "I agree to the Terms of Service and Privacy Policy",
+  "Continue as guest": "Continue as guest",
+  "With an account": "With an account",
+  "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.": "Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.",
+  "Create account": "Create account",
+  "Already have an account?": "Already have an account?",
+  "Create an account": "Create an account",
+  "Already have an account? <login>Log in</login>": "Already have an account? <login>Log in</login>",
+  "A code was sent to {email}. Type the code below to create your profile.": "A code was sent to {email}. Type the code below to create your profile.",
+  "Create profile": "Create profile"
 }

--- a/services/api/src/routers/taxonomy/taxonomyTerms.test.ts
+++ b/services/api/src/routers/taxonomy/taxonomyTerms.test.ts
@@ -26,12 +26,11 @@ describeAccessTierGating('taxonomy.getTerms', {
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits user-JWT caller',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.taxonomy.getTerms({ name: 'xxx' }),
-        'user',
       );
     },
   ),

--- a/services/api/src/routers/taxonomy/taxonomyTerms.ts
+++ b/services/api/src/routers/taxonomy/taxonomyTerms.ts
@@ -2,10 +2,10 @@ import { getTerms } from '@op/common';
 import { z } from 'zod';
 
 import { taxonomyTermsWithChildrenEncoder } from '../../encoders/taxonomyTerms';
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedConfirmedProcedure, router } from '../../trpcFactory';
 
 export const termsRouter = router({
-  getTerms: networkAuthenticatedProcedure()
+  getTerms: authenticatedConfirmedProcedure()
     .input(z.object({ name: z.string().min(3), q: z.string().optional() }))
     .output(z.array(taxonomyTermsWithChildrenEncoder))
     .query(async ({ input }) => {

--- a/tests/e2e/tests/decision-role-capabilities.spec.ts
+++ b/tests/e2e/tests/decision-role-capabilities.spec.ts
@@ -215,9 +215,8 @@ test.describe('Decision Role Capabilities', () => {
     // getByText(...) matches two elements and trips strict mode. We scope to
     // the visible copy until the double-render is fixed. See the
     // double-render investigation for upgrade-anon-account.
-    await expect(
-      memberPage.getByText('TIME TO VOTE.').filter({ visible: true }),
-    ).toBeVisible({
+    // EXPERIMENT: sensitive to the double-render — exactly one copy expected.
+    await expect(memberPage.getByText('TIME TO VOTE.')).toHaveCount(1, {
       timeout: 10000,
     });
   });
@@ -253,12 +252,10 @@ test.describe('Decision Role Capabilities', () => {
     // getByText(...) matches two elements and trips strict mode. We scope to
     // the visible copy until the double-render is fixed. See the
     // double-render investigation for upgrade-anon-account.
-    await expect(
-      authenticatedPage
-        .getByText('SHARE YOUR IDEAS.')
-        .filter({ visible: true }),
-    ).toBeVisible({
-      timeout: 10000,
-    });
+    // EXPERIMENT: sensitive to the double-render — exactly one copy expected.
+    await expect(authenticatedPage.getByText('SHARE YOUR IDEAS.')).toHaveCount(
+      1,
+      { timeout: 10000 },
+    );
   });
 });

--- a/tests/e2e/tests/decision-role-capabilities.spec.ts
+++ b/tests/e2e/tests/decision-role-capabilities.spec.ts
@@ -207,8 +207,17 @@ test.describe('Decision Role Capabilities', () => {
       memberPage.getByRole('heading', { name: instance.name }),
     ).toBeVisible({ timeout: 15000 });
 
-    // The voting phase description confirms VotingPage rendered (not StandardDecisionPage).
-    await expect(memberPage.getByText('Members vote.')).toBeVisible({
+    // The voting hero title is unique to VotingPage (StandardDecisionPage shows
+    // "SHARE YOUR IDEAS."), so it confirms the voting page rendered.
+    //
+    // STOPGAP: in some environments (seen on CI, not locally) the decision
+    // content subtree mounts twice — one copy hidden — so a bare
+    // getByText(...) matches two elements and trips strict mode. We scope to
+    // the visible copy until the double-render is fixed. See the
+    // double-render investigation for upgrade-anon-account.
+    await expect(
+      memberPage.getByText('TIME TO VOTE.').filter({ visible: true }),
+    ).toBeVisible({
       timeout: 10000,
     });
   });
@@ -235,9 +244,21 @@ test.describe('Decision Role Capabilities', () => {
       authenticatedPage.getByRole('heading', { name: instance.name }),
     ).toBeVisible({ timeout: 15000 });
 
-    // Submission phase description confirms StandardDecisionPage rendered, not VotingPage
+    // The submission hero title is unique to StandardDecisionPage (VotingPage
+    // shows "TIME TO VOTE."), confirming the standard page rendered, not the
+    // voting page.
+    //
+    // STOPGAP: in some environments (seen on CI, not locally) the decision
+    // content subtree mounts twice — one copy hidden — so a bare
+    // getByText(...) matches two elements and trips strict mode. We scope to
+    // the visible copy until the double-render is fixed. See the
+    // double-render investigation for upgrade-anon-account.
     await expect(
-      authenticatedPage.getByText('Members submit proposals.'),
-    ).toBeVisible({ timeout: 10000 });
+      authenticatedPage
+        .getByText('SHARE YOUR IDEAS.')
+        .filter({ visible: true }),
+    ).toBeVisible({
+      timeout: 10000,
+    });
   });
 });


### PR DESCRIPTION
Throwaway experiment to confirm whether `PromoteAccountModal` triggers the decision-content double-render seen in CI on #1323. Removes the modal and asserts `toHaveCount(1)`. Will be closed after observing E2E shard 1/2.