### PR TITLE
fix(decisions): card overflow on narrow mobile

### DIFF
--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -12,9 +12,11 @@ import { Avatar } from '@op/ui/Avatar';
 import { Chip } from '@op/ui/Chip';
 import { Header3 } from '@op/ui/Header';
 import { Surface } from '@op/ui/Surface';
+import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
 import { cn } from '@op/ui/utils';
 import Image from 'next/image';
-import type { HTMLAttributes, ReactNode } from 'react';
+import { type HTMLAttributes, type ReactNode, useRef } from 'react';
+import { useFocusable } from 'react-aria';
 import { LuBookmark, LuHeart, LuMessageCircle } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
@@ -448,22 +450,54 @@ export function ProposalCardMetrics({
         className,
       )}
     >
-      <span className="flex shrink-0 items-center gap-1">
-        <LuHeart className="size-4 shrink-0" />
-        {proposal.likesCount || 0}
-        <span className="hidden sm:inline">{t('Likes')}</span>
-      </span>
-      <span className="flex shrink-0 items-center gap-1">
-        <LuMessageCircle className="size-4 shrink-0" />
-        {proposal.commentsCount || 0}
-        <span className="hidden sm:inline">{t('Comments')}</span>
-      </span>
-      <span className="flex shrink-0 items-center gap-1">
-        <LuBookmark className="size-4 shrink-0" />
-        {proposal.followersCount || 0}
-        <span className="hidden sm:inline">{t('Followers')}</span>
-      </span>
+      <ProposalCardMetric
+        icon={<LuHeart className="size-4 shrink-0" />}
+        count={proposal.likesCount || 0}
+        label={t('Likes')}
+      />
+      <ProposalCardMetric
+        icon={<LuMessageCircle className="size-4 shrink-0" />}
+        count={proposal.commentsCount || 0}
+        label={t('Comments')}
+      />
+      <ProposalCardMetric
+        icon={<LuBookmark className="size-4 shrink-0" />}
+        count={proposal.followersCount || 0}
+        label={t('Followers')}
+      />
     </div>
+  );
+}
+
+// The label lives in a tooltip — the chip shows only the icon + count, since
+// room is tight on narrow cards. Focusable so the tooltip is keyboard-reachable;
+// aria-label keeps the bare count meaningful to screen readers.
+function ProposalCardMetric({
+  icon,
+  count,
+  label,
+}: {
+  icon: ReactNode;
+  count: number;
+  label: string;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const { focusableProps } = useFocusable({}, ref);
+
+  return (
+    <TooltipTrigger>
+      <span
+        {...focusableProps}
+        ref={ref}
+        tabIndex={0}
+        aria-label={`${count} ${label}`}
+        className="flex shrink-0 items-center gap-1"
+      >
+        {icon}
+        {count}
+      </span>
+      <Tooltip>{label}</Tooltip>
+    </TooltipTrigger>
   );
 }
 

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -52,7 +52,7 @@ export function ProposalCard({
     <Surface
       variant={isDraft ? 'filled' : 'empty'}
       className={cn(
-        'relative flex w-full min-w-80 flex-col justify-between gap-3 p-4',
+        'relative flex w-full flex-col justify-between gap-3 p-4 md:min-w-80',
         className,
       )}
       {...props}

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -502,7 +502,7 @@ function ProposalCardMetric({
         {icon}
         {count}
       </TooltipTrigger>
-      <TooltipContent>{label}</TooltipContent>
+      <TooltipContent className="text-sm">{label}</TooltipContent>
     </Tooltip>
   );
 }

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -444,7 +444,7 @@ export function ProposalCardMetrics({
   return (
     <div
       className={cn(
-        'flex w-full flex-wrap items-center gap-4 text-base text-neutral-gray4 sm:justify-between',
+        'flex w-full flex-wrap items-center gap-4 text-base text-neutral-gray4',
         className,
       )}
     >

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -444,21 +444,24 @@ export function ProposalCardMetrics({
   return (
     <div
       className={cn(
-        'flex w-full items-center justify-between gap-4 text-base text-neutral-gray4',
+        'flex w-full flex-wrap items-center justify-between gap-4 text-base text-neutral-gray4',
         className,
       )}
     >
-      <span className="flex items-center gap-1 truncate">
+      <span className="flex shrink-0 items-center gap-1">
         <LuHeart className="size-4 shrink-0" />
-        {proposal.likesCount || 0} {t('Likes')}
+        {proposal.likesCount || 0}
+        <span className="hidden sm:inline">{t('Likes')}</span>
       </span>
-      <span className="flex items-center gap-1 truncate">
+      <span className="flex shrink-0 items-center gap-1">
         <LuMessageCircle className="size-4 shrink-0" />
-        {proposal.commentsCount || 0} {t('Comments')}
+        {proposal.commentsCount || 0}
+        <span className="hidden sm:inline">{t('Comments')}</span>
       </span>
-      <span className="flex items-center gap-1 truncate">
+      <span className="flex shrink-0 items-center gap-1">
         <LuBookmark className="size-4 shrink-0" />
-        {proposal.followersCount || 0} {t('Followers')}
+        {proposal.followersCount || 0}
+        <span className="hidden sm:inline">{t('Followers')}</span>
       </span>
     </div>
   );

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -8,15 +8,19 @@ import {
   normalizeProposalCategories,
 } from '@op/common/client';
 import { isNullish, match } from '@op/core';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@op/sense/Tooltip';
 import { Avatar } from '@op/ui/Avatar';
 import { Chip } from '@op/ui/Chip';
 import { Header3 } from '@op/ui/Header';
 import { Surface } from '@op/ui/Surface';
-import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
 import { cn } from '@op/ui/utils';
 import Image from 'next/image';
-import { type HTMLAttributes, type ReactNode, useRef } from 'react';
-import { useFocusable } from 'react-aria';
+import type { HTMLAttributes, ReactNode } from 'react';
 import { LuBookmark, LuHeart, LuMessageCircle } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
@@ -444,34 +448,37 @@ export function ProposalCardMetrics({
   const t = useTranslations();
 
   return (
-    <div
-      className={cn(
-        'flex w-full flex-wrap items-center gap-4 text-base text-neutral-gray4',
-        className,
-      )}
-    >
-      <ProposalCardMetric
-        icon={<LuHeart className="size-4 shrink-0" />}
-        count={proposal.likesCount || 0}
-        label={t('Likes')}
-      />
-      <ProposalCardMetric
-        icon={<LuMessageCircle className="size-4 shrink-0" />}
-        count={proposal.commentsCount || 0}
-        label={t('Comments')}
-      />
-      <ProposalCardMetric
-        icon={<LuBookmark className="size-4 shrink-0" />}
-        count={proposal.followersCount || 0}
-        label={t('Followers')}
-      />
-    </div>
+    <TooltipProvider>
+      <div
+        className={cn(
+          'flex w-full flex-wrap items-center gap-4 text-base text-neutral-gray4',
+          className,
+        )}
+      >
+        <ProposalCardMetric
+          icon={<LuHeart className="size-4 shrink-0" />}
+          count={proposal.likesCount || 0}
+          label={t('Likes')}
+        />
+        <ProposalCardMetric
+          icon={<LuMessageCircle className="size-4 shrink-0" />}
+          count={proposal.commentsCount || 0}
+          label={t('Comments')}
+        />
+        <ProposalCardMetric
+          icon={<LuBookmark className="size-4 shrink-0" />}
+          count={proposal.followersCount || 0}
+          label={t('Followers')}
+        />
+      </div>
+    </TooltipProvider>
   );
 }
 
 // The label lives in a tooltip — the chip shows only the icon + count, since
-// room is tight on narrow cards. Focusable so the tooltip is keyboard-reachable;
-// aria-label keeps the bare count meaningful to screen readers.
+// room is tight on narrow cards. The trigger renders as a focusable span so the
+// tooltip is keyboard-reachable; aria-label keeps the bare count meaningful to
+// screen readers.
 function ProposalCardMetric({
   icon,
   count,
@@ -481,23 +488,22 @@ function ProposalCardMetric({
   count: number;
   label: string;
 }) {
-  const ref = useRef<HTMLSpanElement>(null);
-  const { focusableProps } = useFocusable({}, ref);
-
   return (
-    <TooltipTrigger>
-      <span
-        {...focusableProps}
-        ref={ref}
-        tabIndex={0}
-        aria-label={`${count} ${label}`}
-        className="flex shrink-0 items-center gap-1"
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            tabIndex={0}
+            aria-label={`${count} ${label}`}
+            className="flex shrink-0 items-center gap-1"
+          />
+        }
       >
         {icon}
         {count}
-      </span>
-      <Tooltip>{label}</Tooltip>
-    </TooltipTrigger>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -444,7 +444,7 @@ export function ProposalCardMetrics({
   return (
     <div
       className={cn(
-        'flex w-full flex-wrap items-center justify-between gap-4 text-base text-neutral-gray4',
+        'flex w-full flex-wrap items-center gap-4 text-base text-neutral-gray4 sm:justify-between',
         className,
       )}
     >

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -449,15 +449,15 @@ export function ProposalCardMetrics({
       )}
     >
       <span className="flex items-center gap-1 truncate">
-        <LuHeart className="size-4" />
+        <LuHeart className="size-4 shrink-0" />
         {proposal.likesCount || 0} {t('Likes')}
       </span>
       <span className="flex items-center gap-1 truncate">
-        <LuMessageCircle className="size-4" />
+        <LuMessageCircle className="size-4 shrink-0" />
         {proposal.commentsCount || 0} {t('Comments')}
       </span>
       <span className="flex items-center gap-1 truncate">
-        <LuBookmark className="size-4" />
+        <LuBookmark className="size-4 shrink-0" />
         {proposal.followersCount || 0} {t('Followers')}
       </span>
     </div>

--- a/apps/app/src/components/decisions/ProposalListSkeleton.tsx
+++ b/apps/app/src/components/decisions/ProposalListSkeleton.tsx
@@ -31,7 +31,7 @@ export const ProposalListSkeleton = () => {
 
 const ProposalCardSkeleton = () => {
   return (
-    <Surface className="relative w-full min-w-80 space-y-3 p-4 pb-4">
+    <Surface className="relative w-full space-y-3 p-4 pb-4 md:min-w-80">
       {/* Header with title and budget skeleton */}
       <div className="flex flex-col gap-2">
         <Skeleton className="h-6 w-3/4" />

--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -147,7 +147,7 @@ export function ReviewAssignmentsList({
 }
 
 const ReviewAssignmentCardSkeleton = () => (
-  <Surface className="relative w-full min-w-80 space-y-3 p-4 pb-4">
+  <Surface className="relative w-full space-y-3 p-4 pb-4 md:min-w-80">
     {/* Title */}
     <Skeleton className="h-6 w-3/4" />
 

--- a/apps/app/src/components/decisions/VotingProposalCard.tsx
+++ b/apps/app/src/components/decisions/VotingProposalCard.tsx
@@ -39,7 +39,7 @@ export const VotingProposalCard = ({
   return (
     <ProposalCard
       className={cn(
-        'relative w-full min-w-80 justify-between',
+        'relative w-full justify-between md:min-w-80',
         canInteract && 'cursor-pointer hover:shadow-md',
         canInteract && !isHighlighted && 'hover:border-neutral-gray2',
         isHighlighted && 'border-primary-teal bg-primary-tealWhite',


### PR DESCRIPTION
Narrow-mobile proposal card fixes.

**Card overflow:** cards had a hard 320px floor (`min-w-80`) that overflowed narrow phones, clipping content on the right. Gated to `md:min-w-80` — the floor only matters once the grid goes multi-column; below that it's a single full-width column that should shrink.

**Stats row** (Likes / Comments / Followers): the labels crowded the row on small cards (icons collapsing, labels clipping). Moved the labels into hover/focus **tooltips** — the row now shows just the icon + count, always. Uses `@op/sense`'s Base UI tooltip (the `@op/ui` react-aria one didn't fire with a hook-focusable span); trigger is a focusable span with an `aria-label` so the bare count stays meaningful to screen readers. Tooltip text bumped to `text-sm`.

<img width="866" height="987" alt="mobile before and after" src="https://github.com/user-attachments/assets/0f6a0b3c-c61f-4de8-969c-25e8d70025c1" />

<img width="2430" height="1254" alt="desktop before and after" src="https://github.com/user-attachments/assets/6bb9c995-0e9b-42f6-818c-6f9be25f3f6a" />

