### PR TITLE
feat(decisions): redesign default overview header

### DIFF
--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -6,7 +6,7 @@ import { type ProcessInstance, type ProcessPhase } from '@op/api/encoders';
 import { Avatar } from '@op/ui/Avatar';
 import { Button, ButtonLink } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
-import { Header2, Header3 } from '@op/ui/Header';
+import { Header3 } from '@op/ui/Header';
 import { Link } from '@op/ui/Link';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import he from 'he';

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -142,9 +142,7 @@ function DecisionOverviewContent({
       <OverviewHero
         headline={headline}
         subhead={overview?.description}
-        stewardName={steward?.name}
-        stewardAvatarPath={steward?.avatarImage?.name}
-        stewardSlug={steward?.slug}
+        steward={steward}
         isPublic={isPublic}
         instanceId={instanceId}
         decisionSlug={decisionSlug}
@@ -195,9 +193,7 @@ function DecisionOverviewContent({
 const OverviewHero = ({
   headline,
   subhead,
-  stewardName,
-  stewardAvatarPath,
-  stewardSlug,
+  steward,
   isPublic,
   instanceId,
   decisionSlug,
@@ -206,9 +202,7 @@ const OverviewHero = ({
 }: {
   headline: string;
   subhead?: string;
-  stewardName?: string | null;
-  stewardAvatarPath?: string | null;
-  stewardSlug?: string | null;
+  steward: ProcessInstance['steward'];
   isPublic: boolean;
   instanceId: string;
   decisionSlug: string;
@@ -216,6 +210,7 @@ const OverviewHero = ({
   showCtas: boolean;
 }) => {
   const t = useTranslations();
+  const stewardName = steward?.name;
   const currentPhaseHref = `/decisions/${decisionSlug}/current`;
   const { createProposal, isCreating, isReady } = useCreateProposal({
     instanceId,
@@ -241,9 +236,9 @@ const OverviewHero = ({
               {stewardName ? (
                 <span className="flex items-center gap-1.5">
                   <Avatar placeholder={stewardName} className="size-5">
-                    {stewardAvatarPath ? (
+                    {steward?.avatarImage?.name ? (
                       <Image
-                        src={getPublicUrl(stewardAvatarPath) ?? ''}
+                        src={getPublicUrl(steward.avatarImage.name) ?? ''}
                         alt={stewardName}
                         fill
                         className="object-cover"
@@ -252,8 +247,8 @@ const OverviewHero = ({
                   </Avatar>
                   <span>
                     {t('Stewarded by')}{' '}
-                    {stewardSlug ? (
-                      <Link href={`/profile/${stewardSlug}`}>
+                    {steward?.slug ? (
+                      <Link href={`/profile/${steward.slug}`}>
                         {stewardName}
                       </Link>
                     ) : (

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -233,7 +233,7 @@ const OverviewHero = ({
       <div className="mx-auto flex flex-col items-center gap-4 px-4 pt-16 pb-8 text-center sm:py-12 md:col-span-6 md:col-start-4 md:px-6">
         <div className="flex flex-col items-center gap-3">
           {/* Brand teal→green gradient clipped to the title text. */}
-          <h1 className="bg-tealGreen bg-clip-text font-serif text-title-xl font-light text-transparent sm:text-title-xxl">
+          <h1 className="bg-tealGreen bg-clip-text font-serif text-title-xl font-light text-pretty text-transparent sm:text-title-xxl">
             <bdi>{headline}</bdi>
           </h1>
           {stewardName || isPublic ? (
@@ -276,7 +276,10 @@ const OverviewHero = ({
             </div>
           ) : null}
           {subhead ? (
-            <p dir="auto" className="text-base text-neutral-charcoal">
+            <p
+              dir="auto"
+              className="text-base text-pretty text-neutral-charcoal"
+            >
               {subhead}
             </p>
           ) : null}

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -1,14 +1,18 @@
 'use client';
 
+import { getPublicUrl } from '@/utils';
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { type ProcessInstance, type ProcessPhase } from '@op/api/encoders';
+import { Avatar } from '@op/ui/Avatar';
 import { Button, ButtonLink } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
-import { Header3 } from '@op/ui/Header';
+import { Header2, Header3 } from '@op/ui/Header';
+import { Link } from '@op/ui/Link';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import he from 'he';
+import Image from 'next/image';
 import { Suspense, type ReactNode } from 'react';
-import { LuTriangleAlert } from 'react-icons/lu';
+import { LuBookOpen, LuTriangleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -105,6 +109,12 @@ function DecisionOverviewContent({
   const headline = overview?.headline || instance.name;
   const profileId = instance.profileId;
 
+  // Header meta row: prefer the steward, fall back to the owner (same rule as
+  // DecisionListItem). "Open for learning" shows only for public processes;
+  // private processes hide the badge entirely.
+  const steward = instance.steward ?? instance.owner;
+  const isPublic = !instance.instanceData?.config?.isPrivate;
+
   // Same gate as StandardDecisionPage: the phase must accept proposals and
   // the viewer must have submit access.
   const currentPhase = instance.instanceData?.phases?.find(
@@ -132,6 +142,10 @@ function DecisionOverviewContent({
       <OverviewHero
         headline={headline}
         subhead={overview?.description}
+        stewardName={steward?.name}
+        stewardAvatarPath={steward?.avatarImage?.name}
+        stewardSlug={steward?.slug}
+        isPublic={isPublic}
         instanceId={instanceId}
         decisionSlug={decisionSlug}
         canSubmitProposal={canSubmitProposal}
@@ -181,6 +195,10 @@ function DecisionOverviewContent({
 const OverviewHero = ({
   headline,
   subhead,
+  stewardName,
+  stewardAvatarPath,
+  stewardSlug,
+  isPublic,
   instanceId,
   decisionSlug,
   canSubmitProposal,
@@ -188,6 +206,10 @@ const OverviewHero = ({
 }: {
   headline: string;
   subhead?: string;
+  stewardName?: string | null;
+  stewardAvatarPath?: string | null;
+  stewardSlug?: string | null;
+  isPublic: boolean;
   instanceId: string;
   decisionSlug: string;
   canSubmitProposal: boolean;
@@ -203,16 +225,58 @@ const OverviewHero = ({
   });
 
   return (
-    // Gradient stands in until overview header images exist — same radial
-    // gradient as the results page hero.
-    <section className="grid w-full grid-cols-1 justify-center gap-12 bg-redPurple md:grid-cols-12">
-      <div className="mx-auto flex flex-col items-center gap-4 px-4 pt-16 pb-8 text-center text-neutral-offWhite sm:py-24 md:col-span-6 md:col-start-4 md:px-6">
-        <div className="flex flex-col items-center gap-2">
-          <h1 className="font-serif text-title-xl font-light sm:text-title-xxl">
+    // ponytail: light banner stands in for the header image. When the
+    // upload ships, drop an absolutely-positioned <Image fill> (from
+    // profile.headerImage) behind this content and keep the gradient as the
+    // empty-state fallback.
+    <section className="grid w-full grid-cols-1 justify-center bg-neutral-offWhite md:grid-cols-12">
+      <div className="mx-auto flex flex-col items-center gap-4 px-4 pt-16 pb-8 text-center sm:py-24 md:col-span-6 md:col-start-4 md:px-6">
+        <div className="flex flex-col items-center gap-3">
+          {/* Brand teal→green gradient clipped to the title text. */}
+          <h1 className="bg-tealGreen bg-clip-text font-serif text-title-xl font-light text-transparent sm:text-title-xxl">
             <bdi>{headline}</bdi>
           </h1>
+          {stewardName || isPublic ? (
+            <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm text-neutral-charcoal">
+              {stewardName ? (
+                <span className="flex items-center gap-1.5">
+                  <Avatar placeholder={stewardName} className="size-5">
+                    {stewardAvatarPath ? (
+                      <Image
+                        src={getPublicUrl(stewardAvatarPath) ?? ''}
+                        alt={stewardName}
+                        fill
+                        className="object-cover"
+                      />
+                    ) : null}
+                  </Avatar>
+                  <span>
+                    {t('Stewarded by')}{' '}
+                    {stewardSlug ? (
+                      <Link href={`/profile/${stewardSlug}`}>
+                        {stewardName}
+                      </Link>
+                    ) : (
+                      stewardName
+                    )}
+                  </span>
+                </span>
+              ) : null}
+              {stewardName && isPublic ? (
+                <span aria-hidden="true" className="text-neutral-gray4">
+                  •
+                </span>
+              ) : null}
+              {isPublic ? (
+                <span className="flex items-center gap-1.5">
+                  <LuBookOpen className="size-4" aria-hidden="true" />
+                  {t('Open for learning')}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
           {subhead ? (
-            <p dir="auto" className="text-base">
+            <p dir="auto" className="text-base text-neutral-charcoal">
               {subhead}
             </p>
           ) : null}

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -225,7 +225,7 @@ const OverviewHero = ({
   });
 
   return (
-    // ponytail: light banner stands in for the header image. When the
+    // Light banner stands in for the header image. When the
     // upload ships, drop an absolutely-positioned <Image fill> (from
     // profile.headerImage) behind this content and keep the gradient as the
     // empty-state fallback.

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -233,7 +233,7 @@ const OverviewHero = ({
       <div className="mx-auto flex flex-col items-center gap-4 px-4 pt-16 pb-8 text-center sm:py-12 md:col-span-6 md:col-start-4 md:px-6">
         <div className="flex flex-col items-center gap-3">
           {/* Brand teal→green gradient clipped to the title text. */}
-          <h1 className="bg-tealGreen bg-clip-text font-serif text-title-xl font-light text-pretty text-transparent sm:text-title-xxl">
+          <h1 className="bg-tealGreen bg-clip-text font-serif text-title-xl font-light text-balance text-transparent sm:text-title-xxl">
             <bdi>{headline}</bdi>
           </h1>
           {stewardName || isPublic ? (
@@ -278,7 +278,7 @@ const OverviewHero = ({
           {subhead ? (
             <p
               dir="auto"
-              className="text-base text-pretty text-neutral-charcoal"
+              className="text-base text-balance text-neutral-charcoal"
             >
               {subhead}
             </p>

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -229,8 +229,8 @@ const OverviewHero = ({
     // upload ships, drop an absolutely-positioned <Image fill> (from
     // profile.headerImage) behind this content and keep the gradient as the
     // empty-state fallback.
-    <section className="grid w-full grid-cols-1 justify-center bg-neutral-offWhite md:grid-cols-12">
-      <div className="mx-auto flex flex-col items-center gap-4 px-4 pt-16 pb-8 text-center sm:py-24 md:col-span-6 md:col-start-4 md:px-6">
+    <section className="grid w-full grid-cols-1 justify-center border-b bg-neutral-offWhite md:grid-cols-12">
+      <div className="mx-auto flex flex-col items-center gap-4 px-4 pt-16 pb-8 text-center sm:py-12 md:col-span-6 md:col-start-4 md:px-6">
         <div className="flex flex-col items-center gap-3">
           {/* Brand teal→green gradient clipped to the title text. */}
           <h1 className="bg-tealGreen bg-clip-text font-serif text-title-xl font-light text-transparent sm:text-title-xxl">

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -117,6 +117,7 @@
   "Updates": "التحديثات",
   "Relationships": "العلاقات",
   "Start a proposal": "ابدأ مقترحًا",
+  "Stewarded by": "بإشراف",
   "No proposals yet": "لا توجد مقترحات بعد.",
   "You could be the first one to submit a proposal": "يمكن أن تكون أول من يقدم مقترحًا! 😉",
   "Current Phase": "المرحلة الحالية",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -159,6 +159,7 @@
   "Remove file": "ফাইল সরান",
   "Relationships": "সম্পর্ক",
   "Start a proposal": "একটি প্রস্তাব শুরু করুন",
+  "Stewarded by": "পরিচালনায়",
   "No proposals yet": "এখনও কোন প্রস্তাব নেই।",
   "You could be the first one to submit a proposal": "আপনি একটি প্রস্তাব জমা দেওয়ার ক্ষেত্রে প্রথম হতে পারেন! 😉",
   "You'll see your proposal here once you submit.": "আপনি জমা দেওয়ার পর এখানে আপনার প্রস্তাব দেখতে পাবেন।",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -121,6 +121,7 @@
   "Decision updates panel": "Decision updates panel",
   "Relationships": "Relationships",
   "Start a proposal": "Start a proposal",
+  "Stewarded by": "Stewarded by",
   "No proposals yet": "No proposals yet.",
   "You could be the first one to submit a proposal": "You could be the first one to submit a proposal! 😉",
   "You'll see your proposal here once you submit.": "You'll see your proposal here once you submit.",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -158,6 +158,7 @@
   "Remove file": "Quitar archivo",
   "Relationships": "Relaciones",
   "Start a proposal": "Iniciar una propuesta",
+  "Stewarded by": "Gestionado por",
   "No proposals yet": "Aún no hay propuestas.",
   "You could be the first one to submit a proposal": "¡Podrías ser el primero en enviar una propuesta! 😉",
   "You'll see your proposal here once you submit.": "Verás tu propuesta aquí una vez que la envíes.",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -159,6 +159,7 @@
   "Remove file": "Retirer le fichier",
   "Relationships": "Relations",
   "Start a proposal": "Commencer une proposition",
+  "Stewarded by": "Géré par",
   "No proposals yet": "Aucune proposition pour le moment.",
   "You could be the first one to submit a proposal": "Vous pourriez être le premier à soumettre une proposition ! 😉",
   "You'll see your proposal here once you submit.": "Vous verrez votre proposition ici une fois soumise.",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -159,6 +159,7 @@
   "Remove file": "Remover ficheiro",
   "Relationships": "Relacionamentos",
   "Start a proposal": "Iniciar uma proposta",
+  "Stewarded by": "Gerenciado por",
   "No proposals yet": "Ainda não há propostas.",
   "You could be the first one to submit a proposal": "Você poderia ser o primeiro a enviar uma proposta! 😉",
   "You'll see your proposal here once you submit.": "Você verá sua proposta aqui assim que enviá-la.",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -117,6 +117,7 @@
   "Updates": "Cusboonaysiinta",
   "Relationships": "Xiriiriyaha",
   "Start a proposal": "Bilow soo jeedin",
+  "Stewarded by": "Waxaa maamula",
   "No proposals yet": "Wali ma jiraan soo jeedimo.",
   "You could be the first one to submit a proposal": "Waxaad noqon kartaa kii ugu horreeyay ee soo jeedinaya! 😉",
   "Current Phase": "Marxaladda Hadda",

--- a/packages/common/src/services/decision/getDecisionBySlug.ts
+++ b/packages/common/src/services/decision/getDecisionBySlug.ts
@@ -14,7 +14,7 @@ const decisionProfileQueryConfig = {
       with: {
         process: true,
         owner: { with: { avatarImage: true, organization: true } },
-        steward: true,
+        steward: { with: { avatarImage: true } },
       },
     },
   },


### PR DESCRIPTION
Updates the default overview header to the Figma design.

- Light banner with teal-green gradient title text (replaces the redPurple placeholder)
- New meta row: steward avatar + "Stewarded by" link, and "Open for learning" badge (hidden for private processes)
- `getDecisionBySlug` now loads the steward avatar
- Adds `text-balance` to header and subhead so that the text looks balanced
- Background left as a swappable layer; header-image upload is deferred (coming soon)

<img width="2372" height="1484" alt="before and after screenshot" src="https://github.com/user-attachments/assets/2d9551a4-66a6-43e7-8878-575180f6819f" />
