### PR TITLE
feat(decisions): use masonry layout for proposal card grids

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -98,6 +98,7 @@
     "react-dom": "^19.2.0",
     "react-error-boundary": "^6.0.0",
     "react-icons": "^5.5.0",
+    "react-masonry-css": "^1.0.16",
     "sonner": "^1.7.1",
     "tiptap-extension-iframely": "^1.0.4",
     "use-debounce": "^10.0.4",

--- a/apps/app/src/components/decisions/MyBallot.tsx
+++ b/apps/app/src/components/decisions/MyBallot.tsx
@@ -16,6 +16,7 @@ import {
   ProposalCardMeta,
   ProposalCardPreview,
 } from './ProposalCard';
+import { ProposalMasonry } from './ProposalMasonry';
 import { VotingProposalCard } from './VotingProposalCard';
 
 export const NoVoteFound = () => {
@@ -87,7 +88,7 @@ const MyBallotProposals = ({
         {t('My Ballot')}
       </Header3>
 
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <ProposalMasonry>
         {proposalsData.proposals.map((proposal) => {
           const viewHref = decisionSlug
             ? `/decisions/${decisionSlug}/proposal/${proposal.profileId}`
@@ -129,7 +130,7 @@ const MyBallotProposals = ({
             </VotingProposalCard>
           );
         })}
-      </div>
+      </ProposalMasonry>
     </div>
   );
 };

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardComponents.tsx
@@ -58,7 +58,7 @@ export function ProposalCard({
     <Surface
       variant={isDraft ? 'filled' : 'empty'}
       className={cn(
-        'relative flex w-full flex-col justify-between gap-3 p-4 md:min-w-80',
+        'relative flex w-full flex-col justify-between gap-3 p-4',
         className,
       )}
       {...props}
@@ -128,7 +128,7 @@ export function ProposalCardTitle({
     cardTranslation?.title ??
     (title || proposal.profile.name || t('Untitled Proposal'));
   const titleClasses =
-    'max-w-full truncate text-nowrap font-serif !text-title-sm text-neutral-black';
+    'max-w-full font-serif !text-title-sm text-neutral-black';
 
   if (asLink && viewHref) {
     return (

--- a/apps/app/src/components/decisions/ProposalListSkeleton.tsx
+++ b/apps/app/src/components/decisions/ProposalListSkeleton.tsx
@@ -1,12 +1,14 @@
 import { Skeleton } from '@op/ui/Skeleton';
 import { Surface } from '@op/ui/Surface';
 
+import { ProposalMasonry } from './ProposalMasonry';
+
 export const ProposalListSkeletonGrid = () => (
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+  <ProposalMasonry>
     {Array.from({ length: 6 }).map((_, index) => (
       <ProposalCardSkeleton key={index} />
     ))}
-  </div>
+  </ProposalMasonry>
 );
 
 export const ProposalListSkeleton = () => {
@@ -31,7 +33,7 @@ export const ProposalListSkeleton = () => {
 
 const ProposalCardSkeleton = () => {
   return (
-    <Surface className="relative w-full space-y-3 p-4 pb-4 md:min-w-80">
+    <Surface className="relative w-full space-y-3 p-4 pb-4">
       {/* Header with title and budget skeleton */}
       <div className="flex flex-col gap-2">
         <Skeleton className="h-6 w-3/4" />

--- a/apps/app/src/components/decisions/ProposalListSkeleton.tsx
+++ b/apps/app/src/components/decisions/ProposalListSkeleton.tsx
@@ -1,14 +1,12 @@
 import { Skeleton } from '@op/ui/Skeleton';
 import { Surface } from '@op/ui/Surface';
 
-import { ProposalMasonry } from './ProposalMasonry';
-
 export const ProposalListSkeletonGrid = () => (
-  <ProposalMasonry>
+  <div className="columns-1 gap-6 md:columns-2 lg:columns-3 [&>*]:mb-6 [&>*]:break-inside-avoid">
     {Array.from({ length: 6 }).map((_, index) => (
       <ProposalCardSkeleton key={index} />
     ))}
-  </ProposalMasonry>
+  </div>
 );
 
 export const ProposalListSkeleton = () => {

--- a/apps/app/src/components/decisions/ProposalMasonry.tsx
+++ b/apps/app/src/components/decisions/ProposalMasonry.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { screens } from '@op/styles/constants';
+import type { ReactNode } from 'react';
+import Masonry from 'react-masonry-css';
+
+// react-masonry-css keys are max-widths (applies when window width ≤ key), so
+// subtract 1 from the min-width breakpoints to mirror Tailwind's
+// `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`: ≥lg → 3, md–lg → 2, <md → 1.
+const md = parseInt(screens.md, 10);
+const lg = parseInt(screens.lg, 10);
+const BREAKPOINT_COLS = { default: 3, [lg - 1]: 2, [md - 1]: 1 };
+
+/**
+ * Row-order masonry layout for proposal/review cards. Preserves the server's
+ * sort order left-to-right while packing variable-height cards into columns.
+ * ponytail: react-masonry-css balances by item count, not measured height, so
+ * column bottoms are ragged. Swap for `masonic` only if true packing matters.
+ */
+export function ProposalMasonry({ children }: { children: ReactNode }) {
+  return (
+    <Masonry
+      breakpointCols={BREAKPOINT_COLS}
+      className="flex gap-6"
+      columnClassName="flex min-w-0 flex-1 flex-col gap-6"
+    >
+      {children}
+    </Masonry>
+  );
+}

--- a/apps/app/src/components/decisions/ProposalsGrid.tsx
+++ b/apps/app/src/components/decisions/ProposalsGrid.tsx
@@ -28,6 +28,7 @@ import {
   ProposalCardPreview,
   ProposalCardReviseAction,
 } from './ProposalCard';
+import { ProposalMasonry } from './ProposalMasonry';
 import { VoteSubmissionModal } from './VoteSubmissionModal';
 import { VoteSuccessModal } from './VoteSuccessModal';
 import { VotingProposalCard } from './VotingProposalCard';
@@ -177,7 +178,7 @@ const VotingProposalsList = ({
 
   return (
     <>
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <ProposalMasonry>
         {proposals.map((proposal) => {
           const isSelected = isProposalSelected(proposal.id);
           const isEligibleForVote = isVotingEligible(proposal.status);
@@ -285,7 +286,7 @@ const VotingProposalsList = ({
           } else {
             return (
               <ProposalCard key={proposal.id} proposal={proposal}>
-                <div className="flex h-full flex-col justify-between gap-3 space-y-3">
+                <div className="flex flex-col justify-between gap-3 space-y-3">
                   <ProposalCardContent>
                     <ProposalCardHeader
                       proposal={proposal}
@@ -317,7 +318,7 @@ const VotingProposalsList = ({
             );
           }
         })}
-      </div>
+      </ProposalMasonry>
 
       {canVote && !isReadOnly && (
         <FooterBar position="fixed" className="bg-neutral-offWhite/95">
@@ -396,7 +397,7 @@ const ViewProposalsList = ({
   }
 
   return (
-    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+    <ProposalMasonry>
       {proposals.map((proposal) => {
         const isDraft = proposal.status === ProposalStatus.DRAFT;
         const isEditable = Boolean(proposal.isEditable);
@@ -470,6 +471,6 @@ const ViewProposalsList = ({
           </ProposalCard>
         );
       })}
-    </div>
+    </ProposalMasonry>
   );
 };

--- a/apps/app/src/components/decisions/ResultsList.tsx
+++ b/apps/app/src/components/decisions/ResultsList.tsx
@@ -15,6 +15,7 @@ import {
   ProposalCardMeta,
   ProposalCardPreview,
 } from './ProposalCard';
+import { ProposalMasonry } from './ProposalMasonry';
 
 const NoProposalsFound = () => {
   const t = useTranslations();
@@ -65,7 +66,7 @@ export const ResultsList = ({
         </Header3>
       </div>
 
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <ProposalMasonry>
         {proposals.map((proposal) => {
           const viewHref = decisionSlug
             ? `/decisions/${decisionSlug}/proposal/${proposal.profileId}`
@@ -73,7 +74,7 @@ export const ResultsList = ({
 
           return (
             <ProposalCard key={proposal.id}>
-              <div className="flex h-full flex-col justify-between gap-3 space-y-3">
+              <div className="flex flex-col justify-between gap-3 space-y-3">
                 <ProposalCardContent>
                   <ProposalCardHeader
                     proposal={proposal}
@@ -106,7 +107,7 @@ export const ResultsList = ({
             </ProposalCard>
           );
         })}
-      </div>
+      </ProposalMasonry>
     </div>
   );
 };

--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -172,9 +172,9 @@ const ReviewAssignmentCardSkeleton = () => (
 );
 
 const ReviewAssignmentListSkeletonGrid = () => (
-  <ProposalMasonry>
+  <div className="columns-1 gap-6 md:columns-2 lg:columns-3 [&>*]:mb-6 [&>*]:break-inside-avoid">
     {Array.from({ length: 6 }).map((_, index) => (
       <ReviewAssignmentCardSkeleton key={index} />
     ))}
-  </ProposalMasonry>
+  </div>
 );

--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -12,6 +12,7 @@ import { LuLeaf } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 
 import { Bullet } from '../Bullet';
+import { ProposalMasonry } from './ProposalMasonry';
 import { ResponsiveSelect } from './ResponsiveSelect';
 import { ReviewAssignmentCard } from './ReviewAssignmentCard';
 
@@ -127,7 +128,7 @@ export function ReviewAssignmentsList({
           </p>
         </EmptyState>
       ) : (
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <ProposalMasonry>
           {assignments.map((item) => (
             <ReviewAssignmentCard
               key={item.assignment.id}
@@ -140,14 +141,14 @@ export function ReviewAssignmentsList({
               }
             />
           ))}
-        </div>
+        </ProposalMasonry>
       )}
     </div>
   );
 }
 
 const ReviewAssignmentCardSkeleton = () => (
-  <Surface className="relative w-full space-y-3 p-4 pb-4 md:min-w-80">
+  <Surface className="relative w-full space-y-3 p-4 pb-4">
     {/* Title */}
     <Skeleton className="h-6 w-3/4" />
 
@@ -171,9 +172,9 @@ const ReviewAssignmentCardSkeleton = () => (
 );
 
 const ReviewAssignmentListSkeletonGrid = () => (
-  <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+  <ProposalMasonry>
     {Array.from({ length: 6 }).map((_, index) => (
       <ReviewAssignmentCardSkeleton key={index} />
     ))}
-  </div>
+  </ProposalMasonry>
 );

--- a/apps/app/src/components/decisions/VotingProposalCard.tsx
+++ b/apps/app/src/components/decisions/VotingProposalCard.tsx
@@ -39,7 +39,7 @@ export const VotingProposalCard = ({
   return (
     <ProposalCard
       className={cn(
-        'relative w-full justify-between md:min-w-80',
+        'relative w-full justify-between',
         canInteract && 'cursor-pointer hover:shadow-md',
         canInteract && !isHighlighted && 'hover:border-neutral-gray2',
         isHighlighted && 'border-primary-teal bg-primary-tealWhite',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,6 +670,9 @@ importers:
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@19.2.1)
+      react-masonry-css:
+        specifier: ^1.0.16
+        version: 1.0.16(react@19.2.1)
       sonner:
         specifier: ^1.7.1
         version: 1.7.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -3958,30 +3961,35 @@ packages:
 
   '@react-email/body@0.0.11':
     resolution: {integrity: sha512-ZSD2SxVSgUjHGrB0Wi+4tu3MEpB4fYSbezsFNEJk2xCWDBkFiOeEsjTmR5dvi+CxTK691hQTQlHv0XWuP7ENTg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/button@0.1.0':
     resolution: {integrity: sha512-fg4LtgTu5zXxaRSly9cuv6sHVF/hi1lElbRaIA8EPx5coWOBhCto6rCPfawcXpaN2oER7rNHUrcNBkI+lz5F9A==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/code-block@0.1.0':
     resolution: {integrity: sha512-jSpHFsgqnQXxDIssE4gvmdtFncaFQz5D6e22BnVjcCPk/udK+0A9jRwGFEG8JD2si9ZXBmU4WsuqQEczuZn4ww==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/code-inline@0.0.5':
     resolution: {integrity: sha512-MmAsOzdJpzsnY2cZoPHFPk6uDO/Ncpb4Kh1hAt9UZc1xOW3fIzpe1Pi9y9p6wwUmpaeeDalJxAxH6/fnTquinA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/column@0.0.13':
     resolution: {integrity: sha512-Lqq17l7ShzJG/d3b1w/+lVO+gp2FM05ZUo/nW0rjxB8xBICXOVv6PqjDnn3FXKssvhO5qAV20lHM6S+spRhEwQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
@@ -3995,59 +4003,69 @@ packages:
   '@react-email/container@0.0.15':
     resolution: {integrity: sha512-Qo2IQo0ru2kZq47REmHW3iXjAQaKu4tpeq/M8m1zHIVwKduL2vYOBQWbC2oDnMtWPmkBjej6XxgtZByxM6cCFg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/font@0.0.9':
     resolution: {integrity: sha512-4zjq23oT9APXkerqeslPH3OZWuh5X4crHK6nx82mVHV2SrLba8+8dPEnWbaACWTNjOCbcLIzaC9unk7Wq2MIXw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/head@0.0.12':
     resolution: {integrity: sha512-X2Ii6dDFMF+D4niNwMAHbTkeCjlYYnMsd7edXOsi0JByxt9wNyZ9EnhFiBoQdqkE+SMDcu8TlNNttMrf5sJeMA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/heading@0.0.15':
     resolution: {integrity: sha512-xF2GqsvBrp/HbRHWEfOgSfRFX+Q8I5KBEIG5+Lv3Vb2R/NYr0s8A5JhHHGf2pWBMJdbP4B2WHgj/VUrhy8dkIg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/hr@0.0.11':
     resolution: {integrity: sha512-S1gZHVhwOsd1Iad5IFhpfICwNPMGPJidG/Uysy1AwmspyoAP5a4Iw3OWEpINFdgh9MHladbxcLKO2AJO+cA9Lw==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/html@0.0.11':
     resolution: {integrity: sha512-qJhbOQy5VW5qzU74AimjAR9FRFQfrMa7dn4gkEXKMB/S9xZN8e1yC1uA9C15jkXI/PzmJ0muDIWmFwatm5/+VA==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/img@0.0.11':
     resolution: {integrity: sha512-aGc8Y6U5C3igoMaqAJKsCpkbm1XjguQ09Acd+YcTKwjnC2+0w3yGUJkjWB2vTx4tN8dCqQCXO8FmdJpMfOA9EQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/link@0.0.12':
     resolution: {integrity: sha512-vF+xxQk2fGS1CN7UPQDbzvcBGfffr+GjTPNiWM38fhBfsLv6A/YUfaqxWlmL7zLzVmo0K2cvvV9wxlSyNba1aQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/markdown@0.0.15':
     resolution: {integrity: sha512-UQA9pVm5sbflgtg3EX3FquUP4aMBzmLReLbGJ6DZQZnAskBF36aI56cRykDq1o+1jT+CKIK1CducPYziaXliag==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/preview@0.0.13':
     resolution: {integrity: sha512-F7j9FJ0JN/A4d7yr+aw28p4uX7VLWs7hTHtLo7WRyw4G+Lit6Zucq4UWKRxJC8lpsUdzVmG7aBJnKOT+urqs/w==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
@@ -4061,12 +4079,14 @@ packages:
   '@react-email/row@0.0.12':
     resolution: {integrity: sha512-HkCdnEjvK3o+n0y0tZKXYhIXUNPDx+2vq1dJTmqappVHXS5tXS6W5JOPZr5j+eoZ8gY3PShI2LWj5rWF7ZEtIQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
   '@react-email/section@0.0.16':
     resolution: {integrity: sha512-FjqF9xQ8FoeUZYKSdt8sMIKvoT9XF8BrzhT3xiFKdEMwYNbsDflcjfErJe3jb7Wj/es/lKTbV5QR1dnLzGpL3w==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
@@ -4080,6 +4100,7 @@ packages:
   '@react-email/text@0.1.5':
     resolution: {integrity: sha512-o5PNHFSE085VMXayxH+SJ1LSOtGsTv+RpNKnTiJDrJUwoBu77G3PlKOsZZQHCNyD28WsQpl9v2WcJLbQudqwPg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^19.0.1
 
@@ -8416,6 +8437,11 @@ packages:
     resolution: {integrity: sha512-4mTz7Sya/YQ1jYOrkwO73VcFdkFJ8L8I9ehCxdcV0XrClHyOJGKbBk5FR4OOOG+HnyKw5u+C/Aby9TwinCteYA==}
     peerDependencies:
       '@types/react': 19.0.10
+      react: ^19.0.1
+
+  react-masonry-css@1.0.16:
+    resolution: {integrity: sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==}
+    peerDependencies:
       react: ^19.0.1
 
   react-promise-suspense@0.3.4:
@@ -16522,6 +16548,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-masonry-css@1.0.16(react@19.2.1):
+    dependencies:
+      react: 19.2.1
 
   react-promise-suspense@0.3.4:
     dependencies:


### PR DESCRIPTION
- Shared `ProposalMasonry` wrapper (react-masonry-css) replaces the fixed 3-col grid across the proposals grid, results, ballot, and review-assignment lists (+ skeletons).
- Variable-height cards pack tightly while keeping the server's left-to-right sort order. Breakpoint columns derived from `@op/styles` `screens`.
- Removed proposal-title truncation and the `min-w-80` floor so cards shrink to fit the column near breakpoints.