### PR TITLE
feat(decisions): make emoji reactions read-only for anonymous and logged-out viewers

### DIFF
--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -3,6 +3,7 @@
 import { getPublicUrl } from '@/utils';
 import { useUser } from '@/utils/UserProvider';
 import { detectLinks, linkifyText } from '@/utils/linkDetection';
+import { userCanInteract } from '@/utils/userCanInteract';
 import { trpc } from '@op/api/client';
 import type {
   CommonUser,
@@ -169,9 +170,7 @@ const PostReactions = ({
   onReactionClick: (postId: string, emoji: string) => void;
 }) => {
   const { user } = useUser();
-
-  // Only signed-in members can react; anon and logged-out viewers are read-only.
-  const canReact = Boolean(user?.currentProfile) && !user?.isAnonymous;
+  const canReact = userCanInteract(user);
 
   if (!post?.id) return null;
 

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -168,6 +168,11 @@ const PostReactions = ({
   post: Post;
   onReactionClick: (postId: string, emoji: string) => void;
 }) => {
+  const { user } = useUser();
+
+  // Only signed-in members can react; anon and logged-out viewers are read-only.
+  const canReact = Boolean(user?.currentProfile) && !user?.isAnonymous;
+
   if (!post?.id) return null;
 
   const reactions = post.reactionCounts
@@ -191,6 +196,7 @@ const PostReactions = ({
     <ReactionsButton
       reactions={reactions}
       reactionOptions={REACTION_OPTIONS}
+      canReact={canReact}
       onReactionClick={(emoji) => onReactionClick(post.id!, emoji)}
       onAddReaction={(emoji) => onReactionClick(post.id!, emoji)}
     />

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -5,6 +5,7 @@ import { useUser } from '@/utils/UserProvider';
 import { analyzeError, useConnectionStatus } from '@/utils/connectionErrors';
 import { detectLinks } from '@/utils/linkDetection';
 import { createCommentsQueryKey } from '@/utils/queryKeys';
+import { userCanInteract } from '@/utils/userCanInteract';
 import { trpc } from '@op/api/client';
 import type { Organization, Post } from '@op/api/encoders';
 import { Button } from '@op/ui/Button';
@@ -592,8 +593,7 @@ const PostUpdateWithUser = ({
     }
   }, [content]);
 
-  // Anonymous accounts still get a `currentProfile`, so guard it explicitly.
-  if (!user?.currentProfile || user.isAnonymous) {
+  if (!userCanInteract(user)) {
     return null;
   }
 

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
@@ -2,6 +2,7 @@
 
 import { useRelationshipMutations } from '@/hooks/useRelationshipMutations';
 import { useUser } from '@/utils/UserProvider';
+import { userCanInteract } from '@/utils/userCanInteract';
 import { trpc } from '@op/api/client';
 import type { Proposal } from '@op/common/client';
 import { Button, ButtonLink } from '@op/ui/Button';
@@ -52,7 +53,7 @@ export function ProposalCardActions({
 
   // Like/Follow are user-scoped writes gated at the API — anonymous visitors
   // can read the proposal but aren't offered these actions.
-  if (!user) {
+  if (!userCanInteract(user)) {
     return null;
   }
 

--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useUser } from '@/utils/UserProvider';
+import { userCanInteract } from '@/utils/userCanInteract';
 import { trpc } from '@op/api/client';
 import type { Proposal } from '@op/common/client';
 import { Header3 } from '@op/ui/Header';
@@ -32,8 +33,7 @@ export function ProposalComments({
   const comments = commentsData?.items ?? [];
   const { handleReactionClick } = usePostFeedActions();
 
-  // Visitors and anonymous accounts can't comment — hide the input.
-  const canComment = Boolean(user?.currentProfile) && !user?.isAnonymous;
+  const canComment = userCanInteract(user);
 
   const scrollToComments = useCallback(() => {
     setTimeout(() => {

--- a/apps/app/src/components/decisions/ProposalViewLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalViewLayout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useUser } from '@/utils/UserProvider';
+import { userCanInteract } from '@/utils/userCanInteract';
 import { Button } from '@op/ui/Button';
 import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
 import { ReactNode } from 'react';
@@ -89,9 +90,9 @@ export function ProposalViewLayout({
               {t('Edit')}
             </Button>
           )}
-          {/* Like/Follow are user-scoped writes gated at the API — only offer
-              them to a signed-in viewer. */}
-          {user ? (
+          {/* Report/Like/Follow are user-scoped writes gated at the API — only
+              offer them to a signed-in, non-anonymous member. */}
+          {userCanInteract(user) ? (
             <>
               {reportProposalId && (
                 <ReportProposalDialog proposalId={reportProposalId} />

--- a/apps/app/src/utils/userCanInteract.ts
+++ b/apps/app/src/utils/userCanInteract.ts
@@ -1,0 +1,15 @@
+import type { CommonUser } from '@op/api/encoders';
+
+/**
+ * Whether a user may perform write actions (react, comment, post, …).
+ *
+ * Only a signed-in, non-anonymous account qualifies. Anonymous accounts still
+ * get a `currentProfile`, so the profile check alone isn't enough — the real
+ * discriminator is `isAnonymous`. Logged-out visitors have no user at all.
+ *
+ * This is the single source of truth for "who may act" — keep interactive
+ * surfaces gating on this rather than re-deriving the predicate inline.
+ */
+export const userCanInteract = (
+  user: CommonUser | null | undefined,
+): user is CommonUser => Boolean(user?.currentProfile) && !user?.isAnonymous;

--- a/packages/ui/src/components/ReactionsButton.tsx
+++ b/packages/ui/src/components/ReactionsButton.tsx
@@ -62,6 +62,8 @@ interface ReactionsButtonProps {
   onReactionClick?: (emoji: string) => void;
   onAddReaction?: (emoji: string) => void;
   className?: string;
+  /** When false, reactions render read-only and the add-reaction picker is hidden. */
+  canReact?: boolean;
 }
 
 // We'll import the actual reaction options from @op/types in the consumer component
@@ -152,12 +154,18 @@ export const ReactionsButton = ({
   onReactionClick,
   onAddReaction,
   className,
+  canReact = true,
 }: ReactionsButtonProps) => {
   if (reactions.length === 0) {
+    // Nothing to show, nothing to add.
+    if (!canReact) {
+      return null;
+    }
+
     return (
       <div className={reactionGroupStyle({ className })}>
         <MenuTrigger>
-          <ReactionButton size="icon" />
+          <ReactionButton size="icon" aria-label="Add reaction" />
           <Popover placement="bottom left">
             <ReactionPicker
               reactionOptions={reactionOptions}
@@ -180,20 +188,24 @@ export const ReactionsButton = ({
             count={reaction.count}
             active={reaction.isActive}
             users={reaction.users}
-            onPress={() => onReactionClick?.(reaction.emoji)}
+            onPress={
+              canReact ? () => onReactionClick?.(reaction.emoji) : undefined
+            }
           />
         ) : null,
       )}
-      <MenuTrigger>
-        <ReactionButton size="icon" />
-        <Popover placement="top left">
-          <ReactionPicker
-            reactionOptions={reactionOptions}
-            onReactionSelect={(emoji) => onAddReaction?.(emoji)}
-            existingReactions={reactions}
-          />
-        </Popover>
-      </MenuTrigger>
+      {canReact ? (
+        <MenuTrigger>
+          <ReactionButton size="icon" aria-label="Add reaction" />
+          <Popover placement="top left">
+            <ReactionPicker
+              reactionOptions={reactionOptions}
+              onReactionSelect={(emoji) => onAddReaction?.(emoji)}
+              existingReactions={reactions}
+            />
+          </Popover>
+        </MenuTrigger>
+      ) : null}
     </div>
   );
 };

--- a/packages/ui/src/components/ReactionsButton.tsx
+++ b/packages/ui/src/components/ReactionsButton.tsx
@@ -148,6 +148,29 @@ const ReactionPicker = ({
   );
 };
 
+const AddReactionMenu = ({
+  reactionOptions,
+  onAddReaction,
+  existingReactions,
+  placement,
+}: {
+  reactionOptions?: readonly ReactionOption[];
+  onAddReaction?: (emoji: string) => void;
+  existingReactions: Reaction[];
+  placement: 'top left' | 'bottom left';
+}) => (
+  <MenuTrigger>
+    <ReactionButton size="icon" aria-label="Add reaction" />
+    <Popover placement={placement}>
+      <ReactionPicker
+        reactionOptions={reactionOptions}
+        onReactionSelect={(emoji) => onAddReaction?.(emoji)}
+        existingReactions={existingReactions}
+      />
+    </Popover>
+  </MenuTrigger>
+);
+
 export const ReactionsButton = ({
   reactions = [],
   reactionOptions = DEFAULT_REACTION_OPTIONS,
@@ -157,23 +180,18 @@ export const ReactionsButton = ({
   canReact = true,
 }: ReactionsButtonProps) => {
   if (reactions.length === 0) {
-    // Nothing to show, nothing to add.
     if (!canReact) {
       return null;
     }
 
     return (
       <div className={reactionGroupStyle({ className })}>
-        <MenuTrigger>
-          <ReactionButton size="icon" aria-label="Add reaction" />
-          <Popover placement="bottom left">
-            <ReactionPicker
-              reactionOptions={reactionOptions}
-              onReactionSelect={(emoji) => onAddReaction?.(emoji)}
-              existingReactions={reactions}
-            />
-          </Popover>
-        </MenuTrigger>
+        <AddReactionMenu
+          reactionOptions={reactionOptions}
+          onAddReaction={onAddReaction}
+          existingReactions={reactions}
+          placement="bottom left"
+        />
       </div>
     );
   }
@@ -195,16 +213,12 @@ export const ReactionsButton = ({
         ) : null,
       )}
       {canReact ? (
-        <MenuTrigger>
-          <ReactionButton size="icon" aria-label="Add reaction" />
-          <Popover placement="top left">
-            <ReactionPicker
-              reactionOptions={reactionOptions}
-              onReactionSelect={(emoji) => onAddReaction?.(emoji)}
-              existingReactions={reactions}
-            />
-          </Popover>
-        </MenuTrigger>
+        <AddReactionMenu
+          reactionOptions={reactionOptions}
+          onAddReaction={onAddReaction}
+          existingReactions={reactions}
+          placement="top left"
+        />
       ) : null}
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1654,6 +1654,9 @@ importers:
       '@op/common':
         specifier: workspace:*
         version: link:../../packages/common
+      '@op/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@op/db':
         specifier: workspace:*
         version: link:../../services/db

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -6,7 +6,6 @@ import {
   createInstanceDataFromTemplate,
   createOrganization as createOrganizationService,
   createProposal as createProposalService,
-  decisionPermission,
   getTemplate,
   joinOrganization,
 } from '@op/common';
@@ -21,7 +20,7 @@ import {
   proposals,
   users,
 } from '@op/db/schema';
-import { PERMISSIONS, ROLES } from '@op/db/seedData/accessControl';
+import { ROLES } from '@op/db/seedData/accessControl';
 import type { User } from '@op/supabase/lib';
 import {
   grantDecisionProfileAccess,
@@ -464,23 +463,13 @@ export class TestDecisionsDataManager {
   }
 
   /**
-   * Makes a decision profile publicly accessible to no-JWT (public) visitors,
-   * mirroring the production "make a process public" runbook: the
-   * GLOBAL_USER_PUBLIC sentinel becomes a member of the profile holding the
-   * seeded global Public role, whose grant on this profile is a profile-scoped
-   * `decisions` permission override. READ + SUBMIT_PROPOSALS + VOTE are granted
-   * by default (the Columbus public value), so a public visitor resolves the
-   * same capabilities the access object exposes for a public process.
-   *
-   * The Public role is seeded with no default permissions; the override is
-   * scoped to `profileId`, so the grant never leaks to other decisions and the
-   * membership + override cascade away when the profile is deleted in cleanup.
+   * Opens a decision profile to public (no-JWT) visitors via the shared
+   * {@link makeDecisionPublicShared} helper, registering the profile for cleanup
+   * so the membership + permission override are torn down with it.
    */
   async makeDecisionPublic(
     profileId: string,
-    permissionBits: number = PERMISSIONS.READ |
-      decisionPermission.SUBMIT_PROPOSALS |
-      decisionPermission.VOTE,
+    permissionBits?: number,
   ): Promise<void> {
     this.ensureCleanupRegistered();
     await makeDecisionPublicShared({ profileId, permissionBits });

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -4,30 +4,30 @@ import {
   advancePhase,
   createDecisionInstance,
   createInstanceDataFromTemplate,
-  assertGlobalRole,
   createOrganization as createOrganizationService,
   createProposal as createProposalService,
   decisionPermission,
   getTemplate,
   joinOrganization,
 } from '@op/common';
-import { GLOBAL_USER_PUBLIC } from '@op/core';
 import { db } from '@op/db/client';
 import type { ProcessStatus } from '@op/db/schema';
 import {
   ProposalStatus,
-  accessRolePermissionsOnAccessZones,
   decisionProcesses,
   processInstances,
   profileUserToAccessRoles,
-  profileUsers,
   profiles,
   proposals,
   users,
 } from '@op/db/schema';
-import { PERMISSIONS, ROLES, ZONES } from '@op/db/seedData/accessControl';
+import { PERMISSIONS, ROLES } from '@op/db/seedData/accessControl';
 import type { User } from '@op/supabase/lib';
-import { grantDecisionProfileAccess, testMinimalSchema } from '@op/test';
+import {
+  grantDecisionProfileAccess,
+  makeDecisionPublic as makeDecisionPublicShared,
+  testMinimalSchema,
+} from '@op/test';
 import { eq, inArray } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
 import type { z } from 'zod';
@@ -483,31 +483,7 @@ export class TestDecisionsDataManager {
       decisionPermission.VOTE,
   ): Promise<void> {
     this.ensureCleanupRegistered();
-
-    // Resolve the seeded global Public role by name (global roles are keyed by
-    // name in runtime code; the seed id is not referenced here).
-    const publicRole = await assertGlobalRole('Public');
-
-    const [publicMember] = await db
-      .insert(profileUsers)
-      .values({ profileId, authUserId: GLOBAL_USER_PUBLIC })
-      .returning();
-
-    if (!publicMember) {
-      throw new Error('Failed to create public profileUser');
-    }
-
-    await db.insert(profileUserToAccessRoles).values({
-      profileUserId: publicMember.id,
-      accessRoleId: publicRole.id,
-    });
-
-    await db.insert(accessRolePermissionsOnAccessZones).values({
-      accessRoleId: publicRole.id,
-      accessZoneId: ZONES.DECISIONS.id,
-      permission: permissionBits,
-      profileId,
-    });
+    await makeDecisionPublicShared({ profileId, permissionBits });
   }
 
   /**

--- a/services/db/seedData/accessControl.ts
+++ b/services/db/seedData/accessControl.ts
@@ -9,7 +9,7 @@ import { permission } from 'access-zones';
  * Duplicated from @op/common/src/services/decision/permissions.ts to avoid a
  * circular dependency (@op/db cannot depend on @op/common).
  */
-const DECISION_BITS = {
+export const DECISION_BITS = {
   INVITE_MEMBERS: 0b1_00000, // 32
   REVIEW: 0b10_00000, // 64
   SUBMIT_PROPOSALS: 0b100_00000, // 128

--- a/tests/core/package.json
+++ b/tests/core/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@op/common": "workspace:*",
+    "@op/core": "workspace:*",
     "@op/db": "workspace:*",
     "@supabase/supabase-js": "catalog:",
     "drizzle-orm": "catalog:"

--- a/tests/core/src/decision-data.ts
+++ b/tests/core/src/decision-data.ts
@@ -2,6 +2,7 @@ import type {
   DecisionSchemaDefinition,
   ProposalTemplateSchema,
 } from '@op/common';
+import { GLOBAL_USER_PUBLIC } from '@op/core';
 import {
   EntityType,
   ProcessStatus,
@@ -16,7 +17,12 @@ import {
   proposals,
   users,
 } from '@op/db/schema';
-import { ROLES } from '@op/db/seedData/accessControl';
+import {
+  DECISION_BITS,
+  PERMISSIONS,
+  ROLES,
+  ZONES,
+} from '@op/db/seedData/accessControl';
 import { db, eq } from '@op/db/test';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { randomUUID } from 'node:crypto';
@@ -393,6 +399,50 @@ export async function grantDecisionProfileAccess(
       accessRoleId: isAdmin ? ROLES.ADMIN.id : ROLES.MEMBER.id,
     });
   }
+}
+
+export interface MakeDecisionPublicOptions {
+  /** Decision (process instance) profile ID to open to the public. */
+  profileId: string;
+  /** Permission bits for the Public role (defaults to read + submit + vote). */
+  permissionBits?: number;
+}
+
+/**
+ * Grant the global "Public" role access on a decision profile via a per-profile
+ * override, mirroring the production "make a process public" flow so anonymous
+ * and no-session callers can read the decision.
+ */
+export async function makeDecisionPublic(
+  opts: MakeDecisionPublicOptions,
+): Promise<void> {
+  const {
+    profileId,
+    permissionBits = PERMISSIONS.READ |
+      DECISION_BITS.SUBMIT_PROPOSALS |
+      DECISION_BITS.VOTE,
+  } = opts;
+
+  const [publicMember] = await db
+    .insert(profileUsers)
+    .values({ profileId, authUserId: GLOBAL_USER_PUBLIC })
+    .returning();
+
+  if (!publicMember) {
+    throw new Error('Failed to create public profileUser');
+  }
+
+  await db.insert(profileUserToAccessRoles).values({
+    profileUserId: publicMember.id,
+    accessRoleId: ROLES.PUBLIC.id,
+  });
+
+  await db.insert(accessRolePermissionsOnAccessZones).values({
+    accessRoleId: ROLES.PUBLIC.id,
+    accessZoneId: ZONES.DECISIONS.id,
+    permission: permissionBits,
+    profileId,
+  });
 }
 
 /**

--- a/tests/core/src/index.ts
+++ b/tests/core/src/index.ts
@@ -19,6 +19,7 @@ export {
   getSeededTemplate,
   grantDecisionProfileAccess,
   grantInstanceReviewerRole,
+  makeDecisionPublic,
   SEEDED_SIMPLE_VOTING_TEMPLATE_NAME,
   SEEDED_TEMPLATE_PROFILE_SLUG,
   testMinimalSchema,
@@ -32,6 +33,7 @@ export {
   type CreateProposalOptions,
   type CreateProposalResult,
   type GrantDecisionProfileAccessOptions,
+  type MakeDecisionPublicOptions,
 } from './decision-data';
 
 export {

--- a/tests/e2e/tests/proposal-view.spec.ts
+++ b/tests/e2e/tests/proposal-view.spec.ts
@@ -20,6 +20,7 @@ import {
   getSeededTemplate,
   makeDecisionPublic,
 } from '@op/test';
+import type { Page } from '@playwright/test';
 import { randomUUID } from 'node:crypto';
 
 import { transformFormDataToProcessSchema as cowopSchema } from '../../../apps/app/src/components/Profile/CreateDecisionProcessModal/schemas/cowop';
@@ -725,58 +726,46 @@ test.describe('Proposal View', () => {
 
     const proposalUrl = `/en/decisions/${instance.slug}/proposal/${proposal.profileId}`;
     const likeBadge = /👍\s*1/;
-    const addReactionButton = { role: 'button' as const, name: 'Add reaction' };
 
-    // 1) A signed-in member sees the like and can react (control present).
-    await authenticatedPage.goto(proposalUrl);
-    await expect(
-      authenticatedPage.getByRole('heading', { name: 'Reactable Proposal' }),
-    ).toBeVisible({ timeout: 30_000 });
-    await expect(authenticatedPage.getByText(commentText)).toBeVisible();
-    await expect(authenticatedPage.getByText(likeBadge)).toBeVisible();
-    await expect(
-      authenticatedPage.getByRole(addReactionButton.role, {
-        name: addReactionButton.name,
-      }),
-    ).toBeVisible();
+    // Every viewer sees the proposal, the comment, and the seeded like; only a
+    // signed-in member gets the add-reaction control.
+    const expectReactionView = async (
+      page: Page,
+      { canReact }: { canReact: boolean },
+    ) => {
+      await page.goto(proposalUrl);
+      await expect(
+        page.getByRole('heading', { name: 'Reactable Proposal' }),
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByText(commentText)).toBeVisible();
+      await expect(page.getByText(likeBadge)).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Add reaction' }),
+      ).toHaveCount(canReact ? 1 : 0);
+    };
 
-    // 2) Anonymous account: sees the like, no add-reaction control. Clean
-    //    session so the worker's auth doesn't leak in via newContext().
-    const anonContext = await browser.newContext({
-      storageState: { cookies: [], origins: [] },
+    // A clean context so the worker's auth doesn't leak in via newContext().
+    const withCleanPage = async (fn: (page: Page) => Promise<void>) => {
+      const context = await browser.newContext({
+        storageState: { cookies: [], origins: [] },
+      });
+      try {
+        await fn(await context.newPage());
+      } finally {
+        await context.close();
+      }
+    };
+
+    // 1) Signed-in member: read-write (add-reaction control present).
+    await expectReactionView(authenticatedPage, { canReact: true });
+
+    // 2) Anonymous account and 3) logged-out visitor: read-only.
+    await withCleanPage(async (page) => {
+      await authenticateAnonymously(page);
+      await expectReactionView(page, { canReact: false });
     });
-    const anonPage = await anonContext.newPage();
-    await authenticateAnonymously(anonPage);
-    await anonPage.goto(proposalUrl);
-    await expect(
-      anonPage.getByRole('heading', { name: 'Reactable Proposal' }),
-    ).toBeVisible({ timeout: 30_000 });
-    await expect(anonPage.getByText(commentText)).toBeVisible();
-    await expect(anonPage.getByText(likeBadge)).toBeVisible();
-    await expect(
-      anonPage.getByRole(addReactionButton.role, {
-        name: addReactionButton.name,
-      }),
-    ).toHaveCount(0);
-    await anonContext.close();
-
-    // 3) Logged-out visitor: same read-only treatment. Empty storageState since
-    //    browser.newContext() otherwise reuses the worker's session.
-    const guestContext = await browser.newContext({
-      storageState: { cookies: [], origins: [] },
-    });
-    const guestPage = await guestContext.newPage();
-    await guestPage.goto(proposalUrl);
-    await expect(
-      guestPage.getByRole('heading', { name: 'Reactable Proposal' }),
-    ).toBeVisible({ timeout: 30_000 });
-    await expect(guestPage.getByText(commentText)).toBeVisible();
-    await expect(guestPage.getByText(likeBadge)).toBeVisible();
-    await expect(
-      guestPage.getByRole(addReactionButton.role, {
-        name: addReactionButton.name,
-      }),
-    ).toHaveCount(0);
-    await guestContext.close();
+    await withCleanPage((page) =>
+      expectReactionView(page, { canReact: false }),
+    );
   });
 });

--- a/tests/e2e/tests/proposal-view.spec.ts
+++ b/tests/e2e/tests/proposal-view.spec.ts
@@ -4,6 +4,9 @@ import {
   ProcessStatus,
   ProposalStatus,
   decisionProcesses,
+  postReactions,
+  posts,
+  postsToProfiles,
   processInstances,
   profileUserToAccessRoles,
   profileUsers,
@@ -15,11 +18,12 @@ import {
   createDecisionInstance,
   createProposal,
   getSeededTemplate,
+  makeDecisionPublic,
 } from '@op/test';
 import { randomUUID } from 'node:crypto';
 
 import { transformFormDataToProcessSchema as cowopSchema } from '../../../apps/app/src/components/Profile/CreateDecisionProcessModal/schemas/cowop';
-import { expect, test } from '../fixtures/index.js';
+import { authenticateAnonymously, expect, test } from '../fixtures/index.js';
 
 /**
  * Any doc ID that doesn't contain "nonexistent" will return fixture content
@@ -671,5 +675,108 @@ test.describe('Proposal View', () => {
     await expect(
       authenticatedPage.getByText('Content could not be loaded').first(),
     ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('shows reactions read-only to anonymous and logged-out viewers', async ({
+    authenticatedPage,
+    org,
+    browser,
+  }) => {
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: template.processSchema,
+    });
+
+    const proposal = await createProposal({
+      processInstanceId: instance.instance.id,
+      submittedByProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      status: ProposalStatus.SUBMITTED,
+      proposalData: { title: 'Reactable Proposal' },
+    });
+
+    // Public decision so anonymous and logged-out visitors can read it.
+    await makeDecisionPublic({ profileId: instance.profileId });
+
+    // Reactions render per-comment; seed a top-level post + like on the proposal.
+    const commentText = 'Seeded comment carrying a like';
+    const [comment] = await db
+      .insert(posts)
+      .values({ content: commentText, profileId: org.organizationProfile.id })
+      .returning();
+    if (!comment) {
+      throw new Error('Failed to seed comment');
+    }
+    await db.insert(postsToProfiles).values({
+      postId: comment.id,
+      profileId: proposal.profileId,
+    });
+    await db.insert(postReactions).values({
+      postId: comment.id,
+      profileId: org.organizationProfile.id,
+      reactionType: 'like',
+    });
+
+    const proposalUrl = `/en/decisions/${instance.slug}/proposal/${proposal.profileId}`;
+    const likeBadge = /👍\s*1/;
+    const addReactionButton = { role: 'button' as const, name: 'Add reaction' };
+
+    // 1) A signed-in member sees the like and can react (control present).
+    await authenticatedPage.goto(proposalUrl);
+    await expect(
+      authenticatedPage.getByRole('heading', { name: 'Reactable Proposal' }),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(authenticatedPage.getByText(commentText)).toBeVisible();
+    await expect(authenticatedPage.getByText(likeBadge)).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole(addReactionButton.role, {
+        name: addReactionButton.name,
+      }),
+    ).toBeVisible();
+
+    // 2) Anonymous account: sees the like, no add-reaction control. Clean
+    //    session so the worker's auth doesn't leak in via newContext().
+    const anonContext = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    const anonPage = await anonContext.newPage();
+    await authenticateAnonymously(anonPage);
+    await anonPage.goto(proposalUrl);
+    await expect(
+      anonPage.getByRole('heading', { name: 'Reactable Proposal' }),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(anonPage.getByText(commentText)).toBeVisible();
+    await expect(anonPage.getByText(likeBadge)).toBeVisible();
+    await expect(
+      anonPage.getByRole(addReactionButton.role, {
+        name: addReactionButton.name,
+      }),
+    ).toHaveCount(0);
+    await anonContext.close();
+
+    // 3) Logged-out visitor: same read-only treatment. Empty storageState since
+    //    browser.newContext() otherwise reuses the worker's session.
+    const guestContext = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    const guestPage = await guestContext.newPage();
+    await guestPage.goto(proposalUrl);
+    await expect(
+      guestPage.getByRole('heading', { name: 'Reactable Proposal' }),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(guestPage.getByText(commentText)).toBeVisible();
+    await expect(guestPage.getByText(likeBadge)).toBeVisible();
+    await expect(
+      guestPage.getByRole(addReactionButton.role, {
+        name: addReactionButton.name,
+      }),
+    ).toHaveCount(0);
+    await guestContext.close();
   });
 });

--- a/tests/e2e/tests/proposal-view.spec.ts
+++ b/tests/e2e/tests/proposal-view.spec.ts
@@ -678,7 +678,7 @@ test.describe('Proposal View', () => {
     ).toBeVisible({ timeout: 30_000 });
   });
 
-  test('shows reactions read-only to anonymous and logged-out viewers', async ({
+  test('hides write actions (reactions, like, follow) from anonymous and logged-out viewers', async ({
     authenticatedPage,
     org,
     browser,
@@ -728,10 +728,10 @@ test.describe('Proposal View', () => {
     const likeBadge = /👍\s*1/;
 
     // Every viewer sees the proposal, the comment, and the seeded like; only a
-    // signed-in member gets the add-reaction control.
-    const expectReactionView = async (
+    // signed-in member gets the write controls (add-reaction, Like, Follow).
+    const expectProposalView = async (
       page: Page,
-      { canReact }: { canReact: boolean },
+      { canInteract }: { canInteract: boolean },
     ) => {
       await page.goto(proposalUrl);
       await expect(
@@ -739,9 +739,15 @@ test.describe('Proposal View', () => {
       ).toBeVisible({ timeout: 30_000 });
       await expect(page.getByText(commentText)).toBeVisible();
       await expect(page.getByText(likeBadge)).toBeVisible();
-      await expect(
+
+      const writeControls = [
         page.getByRole('button', { name: 'Add reaction' }),
-      ).toHaveCount(canReact ? 1 : 0);
+        page.getByRole('button', { name: 'Like', exact: true }),
+        page.getByRole('button', { name: 'Follow', exact: true }),
+      ];
+      for (const control of writeControls) {
+        await expect(control).toHaveCount(canInteract ? 1 : 0);
+      }
     };
 
     // A clean context so the worker's auth doesn't leak in via newContext().
@@ -756,16 +762,16 @@ test.describe('Proposal View', () => {
       }
     };
 
-    // 1) Signed-in member: read-write (add-reaction control present).
-    await expectReactionView(authenticatedPage, { canReact: true });
+    // 1) Signed-in member: write controls present.
+    await expectProposalView(authenticatedPage, { canInteract: true });
 
     // 2) Anonymous account and 3) logged-out visitor: read-only.
     await withCleanPage(async (page) => {
       await authenticateAnonymously(page);
-      await expectReactionView(page, { canReact: false });
+      await expectProposalView(page, { canInteract: false });
     });
     await withCleanPage((page) =>
-      expectReactionView(page, { canReact: false }),
+      expectProposalView(page, { canInteract: false }),
     );
   });
 });


### PR DESCRIPTION
Anonymous accounts and logged-out visitors can see reaction counts on public proposal and decision surfaces but can't react — the add/toggle picker is hidden so the UI never offers an action the API rejects. Gates on a signed-in member (currentProfile present, not anonymous), matching the comment-gating predicate. Includes an e2e test covering member / anonymous / no-session viewers and a reusable makeDecisionPublic test helper. Attachments and edits handled separately.