### PR TITLE
refactor(api): add createDecisionSetup.instance accessor

### DIFF
--- a/services/api/src/access/assertProfileTypeAccess.test.ts
+++ b/services/api/src/access/assertProfileTypeAccess.test.ts
@@ -57,7 +57,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
         instanceCount: 1,
         grantAccess: true,
       });
-      const { profileId } = setup.instances[0]!;
+      const { profileId } = setup.instance;
 
       await expect(
         assertProfileTypeAccess({
@@ -116,7 +116,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
         instanceCount: 1,
         grantAccess: true,
       });
-      const { profileId } = setup.instances[0]!;
+      const { profileId } = setup.instance;
 
       await expect(
         assertProfileTypeAccess({
@@ -136,7 +136,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
         instanceCount: 1,
         grantAccess: false,
       });
-      const { profileId } = setup.instances[0]!;
+      const { profileId } = setup.instance;
       const member = await testData.createMemberUser({
         organization: setup.organization,
         instanceProfileIds: [profileId],
@@ -168,7 +168,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
         instanceCount: 1,
         grantAccess: false,
       });
-      const { profileId } = setup.instances[0]!;
+      const { profileId } = setup.instance;
 
       await expect(
         assertProfileTypeAccess({
@@ -192,7 +192,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
       });
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
-        processInstanceId: setup.instances[0]!.instance.id,
+        processInstanceId: setup.instance.instance.id,
         proposalData: { title: `Proposal ${task.id}` },
       });
 
@@ -216,7 +216,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
       });
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
-        processInstanceId: setup.instances[0]!.instance.id,
+        processInstanceId: setup.instance.instance.id,
         proposalData: { title: `Proposal ${task.id}` },
       });
       const other = await testData.createMemberUser({
@@ -286,7 +286,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
         instanceCount: 1,
         grantAccess: true,
       });
-      const { profileId: decisionProfileId } = setup.instances[0]!;
+      const { profileId: decisionProfileId } = setup.instance;
       const individualProfileId = await getIndividualProfileId(setup.user.id);
 
       await expect(
@@ -310,7 +310,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
         instanceCount: 1,
         grantAccess: false,
       });
-      const { profileId: decisionProfileId } = setup.instances[0]!;
+      const { profileId: decisionProfileId } = setup.instance;
       // Member gets decision READ but no admin; expect to fail when policy
       // requires decisions.ADMIN on the decision profile.
       const member = await testData.createMemberUser({
@@ -342,7 +342,7 @@ describe.concurrent('assertProfileTypeAccess', () => {
         instanceCount: 1,
         grantAccess: true,
       });
-      const { profileId: decisionProfileId } = setup.instances[0]!;
+      const { profileId: decisionProfileId } = setup.instance;
 
       // ORG profile would reject this user (no profileUser row), but ORG is
       // not gated by the policy → only the DECISION check runs.

--- a/services/api/src/routers/account/listUserInvites.test.ts
+++ b/services/api/src/routers/account/listUserInvites.test.ts
@@ -315,11 +315,7 @@ describe.concurrent('account.listUserInvites', () => {
       grantAccess: true,
     });
     const invitee = await inviteData.createStandaloneUser();
-    const instance = setup.instances[0];
-
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const [submitter] = await db
       .select({ profileId: users.profileId })

--- a/services/api/src/routers/decision/deleteProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/deleteProposalAttachment.test.ts
@@ -37,10 +37,7 @@ describe.concurrent('deleteProposalAttachment', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -94,10 +91,7 @@ describe.concurrent('deleteProposalAttachment', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -164,10 +158,7 @@ describe.concurrent('deleteProposalAttachment', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -216,10 +207,7 @@ describeDecisionAccessTierGating('deleteProposalAttachment', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -255,10 +243,7 @@ describeDecisionAccessTierGating('deleteProposalAttachment', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -293,10 +278,7 @@ describeDecisionAccessTierGating('deleteProposalAttachment', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -331,10 +313,7 @@ describeDecisionAccessTierGating('deleteProposalAttachment', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/instances/advancePhase.test.ts
+++ b/services/api/src/routers/decision/instances/advancePhase.test.ts
@@ -39,10 +39,7 @@ async function loadPublishedInstance(
     status: ProcessStatus.PUBLISHED,
   });
 
-  const instance = setup.instances[0];
-  if (!instance) {
-    throw new Error('No instance created');
-  }
+  const instance = setup.instance;
 
   const dbInstance = await db.query.processInstances.findFirst({
     where: { id: instance.instance.id },
@@ -185,10 +182,7 @@ describe.concurrent('advancePhase', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create + submit a proposal so it has a proposalHistory row
     const proposal = await testData.createProposal({

--- a/services/api/src/routers/decision/instances/decisionTransitionProposals.test.ts
+++ b/services/api/src/routers/decision/instances/decisionTransitionProposals.test.ts
@@ -46,8 +46,8 @@ describe.concurrent('decisionTransitionProposals constraints', () => {
       }),
     ]);
 
-    const instanceA = setupA.instances[0]!;
-    const instanceB = setupB.instances[0]!;
+    const instanceA = setupA.instance;
+    const instanceB = setupB.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setupB.userEmail,
@@ -86,7 +86,7 @@ describe.concurrent('decisionTransitionProposals constraints', () => {
       instanceCount: 1,
     });
 
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,

--- a/services/api/src/routers/decision/instances/deleteDecision.test.ts
+++ b/services/api/src/routers/decision/instances/deleteDecision.test.ts
@@ -34,10 +34,7 @@ describe.concurrent('deleteDecision', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -69,10 +66,7 @@ describe.concurrent('deleteDecision', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a second user and grant them admin access on the instance profile
     const adminUser = await testData.createMemberUser({
@@ -110,10 +104,7 @@ describe.concurrent('deleteDecision', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member user (non-admin) with access to the instance
     const memberUser = await testData.createMemberUser({
@@ -149,10 +140,7 @@ describe.concurrent('deleteDecision', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a completely separate user with no access
     const otherSetup = await testData.createDecisionSetup({
@@ -214,10 +202,7 @@ describeDecisionAccessTierGating('deleteDecision', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -236,10 +221,7 @@ describeDecisionAccessTierGating('deleteDecision', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -258,10 +240,7 @@ describeDecisionAccessTierGating('deleteDecision', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -279,10 +258,7 @@ describeDecisionAccessTierGating('deleteDecision', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/duplicateInstance.test.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.test.ts
@@ -555,10 +555,7 @@ describeDecisionAccessTierGating('duplicateInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -589,10 +586,7 @@ describeDecisionAccessTierGating('duplicateInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -623,10 +617,7 @@ describeDecisionAccessTierGating('duplicateInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -656,10 +647,7 @@ describeDecisionAccessTierGating('duplicateInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -87,7 +87,7 @@ async function createReviewInstance(
 
   return {
     setup,
-    instance: setup.instances[0]!,
+    instance: setup.instance,
     creatorProfileId: userRecord!.profileId!,
   };
 }

--- a/services/api/src/routers/decision/instances/getCategories.test.ts
+++ b/services/api/src/routers/decision/instances/getCategories.test.ts
@@ -133,10 +133,7 @@ describe.concurrent('getCategories permissions', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -158,10 +155,7 @@ describe.concurrent('getCategories permissions', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const memberUser = await testData.createMemberUser({
       organization: setup.organization,
@@ -188,10 +182,7 @@ describe.concurrent('getCategories permissions', () => {
       grantAccess: false,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // The admin user has org-level access (created the org) but no profile-level
     // access on the instance (grantAccess: false). The org fallback should allow access.
@@ -215,10 +206,7 @@ describe.concurrent('getCategories permissions', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member user with no instance profile access
     const outsiderUser = await testData.createMemberUser({
@@ -253,10 +241,7 @@ describe.concurrent('getCategories permissions', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member with org access but no instance profile access
     const memberUser = await testData.createMemberUser({
@@ -288,10 +273,7 @@ describe.concurrent('getCategories category matching', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Use unique labels per test to avoid (taxonomyId, termUri) unique constraint
     // collisions when tests run concurrently against the shared "proposal" taxonomy
@@ -347,10 +329,7 @@ describe.concurrent('getCategories category matching', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Only seed one matching term — "Water Access" exists but "Nonexistent" does not
     const { termRecords } = await seedProposalTaxonomy(
@@ -398,10 +377,7 @@ describe.concurrent('getCategories category matching', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Seed taxonomy so we can confirm it's not about missing taxonomy
     await seedProposalTaxonomy(['Digital Literacy'], onTestFinished);
@@ -428,10 +404,7 @@ describe.concurrent('getCategories category matching', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Seed taxonomy with terms that won't match our categories
     await seedProposalTaxonomy(['Urban Planning'], onTestFinished);
@@ -464,10 +437,7 @@ describe.concurrent('getCategories category matching', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // The termUri for "Health & Wellness" after conversion:
     // "health & wellness" -> "health--wellness" (& removed, spaces become -)
@@ -511,10 +481,7 @@ describeDecisionAccessTierGating('getCategories', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -534,10 +501,7 @@ describeDecisionAccessTierGating('getCategories', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -557,10 +521,7 @@ describeDecisionAccessTierGating('getCategories', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -580,10 +541,7 @@ describeDecisionAccessTierGating('getCategories', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlug.test.ts
@@ -33,7 +33,7 @@ describe.concurrent('getDecisionBySlug', () => {
       grantAccess: true,
     });
 
-    const { slug, profileId } = setup.instances[0]!;
+    const { slug, profileId } = setup.instance;
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.getDecisionBySlug({ slug });
@@ -58,7 +58,7 @@ describe.concurrent('getDecisionBySlug', () => {
       grantAccess: false,
     });
 
-    const { slug } = setup.instances[0]!;
+    const { slug } = setup.instance;
 
     // Create a different user who doesn't have access to the instance
     const otherUser = await testData.createMemberUser({
@@ -104,7 +104,7 @@ describe.concurrent('getDecisionBySlug', () => {
       grantAccess: true,
     });
 
-    const { slug } = setup.instances[0]!;
+    const { slug } = setup.instance;
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.getDecisionBySlug({ slug });
@@ -125,10 +125,7 @@ describe.concurrent('getDecisionBySlug', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const draftProposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -172,10 +169,7 @@ describeDecisionAccessTierGating('getDecisionBySlug', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -193,10 +187,7 @@ describeDecisionAccessTierGating('getDecisionBySlug', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -214,10 +205,7 @@ describeDecisionAccessTierGating('getDecisionBySlug', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -235,10 +223,7 @@ describeDecisionAccessTierGating('getDecisionBySlug', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/getInstance.test.ts
+++ b/services/api/src/routers/decision/instances/getInstance.test.ts
@@ -35,10 +35,7 @@ describe.concurrent('getInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
     const result = await caller.decision.getInstance({
@@ -61,10 +58,7 @@ describe.concurrent('getInstance', () => {
       grantAccess: false,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Member role has decisions.SUBMIT_PROPOSALS and decisions.VOTE but not admin
     const member = await testData.createMemberUser({
@@ -93,10 +87,7 @@ describe.concurrent('getInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Make the decision public per the runbook: GLOBAL_USER_PUBLIC holds a
     // Public role with a profile-scoped decisions READ+SUBMIT+VOTE override.
@@ -128,10 +119,7 @@ describe.concurrent('getInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // No make-public grant: GLOBAL_USER_PUBLIC has no access to this profile,
     // so a no-JWT visitor is denied (no submit access is ever surfaced).
@@ -173,10 +161,7 @@ describe.concurrent('getInstance', () => {
       grantAccess: false,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a user in a completely separate org — org-level fallback would grant READ
     // to members of the same org, so we must use a different org to test true unauthorized access
@@ -208,10 +193,7 @@ describe.concurrent('getInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const draftProposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -255,10 +237,7 @@ describeDecisionAccessTierGating('getInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -276,10 +255,7 @@ describeDecisionAccessTierGating('getInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -297,10 +273,7 @@ describeDecisionAccessTierGating('getInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -318,10 +291,7 @@ describeDecisionAccessTierGating('getInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 
@@ -341,10 +311,7 @@ describeDecisionAccessTierGating('getLegacyInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -363,10 +330,7 @@ describeDecisionAccessTierGating('getLegacyInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -385,10 +349,7 @@ describeDecisionAccessTierGating('getLegacyInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -407,10 +368,7 @@ describeDecisionAccessTierGating('getLegacyInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
+++ b/services/api/src/routers/decision/instances/getProposalsForPhase.test.ts
@@ -29,7 +29,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     const [p1, p2] = await Promise.all([
@@ -65,7 +65,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     // Create and submit 3 proposals; pipeline limits to 2
@@ -99,7 +99,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     const [p1, p2] = await Promise.all([
@@ -139,7 +139,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     // Create and submit 3 proposals; pipeline limits to 2
@@ -177,7 +177,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
 
     const result = await getProposalsForPhase({
       instanceId,
@@ -197,7 +197,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     const [p1, p2] = await Promise.all([
@@ -244,7 +244,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     // Create one submitted proposal and one draft (not submitted)
@@ -277,7 +277,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     const p1 = await testData.createProposal({
@@ -319,7 +319,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     const submissionPhaseProposal = await testData.createProposal({
@@ -375,7 +375,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     // Create 3 proposals in submission; pipeline will shortlist 2.
@@ -430,7 +430,7 @@ describe.concurrent('getProposalsForPhase', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     const [p1, p2] = await Promise.all([

--- a/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
+++ b/services/api/src/routers/decision/instances/listDecisionProfiles.test.ts
@@ -278,10 +278,7 @@ describe.concurrent('listDecisionProfiles', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const draftProposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -371,9 +368,9 @@ describe.concurrent('listDecisionProfiles', () => {
     // Main user should only see the profile they have access to
     expect(result.items).toMatchObject([
       {
-        id: setup.instances[0]?.profileId,
+        id: setup.instance.profileId,
         processInstance: {
-          id: setup.instances[0]?.instance.id,
+          id: setup.instance.instance.id,
         },
       },
     ]);

--- a/services/api/src/routers/decision/instances/listProposalSubmitters.test.ts
+++ b/services/api/src/routers/decision/instances/listProposalSubmitters.test.ts
@@ -64,7 +64,7 @@ describe.concurrent('listProposalSubmitters', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -101,7 +101,7 @@ describe.concurrent('listProposalSubmitters', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -135,7 +135,7 @@ describe.concurrent('listProposalSubmitters', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -196,7 +196,7 @@ describe.concurrent('listProposalSubmitters', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const proposal = await testData.createProposal({
@@ -251,7 +251,7 @@ describe.concurrent('listProposalSubmitters', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     // Owner submits but has no avatar → counted, never a face.
@@ -307,10 +307,7 @@ describeDecisionAccessTierGating('listProposalSubmitters', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -330,10 +327,7 @@ describeDecisionAccessTierGating('listProposalSubmitters', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -353,10 +347,7 @@ describeDecisionAccessTierGating('listProposalSubmitters', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -376,10 +367,7 @@ describeDecisionAccessTierGating('listProposalSubmitters', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/listSelectionCandidates.test.ts
+++ b/services/api/src/routers/decision/instances/listSelectionCandidates.test.ts
@@ -43,10 +43,7 @@ async function seedInstance(testData: TestDecisionsDataManager): Promise<{
     instanceCount: 1,
     status: ProcessStatus.PUBLISHED,
   });
-  const instance = setup.instances[0];
-  if (!instance) {
-    throw new Error('No instance created');
-  }
+  const instance = setup.instance;
   const caller = await createAuthenticatedCaller(setup.userEmail);
   return {
     instanceId: instance.instance.id,
@@ -353,10 +350,7 @@ describe.concurrent('listSelectionCandidates', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const otherInstance = otherSetup.instances[0];
-    if (!otherInstance) {
-      throw new Error('No other instance created');
-    }
+    const otherInstance = otherSetup.instance;
 
     const proposal = await testData.createProposal({
       userEmail,
@@ -426,10 +420,7 @@ describeDecisionAccessTierGating('listSelectionCandidates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -451,10 +442,7 @@ describeDecisionAccessTierGating('listSelectionCandidates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -476,10 +464,7 @@ describeDecisionAccessTierGating('listSelectionCandidates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -501,10 +486,7 @@ describeDecisionAccessTierGating('listSelectionCandidates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/submitManualSelection.test.ts
+++ b/services/api/src/routers/decision/instances/submitManualSelection.test.ts
@@ -47,10 +47,7 @@ async function seedInstance(
     instanceCount: 1,
     status: ProcessStatus.PUBLISHED,
   });
-  const instance = setup.instances[0];
-  if (!instance) {
-    throw new Error('No instance created');
-  }
+  const instance = setup.instance;
   const caller = await createAuthenticatedCaller(setup.userEmail);
   return {
     instanceId: instance.instance.id,
@@ -683,10 +680,7 @@ describeDecisionAccessTierGating('submitManualSelection', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -708,10 +702,7 @@ describeDecisionAccessTierGating('submitManualSelection', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -733,10 +724,7 @@ describeDecisionAccessTierGating('submitManualSelection', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -757,10 +745,7 @@ describeDecisionAccessTierGating('submitManualSelection', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
+++ b/services/api/src/routers/decision/instances/transitionFromPhase.test.ts
@@ -41,10 +41,7 @@ async function createPublishedInstance(testData: TestDecisionsDataManager) {
     status: ProcessStatus.PUBLISHED,
   });
 
-  const instance = setup.instances[0];
-  if (!instance) {
-    throw new Error('No instance created');
-  }
+  const instance = setup.instance;
 
   return { setup, instance };
 }
@@ -131,10 +128,7 @@ describe('transitionFromPhase', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Instance is DRAFT by default — do not publish
     const caller = await createAuthenticatedCaller(setup.userEmail);
@@ -448,10 +442,7 @@ describeDecisionAccessTierGating('transitionFromPhase', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -472,10 +463,7 @@ describeDecisionAccessTierGating('transitionFromPhase', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -496,10 +484,7 @@ describeDecisionAccessTierGating('transitionFromPhase', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -519,10 +504,7 @@ describeDecisionAccessTierGating('transitionFromPhase', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
+++ b/services/api/src/routers/decision/instances/transitionPipelineProposals.test.ts
@@ -28,7 +28,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     // Create and submit 3 proposals (submitted proposals are eligible for transition)
@@ -77,7 +77,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     // Submit 4 proposals; first pipeline limits to 3, second limits to 2
@@ -140,7 +140,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     // Create and submit 3 proposals (submitted proposals are eligible for transition)
@@ -188,7 +188,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     for (let i = 1; i <= 3; i++) {
@@ -252,7 +252,7 @@ describe.concurrent('Transition pipeline: join table population', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     await testData.createProposal({

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -36,10 +36,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -64,10 +61,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -100,10 +94,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -134,10 +125,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -169,10 +157,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -196,10 +181,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -222,10 +204,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -255,10 +234,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -303,10 +279,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -340,10 +313,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -390,10 +360,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -427,10 +394,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Plant a corrupt overview shape (body is neither an HTML string nor a
     // JSON doc — here a number) directly in the database. Both string and
@@ -474,10 +438,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -526,10 +487,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -571,10 +529,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member user (non-admin)
     const memberUser = await testData.createMemberUser({
@@ -640,10 +595,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -667,10 +619,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -721,10 +670,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -765,10 +711,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -806,10 +749,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -932,10 +872,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -974,10 +911,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -1026,10 +960,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -1062,10 +993,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member user and grant them admin access on the decision profile
     // (skip instanceProfileIds to avoid duplicate profileUsers rows)
@@ -1103,10 +1031,7 @@ describe.concurrent('updateDecisionInstance', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member user and grant them admin access on the decision profile
     // (skip instanceProfileIds to avoid duplicate profileUsers rows)
@@ -1142,10 +1067,7 @@ describeDecisionAccessTierGating('updateDecisionInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -1167,10 +1089,7 @@ describeDecisionAccessTierGating('updateDecisionInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -1192,10 +1111,7 @@ describeDecisionAccessTierGating('updateDecisionInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -1216,10 +1132,7 @@ describeDecisionAccessTierGating('updateDecisionInstance', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/instances/voteDataAggregator.test.ts
+++ b/services/api/src/routers/decision/instances/voteDataAggregator.test.ts
@@ -22,7 +22,7 @@ describe.concurrent('aggregateProposalMetrics', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
 
     const proposal = await testData.createProposal({

--- a/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
+++ b/services/api/src/routers/decision/proposals/acceptProposalInvite.test.ts
@@ -37,10 +37,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -121,10 +118,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -202,10 +196,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -300,10 +291,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -378,10 +366,7 @@ describe.concurrent('decision.acceptProposalInvite', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -430,10 +415,7 @@ describeDecisionAccessTierGating('acceptProposalInvite', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -457,10 +439,7 @@ describeDecisionAccessTierGating('acceptProposalInvite', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -484,10 +463,7 @@ describeDecisionAccessTierGating('acceptProposalInvite', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -516,10 +492,7 @@ describeDecisionAccessTierGating('acceptProposalInvite', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/proposals/create.test.ts
+++ b/services/api/src/routers/decision/proposals/create.test.ts
@@ -19,10 +19,7 @@ describeDecisionAccessTierGating('createProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -45,10 +42,7 @@ describeDecisionAccessTierGating('createProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -70,10 +64,7 @@ describeDecisionAccessTierGating('createProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -95,10 +86,7 @@ describeDecisionAccessTierGating('createProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/proposals/delete.test.ts
+++ b/services/api/src/routers/decision/proposals/delete.test.ts
@@ -17,10 +17,7 @@ describeDecisionAccessTierGating('deleteProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -44,10 +41,7 @@ describeDecisionAccessTierGating('deleteProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -70,10 +64,7 @@ describeDecisionAccessTierGating('deleteProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -96,10 +87,7 @@ describeDecisionAccessTierGating('deleteProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/proposals/export.test.ts
+++ b/services/api/src/routers/decision/proposals/export.test.ts
@@ -16,10 +16,7 @@ describeDecisionAccessTierGating('export', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -42,10 +39,7 @@ describeDecisionAccessTierGating('export', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -68,10 +62,7 @@ describeDecisionAccessTierGating('export', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -94,10 +85,7 @@ describeDecisionAccessTierGating('export', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/proposals/get.test.ts
+++ b/services/api/src/routers/decision/proposals/get.test.ts
@@ -48,10 +48,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposalData = {
       title: 'Community Garden Project',
@@ -94,10 +91,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -125,10 +119,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create two non-admin members in parallel
     const [memberA, memberB] = await Promise.all([
@@ -178,10 +169,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who will submit a proposal
     const submitter = await testData.createMemberUser({
@@ -235,10 +223,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -274,10 +259,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who will submit a proposal and admin caller in parallel
     const [submitter, adminCaller] = await Promise.all([
@@ -321,10 +303,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Submitter creates the proposal; another member tries to fetch it once hidden
     const [submitter, otherMember, adminCaller] = await Promise.all([
@@ -371,10 +350,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Submitter, a separate collaborator, and the org admin caller
     const [submitter, collaborator, adminCaller] = await Promise.all([
@@ -445,10 +421,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposal first to get the API-generated collaborationDocId
     const proposal = await testData.createProposal({
@@ -502,10 +475,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // 404 is the default behavior when docId not in docResponses
 
@@ -544,10 +514,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const latestContent = {
       type: 'doc',
@@ -652,7 +619,7 @@ describe.concurrent('getProposal', () => {
       },
     });
 
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -738,10 +705,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const latestContent = {
       type: 'doc',
@@ -815,10 +779,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposal first
     const proposal = await testData.createProposal({
@@ -902,10 +863,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // 1. Generate the legacy cowop process_schema using the actual schema function.
     //    Budget is { type: 'number' }, no x-field-order — matching production.
@@ -1000,10 +958,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Generate the legacy horizon process_schema using the actual schema function.
     // Horizon: no categories, budget not required.
@@ -1088,10 +1043,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Generate the legacy simple process_schema using the actual schema function.
     // Simple: has categories, budget required.
@@ -1183,10 +1135,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -1234,7 +1183,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: false,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -1266,7 +1215,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: false,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -1310,7 +1259,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: false,
     });
 
-    const { instance, profileId } = setup.instances[0]!;
+    const { instance, profileId } = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -1360,7 +1309,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: false,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -1397,10 +1346,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a proposal
     const proposal = await testData.createProposal({
@@ -1461,10 +1407,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who submits a draft proposal
     const submitter = await testData.createMemberUser({
@@ -1508,10 +1451,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create two members: one submits a draft, the other tries to view it
     const [submitter, viewer] = await Promise.all([
@@ -1552,10 +1492,7 @@ describe.concurrent('getProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create two members
     const [submitter, viewer] = await Promise.all([
@@ -1602,10 +1539,7 @@ describeDecisionAccessTierGating('getProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -1628,10 +1562,7 @@ describeDecisionAccessTierGating('getProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -1654,10 +1585,7 @@ describeDecisionAccessTierGating('getProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -1680,10 +1608,7 @@ describeDecisionAccessTierGating('getProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/proposals/getLatestSelection.test.ts
+++ b/services/api/src/routers/decision/proposals/getLatestSelection.test.ts
@@ -38,7 +38,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
@@ -65,7 +65,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
@@ -122,7 +122,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const [picked, skipped] = await Promise.all([
       testData.createProposal({
         userEmail: setup.userEmail,
@@ -173,7 +173,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
@@ -221,7 +221,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
@@ -268,7 +268,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
@@ -336,7 +336,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const [keeper, dropped] = await Promise.all([
       testData.createProposal({
         userEmail: setup.userEmail,
@@ -439,7 +439,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
@@ -473,7 +473,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
@@ -526,7 +526,7 @@ describe.concurrent('getLatestSelectionForProposal', () => {
       grantAccess: true,
     });
 
-    const { instance, profileId } = setup.instances[0]!;
+    const { instance, profileId } = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.id,
@@ -584,10 +584,7 @@ describeDecisionAccessTierGating('getLatestSelectionForProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -612,10 +609,7 @@ describeDecisionAccessTierGating('getLatestSelectionForProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -640,10 +634,7 @@ describeDecisionAccessTierGating('getLatestSelectionForProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -668,10 +659,7 @@ describeDecisionAccessTierGating('getLatestSelectionForProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
+++ b/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
@@ -318,10 +318,7 @@ describeDecisionAccessTierGating('getProposalWithReviewAggregates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -348,10 +345,7 @@ describeDecisionAccessTierGating('getProposalWithReviewAggregates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -378,10 +372,7 @@ describeDecisionAccessTierGating('getProposalWithReviewAggregates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -408,10 +399,7 @@ describeDecisionAccessTierGating('getProposalWithReviewAggregates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -53,10 +53,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create multiple proposals and caller in parallel
     const [proposal1, proposal2, caller] = await Promise.all([
@@ -100,10 +97,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who will submit a proposal
     const memberUser = await testData.createMemberUser({
@@ -139,10 +133,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposal and non-admin member in parallel
     const [, memberUser] = await Promise.all([
@@ -177,10 +168,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who will submit a proposal
     const submitter = await testData.createMemberUser({
@@ -217,10 +205,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create visible and hidden proposals, admin caller, and non-admin member in parallel
     const [visibleProposal, hiddenProposal, adminCaller, memberUser] =
@@ -280,10 +265,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who will submit proposals
     const memberUser = await testData.createMemberUser({
@@ -342,10 +324,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who will submit a proposal and admin caller in parallel
     const [submitter, adminCaller] = await Promise.all([
@@ -390,10 +369,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const [submitter, collaborator, adminCaller] = await Promise.all([
       testData.createMemberUser({
@@ -470,10 +446,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create 3 proposals and caller in parallel
     const [, , , caller] = await Promise.all([
@@ -534,10 +507,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposals with different data formats in parallel
     const [newFormatProposal, legacyProposal, caller] = await Promise.all([
@@ -596,10 +566,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -623,10 +590,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a proposal
     await testData.createProposal({
@@ -675,10 +639,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const htmlDescription = '<p>This is <strong>rich</strong> content</p>';
 
@@ -716,10 +677,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposal first to get the API-generated collaborationDocId
     const proposal = await testData.createProposal({
@@ -773,10 +731,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Mock returns 404 by default for unknown docIds (no explicit setup needed)
 
@@ -812,10 +767,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposals first to get API-generated collaborationDocIds
     const [proposal1, proposal2] = await Promise.all([
@@ -888,10 +840,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposals first (collab and empty both get API-generated docIds)
     const [collabProposal, legacyProposal, emptyProposal] = await Promise.all([
@@ -979,10 +928,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // 1. Set legacy cowop process_schema on the decision process
     const cowopProcessSchema = cowopSchema({
@@ -1104,10 +1050,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposals via API (new schema — gets collaborationDocId)
     const [newSchemaProposal, legacyProposal] = await Promise.all([
@@ -1206,10 +1149,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who creates a draft proposal and a collaborator
     const [creator, collaborator] = await Promise.all([
@@ -1276,10 +1216,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who creates a draft proposal
     const member = await testData.createMemberUser({
@@ -1318,10 +1255,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create two members
     const [memberA, memberB] = await Promise.all([
@@ -1362,10 +1296,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who submits a proposal
     const submitter = await testData.createMemberUser({
@@ -1414,10 +1345,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who submits a proposal
     const submitter = await testData.createMemberUser({
@@ -1459,10 +1387,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a member who creates a draft proposal
     const creator = await testData.createMemberUser({
@@ -1514,10 +1439,7 @@ describe.concurrent('listProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create two members
     const [memberA, memberB] = await Promise.all([
@@ -1625,7 +1547,7 @@ describe.concurrent('listProposals', () => {
       },
     });
 
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -1714,7 +1636,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -1752,7 +1674,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -1789,7 +1711,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -1839,7 +1761,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -1890,7 +1812,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -1938,7 +1860,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -1986,7 +1908,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -2028,10 +1950,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       status: ProcessStatus.PUBLISHED,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const [creator, otherMember] = await Promise.all([
       testData.createMemberUser({
@@ -2072,10 +1991,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       status: ProcessStatus.PUBLISHED,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const [creator, collaborator] = await Promise.all([
       testData.createMemberUser({
@@ -2129,7 +2045,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -2186,7 +2102,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -2249,10 +2165,7 @@ describe.concurrent('listProposals: phase-scoped proposal visibility', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const [p1, p2, p3, caller] = await Promise.all([
       testData.createProposal({
@@ -2307,10 +2220,7 @@ describeDecisionAccessTierGating('listProposals', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -2330,10 +2240,7 @@ describeDecisionAccessTierGating('listProposals', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -2353,10 +2260,7 @@ describeDecisionAccessTierGating('listProposals', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -2376,10 +2280,7 @@ describeDecisionAccessTierGating('listProposals', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/proposals/listAllProposals.test.ts
+++ b/services/api/src/routers/decision/proposals/listAllProposals.test.ts
@@ -85,7 +85,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
     const { userEmail } = setup;
     const caller = await createAuthenticatedCaller(userEmail);
 
@@ -126,7 +126,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
 
     const memberUser = await testData.createMemberUser({
       organization: setup.organization,
@@ -190,7 +190,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
 
     const memberUser = await testData.createMemberUser({
       organization: setup.organization,
@@ -231,7 +231,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
 
     const memberUser = await testData.createMemberUser({
       organization: setup.organization,
@@ -278,7 +278,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
 
     const [visible, hidden] = await Promise.all([
@@ -322,7 +322,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
 
     const [submitted, draft, rejected, duplicate, hidden, deleted] =
@@ -397,7 +397,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const termId = randomUUID();
@@ -497,10 +497,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const created = [];
     for (let i = 1; i <= 5; i++) {
@@ -553,10 +550,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const [mine, other] = await Promise.all([
       testData.createMemberUser({
@@ -608,10 +602,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const voter = await testData.createMemberUser({
       organization: setup.organization,
@@ -674,10 +665,7 @@ describe.concurrent('listAllProposals', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const [voter, snoop] = await Promise.all([
       testData.createMemberUser({
@@ -709,10 +697,7 @@ describeDecisionAccessTierGating('listAllProposals', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -732,10 +717,7 @@ describeDecisionAccessTierGating('listAllProposals', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -755,10 +737,7 @@ describeDecisionAccessTierGating('listAllProposals', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -778,10 +757,7 @@ describeDecisionAccessTierGating('listAllProposals', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/proposals/listProposalsBallot.test.ts
+++ b/services/api/src/routers/decision/proposals/listProposalsBallot.test.ts
@@ -66,10 +66,7 @@ describe.concurrent('listProposals: votedByProfileId (ballot filter)', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a voter and a submitter; the submitter contributes 3 proposals,
     // the voter votes on 2 of them.
@@ -136,10 +133,7 @@ describe.concurrent('listProposals: votedByProfileId (ballot filter)', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const [voter, snoop] = await Promise.all([
       testData.createMemberUser({
@@ -186,10 +180,7 @@ describe.concurrent('listProposals: votedByProfileId (ballot filter)', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const voter = await testData.createMemberUser({
       organization: setup.organization,
@@ -241,10 +232,7 @@ describe.concurrent('listProposals: votedByProfileId (ballot filter)', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const voter = await testData.createMemberUser({
       organization: setup.organization,

--- a/services/api/src/routers/decision/proposals/listWithReviewAggregates.test.ts
+++ b/services/api/src/routers/decision/proposals/listWithReviewAggregates.test.ts
@@ -383,10 +383,7 @@ describeDecisionAccessTierGating('listWithReviewAggregates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -407,10 +404,7 @@ describeDecisionAccessTierGating('listWithReviewAggregates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -431,10 +425,7 @@ describeDecisionAccessTierGating('listWithReviewAggregates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -455,10 +446,7 @@ describeDecisionAccessTierGating('listWithReviewAggregates', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/proposals/proposalHistoryTrigger.test.ts
+++ b/services/api/src/routers/decision/proposals/proposalHistoryTrigger.test.ts
@@ -28,10 +28,7 @@ describe.concurrent('proposal history trigger', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a draft proposal, then submit it (draft → submitted)
     const proposal = await testData.createProposal({
@@ -66,10 +63,7 @@ describe.concurrent('proposal history trigger', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -113,10 +107,7 @@ describe.concurrent('proposal history trigger', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,

--- a/services/api/src/routers/decision/proposals/submit.test.ts
+++ b/services/api/src/routers/decision/proposals/submit.test.ts
@@ -42,10 +42,7 @@ describe.concurrent('submitProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -73,10 +70,7 @@ describe.concurrent('submitProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -112,10 +106,7 @@ describe.concurrent('submitProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -154,10 +145,7 @@ describe.concurrent('submitProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -219,10 +207,7 @@ describe.concurrent('submitProposal', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -293,10 +278,7 @@ describe.concurrent('submitProposal', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a proposal with an empty title
     const proposal = await testData.createProposal({
@@ -342,10 +324,7 @@ describe.concurrent('submitProposal', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -421,10 +400,7 @@ describe.concurrent('submitProposal', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposal with only title — missing the UUID-keyed required fields
     const proposal = await testData.createProposal({
@@ -478,10 +454,7 @@ describe.concurrent('submitProposal', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a proposal, then directly overwrite proposalData
     // with a budget that exceeds the template maximum
@@ -554,10 +527,7 @@ describe.concurrent('submitProposal', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -621,10 +591,7 @@ describe.concurrent('submitProposal', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -692,10 +659,7 @@ describe.concurrent('submitProposal', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -763,10 +727,7 @@ describe.concurrent('submitProposal', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -813,10 +774,7 @@ describe.concurrent('submitProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Enable defaults.hidden on the initial phase
     const instanceRecord = await db.query.processInstances.findFirst({
@@ -886,10 +844,7 @@ describe.concurrent('submitProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -926,10 +881,7 @@ describe.concurrent('submitProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const instanceRecord = await db.query.processInstances.findFirst({
       where: { id: instance.instance.id },
@@ -990,10 +942,7 @@ describe.concurrent('submitProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const instanceRecord = await db.query.processInstances.findFirst({
       where: { id: instance.instance.id },
@@ -1054,10 +1003,7 @@ describe.concurrent('submitProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create the proposal first (while currentStateId is still valid), then
     // corrupt the instance to point at a phase that doesn't exist. We expect
@@ -1091,10 +1037,7 @@ describeDecisionAccessTierGating('submitProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -1119,10 +1062,7 @@ describeDecisionAccessTierGating('submitProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -1146,10 +1086,7 @@ describeDecisionAccessTierGating('submitProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -1173,10 +1110,7 @@ describeDecisionAccessTierGating('submitProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/proposals/update.test.ts
+++ b/services/api/src/routers/decision/proposals/update.test.ts
@@ -35,10 +35,7 @@ describe.concurrent('updateProposal visibility', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a proposal via router
     const proposal = await testData.createProposal({
@@ -69,10 +66,7 @@ describe.concurrent('updateProposal visibility', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a proposal via router
     const proposal = await testData.createProposal({
@@ -109,10 +103,7 @@ describe.concurrent('updateProposal visibility', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a proposal as the admin via router
     const proposal = await testData.createProposal({
@@ -151,10 +142,7 @@ describe.concurrent('updateProposal visibility', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create two proposals via router
     const visibleProposal = await testData.createProposal({
@@ -215,10 +203,7 @@ describe.concurrent('updateProposal visibility', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a non-admin member user who will submit a proposal
     const submitter = await testData.createMemberUser({
@@ -262,10 +247,7 @@ describe.concurrent('updateProposal visibility', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create two proposals via router
     await testData.createProposal({
@@ -310,10 +292,7 @@ describe.concurrent('updateProposal status', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -343,10 +322,7 @@ describe.concurrent('updateProposal status', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -374,10 +350,7 @@ describe.concurrent('updateProposal status', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -414,10 +387,7 @@ describe.concurrent('updateProposal status', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -459,10 +429,7 @@ describe.concurrent('updateProposal status', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -516,10 +483,7 @@ describe.concurrent('updateProposal validation', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Proposal is created in DRAFT status by default
     const proposal = await testData.createProposal({
@@ -569,10 +533,7 @@ describe.concurrent('updateProposal validation', () => {
       },
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -613,10 +574,7 @@ describe.concurrent('updateProposal checkpointVersion', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -658,10 +616,7 @@ describe.concurrent('updateProposal checkpointVersion', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -702,10 +657,7 @@ describe.concurrent('updateProposal checkpointVersion', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Proposal is created in DRAFT status by default
     const proposal = await testData.createProposal({
@@ -741,10 +693,7 @@ describeDecisionAccessTierGating('updateProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -772,10 +721,7 @@ describeDecisionAccessTierGating('updateProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -802,10 +748,7 @@ describeDecisionAccessTierGating('updateProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -832,10 +775,7 @@ describeDecisionAccessTierGating('updateProposal', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/results/getInstanceResults.test.ts
+++ b/services/api/src/routers/decision/results/getInstanceResults.test.ts
@@ -16,10 +16,7 @@ describeDecisionAccessTierGating('getInstanceResults', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -40,10 +37,7 @@ describeDecisionAccessTierGating('getInstanceResults', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -64,10 +58,7 @@ describeDecisionAccessTierGating('getInstanceResults', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -88,10 +79,7 @@ describeDecisionAccessTierGating('getInstanceResults', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/results/getResultsStats.test.ts
+++ b/services/api/src/routers/decision/results/getResultsStats.test.ts
@@ -38,7 +38,7 @@ describe.concurrent('getResultsStats', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.getResultsStats({
@@ -59,7 +59,7 @@ describe.concurrent('getResultsStats', () => {
       grantAccess: true,
     });
 
-    const { instance, profileId } = setup.instances[0]!;
+    const { instance, profileId } = setup.instance;
 
     const memberUser = await testData.createMemberUser({
       organization: setup.organization,
@@ -88,7 +88,7 @@ describe.concurrent('getResultsStats', () => {
       grantAccess: false,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
     const result = await caller.decision.getResultsStats({
@@ -109,7 +109,7 @@ describe.concurrent('getResultsStats', () => {
       grantAccess: false,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
 
     // Member has no profile-level access (instanceProfileIds: []),
     // but the org Member role has decisions: READ so the fallback should pass
@@ -138,7 +138,7 @@ describe.concurrent('getResultsStats', () => {
       grantAccess: false,
     });
 
-    const { instance, profileId } = setup.instances[0]!;
+    const { instance, profileId } = setup.instance;
 
     // Create a user in a different org, then grant them profile-level access
     // to the first setup's instance — they are NOT in setup's org
@@ -173,7 +173,7 @@ describe.concurrent('getResultsStats', () => {
       grantAccess: true,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
 
     // Create a proposal so we can reference it in result selections
     const proposal = await testData.createProposal({
@@ -230,7 +230,7 @@ describe.concurrent('getResultsStats', () => {
       grantAccess: false,
     });
 
-    const { instance } = setup.instances[0]!;
+    const { instance } = setup.instance;
 
     // Create a separate setup — this user belongs to a different organization
     const otherSetup = await testData.createDecisionSetup({
@@ -271,10 +271,7 @@ describeDecisionAccessTierGating('getResultsStats', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -293,10 +290,7 @@ describeDecisionAccessTierGating('getResultsStats', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -315,10 +309,7 @@ describeDecisionAccessTierGating('getResultsStats', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -337,10 +328,7 @@ describeDecisionAccessTierGating('getResultsStats', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/survey.test.ts
+++ b/services/api/src/routers/decision/survey.test.ts
@@ -25,18 +25,6 @@ const createAuthenticatedCaller = async (email: string) => {
   return createCaller(await createTestContextWithSession(session));
 };
 
-const requireFirstInstance = <
-  T extends { profileId: string; instance: { id: string } },
->(
-  instances: T[],
-): { id: string; profileId: string } => {
-  const created = instances[0];
-  if (!created) {
-    throw new Error('No instance created');
-  }
-  return { id: created.instance.id, profileId: created.profileId };
-};
-
 const sampleInternalData = {
   wasAdmin: false,
   npsScore: 9,
@@ -52,7 +40,7 @@ describe.concurrent('process survey submission', () => {
   }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
     const setup = await testData.createDecisionSetup({ instanceCount: 1 });
-    const instance = requireFirstInstance(setup.instances);
+    const { instance } = setup.instance;
 
     const outsiderSetup = await testData.createDecisionSetup({
       instanceCount: 0,
@@ -87,7 +75,7 @@ describe.concurrent('process survey submission', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const { instance } = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -133,7 +121,7 @@ describe.concurrent('process survey submission', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const { instance } = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
     await caller.decision.submitProcessSurveyResponse({
@@ -160,7 +148,7 @@ describe.concurrent('process survey submission', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const { instance } = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
 
@@ -191,7 +179,7 @@ describeDecisionAccessTierGating('submitProcessSurveyResponse', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = requireFirstInstance(setup.instances);
+      const { instance } = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -214,7 +202,7 @@ describeDecisionAccessTierGating('submitProcessSurveyResponse', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = requireFirstInstance(setup.instances);
+      const { instance } = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -237,7 +225,7 @@ describeDecisionAccessTierGating('submitProcessSurveyResponse', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = requireFirstInstance(setup.instances);
+      const { instance } = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -260,7 +248,7 @@ describeDecisionAccessTierGating('submitProcessSurveyResponse', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = requireFirstInstance(setup.instances);
+      const { instance } = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 
@@ -284,7 +272,7 @@ describeDecisionAccessTierGating('getProcessSurveyResponse', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = requireFirstInstance(setup.instances);
+      const { instance } = setup.instance;
 
       const caller = await callers.noJwt();
 
@@ -305,7 +293,7 @@ describeDecisionAccessTierGating('getProcessSurveyResponse', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = requireFirstInstance(setup.instances);
+      const { instance } = setup.instance;
 
       const caller = await callers.anonJwt();
 
@@ -326,7 +314,7 @@ describeDecisionAccessTierGating('getProcessSurveyResponse', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = requireFirstInstance(setup.instances);
+      const { instance } = setup.instance;
 
       const caller = await callers.userJwt();
 
@@ -347,7 +335,7 @@ describeDecisionAccessTierGating('getProcessSurveyResponse', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = requireFirstInstance(setup.instances);
+      const { instance } = setup.instance;
 
       const caller = await callers.networkJwt(setup.userEmail);
 

--- a/services/api/src/routers/decision/uploadProposalAttachment.test.ts
+++ b/services/api/src/routers/decision/uploadProposalAttachment.test.ts
@@ -37,10 +37,7 @@ describe.concurrent('uploadProposalAttachment', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -86,10 +83,7 @@ describe.concurrent('uploadProposalAttachment', () => {
       grantAccess: true,
     });
 
-    const instance = setupA.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setupA.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setupA.userEmail,
@@ -147,10 +141,7 @@ describe.concurrent('uploadProposalAttachment', () => {
       grantAccess: true,
     });
 
-    const instanceA = setupA.instances[0];
-    if (!instanceA) {
-      throw new Error('No instance created');
-    }
+    const instanceA = setupA.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setupA.userEmail,
@@ -189,10 +180,7 @@ describeDecisionAccessTierGating('uploadProposalAttachment', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -221,10 +209,7 @@ describeDecisionAccessTierGating('uploadProposalAttachment', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -253,10 +238,7 @@ describeDecisionAccessTierGating('uploadProposalAttachment', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,
@@ -285,10 +267,7 @@ describeDecisionAccessTierGating('uploadProposalAttachment', {
         instanceCount: 1,
         grantAccess: true,
       });
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
       const proposal = await testData.createProposal({
         userEmail: setup.userEmail,
         processInstanceId: instance.instance.id,

--- a/services/api/src/routers/decision/voting.test.ts
+++ b/services/api/src/routers/decision/voting.test.ts
@@ -82,10 +82,7 @@ async function setupVotingInstance(
     processSchema: buildVotingSchema(opts.maxVotesPerMember),
   });
 
-  const instance = setup.instances[0];
-  if (!instance) {
-    throw new Error('No instance created');
-  }
+  const instance = setup.instance;
 
   const proposals = await Promise.all(
     Array.from({ length: opts.proposalCount }, (_, i) =>

--- a/services/api/src/routers/moderationVisibility.test.ts
+++ b/services/api/src/routers/moderationVisibility.test.ts
@@ -278,10 +278,7 @@ describe.concurrent('moderation read visibility', () => {
         grantAccess: true,
       });
 
-      const instance = setup.instances[0];
-      if (!instance) {
-        throw new Error('No instance created');
-      }
+      const instance = setup.instance;
 
       const [submitter, otherMember] = await Promise.all([
         testData.createMemberUser({

--- a/services/api/src/routers/platform/admin/listAllDecisionInstances.test.ts
+++ b/services/api/src/routers/platform/admin/listAllDecisionInstances.test.ts
@@ -87,7 +87,7 @@ describe.concurrent('platform.admin.listAllDecisionInstances', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
 
     await Promise.all([
       testData.createProposal({
@@ -137,7 +137,7 @@ describe.concurrent('platform.admin.listAllDecisionInstances', () => {
       instanceCount: 1,
       status: ProcessStatus.PUBLISHED,
     });
-    const instanceId = setup.instances[0]!.instance.id;
+    const instanceId = setup.instance.instance.id;
 
     const { session } = await createIsolatedSession(setup.userEmail);
     const caller = createCaller(await createTestContextWithSession(session));

--- a/services/api/src/routers/posts/deletePost.test.ts
+++ b/services/api/src/routers/posts/deletePost.test.ts
@@ -29,16 +29,6 @@ const createOutsiderCaller = async (testData: TestDecisionsDataManager) => {
   return createAuthenticatedCaller(outsider.email);
 };
 
-const requireFirstInstance = <T extends { profileId: string }>(
-  instances: T[],
-): T => {
-  const instance = instances[0];
-  if (!instance) {
-    throw new Error('No instance created');
-  }
-  return instance;
-};
-
 const postExists = async (postId: string): Promise<boolean> => {
   const [row] = await db
     .select({ id: posts.id })
@@ -164,7 +154,7 @@ describe.concurrent('decision update post deletion (postsToProfiles)', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const update = await adminCaller.posts.createPost({
@@ -186,7 +176,7 @@ describe.concurrent('decision update post deletion (postsToProfiles)', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const firstAdminCaller = await createAuthenticatedCaller(setup.userEmail);
     const update = await firstAdminCaller.posts.createPost({
@@ -222,7 +212,7 @@ describe.concurrent('decision update post deletion (postsToProfiles)', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const update = await adminCaller.posts.createPost({
@@ -252,7 +242,7 @@ describe.concurrent('decision update post deletion (postsToProfiles)', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const update = await adminCaller.posts.createPost({
@@ -280,7 +270,7 @@ describe.concurrent('decision comment deletion', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const update = await adminCaller.posts.createPost({
@@ -313,7 +303,7 @@ describe.concurrent('decision comment deletion', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const update = await adminCaller.posts.createPost({
@@ -345,7 +335,7 @@ describe.concurrent('decision comment deletion', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const update = await adminCaller.posts.createPost({
@@ -387,7 +377,7 @@ describe.concurrent('decision comment deletion', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const update = await adminCaller.posts.createPost({
@@ -425,7 +415,7 @@ describe.concurrent('proposal comment deletion', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -464,7 +454,7 @@ describe.concurrent('proposal comment deletion', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,

--- a/services/api/src/routers/posts/listProfilePosts.proposalAccess.test.ts
+++ b/services/api/src/routers/posts/listProfilePosts.proposalAccess.test.ts
@@ -24,7 +24,7 @@ describe('posts.listProfilePosts — proposal post access', () => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
 
     const setup = await testData.createDecisionSetup({ instanceCount: 1 });
-    const instance = setup.instances[0]!;
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,

--- a/services/api/src/routers/posts/postAuthorization.test.ts
+++ b/services/api/src/routers/posts/postAuthorization.test.ts
@@ -17,16 +17,6 @@ const createAuthenticatedCaller = async (email: string) => {
   return createCaller(await createTestContextWithSession(session));
 };
 
-const requireFirstInstance = <T extends { profileId: string }>(
-  instances: T[],
-): T => {
-  const instance = instances[0];
-  if (!instance) {
-    throw new Error('No instance created');
-  }
-  return instance;
-};
-
 const createOutsiderCaller = async (testData: TestDecisionsDataManager) => {
   const outsiderSetup = await testData.createDecisionSetup({
     instanceCount: 0,
@@ -64,7 +54,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
     const post = await caller.posts.createPost({
@@ -92,7 +82,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: false,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const member = await testData.createMemberUser({
       organization: setup.organization,
@@ -126,7 +116,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: false,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const outsiderCaller = await createOutsiderCaller(testData);
 
@@ -147,7 +137,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const adminPost = await adminCaller.posts.createPost({
@@ -179,7 +169,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const adminPost = await adminCaller.posts.createPost({
@@ -209,7 +199,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const update = await adminCaller.posts.createPost({
@@ -258,7 +248,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     await adminCaller.posts.createPost({
@@ -303,7 +293,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const adminPost = await adminCaller.posts.createPost({
@@ -331,7 +321,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const adminPost = await adminCaller.posts.createPost({
@@ -364,7 +354,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const adminPost = await adminCaller.posts.createPost({
@@ -398,7 +388,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const adminPost = await adminCaller.posts.createPost({
@@ -434,7 +424,7 @@ describe.concurrent('decision-profile post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const adminPost = await adminCaller.posts.createPost({
@@ -601,7 +591,7 @@ describe.concurrent('listProfilePosts authorization and pagination', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     await adminCaller.posts.createPost({
@@ -637,7 +627,7 @@ describe.concurrent('listProfilePosts authorization and pagination', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const outsiderCaller = await createOutsiderCaller(testData);
 
@@ -679,7 +669,7 @@ describe.concurrent('listProfilePosts authorization and pagination', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     // Sequential creates with a small delay so postsToProfiles.createdAt
@@ -730,7 +720,7 @@ describe.concurrent('listProfilePosts authorization and pagination', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const member = await testData.createMemberUser({
@@ -801,7 +791,7 @@ describe.concurrent('proposal post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
@@ -827,7 +817,7 @@ describe.concurrent('proposal post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
@@ -859,7 +849,7 @@ describe.concurrent('proposal post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
@@ -898,7 +888,7 @@ describe.concurrent('proposal post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
@@ -955,7 +945,7 @@ describe.concurrent('proposal post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
@@ -987,7 +977,7 @@ describe.concurrent('proposal post authorization', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
@@ -1020,7 +1010,7 @@ describe.concurrent('rootProfileId / rootPostId column writes', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const caller = await createAuthenticatedCaller(setup.userEmail);
     const post = await caller.posts.createPost({
@@ -1042,7 +1032,7 @@ describe.concurrent('rootProfileId / rootPostId column writes', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
       processInstanceId: instance.instance.id,
@@ -1084,7 +1074,7 @@ describe.concurrent('rootProfileId / rootPostId column writes', () => {
       instanceCount: 1,
       grantAccess: true,
     });
-    const instance = requireFirstInstance(setup.instances);
+    const instance = setup.instance;
 
     const adminCaller = await createAuthenticatedCaller(setup.userEmail);
     const topLevel = await adminCaller.posts.createPost({

--- a/services/api/src/routers/translation/translateDecision.test.ts
+++ b/services/api/src/routers/translation/translateDecision.test.ts
@@ -114,10 +114,7 @@ describe('translation.translateDecision', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Patch instanceData to add translatable phase content
     const instanceRecord = await db.query.processInstances.findFirst({
@@ -184,10 +181,7 @@ describe('translation.translateDecision', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const instanceRecord = await db.query.processInstances.findFirst({
       where: { id: instance.instance.id },
@@ -254,10 +248,7 @@ describe('translation.translateDecision', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Remove phase names from instanceData to produce an instance with no translatable content
     const instanceRecord = await db.query.processInstances.findFirst({
@@ -311,10 +302,7 @@ describe('translation.translateDecision', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const instanceRecord = await db.query.processInstances.findFirst({
       where: { id: instance.instance.id },
@@ -399,10 +387,7 @@ describe('translation.translateDecision', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Clean up any cache entries written before auth fails (runTranslateBatch runs
     // in parallel with the auth check and may write rows before rejection)
@@ -443,10 +428,7 @@ describe('translation.translateDecision', () => {
       grantAccess: false, // owner gets profile access, not the member
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Patch instance with some content so we get a non-empty result
     const instanceRecord = await db.query.processInstances.findFirst({

--- a/services/api/src/routers/translation/translateProposal.test.ts
+++ b/services/api/src/routers/translation/translateProposal.test.ts
@@ -115,10 +115,7 @@ describe('translation.translateProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create proposal with collaborationDocId (no description → keeps the doc)
     const proposal = await testData.createProposal({
@@ -192,10 +189,7 @@ describe('translation.translateProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -273,10 +267,7 @@ describe('translation.translateProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -357,10 +348,7 @@ describe('translation.translateProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a legacy proposal with description instead of collaborationDocId
     const proposal = await testData.createProposal({
@@ -441,10 +429,7 @@ describe('translation.translateProposal', () => {
       proposalTemplate,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -525,10 +510,7 @@ describe('translation.translateProposal', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -607,10 +589,7 @@ describe('translation.translateProposal', () => {
       proposalTemplate,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,

--- a/services/api/src/routers/translation/translateProposals.test.ts
+++ b/services/api/src/routers/translation/translateProposals.test.ts
@@ -115,10 +115,7 @@ describe('translation.translateProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create two proposals with different content
     const proposal1 = await testData.createProposal({
@@ -219,10 +216,7 @@ describe('translation.translateProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,
@@ -288,10 +282,7 @@ describe('translation.translateProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     // Create a proposal with a title but an empty TipTap document
     const proposal = await testData.createProposal({
@@ -342,10 +333,7 @@ describe('translation.translateProposals', () => {
       grantAccess: true,
     });
 
-    const instance = setup.instances[0];
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const proposal = await testData.createProposal({
       userEmail: setup.userEmail,

--- a/services/api/src/test/helpers/TestDecisionsDataManager.ts
+++ b/services/api/src/test/helpers/TestDecisionsDataManager.ts
@@ -71,6 +71,12 @@ interface DecisionSetupOutput {
   organization: Record<string, unknown> & { id: string; profileId: string };
   process: EncodedDecisionProcess;
   instances: CreatedInstance[];
+  /**
+   * The first (and usually only) created instance, already narrowed.
+   * Throws if no instance was created (i.e. `instanceCount` was 0), so
+   * callers don't have to re-check `instances[0]` everywhere.
+   */
+  readonly instance: CreatedInstance;
 }
 
 interface MemberUserOutput {
@@ -295,6 +301,15 @@ export class TestDecisionsDataManager {
       organization: { ...organization, profileId: orgProfileId },
       process,
       instances,
+      get instance() {
+        const first = instances[0];
+        if (!first) {
+          throw new Error(
+            'createDecisionSetup: no instance available (instanceCount was 0)',
+          );
+        }
+        return first;
+      },
     };
   }
 

--- a/services/api/src/test/helpers/TestReviewsDataManager.ts
+++ b/services/api/src/test/helpers/TestReviewsDataManager.ts
@@ -67,11 +67,7 @@ export class TestReviewsDataManager {
       processSchema: testSimpleVotingSchema,
     });
 
-    const instance = setup.instances[0];
-
-    if (!instance) {
-      throw new Error('No instance created');
-    }
+    const instance = setup.instance;
 
     const reviewerUser = await db.query.users.findFirst({
       where: {

--- a/services/api/src/test/helpers/resourcesTestUtils.ts
+++ b/services/api/src/test/helpers/resourcesTestUtils.ts
@@ -11,16 +11,6 @@ import { TestDecisionsDataManager } from './TestDecisionsDataManager';
 
 type OnTestFinished = (fn: () => void | Promise<void>) => void;
 
-export const requireFirstInstance = <T extends { profileId: string }>(
-  instances: T[],
-): T => {
-  const instance = instances[0];
-  if (!instance) {
-    throw new Error('No instance created');
-  }
-  return instance;
-};
-
 /**
  * Cleans up every resource + collection visible to any of the given profile
  * IDs. Resources are removed before collections so we don't leave orphan
@@ -98,7 +88,7 @@ export const setupInstance = async ({
     instanceCount: 1,
     grantAccess: true,
   });
-  const instance = requireFirstInstance(setup.instances);
+  const instance = setup.instance;
   registerResourcesCleanup(onTestFinished, [instance.profileId]);
 
   const adminCaller = await createAuthenticatedCaller(setup.userEmail);


### PR DESCRIPTION
Tests re-checked setup.instances[0] everywhere and several files grew their own requireFirstInstance helpers to work around it. Expose a single narrowed accessor so callers stop re-parsing and re-guarding the array.