### PR TITLE
fix(decisions): stop foresight clobbering data-active on tabs

### DIFF
--- a/apps/app/src/hooks/useForesight.ts
+++ b/apps/app/src/hooks/useForesight.ts
@@ -16,6 +16,12 @@ ForesightManager.initialize({
   defaultHitSlop: 50,
   positionHistorySize: 10,
   scrollMargin: 200,
+  // Foresight otherwise writes debug attributes (data-active, data-predicted,
+  // data-status) onto every registered element. Its `data-active` (= "tracked
+  // for prefetch") collides with the data-active our UI components use for
+  // selected state — e.g. a sense Tabs trigger rendered as a Link gets styled
+  // active on every tab. Off in prod; the foresight devtools can re-enable it.
+  setDataAttributes: false,
 });
 
 export function useForesight<T extends HTMLElement = HTMLElement>(


### PR DESCRIPTION
## Root cause

ForesightJS (`js.foresight`) ships `setDataAttributes: true` by default. On registering an element it writes `data-active`, `data-predicted`, and `data-status` onto it, where its `data-active` means "actively tracked for prefetch" — true for **every** registered link.

That attribute name collides with the `data-active` our UI components use for selected state. The decision Overview/Current Phase toggle renders sense `Tabs` triggers as `Link`s; foresight registered both links and set `data-active` on both, so both tabs rendered as active. It self-healed after the prefetch callback fired (foresight cleared `isActive`) and broke again on refresh.

## Fix

Set `setDataAttributes: false` in `ForesightManager.initialize` (`useForesight.ts`). Foresight stops writing its debug attributes; base-ui's own declarative `data-active` drives the selected styling correctly.

This also protects any other UI styled off `data-active` / `data-predicted` / `data-status` that's wrapped in the app `Link`.