### PR TITLE
fix(decisions): gate proposal editor share and history controls to interacting users

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/edit/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/edit/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRequiredUser } from '@/utils/UserProvider';
+import { userCanInteract } from '@/utils/userCanInteract';
 import { trpc } from '@op/api/client';
 import type { ProcessInstance } from '@op/api/encoders';
 import {
@@ -159,30 +160,36 @@ export default function ProposalEditorLayout() {
     );
   };
 
+  // The version-history and revision-request controls are interactive editing
+  // surfaces — hide them from anonymous accounts and logged-out visitors.
+  const canInteract = userCanInteract(user);
+
   const revisionRequestLabel = t('Revision request');
-  const headerIcons = firstRevisionRequestId
-    ? [
-        <TooltipTrigger key="revision-request">
-          <Button
-            color="secondary"
-            variant="icon"
-            size="small"
-            onPress={toggleRevisionRequest}
-            aria-label={revisionRequestLabel}
-            aria-pressed={Boolean(reviewRevision)}
-            className="relative size-8 min-w-8 rounded-sm p-0"
-          >
-            <LuStickyNote className="size-4" />
-            <span
-              aria-hidden
-              className="absolute -end-0.5 -top-0.5 size-1.5 rounded-full bg-primary-orange2"
-            />
-          </Button>
-          <Tooltip>{revisionRequestLabel}</Tooltip>
-        </TooltipTrigger>,
-        ...asideHeaderIcons,
-      ]
-    : asideHeaderIcons;
+  const headerIcons = !canInteract
+    ? []
+    : firstRevisionRequestId
+      ? [
+          <TooltipTrigger key="revision-request">
+            <Button
+              color="secondary"
+              variant="icon"
+              size="small"
+              onPress={toggleRevisionRequest}
+              aria-label={revisionRequestLabel}
+              aria-pressed={Boolean(reviewRevision)}
+              className="relative size-8 min-w-8 rounded-sm p-0"
+            >
+              <LuStickyNote className="size-4" />
+              <span
+                aria-hidden
+                className="absolute -end-0.5 -top-0.5 size-1.5 rounded-full bg-primary-orange2"
+              />
+            </Button>
+            <Tooltip>{revisionRequestLabel}</Tooltip>
+          </TooltipTrigger>,
+          ...asideHeaderIcons,
+        ]
+      : asideHeaderIcons;
 
   const collaborationDocId = useMemo(() => {
     const { collaborationDocId: existingId } = parseProposalData(

--- a/apps/app/src/components/decisions/ProposalEditorLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalEditorLayout.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useUser } from '@/utils/UserProvider';
+import { userCanInteract } from '@/utils/userCanInteract';
 import type { ProposalReviewRequest } from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { Header4 } from '@op/ui/Header';
@@ -62,10 +64,14 @@ export function ProposalEditorLayout({
 }: ProposalEditorLayoutProps) {
   const router = useRouter();
   const t = useTranslations();
+  const { user } = useUser();
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const [isResubmitModalOpen, setIsResubmitModalOpen] = useState(false);
 
-  const canShare = access?.admin || access?.inviteMembers;
+  // Sharing is a write surface — only offer it to signed-in, non-anonymous
+  // members, on top of the existing admin/invite permission check.
+  const canShare =
+    userCanInteract(user) && (access?.admin || access?.inviteMembers);
   const isRevisionMode = Boolean(revisionRequest);
 
   return (


### PR DESCRIPTION
Anonymous accounts and logged-out visitors can read proposals but must not be offered write/management surfaces, so the share button and the version-history/revision-request header controls are restricted to signed-in, non-anonymous members.