### PR TITLE
fix(decisions): remove decision_overview flag gate from view layout

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -5,9 +5,6 @@ import {
 } from '@op/api/server';
 import { type ReactNode, Suspense } from 'react';
 
-import { getServerFeatureFlag } from '@/lib/getServerFeatureFlag';
-import { redirect } from '@/lib/i18n/routing';
-
 import { DecisionHeader } from '@/components/decisions/DecisionHeader';
 import { DecisionSidePanel } from '@/components/decisions/DecisionSidePanel';
 import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
@@ -23,10 +20,6 @@ import { loadDecision } from './loadDecision';
  * swaps, which is what makes the switch feel like a single page. The instance
  * is prefetched once here so both tabs' client suspense reads resolve from a
  * warm cache.
- *
- * This whole branch is gated by the `decision_overview` flag, evaluated
- * server-side so flag-off visitors are redirected to the canonical root (the
- * original, unflagged page) before anything renders — no client flash.
  */
 const DecisionViewLayout = async ({
   children,
@@ -35,11 +28,7 @@ const DecisionViewLayout = async ({
   children: ReactNode;
   params: Promise<{ slug: string; locale: string }>;
 }) => {
-  const { slug, locale } = await params;
-
-  if (!(await getServerFeatureFlag('decision_overview'))) {
-    redirect({ href: `/decisions/${slug}`, locale });
-  }
+  const { slug } = await params;
 
   const { decisionProfile, instanceId } = await loadDecision(slug);
   const { utils, queryClient } = await createServerUtils();


### PR DESCRIPTION
## What
Removes the server-side `decision_overview` feature-flag gate (and its redirect) from the decision-view layout.

## Why
In our testing we're having to load the `/overview` page twice to get it to render. The gate redirects first-time visitors from `/overview` to `/decisions/[slug]` because the PostHog `distinct_id` cookie (written by client-side posthog-js) isn't present on the first server render — so `getServerFeatureFlag` resolved `false` and bounced. Second load works because the cookie existed by then.

## We could wait
We're going to remove the flag anyway when we launch. But the `/overview` page is not discoverable right now, so I think it could be safe to remove this gate (and keep the one that hides the `Overview` tab in the process builder).