### PR TITLE
fix(db): give the e2e server a real connection pool instead of one socket

### DIFF
--- a/services/db/index.ts
+++ b/services/db/index.ts
@@ -11,15 +11,9 @@ if (!process.env.DATABASE_URL) {
 export const db = drizzle({
   connection: {
     url: process.env.DATABASE_URL,
-    // IMPORTANT: postgres-js treats an explicit `max: undefined` as
-    // Array(undefined) → length 1, i.e. a single-socket pool. Parallel queries
-    // then pipeline onto that one socket, which hangs forever against
-    // Supavisor transaction-mode pooling. Keep this as a concrete number so
-    // the pool actually has the intended size.
-    max:
-      process.env.DB_MIGRATING || process.env.DB_SEEDING || process.env.E2E
-        ? 1
-        : 10,
+    // Keep a concrete number — postgres-js treats `max: undefined` as a
+    // single socket. Migrations/seeding run serial DDL and stay at 1.
+    max: process.env.DB_MIGRATING || process.env.DB_SEEDING ? 1 : 10,
     onnotice: () => {},
     prepare: false,
   },


### PR DESCRIPTION
E2E revision-panel tests flaked under shard contention because the e2e server's database pool was pinned to a single socket (max:1), so every query from the parallel Playwright workers serialized onto one connection and page reads were starved long enough to time out. #1053 raised only the non-E2E branch and left E2E single-socket; this restores a real pool for the e2e server while migrations and seeding stay single-connection.

Verified by re-running the contended shard against unmodified product code and tests with only this change: the previously all-retries-failing tests pass clean.

Asana: https://app.asana.com/0/1213315744811204/1216032871668356/f
