### PR TITLE
fix(decisions): rewrite vanity /current sub-page to decision route

### DIFF
--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -146,12 +146,8 @@ const config = {
       // page as `/en/decisions/columbus`. Allow-listed one slug at a time —
       // extend `VANITY_DECISION_SLUGS` when adding a new vanity process.
       {
-        source: `/:locale(${SUPPORTED_LOCALES.join('|')})/:slug(${VANITY_DECISION_SLUGS.join('|')})`,
-        destination: '/:locale/decisions/:slug',
-      },
-      {
-        source: `/:locale(${SUPPORTED_LOCALES.join('|')})/:slug(${VANITY_DECISION_SLUGS.join('|')})/current`,
-        destination: '/:locale/decisions/:slug/current',
+        source: `/:locale(${SUPPORTED_LOCALES.join('|')})/:slug(${VANITY_DECISION_SLUGS.join('|')})/:path*`,
+        destination: '/:locale/decisions/:slug/:path*',
       },
       {
         source: '/assets/:path*',

--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -150,6 +150,10 @@ const config = {
         destination: '/:locale/decisions/:slug',
       },
       {
+        source: `/:locale(${SUPPORTED_LOCALES.join('|')})/:slug(${VANITY_DECISION_SLUGS.join('|')})/current`,
+        destination: '/:locale/decisions/:slug/current',
+      },
+      {
         source: '/assets/:path*',
         destination: `${process.env.S3_ASSET_ROOT}/:path*`,
       },


### PR DESCRIPTION
Vanity decision URLs now work for all sub-pages, not just the base slug.

A single catch-all rewrite maps `/:locale/:slug/:path*` → `/:locale/decisions/:slug/:path*`, so `/en/columbus`, `/en/columbus/current`, and any future sub-page resolve to the decision route. (`:path*` matches zero-or-more segments, covering the bare slug too.)