### PR TITLE
refactor(decisions): remove dead grid classes from decision pages

### DIFF
--- a/apps/app/src/components/decisions/pages/FinalPhaseManualSelectionPage.tsx
+++ b/apps/app/src/components/decisions/pages/FinalPhaseManualSelectionPage.tsx
@@ -41,7 +41,7 @@ export function FinalPhaseManualSelectionPage({
       </div>
 
       <div className="mt-8 flex w-full justify-center border-t bg-white">
-        <div className="w-full gap-8 p-4 sm:max-w-6xl sm:p-8">
+        <div className="w-full p-4 sm:max-w-6xl sm:p-8">
           <div className="flex flex-col gap-6">
             <APIErrorBoundary
               fallbacks={{

--- a/apps/app/src/components/decisions/pages/ResultsPage.tsx
+++ b/apps/app/src/components/decisions/pages/ResultsPage.tsx
@@ -167,7 +167,7 @@ function ResultsPageContent({
       </div>
 
       <div className="flex w-full justify-center border-t bg-white">
-        <div className="w-full gap-8 p-4 sm:max-w-6xl">
+        <div className="w-full p-4 sm:max-w-6xl">
           <DecisionResultsTabs>
             <DecisionResultsTabPanel id="funded">
               <APIErrorBoundary
@@ -184,30 +184,26 @@ function ResultsPageContent({
                   ),
                 }}
               >
-                <div className="lg:col-span-3">
-                  <Suspense fallback={<ProposalListSkeleton />}>
-                    <ResultsList
-                      slug={profileSlug}
-                      instanceId={instanceId}
-                      decisionSlug={decisionSlug}
-                    />
-                  </Suspense>
-                </div>
+                <Suspense fallback={<ProposalListSkeleton />}>
+                  <ResultsList
+                    slug={profileSlug}
+                    instanceId={instanceId}
+                    decisionSlug={decisionSlug}
+                  />
+                </Suspense>
               </APIErrorBoundary>
             </DecisionResultsTabPanel>
 
             <DecisionResultsTabPanel id="all-proposals">
-              <div className="lg:col-span-3">
-                <Suspense fallback={<ProposalListSkeleton />}>
-                  <ProposalsList
-                    slug={profileSlug}
-                    instanceId={instanceId}
-                    decisionSlug={decisionSlug}
-                    initialFilter={ProposalFilter.ALL}
-                    phase="results"
-                  />
-                </Suspense>
-              </div>
+              <Suspense fallback={<ProposalListSkeleton />}>
+                <ProposalsList
+                  slug={profileSlug}
+                  instanceId={instanceId}
+                  decisionSlug={decisionSlug}
+                  initialFilter={ProposalFilter.ALL}
+                  phase="results"
+                />
+              </Suspense>
             </DecisionResultsTabPanel>
 
             <DecisionResultsTabPanel id="ballot">
@@ -216,15 +212,13 @@ function ResultsPageContent({
                   default: () => <NoVoteFound />,
                 }}
               >
-                <div className="lg:col-span-3">
-                  <Suspense fallback={<ProposalListSkeleton />}>
-                    <MyBallot
-                      slug={profileSlug}
-                      instanceId={instanceId}
-                      decisionSlug={decisionSlug}
-                    />
-                  </Suspense>
-                </div>
+                <Suspense fallback={<ProposalListSkeleton />}>
+                  <MyBallot
+                    slug={profileSlug}
+                    instanceId={instanceId}
+                    decisionSlug={decisionSlug}
+                  />
+                </Suspense>
               </APIErrorBoundary>
             </DecisionResultsTabPanel>
           </DecisionResultsTabs>

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -96,7 +96,7 @@ export function ReviewPage({
       </div>
 
       <div className="flex w-full justify-center bg-white">
-        <div className="w-full gap-8 p-4 sm:max-w-6xl sm:p-8">
+        <div className="w-full p-4 sm:max-w-6xl sm:p-8">
           <APIErrorBoundary
             fallbacks={{
               default: () => (

--- a/apps/app/src/components/decisions/pages/ReviewSelectionPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewSelectionPage.tsx
@@ -45,7 +45,7 @@ export function ReviewSelectionPage({
       </div>
 
       <div className="flex w-full justify-center border-t bg-white">
-        <div className="w-full gap-8 p-4 sm:max-w-6xl sm:p-8">
+        <div className="w-full p-4 sm:max-w-6xl sm:p-8">
           <APIErrorBoundary
             fallbacks={{
               default: () => (

--- a/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
+++ b/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
@@ -99,67 +99,65 @@ export function StandardDecisionPage({
             currentPhaseEndDate={currentPhase?.endDate}
           />
         )}
-        <div className="w-full gap-8 p-4 sm:max-w-6xl sm:p-8">
-          <div className="flex flex-col gap-6 lg:col-span-3">
-            {isAwaitingFinalResults ? (
-              <EmptyState icon={<LuClock className="size-6" />}>
-                <Header3 className="font-serif font-light">
-                  {t('Results pending')}
-                </Header3>
-                <p className="text-base text-neutral-charcoal">
-                  {t("Results for this process haven't been processed yet.")}
-                </p>
-              </EmptyState>
-            ) : !instance.selectionsAreConfirmed && isAdmin && decisionSlug ? (
-              <APIErrorBoundary
-                fallbacks={{
-                  default: () => (
-                    <EmptyState icon={<LuTriangleAlert className="size-6" />}>
-                      <Header3 className="font-serif font-light">
-                        {t("Couldn't load manual selection")}
-                      </Header3>
-                      <p className="text-base text-neutral-charcoal">
-                        {t('Refresh the page to try again.')}
-                      </p>
-                    </EmptyState>
-                  ),
-                }}
-              >
-                <Suspense fallback={null}>
-                  <ManualSelectionList
-                    instanceId={instanceId}
-                    decisionSlug={decisionSlug}
-                  />
-                </Suspense>
-              </APIErrorBoundary>
-            ) : (
-              <APIErrorBoundary
-                fallbacks={{
-                  default: () => (
-                    <EmptyState icon={<LuTriangleAlert className="size-6" />}>
-                      <Header3 className="font-serif font-light">
-                        {t("Couldn't load proposals")}
-                      </Header3>
-                      <p className="text-base text-neutral-charcoal">
-                        {t('Refresh the page to try again.')}
-                      </p>
-                    </EmptyState>
-                  ),
-                }}
-              >
-                <Suspense fallback={<ProposalListSkeleton />}>
-                  <ProposalsList
-                    slug={slug}
-                    instanceId={instanceId}
-                    decisionSlug={decisionSlug}
-                    decisionProfileId={decisionProfileId}
-                    permissions={instance.access}
-                    proposalsHidden={proposalsHidden}
-                  />
-                </Suspense>
-              </APIErrorBoundary>
-            )}
-          </div>
+        <div className="flex w-full flex-col gap-6 p-4 sm:max-w-6xl sm:p-8">
+          {isAwaitingFinalResults ? (
+            <EmptyState icon={<LuClock className="size-6" />}>
+              <Header3 className="font-serif font-light">
+                {t('Results pending')}
+              </Header3>
+              <p className="text-base text-neutral-charcoal">
+                {t("Results for this process haven't been processed yet.")}
+              </p>
+            </EmptyState>
+          ) : !instance.selectionsAreConfirmed && isAdmin && decisionSlug ? (
+            <APIErrorBoundary
+              fallbacks={{
+                default: () => (
+                  <EmptyState icon={<LuTriangleAlert className="size-6" />}>
+                    <Header3 className="font-serif font-light">
+                      {t("Couldn't load manual selection")}
+                    </Header3>
+                    <p className="text-base text-neutral-charcoal">
+                      {t('Refresh the page to try again.')}
+                    </p>
+                  </EmptyState>
+                ),
+              }}
+            >
+              <Suspense fallback={null}>
+                <ManualSelectionList
+                  instanceId={instanceId}
+                  decisionSlug={decisionSlug}
+                />
+              </Suspense>
+            </APIErrorBoundary>
+          ) : (
+            <APIErrorBoundary
+              fallbacks={{
+                default: () => (
+                  <EmptyState icon={<LuTriangleAlert className="size-6" />}>
+                    <Header3 className="font-serif font-light">
+                      {t("Couldn't load proposals")}
+                    </Header3>
+                    <p className="text-base text-neutral-charcoal">
+                      {t('Refresh the page to try again.')}
+                    </p>
+                  </EmptyState>
+                ),
+              }}
+            >
+              <Suspense fallback={<ProposalListSkeleton />}>
+                <ProposalsList
+                  slug={slug}
+                  instanceId={instanceId}
+                  decisionSlug={decisionSlug}
+                  decisionProfileId={decisionProfileId}
+                  permissions={instance.access}
+                  proposalsHidden={proposalsHidden}
+                />
+              </Suspense>
+            </APIErrorBoundary>
+          )}
         </div>
       </div>
     </div>

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -97,18 +97,16 @@ export function VotingPage({
       </div>
 
       <div className="mt-8 flex w-full justify-center border-t bg-white">
-        <div className="w-full gap-8 p-4 sm:max-w-6xl sm:p-8">
-          <div className="lg:col-span-3">
-            <Suspense fallback={<ProposalListSkeleton />}>
-              <ProposalsList
-                slug={slug}
-                instanceId={instanceId}
-                decisionSlug={decisionSlug}
-                permissions={instance.access}
-                currentPhase={currentPhase}
-              />
-            </Suspense>
-          </div>
+        <div className="w-full p-4 sm:max-w-6xl sm:p-8">
+          <Suspense fallback={<ProposalListSkeleton />}>
+            <ProposalsList
+              slug={slug}
+              instanceId={instanceId}
+              decisionSlug={decisionSlug}
+              permissions={instance.access}
+              currentPhase={currentPhase}
+            />
+          </Suspense>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Drop orphaned `gap-8` / `lg:col-span-3` classes left over from a removed multi-column grid layout, and collapse the now-redundant wrapper divs.

- StandardDecisionPage / VotingPage / ResultsPage / ReviewPage / ReviewSelectionPage / FinalPhaseManualSelectionPage
- Purely structural — no behavior change.