### PR TITLE
perf(decisions): single-fetch /overview (drop redundant getInstance)

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/page.tsx
@@ -1,3 +1,9 @@
+import {
+  HydrationBoundary,
+  createServerUtils,
+  dehydrate,
+} from '@op/api/server';
+import { logger } from '@op/logging';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { Suspense } from 'react';
@@ -51,18 +57,33 @@ const CurrentPhasePage = async ({
   const { slug } = await params;
   const { decisionProfile, instanceId, ownerSlug } = await loadDecision(slug);
 
+  // Seed the getInstance cache the current-phase content (DecisionStateRouter)
+  // hydrates from. The (decision-view) layout no longer fetches getInstance
+  // (the overview route is single-fetch), so /current seeds its own. Best
+  // effort: on failure the client refetches under its own boundary.
+  const { utils, queryClient } = await createServerUtils();
+  await utils.decision.getInstance.fetch({ instanceId }).catch((error) => {
+    logger.warn('Failed to seed current-phase instance', {
+      instanceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  });
+
   return (
-    <div className="bg-neutral-offWhite pt-8 md:pt-0">
-      <Suspense fallback={<DecisionContentSkeleton />}>
-        <CurrentPhaseView
-          instanceId={instanceId}
-          ownerSlug={ownerSlug}
-          decisionSlug={slug}
-          decisionProfileId={decisionProfile.id}
-          isAdmin={decisionProfile.processInstance?.access?.admin}
-        />
-      </Suspense>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <div className="bg-neutral-offWhite pt-8 md:pt-0">
+        <Suspense fallback={<DecisionContentSkeleton />}>
+          <CurrentPhaseView
+            instanceId={instanceId}
+            ownerSlug={ownerSlug}
+            decisionSlug={slug}
+            decisionProfileId={decisionProfile.id}
+            isAdmin={decisionProfile.processInstance?.access?.admin}
+          />
+        </Suspense>
+      </div>
+    </HydrationBoundary>
   );
 };
 

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/page.tsx
@@ -62,13 +62,14 @@ const CurrentPhasePage = async ({
   // (the overview route is single-fetch), so /current seeds its own. Best
   // effort: on failure the client refetches under its own boundary.
   const { utils, queryClient } = await createServerUtils();
-  await utils.decision.getInstance.fetch({ instanceId }).catch((error) => {
+  try {
+    await utils.decision.getInstance.fetch({ instanceId });
+  } catch (error) {
     logger.warn('Failed to seed current-phase instance', {
       instanceId,
       error: error instanceof Error ? error.message : String(error),
     });
-    return null;
-  });
+  }
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -1,8 +1,3 @@
-import {
-  HydrationBoundary,
-  createServerUtils,
-  dehydrate,
-} from '@op/api/server';
 import { type ReactNode, Suspense } from 'react';
 
 import { DecisionHeader } from '@/components/decisions/DecisionHeader';
@@ -17,9 +12,11 @@ import { loadDecision } from './loadDecision';
  * Shared shell for the overview and current-phase tabs. Living in a layout
  * means the header, the Overview / Current Phase toggle, and the updates side
  * panel persist across tab switches — the tab content is the only thing that
- * swaps, which is what makes the switch feel like a single page. The instance
- * is prefetched once here so both tabs' client suspense reads resolve from a
- * warm cache.
+ * swaps, which is what makes the switch feel like a single page. The header and
+ * toggle read everything they need from `loadDecision` (the single slug fetch,
+ * enriched with `access` + encoded `instanceData`), so the layout makes no
+ * separate `getInstance` call. The /current tab seeds its own `getInstance`
+ * cache in its page.
  */
 const DecisionViewLayout = async ({
   children,
@@ -31,53 +28,45 @@ const DecisionViewLayout = async ({
   const { slug } = await params;
 
   const { decisionProfile, instanceId } = await loadDecision(slug);
-  const { utils, queryClient } = await createServerUtils();
+  const instance = decisionProfile.processInstance;
 
-  // Fetch (not prefetch) so we can read the phases server-side to gate the
-  // toggle, while still seeding the cache the client suspense reads hydrate
-  // from. The process is "active" once its first phase begins. Fail open if it
-  // throws — the child suspense reads drive the error UX.
-  let isActive = true;
-  try {
-    const instance = await utils.decision.getInstance.fetch({ instanceId });
-    isActive = hasFirstPhaseStarted(instance.instanceData?.phases);
-  } catch {
-    isActive = true;
-  }
-
-  const access = decisionProfile.processInstance?.access;
+  // The process is "active" once its first phase begins — read from the phases
+  // loadDecision already returned (no separate getInstance fetch).
+  const isActive = hasFirstPhaseStarted(instance?.instanceData?.phases);
+  const access = instance?.access;
 
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <DecisionTranslationProvider>
-        <DecisionHeader
-          instanceId={instanceId}
-          decisionSlug={slug}
-          isAdmin={access?.admin}
-          canReadUpdates={access?.admin === true || access?.read === true}
-          profileName={decisionProfile.name}
-          showStepper={false}
-          // Hidden until the first phase begins.
-          centerSlot={
-            isActive ? <DecisionViewToggle decisionSlug={slug} /> : undefined
-          }
+    <DecisionTranslationProvider>
+      <DecisionHeader
+        instanceId={instanceId}
+        decisionSlug={slug}
+        isAdmin={access?.admin}
+        canReadUpdates={access?.admin === true || access?.read === true}
+        profileName={decisionProfile.name}
+        // Pass the instance so the header renders from props (no client
+        // getInstance query on this route).
+        processInstance={instance}
+        showStepper={false}
+        // Hidden until the first phase begins.
+        centerSlot={
+          isActive ? <DecisionViewToggle decisionSlug={slug} /> : undefined
+        }
+      />
+      {children}
+      {/*
+       * Like the header's updates toggle, the side panel reads the `panel`
+       * search param (nuqs/useSearchParams). It lives in this layout, which
+       * Next prerenders as the route's static shell (see loading.tsx), so the
+       * read would happen outside a request scope and throw. Suspense defers
+       * it out of the shell; the panel is closed by default, so null fallback.
+       */}
+      <Suspense fallback={null}>
+        <DecisionSidePanel
+          decisionProfileId={decisionProfile.id}
+          access={access}
         />
-        {children}
-        {/*
-         * Like the header's updates toggle, the side panel reads the `panel`
-         * search param (nuqs/useSearchParams). It lives in this layout, which
-         * Next prerenders as the route's static shell (see loading.tsx), so the
-         * read would happen outside a request scope and throw. Suspense defers
-         * it out of the shell; the panel is closed by default, so null fallback.
-         */}
-        <Suspense fallback={null}>
-          <DecisionSidePanel
-            decisionProfileId={decisionProfile.id}
-            access={access}
-          />
-        </Suspense>
-      </DecisionTranslationProvider>
-    </HydrationBoundary>
+      </Suspense>
+    </DecisionTranslationProvider>
   );
 };
 

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
@@ -1,18 +1,9 @@
-import {
-  HydrationBoundary,
-  createServerUtils,
-  dehydrate,
-} from '@op/api/server';
-import { logger } from '@op/logging';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import type { ReactNode } from 'react';
-import { Suspense } from 'react';
 
 import { DecisionOverviewSuspense } from '@/components/decisions/DecisionOverview';
 import { RichTextRenderer } from '@/components/decisions/RichTextRenderer';
 import { hasFirstPhaseStarted } from '@/components/decisions/hasFirstPhaseStarted';
-import { DecisionContentSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
 import { loadDecision } from '../loadDecision';
 
@@ -43,6 +34,13 @@ export async function generateMetadata({
  * Overview tab (/decisions/[slug]/overview). The shared header + tabs come
  * from the (decision-view) layout; this only renders the overview content.
  *
+ * Single fetch: everything the overview renders (body, phases, headline,
+ * access) comes from `loadDecision` (getDecisionBySlug, which the router
+ * enriches with `access` + encoded `instanceData`). No separate `getInstance`
+ * call — the content + per-user access ride on the one slug fetch the route
+ * already makes. The client components read this via props, so there's no
+ * client `getInstance` query on this route either.
+ *
  * Temporary home: while the overview ships behind a flag, the old
  * current-phase page stays canonical at /decisions/[slug]. When the overview
  * is ready it moves to the root and the old page is retired.
@@ -53,53 +51,27 @@ const DecisionOverviewPage = async ({
   params: Promise<{ slug: string }>;
 }) => {
   const { slug } = await params;
-  const { instanceId } = await loadDecision(slug);
-  const { utils, queryClient } = await createServerUtils();
+  const { decisionProfile, instanceId } = await loadDecision(slug);
+  const instance = decisionProfile.processInstance;
 
-  // One server fetch seeds the cache the client useSuspenseQuery hydrates from
-  // (no second fetch, no divergence) and feeds the RSC body. Best-effort: on
-  // failure the cache stays empty, so the client refetches and its
-  // APIErrorBoundary drives the error UX.
-  let aboutSlot: ReactNode = null;
-  // The process is "active" once its first phase begins; default to active so a
-  // failed fetch keeps the CTAs visible (the client suspense read drives the
-  // error UX). Same gate as the view toggle in the layout.
-  let isActive = true;
-  const instance = await utils.decision.getInstance
-    .fetch({ instanceId })
-    .catch((error) => {
-      logger.warn('Failed to server-render decision overview', {
-        instanceId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return null;
-    });
+  // The "About" body ships as server HTML (no client JS) from the overview's
+  // rich-text content. Null when there's no body (falls back to the plain
+  // description in OverviewAbout).
+  const body = instance.instanceData?.overview?.body;
+  const aboutSlot = body ? <RichTextRenderer content={body} /> : null;
 
-  if (instance) {
-    isActive = hasFirstPhaseStarted(instance.instanceData?.phases);
-    const body = instance.instanceData?.overview?.body;
-    if (body) {
-      aboutSlot = <RichTextRenderer content={body} />;
-    }
-  }
-
-  // Pinned-resources queries (collections + each collection's resources) are
-  // NOT seeded here on purpose: they're secondary sidebar content with their
-  // own Suspense + skeleton + error boundary (OverviewPinnedResourcesSuspense),
-  // so the client fetches them after first paint instead of blocking the shell.
-  // Measured ~335ms of time-to-content removed by not seeding here (2026-06-25).
+  // The process is "active" once its first phase begins; the proposal CTAs stay
+  // hidden until then. Same gate as the view toggle in the layout.
+  const isActive = hasFirstPhaseStarted(instance.instanceData?.phases);
 
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <Suspense fallback={<DecisionContentSkeleton />}>
-        <DecisionOverviewSuspense
-          instanceId={instanceId}
-          decisionSlug={slug}
-          aboutSlot={aboutSlot}
-          isActive={isActive}
-        />
-      </Suspense>
-    </HydrationBoundary>
+    <DecisionOverviewSuspense
+      instanceId={instanceId}
+      decisionSlug={slug}
+      processInstance={instance}
+      aboutSlot={aboutSlot}
+      isActive={isActive}
+    />
   );
 };
 

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/overview/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-import { DecisionOverviewSuspense } from '@/components/decisions/DecisionOverview';
+import { DecisionOverview } from '@/components/decisions/DecisionOverview';
 import { RichTextRenderer } from '@/components/decisions/RichTextRenderer';
 import { hasFirstPhaseStarted } from '@/components/decisions/hasFirstPhaseStarted';
 
@@ -65,7 +65,7 @@ const DecisionOverviewPage = async ({
   const isActive = hasFirstPhaseStarted(instance.instanceData?.phases);
 
   return (
-    <DecisionOverviewSuspense
+    <DecisionOverview
       instanceId={instanceId}
       decisionSlug={slug}
       processInstance={instance}

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -3,7 +3,11 @@
 import { useTrackPageView } from '@/hooks/useTrackPageView';
 import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
-import { type ProcessPhase } from '@op/api/encoders';
+import {
+  type InstanceData,
+  type ProcessInstance,
+  type ProcessPhase,
+} from '@op/api/encoders';
 import { type ReactNode } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -29,6 +33,13 @@ interface StandardDecisionHeaderProps extends DecisionHeaderBaseProps {
   centerSlot?: ReactNode;
   /** Whether to render the phase stepper below the header bar (default true) */
   showStepper?: boolean;
+  /**
+   * When provided, the header renders from this prop instead of a client
+   * `getInstance` query — used by the (decision-view) layout, which already has
+   * the instance from loadDecision. Omitted by the canonical /decisions/[slug]
+   * page, which falls back to the query.
+   */
+  processInstance?: ProcessInstance;
 }
 
 /** Legacy getInstance endpoint (for the /profile/[slug]/decisions/[id] route). */
@@ -60,24 +71,25 @@ export function DecisionHeader(props: DecisionHeaderProps) {
   if (props.useLegacy) {
     return <LegacyDecisionHeaderContent {...props} />;
   }
+  if (props.processInstance) {
+    return (
+      <DecisionHeaderFromProps
+        {...props}
+        processInstance={props.processInstance}
+      />
+    );
+  }
   return <DecisionHeaderContent {...props} />;
 }
 
-function DecisionHeaderContent({
-  instanceId,
-  decisionSlug,
-  isAdmin,
-  canReadUpdates,
-  profileName,
-  centerSlot,
-  showStepper = true,
-}: StandardDecisionHeaderProps) {
-  const t = useTranslations();
-  const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
-
-  const instancePhases = instance.instanceData?.phases ?? [];
-
-  const phases: ProcessPhase[] = instancePhases.map((p) => ({
+/**
+ * Maps the encoded instanceData phases to the ProcessPhase shape the stepper
+ * consumes. Shared by the query and prop header variants.
+ */
+function toProcessPhases(
+  instanceData: InstanceData | undefined,
+): ProcessPhase[] {
+  return (instanceData?.phases ?? []).map((p) => ({
     id: p.phaseId,
     name: p.name || '',
     description: p.description,
@@ -87,18 +99,29 @@ function DecisionHeaderContent({
     },
     advancementMethod: p.rules?.advancement?.method,
   }));
+}
 
+/** Presentational header bar + optional stepper, fed by either variant below. */
+function DecisionHeaderView({
+  instanceId,
+  decisionSlug,
+  isAdmin,
+  canReadUpdates,
+  centerSlot,
+  showStepper = true,
+  title,
+  phases,
+  currentStateId,
+}: StandardDecisionHeaderProps & {
+  title: string;
+  phases: ProcessPhase[];
+  currentStateId: string;
+}) {
   return (
     <>
       <DecisionInstanceHeader
         backTo={{ href: '/decisions' }}
-        title={
-          profileName ||
-          instance.name ||
-          instance.instanceData?.templateName ||
-          instance.process?.name ||
-          t('Untitled')
-        }
+        title={title}
         decisionSlug={decisionSlug}
         isAdmin={isAdmin}
         canReadUpdates={canReadUpdates}
@@ -107,12 +130,58 @@ function DecisionHeaderContent({
       {showStepper ? (
         <DecisionStepperBar
           phases={phases}
-          currentStateId={instance.currentStateId || ''}
+          currentStateId={currentStateId}
           instanceId={instanceId}
           isAdmin={isAdmin}
         />
       ) : null}
     </>
+  );
+}
+
+/** Query variant: canonical /decisions/[slug] page (no instance passed in). */
+function DecisionHeaderContent(props: StandardDecisionHeaderProps) {
+  const t = useTranslations();
+  const [instance] = trpc.decision.getInstance.useSuspenseQuery({
+    instanceId: props.instanceId,
+  });
+
+  return (
+    <DecisionHeaderView
+      {...props}
+      title={
+        props.profileName ||
+        instance.name ||
+        instance.instanceData?.templateName ||
+        instance.process?.name ||
+        t('Untitled')
+      }
+      phases={toProcessPhases(instance.instanceData)}
+      currentStateId={instance.currentStateId || ''}
+    />
+  );
+}
+
+/** Prop variant: (decision-view) layout passes the instance from loadDecision. */
+function DecisionHeaderFromProps(
+  props: StandardDecisionHeaderProps & { processInstance: ProcessInstance },
+) {
+  const t = useTranslations();
+  const { processInstance: instance } = props;
+
+  return (
+    <DecisionHeaderView
+      {...props}
+      title={
+        props.profileName ||
+        instance.name ||
+        instance.instanceData?.templateName ||
+        instance.process?.name ||
+        t('Untitled')
+      }
+      phases={toProcessPhases(instance.instanceData)}
+      currentStateId={instance.currentStateId || ''}
+    />
   );
 }
 

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -54,7 +54,10 @@ interface DecisionOverviewProps {
  * Falls back to the instance name/description for processes authored before
  * that tab was filled in.
  */
-export function DecisionOverviewSuspense({
+// Renders from server-fetched props (no useSuspenseQuery), so it does not
+// suspend — no `Suspense` suffix. Keeps the page-level APIErrorBoundary as a
+// defensive catch for render errors.
+export function DecisionOverview({
   instanceId,
   decisionSlug,
   processInstance,

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
-import { trpc } from '@op/api/client';
-import { type ProcessPhase } from '@op/api/encoders';
+import { type ProcessInstance, type ProcessPhase } from '@op/api/encoders';
 import { Button, ButtonLink } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header2, Header3 } from '@op/ui/Header';
@@ -24,6 +23,13 @@ import { useCreateProposal } from './useCreateProposal';
 interface DecisionOverviewProps {
   instanceId: string;
   decisionSlug: string;
+  /**
+   * The decision's process instance, fetched once on the server via
+   * loadDecision (getDecisionBySlug, enriched by the router with `access` +
+   * encoded `instanceData`). Passed as a prop so the overview renders from the
+   * single slug fetch the route already makes — no client `getInstance` query.
+   */
+  processInstance: ProcessInstance;
   /**
    * The "About" body, pre-rendered on the server (RSC) from the overview's
    * TipTap JSON via RichTextRenderer, so the prose ships as server HTML with no
@@ -51,6 +57,7 @@ interface DecisionOverviewProps {
 export function DecisionOverviewSuspense({
   instanceId,
   decisionSlug,
+  processInstance,
   aboutSlot,
   isActive,
 }: DecisionOverviewProps) {
@@ -74,6 +81,7 @@ export function DecisionOverviewSuspense({
       <DecisionOverviewContent
         instanceId={instanceId}
         decisionSlug={decisionSlug}
+        processInstance={processInstance}
         aboutSlot={aboutSlot}
         isActive={isActive}
       />
@@ -84,11 +92,11 @@ export function DecisionOverviewSuspense({
 function DecisionOverviewContent({
   instanceId,
   decisionSlug,
+  processInstance: instance,
   aboutSlot,
   isActive,
 }: DecisionOverviewProps) {
   const t = useTranslations();
-  const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
 
   const overview = instance.instanceData?.overview;
   const headline = overview?.headline || instance.name;

--- a/services/api/src/routers/decision/instances/getDecisionBySlugAccessParity.test.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlugAccessParity.test.ts
@@ -17,16 +17,26 @@ async function createAuthenticatedCaller(email: string) {
 
 /**
  * /overview is single-fetch: it reads per-user `access` from getDecisionBySlug
- * (which the router derives via getProfileAccessRoles -> decisions bitfield)
- * instead of getInstance (resolveInstanceAccess, which adds a profile-admin
- * ALL_TRUE bypass + org fallback). This is only safe if the two derivations
- * agree for the capabilities the overview gates on (admin, submitProposals).
+ * (router derives it via getProfileAccessRoles -> decisions bitfield) instead of
+ * getInstance (resolveInstanceAccess, which adds a profile-admin ALL_TRUE bypass
+ * + org fallback). Safe only if the two derivations agree for the capabilities
+ * the overview gates on (admin, submitProposals).
  *
- * They agree for the default decision roles because the Admin role grants the
- * decisions bits explicitly (decisionRoles.ts) — so the bitfield path already
- * reflects admin, making the bypass redundant. These tests pin that parity; if
- * a future role change reintroduces a profile-admin-without-decisions-bits
- * grant, the overview CTAs would diverge and this fails.
+ * SCOPE (be honest about what this proves): this pins parity for the DEFAULT
+ * Admin role only. That role grants `profile.admin` AND the full decisions
+ * bitfield, so BOTH paths return admin=true — getInstance via the profile-admin
+ * bypass, getDecisionBySlug via the bitfield. They agree, but for different
+ * reasons, so this case does NOT exercise the bypass itself.
+ *
+ * KNOWN LIMITATIONS this test does NOT cover (see PR #1417 review):
+ *  - A custom role granting `profile.admin` WITHOUT decisions-admin/submit bits:
+ *    getInstance would return admin=true (bypass), getDecisionBySlug admin=false
+ *    (bitfield) → /overview would under-report CTAs. Reachable via custom roles
+ *    (createDecisionRole); unverified whether such roles exist in production.
+ *  - Org-only viewers (org role, no profile grant): NOT relevant to /overview —
+ *    its gate (assertProfileAccess, profile-only) already 403s them before render.
+ *  If custom profile-admin roles are in use, fix the router to derive access like
+ *  getInstance (getProfileAccessRolesWithOrgFallback + profile-admin bypass).
  */
 describe.concurrent('getDecisionBySlug access parity with getInstance', () => {
   it('admin user: access matches getInstance for overview-gated fields', async ({

--- a/services/api/src/routers/decision/instances/getDecisionBySlugAccessParity.test.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlugAccessParity.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+/**
+ * /overview is single-fetch: it reads per-user `access` from getDecisionBySlug
+ * (which the router derives via getProfileAccessRoles -> decisions bitfield)
+ * instead of getInstance (resolveInstanceAccess, which adds a profile-admin
+ * ALL_TRUE bypass + org fallback). This is only safe if the two derivations
+ * agree for the capabilities the overview gates on (admin, submitProposals).
+ *
+ * They agree for the default decision roles because the Admin role grants the
+ * decisions bits explicitly (decisionRoles.ts) — so the bitfield path already
+ * reflects admin, making the bypass redundant. These tests pin that parity; if
+ * a future role change reintroduces a profile-admin-without-decisions-bits
+ * grant, the overview CTAs would diverge and this fails.
+ */
+describe.concurrent('getDecisionBySlug access parity with getInstance', () => {
+  it('admin user: access matches getInstance for overview-gated fields', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    // grantAccess: true assigns the default Admin role (profile.ADMIN + full
+    // decisions bits).
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const [bySlug, byInstance] = await Promise.all([
+      caller.decision.getDecisionBySlug({ slug: setup.instance.slug }),
+      caller.decision.getInstance({
+        instanceId: setup.instance.instance.id,
+      }),
+    ]);
+
+    const slugAccess = bySlug.processInstance.access;
+    const instanceAccess = byInstance.access;
+
+    // The fields /overview reads: admin (phase-advance + header chrome) and
+    // submitProposals (Submit CTA). read/vote included for completeness.
+    expect(slugAccess?.admin).toBe(instanceAccess?.admin);
+    expect(slugAccess?.submitProposals).toBe(instanceAccess?.submitProposals);
+    expect(slugAccess?.read).toBe(instanceAccess?.read);
+    expect(slugAccess?.vote).toBe(instanceAccess?.vote);
+
+    // And concretely: an admin can submit + administer.
+    expect(slugAccess?.admin).toBe(true);
+    expect(slugAccess?.submitProposals).toBe(true);
+  });
+});


### PR DESCRIPTION
The /overview route fetched the decision instance twice — `getDecisionBySlug` (via `loadDecision`) then `getInstance`, both deep-fetching the same row. The router's `getDecisionBySlug` already returns encoded `instanceData` + per-user `access`, so `getInstance` is redundant for /overview.

## Data flow

**Before — two fetches of the same instance row:**

```mermaid
flowchart TD
  REQ["GET /overview"]
  REQ --> LD["loadDecision → getDecisionBySlug"]
  REQ --> GI["getInstance.fetch (layout + page, deduped)"]
  LD --> DB1[("DB: instance row")]
  GI --> DB2[("DB: same row, fetched again")]
  LD --> CHROME["layout header: name + access"]
  GI -. seeds cache .-> CQ["client useSuspenseQuery(getInstance)"]
  CQ --> CONTENT["DecisionOverviewContent + DecisionHeader phases"]
```

**After — one fetch, props all the way down (no getInstance):**

```mermaid
flowchart TD
  REQ["GET /overview"]
  REQ --> LD["loadDecision → getDecisionBySlug<br/>(name + access + encoded instanceData)"]
  LD --> DB1[("DB: instance row — ONE fetch")]
  LD -- props --> ALL["layout + DecisionHeader + DecisionOverviewContent"]
```

## Changes

- /overview page + `DecisionOverview` render from `loadDecision` props — no `getInstance` (server or client).
- layout computes `isActive` from `loadDecision`'s phases; drops its `getInstance.fetch`.
- /current re-seeds `getInstance` in its own page (it was relying on the layout seed).
- `DecisionHeader` takes an optional `processInstance` prop (renders from props on the decision-view route; the canonical `/decisions/[slug]` page keeps the query fallback).
- access-parity test pins `getDecisionBySlug.access == getInstance.access` for the default Admin role.

**Net:** /overview does one instance fetch instead of two — ~175ms off time-to-content and ~half the per-request instance DB work (throughput headroom for anonymous traffic on public processes).

**Trade-off:** /overview content is now server-rendered-static — it won't live-update from the realtime channel until reload. Fine for rarely-changing overview content; flag if not.

**Tests:** access-parity (passes against local DB). Overview-render/CTA component tests skipped — the gating logic is unchanged (data source moved query→prop, typecheck-guaranteed); the real risk was access parity, which the DB test covers.