### PR TITLE
feat(decisions): full-width horizontal-scrolling filter row on mobile

### DIFF
--- a/apps/app/src/components/decisions/ProposalsFilterBar.tsx
+++ b/apps/app/src/components/decisions/ProposalsFilterBar.tsx
@@ -73,7 +73,7 @@ export const ProposalsFilterBar = ({
   const filterItems = useProposalFilterItems({ hasVoted, currentProfileId });
 
   return (
-    <div className="grid max-w-fit grid-cols-2 justify-end gap-4 sm:flex sm:flex-1 sm:flex-wrap sm:items-center">
+    <>
       <ResponsiveSelect
         selectedKey={proposalFilter}
         onSelectionChange={(key) => {
@@ -130,7 +130,7 @@ export const ProposalsFilterBar = ({
           </Button>
         )
       ) : null}
-    </div>
+    </>
   );
 };
 

--- a/apps/app/src/components/decisions/ProposalsStickyFilterBar.tsx
+++ b/apps/app/src/components/decisions/ProposalsStickyFilterBar.tsx
@@ -127,6 +127,9 @@ export const ProposalsStickyFilterBar = ({
           // Bottom hairline fades in on pin — all breakpoints.
           "after:pointer-events-none after:absolute after:-bottom-px after:left-1/2 after:w-screen after:-translate-x-1/2 after:border-b after:border-neutral-gray1 after:opacity-0 after:content-['']",
           'data-[pinned=true]:after:opacity-100',
+          // Break the bar out to full viewport width on mobile so the filter row
+          // can scroll edge-to-edge. Content keeps its gutter via px-4.
+          'max-md:ml-[calc(50%_-_50vw)] max-md:w-screen max-md:px-4',
         )}
       >
         {/* Full-bleed white that fades in once pinned — covers the bar and its
@@ -147,7 +150,7 @@ export const ProposalsStickyFilterBar = ({
           count={total}
         />
         {!hideFilters && (
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-4 max-md:-mx-4 max-md:w-screen max-md:overflow-x-scroll max-md:px-4">
             <ProposalsFilterBar
               hasVoted={hasVoted}
               currentProfileId={currentProfileId}

--- a/apps/app/src/components/decisions/ResponsiveSelect.tsx
+++ b/apps/app/src/components/decisions/ResponsiveSelect.tsx
@@ -64,7 +64,7 @@ export function ResponsiveSelect<T extends string>({
         <Button
           color="secondary"
           size={size}
-          className={`${className} justify-between`}
+          className={`${className} justify-between shadow-none`}
           onPress={() => setIsOpen(true)}
         >
           {displayLabel}


### PR DESCRIPTION
**Stack** (merge bottom → top):
- #1450 — extract ProposalsList sub-components
- #1470 — fixed header + sticky bar + floating toggle
- **#1449 — full-width horizontal-scrolling filter row ← this PR**

---

Top of the stack, builds on #1470. Addresses https://app.asana.com/1/1108348036672214/project/1213315744811204/task/1209362582517139?focus=true

- Break the filter bar out to full viewport width on mobile and let the filter controls scroll horizontally (`overflow-x-scroll`) instead of wrapping.
- Unwrap `ProposalsFilterBar` to a fragment so the sticky bar owns the scroll container.
- Drop the now-redundant shadow on the select triggers.
