### PR TITLE
refactor(decisions): extract ProposalsList sub-components

### DIFF
--- a/apps/app/src/components/decisions/MobileViewSwitch.tsx
+++ b/apps/app/src/components/decisions/MobileViewSwitch.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Button } from '@op/ui/Button';
+import { LuLayoutGrid, LuMap } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+import type { ProposalView } from './ProposalViewToggle';
+
+// Mobile-only view switch, sticky at the bottom of the screen. Reads "Map"
+// while listing, "List" while showing the map.
+export const MobileViewSwitch = ({
+  view,
+  onChange,
+}: {
+  view: ProposalView;
+  onChange: (next: ProposalView) => void;
+}) => {
+  const t = useTranslations();
+
+  return (
+    <div className="fixed inset-x-0 bottom-6 z-40 flex justify-center sm:hidden">
+      <Button
+        color="secondary"
+        onPress={() => onChange(view === 'map' ? 'grid' : 'map')}
+        className="shadow-lg"
+      >
+        {view === 'map' ? (
+          <>
+            <LuLayoutGrid className="size-4" />
+            {t('List')}
+          </>
+        ) : (
+          <>
+            <LuMap className="size-4" />
+            {t('Map')}
+          </>
+        )}
+      </Button>
+    </div>
+  );
+};

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -15,27 +15,20 @@ import {
   getLocationFieldMapView,
   templateCollectsLocation,
 } from '@op/common/client';
-import { useInfiniteScroll, useIntersectionObserver } from '@op/hooks';
-import { Button } from '@op/ui/Button';
-import { Link } from '@op/ui/Link';
+import { useInfiniteScroll } from '@op/hooks';
 import { cn } from '@op/ui/utils';
 import { parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs';
 import { type RefObject, useCallback, useMemo } from 'react';
-import { LuLayoutGrid, LuMap } from 'react-icons/lu';
 
-import { useTranslations } from '@/lib/i18n';
-
+import { MobileViewSwitch } from './MobileViewSwitch';
 import { ProposalListSkeletonGrid } from './ProposalListSkeleton';
 import { ProposalTranslationProvider } from './ProposalTranslationContext';
-import {
-  PROPOSAL_VIEWS,
-  type ProposalView,
-  ProposalViewToggle,
-} from './ProposalViewToggle';
-import { ProposalsFilterBar, ProposalsListHeader } from './ProposalsFilterBar';
+import { PROPOSAL_VIEWS, type ProposalView } from './ProposalViewToggle';
 import { ProposalsGrid } from './ProposalsGrid';
 import { ProposalsMapView } from './ProposalsMapView';
+import { ProposalsStickyFilterBar } from './ProposalsStickyFilterBar';
 import { TranslateBanner } from './TranslateBanner';
+import { TranslationNotice } from './TranslationNotice';
 import { DEFAULT_LOCATION_FIELD_MAP_VIEW } from './location/mapConfig';
 import { useProposalExport } from './useProposalExport';
 import { useProposalsTranslation } from './useProposalsTranslation';
@@ -312,7 +305,6 @@ const ProposalsListContent = ({
 }: ProposalsListContentProps) => {
   const isReviewPhase = currentPhase?.rules?.proposals?.review === true;
   const isVotingPhase = currentPhase?.rules?.voting?.submit === true;
-  const t = useTranslations();
   const { user } = useUser();
 
   const currentProfileId = user?.currentProfile?.id;
@@ -343,7 +335,7 @@ const ProposalsListContent = ({
   const gisMapsEnabled = useFeatureFlag('gis_maps');
   const proposalTemplate = instance.instanceData?.proposalTemplate;
   const hasLocationField =
-    gisMapsEnabled && templateCollectsLocation(proposalTemplate);
+    !!gisMapsEnabled && templateCollectsLocation(proposalTemplate);
   const mapView =
     getLocationFieldMapView(proposalTemplate) ??
     DEFAULT_LOCATION_FIELD_MAP_VIEW;
@@ -381,10 +373,14 @@ const ProposalsListContent = ({
       { enabled: !!isReviewPhase },
     );
 
-  const revisionRequestIdByProposalId = new Map<string, string>(
-    revisionRequestsData?.revisionRequests.map(
-      ({ proposal, revisionRequest }) => [proposal.id, revisionRequest.id],
-    ),
+  const revisionRequestIdByProposalId = useMemo(
+    () =>
+      new Map<string, string>(
+        revisionRequestsData?.revisionRequests.map(
+          ({ proposal, revisionRequest }) => [proposal.id, revisionRequest.id],
+        ),
+      ),
+    [revisionRequestsData],
   );
 
   const translation = useProposalsTranslation({
@@ -407,18 +403,6 @@ const ProposalsListContent = ({
 
   const hideFilters = !!proposalsHidden && !canManageProposals;
 
-  // The filter bar pins at top-14 (56px). A zero-height sentinel at its natural
-  // top is observed against the viewport shrunk by that offset; once the
-  // sentinel scrolls past it the bar is pinned. initialIsIntersecting avoids a
-  // one-frame "stuck" flash on mount. Drives the full-width borders via the
-  // data-stuck attribute on the bar below.
-  const { ref: filterSentinelRef, isIntersecting } =
-    useIntersectionObserver<HTMLDivElement>({
-      rootMargin: '-56px 0px 0px 0px',
-      initialIsIntersecting: true,
-    });
-  const isFilterBarStuck = !isIntersecting;
-
   return (
     <div
       className={cn(
@@ -427,82 +411,35 @@ const ProposalsListContent = ({
         isMapMode && 'max-sm:pb-0',
       )}
     >
-      {/* Sentinel at the filter bar's pre-pin top — drives the JS "stuck"
-          detection that toggles data-stuck on the bar below. */}
-      <div
-        ref={filterSentinelRef}
-        aria-hidden
-        className="pointer-events-none absolute inset-x-0 top-0 h-px"
+      <ProposalsStickyFilterBar
+        isMapMode={isMapMode}
+        hideFilters={hideFilters}
+        total={total}
+        proposalFilter={proposalFilter}
+        setProposalFilter={setProposalFilter}
+        hasVoted={hasVoted}
+        currentProfileId={currentProfileId}
+        categories={categories}
+        selectedCategory={selectedCategory}
+        setSelectedCategory={setSelectedCategory}
+        sortOrder={sortOrder}
+        setSortOrder={setSortOrder}
+        canManageProposals={canManageProposals}
+        isExporting={isExporting}
+        isDownloadReady={isDownloadReady}
+        downloadUrl={downloadUrl}
+        downloadFileName={downloadFileName}
+        onExport={handleExport}
+        hasLocationField={hasLocationField}
+        effectiveView={effectiveView}
+        onViewChange={handleViewChange}
       />
-      {/* Filters Bar — sticks beneath the decision nav while the list/map
-          scroll under it. Only once pinned, full-bleed top/bottom lines fade
-          in via the before/after pseudo-elements (toggled by data-stuck). */}
-      <div
-        data-stuck={isFilterBarStuck || undefined}
-        className={cn(
-          'sticky top-14 z-20 flex flex-wrap items-center justify-between gap-4 bg-white py-3',
-          "before:pointer-events-none before:absolute before:top-0 before:left-1/2 before:w-screen before:-translate-x-1/2 before:border-t before:border-neutral-gray1 before:opacity-0 before:content-['']",
-          "after:pointer-events-none after:absolute after:-bottom-px after:left-1/2 after:w-screen after:-translate-x-1/2 after:border-b after:border-neutral-gray1 after:opacity-0 after:content-['']",
-          'data-[stuck=true]:before:opacity-100 data-[stuck=true]:after:opacity-100',
-          // On mobile the map view is edge-to-edge, so break the bar out to full
-          // width too (restoring the container's 1rem gutter).
-          isMapMode &&
-            'max-sm:ml-[calc(50%_-_50vw)] max-sm:w-screen max-sm:px-4',
-        )}
-      >
-        <div className="flex items-center gap-4">
-          <ProposalsListHeader
-            hideFilters={hideFilters}
-            proposalFilter={proposalFilter}
-            // Server-side filtering makes `total` accurate for the active filter.
-            count={total}
-          />
-        </div>
-        {!hideFilters && (
-          <div className="flex items-center gap-4">
-            <ProposalsFilterBar
-              hasVoted={hasVoted}
-              currentProfileId={currentProfileId}
-              proposalFilter={proposalFilter}
-              setProposalFilter={setProposalFilter}
-              categories={categories}
-              selectedCategory={selectedCategory}
-              onSelectCategory={setSelectedCategory}
-              sortOrder={sortOrder}
-              onSelectSort={setSortOrder}
-              canManageProposals={canManageProposals}
-              isExporting={isExporting}
-              isDownloadReady={isDownloadReady}
-              downloadUrl={downloadUrl}
-              downloadFileName={downloadFileName}
-              onExport={handleExport}
-            />
-            {hasLocationField && (
-              <div className="hidden items-center gap-4 sm:flex">
-                <span aria-hidden className="h-6 w-px bg-neutral-gray2" />
-                <ProposalViewToggle
-                  value={effectiveView}
-                  onChange={handleViewChange}
-                />
-              </div>
-            )}
-          </div>
-        )}
-      </div>
 
       {translation.translationState && (
-        <p className="text-sm text-neutral-gray3">
-          {t('Translated from {language}', {
-            language: translation.sourceLanguageName,
-          })}{' '}
-          &middot;{' '}
-          <Link
-            onPress={translation.handleViewOriginal}
-            className="text-sm font-semibold"
-          >
-            {t('View original')}
-          </Link>
-        </p>
+        <TranslationNotice
+          sourceLanguageName={translation.sourceLanguageName}
+          onViewOriginal={translation.handleViewOriginal}
+        />
       )}
 
       <ProposalTranslationProvider
@@ -556,30 +493,8 @@ const ProposalsListContent = ({
         />
       )}
 
-      {/* Mobile-only view switch, sticky at the bottom of the screen. Reads
-          "Map" while listing, "List" while showing the map. */}
       {hasLocationField && (
-        <div className="fixed inset-x-0 bottom-6 z-40 flex justify-center sm:hidden">
-          <Button
-            color="secondary"
-            onPress={() =>
-              handleViewChange(effectiveView === 'map' ? 'grid' : 'map')
-            }
-            className="shadow-lg"
-          >
-            {effectiveView === 'map' ? (
-              <>
-                <LuLayoutGrid className="size-4" />
-                {t('List')}
-              </>
-            ) : (
-              <>
-                <LuMap className="size-4" />
-                {t('Map')}
-              </>
-            )}
-          </Button>
-        </div>
+        <MobileViewSwitch view={effectiveView} onChange={handleViewChange} />
       )}
     </div>
   );

--- a/apps/app/src/components/decisions/ProposalsStickyFilterBar.tsx
+++ b/apps/app/src/components/decisions/ProposalsStickyFilterBar.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import type { ProposalFilter } from '@op/api/encoders';
+import { useIntersectionObserver } from '@op/hooks';
+import { cn } from '@op/ui/utils';
+
+import { type ProposalView, ProposalViewToggle } from './ProposalViewToggle';
+import { ProposalsFilterBar, ProposalsListHeader } from './ProposalsFilterBar';
+
+export interface ProposalsStickyFilterBarProps {
+  isMapMode: boolean;
+  hideFilters: boolean;
+  /** Full server-side proposal count for the active filter. */
+  total: number;
+  proposalFilter: ProposalFilter;
+  setProposalFilter: (filter: ProposalFilter) => void;
+  hasVoted: boolean;
+  currentProfileId: string | undefined;
+  categories: { id: string; name: string }[];
+  selectedCategory: string;
+  setSelectedCategory: (value: string) => void;
+  sortOrder: string;
+  setSortOrder: (value: string) => void;
+  canManageProposals: boolean;
+  isExporting: boolean;
+  isDownloadReady: boolean;
+  downloadUrl?: string | null;
+  downloadFileName?: string | null;
+  onExport: () => void;
+  hasLocationField: boolean;
+  effectiveView: ProposalView;
+  onViewChange: (next: ProposalView) => void;
+}
+
+// Filters bar — sticks beneath the decision nav while the list/map scroll under
+// it. Owns its own stuck-detection so the full-bleed top/bottom border lines can
+// fade in only once pinned.
+export const ProposalsStickyFilterBar = ({
+  isMapMode,
+  hideFilters,
+  total,
+  proposalFilter,
+  setProposalFilter,
+  hasVoted,
+  currentProfileId,
+  categories,
+  selectedCategory,
+  setSelectedCategory,
+  sortOrder,
+  setSortOrder,
+  canManageProposals,
+  isExporting,
+  isDownloadReady,
+  downloadUrl,
+  downloadFileName,
+  onExport,
+  hasLocationField,
+  effectiveView,
+  onViewChange,
+}: ProposalsStickyFilterBarProps) => {
+  // The filter bar pins at top-14 (56px). A zero-height sentinel at its natural
+  // top is observed against the viewport shrunk by that offset; once the
+  // sentinel scrolls past it the bar is pinned. initialIsIntersecting avoids a
+  // one-frame "stuck" flash on mount. Drives the full-width borders via the
+  // data-stuck attribute on the bar below.
+  const { ref: filterSentinelRef, isIntersecting } =
+    useIntersectionObserver<HTMLDivElement>({
+      rootMargin: '-56px 0px 0px 0px',
+      initialIsIntersecting: true,
+    });
+  const isFilterBarStuck = !isIntersecting;
+
+  return (
+    <>
+      {/* Sentinel at the filter bar's pre-pin top — drives the JS "stuck"
+          detection that toggles data-stuck on the bar below. */}
+      <div
+        ref={filterSentinelRef}
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-px"
+      />
+      {/* Filters Bar — sticks beneath the decision nav while the list/map
+          scroll under it. Only once pinned, full-bleed top/bottom lines fade
+          in via the before/after pseudo-elements (toggled by data-stuck). */}
+      <div
+        data-stuck={isFilterBarStuck || undefined}
+        className={cn(
+          'sticky top-14 z-20 flex flex-wrap items-center justify-between gap-4 bg-white py-3',
+          "before:pointer-events-none before:absolute before:top-0 before:left-1/2 before:w-screen before:-translate-x-1/2 before:border-t before:border-neutral-gray1 before:opacity-0 before:content-['']",
+          "after:pointer-events-none after:absolute after:-bottom-px after:left-1/2 after:w-screen after:-translate-x-1/2 after:border-b after:border-neutral-gray1 after:opacity-0 after:content-['']",
+          'data-[stuck=true]:before:opacity-100 data-[stuck=true]:after:opacity-100',
+          // On mobile the map view is edge-to-edge, so break the bar out to full
+          // width too (restoring the container's 1rem gutter).
+          isMapMode &&
+            'max-sm:ml-[calc(50%_-_50vw)] max-sm:w-screen max-sm:px-4',
+        )}
+      >
+        <ProposalsListHeader
+          hideFilters={hideFilters}
+          proposalFilter={proposalFilter}
+          // Server-side filtering makes `total` accurate for the active filter.
+          count={total}
+        />
+        {!hideFilters && (
+          <div className="flex items-center gap-4">
+            <ProposalsFilterBar
+              hasVoted={hasVoted}
+              currentProfileId={currentProfileId}
+              proposalFilter={proposalFilter}
+              setProposalFilter={setProposalFilter}
+              categories={categories}
+              selectedCategory={selectedCategory}
+              onSelectCategory={setSelectedCategory}
+              sortOrder={sortOrder}
+              onSelectSort={setSortOrder}
+              canManageProposals={canManageProposals}
+              isExporting={isExporting}
+              isDownloadReady={isDownloadReady}
+              downloadUrl={downloadUrl}
+              downloadFileName={downloadFileName}
+              onExport={onExport}
+            />
+            {hasLocationField && (
+              <div className="hidden items-center gap-4 sm:flex">
+                <span aria-hidden className="h-6 w-px bg-neutral-gray2" />
+                <ProposalViewToggle
+                  value={effectiveView}
+                  onChange={onViewChange}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+};

--- a/apps/app/src/components/decisions/TranslationNotice.tsx
+++ b/apps/app/src/components/decisions/TranslationNotice.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Link } from '@op/ui/Link';
+
+import { useTranslations } from '@/lib/i18n';
+
+export const TranslationNotice = ({
+  sourceLanguageName,
+  onViewOriginal,
+}: {
+  sourceLanguageName: string;
+  onViewOriginal: () => void;
+}) => {
+  const t = useTranslations();
+
+  return (
+    <p className="text-sm text-neutral-gray3">
+      {t('Translated from {language}', { language: sourceLanguageName })}{' '}
+      &middot;{' '}
+      <Link onPress={onViewOriginal} className="text-sm font-semibold">
+        {t('View original')}
+      </Link>
+    </p>
+  );
+};


### PR DESCRIPTION
**Stack** (merge bottom → top):
- **#1450 — extract ProposalsList sub-components ← this PR**
- #1470 — fixed header + sticky bar + floating toggle
- #1449 — full-width horizontal-scrolling filter row

---

Behavior-neutral cleanup. Splits the ~250-line `ProposalsListContent` into focused pieces ahead of the sticky-filter-bar feature work.

- New `ProposalsStickyFilterBar`, `MobileViewSwitch`, `TranslationNotice` — code moved verbatim (sticky bar keeps its existing sentinel-based stuck detection).
- Memoize the revision-request lookup map.

No behavior change. Feature work stacks on top.
