### PR TITLE
fix(decisions): remove un-needed header on the process overview page

### DIFF
--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -273,10 +273,5 @@ const OverviewAbout = ({
     return null;
   }
 
-  return (
-    <section className="flex flex-col gap-4">
-      <Header2 className="font-serif">{t('About the process')}</Header2>
-      {body}
-    </section>
-  );
+  return <section className="flex flex-col gap-4">{body}</section>;
 };

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -4,7 +4,7 @@ import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { type ProcessInstance, type ProcessPhase } from '@op/api/encoders';
 import { Button, ButtonLink } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
-import { Header2, Header3 } from '@op/ui/Header';
+import { Header3 } from '@op/ui/Header';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import he from 'he';
 import { Suspense, type ReactNode } from 'react';
@@ -253,8 +253,6 @@ const OverviewAbout = ({
   /** Plain-text process description shown when no overview body exists. */
   fallbackText?: string;
 }) => {
-  const t = useTranslations();
-
   // Prefer the server-rendered body; otherwise fall back to the plain-text
   // description (entity-encoded for some orgs, same as DecisionActionBar —
   // decode and render as text, not HTML).

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -271,5 +271,5 @@ const OverviewAbout = ({
     return null;
   }
 
-  return <section className="flex flex-col gap-4">{body}</section>;
+  return body;
 };


### PR DESCRIPTION
- Removes the "About the process" `Header2` heading from the overview page
- Drops the now-vestigial section wrapper in `OverviewAbout` (returned body directly)
- Cleans up unused `Header2` import and local `useTranslations`

Typecheck + format pass. Pure JSX/import cleanup, no logic change.