### PR TITLE
fix(api): open attachment and translation procedures to anonymous callers

### DIFF
--- a/packages/common/src/services/translation/translateDecision.ts
+++ b/packages/common/src/services/translation/translateDecision.ts
@@ -35,7 +35,7 @@ export async function translateDecision({
 }: {
   decisionProfileId: string;
   targetLocale: SupportedLocale;
-  user: User;
+  user: User | undefined;
 }): Promise<DecisionTranslationResult> {
   const instances = await db
     .select({

--- a/packages/common/src/services/translation/translateProposal.ts
+++ b/packages/common/src/services/translation/translateProposal.ts
@@ -26,7 +26,7 @@ export async function translateProposal({
 }: {
   profileId: string;
   targetLocale: SupportedLocale;
-  user: User;
+  user: User | undefined;
 }): Promise<{
   translated: ProposalTranslation;
   sourceLocale: string;

--- a/packages/common/src/services/translation/translateProposals.ts
+++ b/packages/common/src/services/translation/translateProposals.ts
@@ -28,7 +28,7 @@ export async function translateProposals({
 }: {
   profileIds: string[];
   targetLocale: SupportedLocale;
-  user: User;
+  user: User | undefined;
 }): Promise<{
   translations: Record<string, ProposalTranslation>;
   sourceLocale: string;
@@ -92,7 +92,7 @@ export async function translateProposals({
     [...uniqueProcesses.values()].map(async (instance) => {
       // Assert the user has decisions:READ on each unique process instance
       await assertInstanceProfileAccess({
-        user: { id: user.id },
+        user: user ? { id: user.id } : undefined,
         instance,
         profilePermissions: [
           { decisions: permission.READ },

--- a/services/api/src/routers/decision/deleteProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/deleteProposalAttachment.test.ts
@@ -5,9 +5,10 @@ import { appRouter } from '..';
 import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
 import {
   accessTierGatingCell,
-  describeDecisionAccessTierGating,
+  describeAccessTierGating,
   expectFailsAccessTierGate,
-} from '../../test/helpers/gating/decision';
+  expectPassesAccessTierGate,
+} from '../../test/helpers/gating';
 import {
   createIsolatedSession,
   createTestContextWithSession,
@@ -207,9 +208,9 @@ describe.concurrent('deleteProposalAttachment', () => {
   });
 });
 
-describeDecisionAccessTierGating('deleteProposalAttachment', {
-  noJwtNonPublic: accessTierGatingCell(
-    'rejects no-JWT caller on non-public instance',
+describeAccessTierGating('deleteProposalAttachment', {
+  noJwt: accessTierGatingCell(
+    'rejects no-JWT caller',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -247,8 +248,8 @@ describeDecisionAccessTierGating('deleteProposalAttachment', {
     },
   ),
 
-  anonJwtNonPublic: accessTierGatingCell(
-    'rejects anon-JWT caller on non-public instance',
+  anonJwt: accessTierGatingCell(
+    'admits anon-JWT past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -262,7 +263,7 @@ describeDecisionAccessTierGating('deleteProposalAttachment', {
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
-        proposalData: { title: 'anon should bounce' },
+        proposalData: { title: 'anon gets past the gate' },
       });
 
       const ownerCaller = await createAuthenticatedCaller(setup.userEmail);
@@ -275,18 +276,17 @@ describeDecisionAccessTierGating('deleteProposalAttachment', {
 
       const caller = await callers.anonJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.deleteProposalAttachment({
           attachmentId: uploadResult.id,
           proposalId: proposal.id,
         }),
-        'anon',
       );
     },
   ),
 
-  userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+  userJwt: accessTierGatingCell(
+    'admits out-of-network user-JWT past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -300,31 +300,30 @@ describeDecisionAccessTierGating('deleteProposalAttachment', {
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
-        proposalData: { title: 'anon should bounce' },
+        proposalData: { title: 'out-of-network user gets past the gate' },
       });
 
       const ownerCaller = await createAuthenticatedCaller(setup.userEmail);
       const uploadResult = await ownerCaller.decision.uploadProposalAttachment({
         file: VALID_PNG_BASE64,
-        fileName: 'anon-target.png',
+        fileName: 'user-target.png',
         mimeType: 'image/png',
         proposalId: proposal.id,
       });
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.deleteProposalAttachment({
           attachmentId: uploadResult.id,
           proposalId: proposal.id,
         }),
-        'user',
       );
     },
   ),
 
-  networkJwtNonPublic: accessTierGatingCell(
-    'admits network-JWT caller on non-public instance',
+  networkJwt: accessTierGatingCell(
+    'admits network-JWT caller',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({

--- a/services/api/src/routers/decision/deleteProposalAttachment.ts
+++ b/services/api/src/routers/decision/deleteProposalAttachment.ts
@@ -1,10 +1,10 @@
 import { deleteProposalAttachment as deleteProposalAttachmentService } from '@op/common';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedProcedure, router } from '../../trpcFactory';
 
 export const deleteProposalAttachment = router({
-  deleteProposalAttachment: networkAuthenticatedProcedure({
+  deleteProposalAttachment: authenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(

--- a/services/api/src/routers/decision/uploadProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.test.ts
@@ -5,9 +5,10 @@ import { appRouter } from '..';
 import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
 import {
   accessTierGatingCell,
-  describeDecisionAccessTierGating,
+  describeAccessTierGating,
   expectFailsAccessTierGate,
-} from '../../test/helpers/gating/decision';
+  expectPassesAccessTierGate,
+} from '../../test/helpers/gating';
 import {
   createIsolatedSession,
   createTestContextWithSession,
@@ -180,9 +181,9 @@ describe.concurrent('uploadProposalAttachment', () => {
   });
 });
 
-describeDecisionAccessTierGating('uploadProposalAttachment', {
-  noJwtNonPublic: accessTierGatingCell(
-    'rejects no-JWT caller on non-public instance',
+describeAccessTierGating('uploadProposalAttachment', {
+  noJwt: accessTierGatingCell(
+    'rejects no-JWT caller',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -213,8 +214,8 @@ describeDecisionAccessTierGating('uploadProposalAttachment', {
     },
   ),
 
-  anonJwtNonPublic: accessTierGatingCell(
-    'rejects anon-JWT caller on non-public instance',
+  anonJwt: accessTierGatingCell(
+    'admits anon-JWT past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -228,25 +229,24 @@ describeDecisionAccessTierGating('uploadProposalAttachment', {
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
-        proposalData: { title: 'anon should bounce' },
+        proposalData: { title: 'anon gets past the gate' },
       });
 
       const caller = await callers.anonJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.uploadProposalAttachment({
           file: VALID_PNG_BASE64,
           fileName: 'anon.png',
           mimeType: 'image/png',
           proposalId: proposal.id,
         }),
-        'anon',
       );
     },
   ),
 
-  userJwtNonPublic: accessTierGatingCell(
-    'rejects user-JWT caller on non-public instance',
+  userJwt: accessTierGatingCell(
+    'admits out-of-network user-JWT past the tier gate',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({
@@ -260,25 +260,24 @@ describeDecisionAccessTierGating('uploadProposalAttachment', {
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
-        proposalData: { title: 'anon should bounce' },
+        proposalData: { title: 'out-of-network user gets past the gate' },
       });
 
       const caller = await callers.userJwt();
 
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.decision.uploadProposalAttachment({
           file: VALID_PNG_BASE64,
-          fileName: 'anon.png',
+          fileName: 'user.png',
           mimeType: 'image/png',
           proposalId: proposal.id,
         }),
-        'user',
       );
     },
   ),
 
-  networkJwtNonPublic: accessTierGatingCell(
-    'admits network-JWT caller on non-public instance',
+  networkJwt: accessTierGatingCell(
+    'admits network-JWT caller',
     async ({ task, onTestFinished, callers }) => {
       const testData = new TestDecisionsDataManager(task.id, onTestFinished);
       const setup = await testData.createDecisionSetup({

--- a/services/api/src/routers/decision/uploadProposalAttachment.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.ts
@@ -7,7 +7,7 @@ import { createServerClient } from '@op/supabase/lib';
 import { Buffer } from 'node:buffer';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { authenticatedProcedure, router } from '../../trpcFactory';
 import { MAX_FILE_SIZE, sanitizeS3Filename } from '../../utils';
 
 const ALLOWED_MIME_TYPES = [
@@ -22,7 +22,7 @@ const ALLOWED_MIME_TYPES = [
 ];
 
 export const uploadProposalAttachment = router({
-  uploadProposalAttachment: networkAuthenticatedProcedure({
+  uploadProposalAttachment: authenticatedProcedure({
     rateLimit: { windowSize: 10, maxRequests: 20 },
   })
     .input(

--- a/services/api/src/routers/translation/translateDecision.test.ts
+++ b/services/api/src/routers/translation/translateDecision.test.ts
@@ -9,7 +9,6 @@ import { TestTranslationDataManager } from '../../test/helpers/TestTranslationDa
 import {
   accessTierGatingCell,
   describeAccessTierGating,
-  expectFailsAccessTierGate,
   expectPassesAccessTierGate,
 } from '../../test/helpers/gating';
 import {
@@ -44,42 +43,44 @@ async function createAuthenticatedCaller(email: string) {
   return createCaller(await createTestContextWithSession(session));
 }
 
+// openProcedure admits every tier past the gate; service-layer fail-closed is
+// covered by the describe block below.
 describeAccessTierGating('translation.translateDecision', {
-  noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {
-    const caller = await callers.noJwt();
-    await expectFailsAccessTierGate(
-      caller.translation.translateDecision({
-        decisionProfileId: '00000000-0000-0000-0000-000000000000',
-        targetLocale: 'en',
-      }),
-      'none',
-    );
-  }),
-
-  anonJwt: accessTierGatingCell(
-    'rejects anon-JWT caller',
+  noJwt: accessTierGatingCell(
+    'admits no-JWT caller past the tier gate',
     async ({ callers }) => {
-      const caller = await callers.anonJwt();
-      await expectFailsAccessTierGate(
+      const caller = await callers.noJwt();
+      await expectPassesAccessTierGate(
         caller.translation.translateDecision({
           decisionProfileId: '00000000-0000-0000-0000-000000000000',
           targetLocale: 'en',
         }),
-        'anon',
+      );
+    },
+  ),
+
+  anonJwt: accessTierGatingCell(
+    'admits anon-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.anonJwt();
+      await expectPassesAccessTierGate(
+        caller.translation.translateDecision({
+          decisionProfileId: '00000000-0000-0000-0000-000000000000',
+          targetLocale: 'en',
+        }),
       );
     },
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits out-of-network user-JWT caller past the tier gate',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.translation.translateDecision({
           decisionProfileId: '00000000-0000-0000-0000-000000000000',
           targetLocale: 'en',
         }),
-        'user',
       );
     },
   ),
@@ -385,6 +386,112 @@ describe('translation.translateDecision', () => {
         targetLocale: 'es',
       }),
     ).rejects.toThrow();
+  });
+
+  it('should let a no-JWT visitor translate a public decision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Give the decision some translatable content.
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instance.instance.id },
+    });
+    if (!instanceRecord) {
+      throw new Error('Instance record not found');
+    }
+
+    const instanceData = instanceRecord.instanceData as Record<string, unknown>;
+    const phases = instanceData.phases as Array<Record<string, unknown>>;
+    phases[0] = { ...phases[0], headline: 'Public Headline' };
+
+    await db
+      .update(processInstances)
+      .set({ instanceData: { ...instanceData, phases } })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    // Open the decision to visitors: GLOBAL_USER_PUBLIC gets the Public role
+    // (decisions READ), which a no-JWT caller resolves to via the sentinel.
+    await testData.makeDecisionPublic(instance.profileId);
+
+    onTestFinished(async () => {
+      await db
+        .delete(contentTranslations)
+        .where(
+          like(
+            contentTranslations.contentKey,
+            `decision:${instance.profileId}:%`,
+          ),
+        );
+    });
+
+    const visitorCaller = createCaller(
+      await createTestContextWithSession(null),
+    );
+
+    const result = await visitorCaller.translation.translateDecision({
+      decisionProfileId: instance.profileId,
+      targetLocale: 'es',
+    });
+
+    expect(result.targetLocale).toBe('es');
+    expect(result.headline).toBe('[ES] Public Headline');
+  });
+
+  it('should reject a logged-out caller without decisions:READ on the decision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Clean up any cache entries written before auth fails (runTranslateBatch
+    // runs in parallel with the auth check and may write rows before rejection).
+    onTestFinished(async () => {
+      await db
+        .delete(contentTranslations)
+        .where(
+          like(
+            contentTranslations.contentKey,
+            `decision:${instance.profileId}:%`,
+          ),
+        );
+    });
+
+    // Past the gate, but the service must fail closed — the public sentinel
+    // has no decisions:READ grant on this decision.
+    const loggedOutCaller = createCaller(
+      await createTestContextWithSession(null),
+    );
+
+    await expect(
+      loggedOutCaller.translation.translateDecision({
+        decisionProfileId: instance.profileId,
+        targetLocale: 'es',
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
   });
 
   it('should throw UnauthorizedError for user without decision access', async ({

--- a/services/api/src/routers/translation/translateDecision.ts
+++ b/services/api/src/routers/translation/translateDecision.ts
@@ -1,7 +1,7 @@
 import { SUPPORTED_LOCALES, translateDecision } from '@op/common';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { openProcedure, router } from '../../trpcFactory';
 
 const translateDecisionOutput = z.object({
   headline: z.string().optional(),
@@ -14,7 +14,7 @@ const translateDecisionOutput = z.object({
 });
 
 export const translateDecisionRouter = router({
-  translateDecision: networkAuthenticatedProcedure()
+  translateDecision: openProcedure()
     .input(
       z.object({
         decisionProfileId: z.string().uuid(),

--- a/services/api/src/routers/translation/translateProposal.test.ts
+++ b/services/api/src/routers/translation/translateProposal.test.ts
@@ -1,6 +1,6 @@
 import { mockCollab } from '@op/collab/testing';
 import { db, eq } from '@op/db/client';
-import { contentTranslations, proposals } from '@op/db/schema';
+import { contentTranslations, ProposalStatus, proposals } from '@op/db/schema';
 import { like } from 'drizzle-orm';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -10,7 +10,6 @@ import { TestTranslationDataManager } from '../../test/helpers/TestTranslationDa
 import {
   accessTierGatingCell,
   describeAccessTierGating,
-  expectFailsAccessTierGate,
   expectPassesAccessTierGate,
 } from '../../test/helpers/gating';
 import {
@@ -45,42 +44,44 @@ async function createAuthenticatedCaller(email: string) {
   return createCaller(await createTestContextWithSession(session));
 }
 
+// openProcedure admits every tier past the gate; service-layer fail-closed is
+// covered by the describe block below.
 describeAccessTierGating('translation.translateProposal', {
-  noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {
-    const caller = await callers.noJwt();
-    await expectFailsAccessTierGate(
-      caller.translation.translateProposal({
-        profileId: '00000000-0000-0000-0000-000000000000',
-        targetLocale: 'en',
-      }),
-      'none',
-    );
-  }),
-
-  anonJwt: accessTierGatingCell(
-    'rejects anon-JWT caller',
+  noJwt: accessTierGatingCell(
+    'admits no-JWT caller past the tier gate',
     async ({ callers }) => {
-      const caller = await callers.anonJwt();
-      await expectFailsAccessTierGate(
+      const caller = await callers.noJwt();
+      await expectPassesAccessTierGate(
         caller.translation.translateProposal({
           profileId: '00000000-0000-0000-0000-000000000000',
           targetLocale: 'en',
         }),
-        'anon',
+      );
+    },
+  ),
+
+  anonJwt: accessTierGatingCell(
+    'admits anon-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.anonJwt();
+      await expectPassesAccessTierGate(
+        caller.translation.translateProposal({
+          profileId: '00000000-0000-0000-0000-000000000000',
+          targetLocale: 'en',
+        }),
       );
     },
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits out-of-network user-JWT caller past the tier gate',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.translation.translateProposal({
           profileId: '00000000-0000-0000-0000-000000000000',
           targetLocale: 'en',
         }),
-        'user',
       );
     },
   ),
@@ -102,6 +103,95 @@ describeAccessTierGating('translation.translateProposal', {
 describe('translation.translateProposal', () => {
   beforeEach(() => {
     mockTranslateText.mockClear();
+  });
+
+  it('should let a no-JWT visitor translate a proposal on a public decision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    // Submitted (not draft): a draft is visible only to proposal-level
+    // grantees, so a public visitor must read a submitted proposal.
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Public Garden Project' },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    // Open the decision to visitors: GLOBAL_USER_PUBLIC gets the Public role
+    // (decisions READ), which a no-JWT caller resolves to via the sentinel.
+    await testData.makeDecisionPublic(instance.profileId);
+
+    const proposalId = proposal.id;
+    onTestFinished(async () => {
+      await db
+        .delete(contentTranslations)
+        .where(
+          like(contentTranslations.contentKey, `proposal:${proposalId}:%`),
+        );
+    });
+
+    const visitorCaller = createCaller(
+      await createTestContextWithSession(null),
+    );
+
+    const result = await visitorCaller.translation.translateProposal({
+      profileId: proposal.profileId,
+      targetLocale: 'es',
+    });
+
+    expect(result.targetLocale).toBe('es');
+    expect(result.translated.title).toBe('[ES] Public Garden Project');
+  });
+
+  it('should reject a no-JWT visitor on a non-public proposal', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Private Proposal' },
+    });
+
+    // No make-public grant: GLOBAL_USER_PUBLIC has no decisions:READ on this
+    // decision, so the service must fail closed past the open tier gate.
+    const visitorCaller = createCaller(
+      await createTestContextWithSession(null),
+    );
+
+    await expect(
+      visitorCaller.translation.translateProposal({
+        profileId: proposal.profileId,
+        targetLocale: 'es',
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
   });
 
   it('should translate proposal title and body content', async ({

--- a/services/api/src/routers/translation/translateProposal.ts
+++ b/services/api/src/routers/translation/translateProposal.ts
@@ -1,7 +1,7 @@
 import { SUPPORTED_LOCALES, translateProposal } from '@op/common';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { openProcedure, router } from '../../trpcFactory';
 
 /**
  * Generic output schema for all translation endpoints.
@@ -14,7 +14,7 @@ export const translateOutput = z.object({
 });
 
 export const translateProposalRouter = router({
-  translateProposal: networkAuthenticatedProcedure()
+  translateProposal: openProcedure()
     .input(
       z.object({
         profileId: z.uuid(),

--- a/services/api/src/routers/translation/translateProposals.test.ts
+++ b/services/api/src/routers/translation/translateProposals.test.ts
@@ -10,7 +10,6 @@ import { TestTranslationDataManager } from '../../test/helpers/TestTranslationDa
 import {
   accessTierGatingCell,
   describeAccessTierGating,
-  expectFailsAccessTierGate,
   expectPassesAccessTierGate,
 } from '../../test/helpers/gating';
 import {
@@ -45,42 +44,44 @@ async function createAuthenticatedCaller(email: string) {
   return createCaller(await createTestContextWithSession(session));
 }
 
+// openProcedure admits every tier past the gate; service-layer fail-closed is
+// covered by the describe block below.
 describeAccessTierGating('translation.translateProposals', {
-  noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {
-    const caller = await callers.noJwt();
-    await expectFailsAccessTierGate(
-      caller.translation.translateProposals({
-        profileIds: ['00000000-0000-0000-0000-000000000000'],
-        targetLocale: 'en',
-      }),
-      'none',
-    );
-  }),
-
-  anonJwt: accessTierGatingCell(
-    'rejects anon-JWT caller',
+  noJwt: accessTierGatingCell(
+    'admits no-JWT caller past the tier gate',
     async ({ callers }) => {
-      const caller = await callers.anonJwt();
-      await expectFailsAccessTierGate(
+      const caller = await callers.noJwt();
+      await expectPassesAccessTierGate(
         caller.translation.translateProposals({
           profileIds: ['00000000-0000-0000-0000-000000000000'],
           targetLocale: 'en',
         }),
-        'anon',
+      );
+    },
+  ),
+
+  anonJwt: accessTierGatingCell(
+    'admits anon-JWT caller past the tier gate',
+    async ({ callers }) => {
+      const caller = await callers.anonJwt();
+      await expectPassesAccessTierGate(
+        caller.translation.translateProposals({
+          profileIds: ['00000000-0000-0000-0000-000000000000'],
+          targetLocale: 'en',
+        }),
       );
     },
   ),
 
   userJwt: accessTierGatingCell(
-    'rejects user-JWT caller',
+    'admits out-of-network user-JWT caller past the tier gate',
     async ({ callers }) => {
       const caller = await callers.userJwt();
-      await expectFailsAccessTierGate(
+      await expectPassesAccessTierGate(
         caller.translation.translateProposals({
           profileIds: ['00000000-0000-0000-0000-000000000000'],
           targetLocale: 'en',
         }),
-        'user',
       );
     },
   ),
@@ -102,6 +103,185 @@ describeAccessTierGating('translation.translateProposals', {
 describe('translation.translateProposals', () => {
   beforeEach(() => {
     mockTranslateText.mockClear();
+  });
+
+  it('should let a no-JWT visitor translate proposals on a public decision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Public Batch Proposal' },
+    });
+
+    const { collaborationDocId } = proposal.proposalData as {
+      collaborationDocId: string;
+    };
+    mockCollab.setDocResponse(collaborationDocId, {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Public preview body' }],
+        },
+      ],
+    });
+
+    // Open the decision to visitors: GLOBAL_USER_PUBLIC gets the Public role
+    // (decisions READ), which a no-JWT caller resolves to via the sentinel.
+    await testData.makeDecisionPublic(instance.profileId);
+
+    onTestFinished(async () => {
+      await db
+        .delete(contentTranslations)
+        .where(
+          like(contentTranslations.contentKey, `batch:${proposal.profileId}:%`),
+        );
+    });
+
+    const visitorCaller = createCaller(
+      await createTestContextWithSession(null),
+    );
+
+    const result = await visitorCaller.translation.translateProposals({
+      profileIds: [proposal.profileId],
+      targetLocale: 'es',
+    });
+
+    const t = result.translations[proposal.profileId];
+    expect(t?.title).toBe('[ES] Public Batch Proposal');
+  });
+
+  it('should reject a no-JWT visitor on non-public proposals', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const instance = setup.instances[0];
+    if (!instance) {
+      throw new Error('No instance created');
+    }
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Private Batch Proposal' },
+    });
+
+    onTestFinished(async () => {
+      await db
+        .delete(contentTranslations)
+        .where(
+          like(contentTranslations.contentKey, `batch:${proposal.profileId}:%`),
+        );
+    });
+
+    // No make-public grant: GLOBAL_USER_PUBLIC has no decisions:READ on this
+    // decision, so the service must fail closed past the open tier gate.
+    const visitorCaller = createCaller(
+      await createTestContextWithSession(null),
+    );
+
+    await expect(
+      visitorCaller.translation.translateProposals({
+        profileIds: [proposal.profileId],
+        targetLocale: 'es',
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
+  });
+
+  it('should fail closed when a batch spans a non-public decision', async ({
+    task,
+    onTestFinished,
+  }) => {
+    // Two independent decisions (separate processes) — translateProposals
+    // asserts once per unique processId, so the private one must be its own
+    // process, not a second instance of the public one.
+    const publicData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const privateData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const publicSetup = await publicData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const privateSetup = await privateData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const publicInstance = publicSetup.instances[0];
+    const privateInstance = privateSetup.instances[0];
+    if (!publicInstance || !privateInstance) {
+      throw new Error('Expected an instance in each setup');
+    }
+
+    const publicProposal = await publicData.createProposal({
+      userEmail: publicSetup.userEmail,
+      processInstanceId: publicInstance.instance.id,
+      proposalData: { title: 'Readable Proposal' },
+    });
+    const privateProposal = await privateData.createProposal({
+      userEmail: privateSetup.userEmail,
+      processInstanceId: privateInstance.instance.id,
+      proposalData: { title: 'Off-limits Proposal' },
+    });
+
+    // Only the first decision is public — the batch must still fail closed
+    // because the second decision's assert rejects the visitor.
+    await publicData.makeDecisionPublic(publicInstance.profileId);
+
+    onTestFinished(async () => {
+      await db
+        .delete(contentTranslations)
+        .where(
+          like(
+            contentTranslations.contentKey,
+            `batch:${publicProposal.profileId}:%`,
+          ),
+        );
+      await db
+        .delete(contentTranslations)
+        .where(
+          like(
+            contentTranslations.contentKey,
+            `batch:${privateProposal.profileId}:%`,
+          ),
+        );
+    });
+
+    const visitorCaller = createCaller(
+      await createTestContextWithSession(null),
+    );
+
+    await expect(
+      visitorCaller.translation.translateProposals({
+        profileIds: [publicProposal.profileId, privateProposal.profileId],
+        targetLocale: 'es',
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
   });
 
   it('should translate title and preview for multiple proposals', async ({

--- a/services/api/src/routers/translation/translateProposals.ts
+++ b/services/api/src/routers/translation/translateProposals.ts
@@ -1,10 +1,10 @@
 import { SUPPORTED_LOCALES, translateProposals } from '@op/common';
 import { z } from 'zod';
 
-import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { openProcedure, router } from '../../trpcFactory';
 
 export const translateProposalsRouter = router({
-  translateProposals: networkAuthenticatedProcedure()
+  translateProposals: openProcedure()
     .input(
       z.object({
         profileIds: z.array(z.uuid()).min(1).max(100),


### PR DESCRIPTION
fix(api): open proposal attachment endpoints to anonymous callers via authenticatedProcedure
fix(api): open translation procedures to anonymous/logged-out callers via openProcedure