### PR TITLE
fix(decisions): show login button instead of avatar for visitors and anonymous users in proposal editor/viewer

### DIFF
--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -471,6 +471,32 @@ export const UserAvatarMenu = ({ className }: { className?: string }) => {
 };
 
 /**
+ * Account control for headers on public surfaces: signed-in, non-anonymous
+ * users get the avatar menu; logged-out visitors and anonymous accounts get a
+ * "Log in" button instead (they have no account menu to show).
+ */
+export const HeaderUserMenu = ({ className }: { className?: string }) => {
+  const t = useTranslations();
+  const { user } = useUser();
+
+  if (user && !user.isAnonymous) {
+    return <UserAvatarMenu className={className} />;
+  }
+
+  return (
+    // Native nav: /login is outside the [locale] tree, so a RAC link 404s at /en/login.
+    <Button
+      color="primary"
+      size="small"
+      className={className}
+      onPress={() => window.location.assign('/login')}
+    >
+      {t('Log in')}
+    </Button>
+  );
+};
+
+/**
  * Right-side header actions. Creating and the account menu are authed
  * features; signed-out visitors only get the locale chooser.
  */

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useUser } from '@/utils/UserProvider';
 import { userCanInteract } from '@/utils/userCanInteract';
-import { Button, ButtonLink } from '@op/ui/Button';
+import { ButtonLink } from '@op/ui/Button';
 import { Header1 } from '@op/ui/Header';
 import { IconButton } from '@op/ui/IconButton';
 import { MegaphoneIcon } from '@op/ui/MegaphoneIcon';
@@ -14,7 +14,7 @@ import { useTranslations } from '@/lib/i18n';
 import { Link } from '@/lib/i18n/routing';
 
 import { LocaleChooser } from '../LocaleChooser';
-import { UserAvatarMenu } from '../SiteHeader';
+import { HeaderUserMenu } from '../SiteHeader';
 import { panelStateParser } from './panelState';
 
 export const DecisionInstanceHeader = ({
@@ -119,18 +119,7 @@ export const DecisionInstanceHeader = ({
           </ButtonLink>
         )}
         <LocaleChooser />
-        {user && !user.isAnonymous ? (
-          <UserAvatarMenu />
-        ) : (
-          // Native nav: /login is outside the [locale] tree, so a RAC link 404s at /en/login.
-          <Button
-            color="primary"
-            size="small"
-            onPress={() => window.location.assign('/login')}
-          >
-            {t('Log in')}
-          </Button>
-        )}
+        <HeaderUserMenu />
       </div>
 
       {centerSlot ? (

--- a/apps/app/src/components/decisions/ProposalEditorLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalEditorLayout.tsx
@@ -140,7 +140,10 @@ export function ProposalEditorLayout({
                 </Button>
               )}
               <LocaleChooser />
-              <UserAvatarMenu className="hidden sm:block" />
+              {/* No avatar or login for visitors/anonymous. */}
+              {userCanInteract(user) ? (
+                <UserAvatarMenu className="hidden sm:block" />
+              ) : null}
             </>
           )}
         </div>

--- a/apps/app/src/components/decisions/ProposalViewLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalViewLayout.tsx
@@ -17,7 +17,7 @@ import { useTranslations } from '@/lib/i18n';
 import { useRouter } from '@/lib/i18n/routing';
 
 import { LocaleChooser } from '../LocaleChooser';
-import { UserAvatarMenu } from '../SiteHeader';
+import { HeaderUserMenu } from '../SiteHeader';
 import { ReportProposalDialog } from './ReportProposalDialog';
 
 export function ProposalViewLayout({
@@ -141,9 +141,7 @@ export function ProposalViewLayout({
           )}
           <div className="hidden gap-4 sm:flex">
             <LocaleChooser />
-            {/* Required-user leaf: only mount when a session exists so anonymous
-                visitors can still read the proposal. */}
-            {user ? <UserAvatarMenu /> : null}
+            <HeaderUserMenu />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Extends the decision page's avatar-or-login behavior to the proposal viewer and editor, which previously showed (or required) the signed-in avatar for visitors and anonymous accounts.