### PR TITLE
fix(decisions): don't render active phase if process has not started

### DIFF
--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -114,6 +114,8 @@ function DecisionOverviewContent({
     }),
   );
 
+  const currentPhaseId = currentPhase?.phaseId || '';
+
   return (
     <div className="flex w-full flex-col">
       <OverviewHero
@@ -135,7 +137,7 @@ function DecisionOverviewContent({
             </Header3>
             <DecisionPhaseTimeline
               phases={phases}
-              currentStateId={isActive ? (instance.currentStateId ?? '') : ''}
+              currentPhaseId={isActive ? currentPhaseId : ''}
               instanceId={instanceId}
               isAdmin={instance.access?.admin}
               decisionSlug={decisionSlug}

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -135,7 +135,7 @@ function DecisionOverviewContent({
             </Header3>
             <DecisionPhaseTimeline
               phases={phases}
-              currentStateId={instance.currentStateId ?? ''}
+              currentStateId={isActive ? (instance.currentStateId ?? '') : ''}
               instanceId={instanceId}
               isAdmin={instance.access?.admin}
               decisionSlug={decisionSlug}

--- a/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
+++ b/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
@@ -21,14 +21,14 @@ import { useAdvancePhase } from './useAdvancePhase';
  */
 export function DecisionPhaseTimeline({
   phases,
-  currentStateId,
+  currentPhaseId,
   instanceId,
   isAdmin,
   decisionSlug,
   className,
 }: {
   phases: ProcessPhase[];
-  currentStateId: string;
+  currentPhaseId: string;
   instanceId?: string;
   isAdmin?: boolean;
   decisionSlug: string;
@@ -48,14 +48,14 @@ export function DecisionPhaseTimeline({
   const phaseName = (phase: ProcessPhase) =>
     translatedPhaseNames?.get(phase.id) ?? phase.name;
 
-  const currentIndex = phases.findIndex((p) => p.id === currentStateId);
+  const currentIndex = phases.findIndex((p) => p.id === currentPhaseId);
   const currentPhase = currentIndex >= 0 ? phases[currentIndex] : undefined;
   const nextPhase = currentIndex >= 0 ? phases[currentIndex + 1] : undefined;
   const nextPhaseId = nextPhase?.id;
 
   const { requestAdvance, advanceConfirm } = useAdvancePhase({
     instanceId,
-    currentPhaseId: currentStateId,
+    currentPhaseId: currentPhaseId,
     nextPhaseId,
     currentPhaseName: currentPhase ? phaseName(currentPhase) : '',
     nextPhaseName: nextPhase ? phaseName(nextPhase) : '',

--- a/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
+++ b/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
@@ -55,7 +55,7 @@ export function DecisionPhaseTimeline({
 
   const { requestAdvance, advanceConfirm } = useAdvancePhase({
     instanceId,
-    currentPhaseId: currentPhaseId,
+    currentPhaseId,
     nextPhaseId,
     currentPhaseName: currentPhase ? phaseName(currentPhase) : '',
     nextPhaseName: nextPhase ? phaseName(nextPhase) : '',


### PR DESCRIPTION
Ensure that the phase timeline on the overview page doesn't render the first phase as active if the process hasn't started yet. Also renames `currentStateId` -> `currentPhaseId`