### PR TITLE
fix(decisions): keep masonry columns when only one proposal

### DIFF
--- a/apps/app/src/components/decisions/ProposalMasonry.tsx
+++ b/apps/app/src/components/decisions/ProposalMasonry.tsx
@@ -16,7 +16,7 @@ export function ProposalMasonry({ children }: { children: ReactNode }) {
     <Masonry
       breakpointCols={BREAKPOINT_COLS}
       className="-ml-6 flex w-auto"
-      columnClassName="flex min-w-0 flex-col gap-6 bg-clip-padding pl-6"
+      columnClassName="flex min-w-0 flex-col gap-6 pl-6"
     >
       {children}
     </Masonry>

--- a/apps/app/src/components/decisions/ProposalMasonry.tsx
+++ b/apps/app/src/components/decisions/ProposalMasonry.tsx
@@ -4,25 +4,19 @@ import { screens } from '@op/styles/constants';
 import type { ReactNode } from 'react';
 import Masonry from 'react-masonry-css';
 
-// react-masonry-css keys are max-widths (applies when window width ≤ key), so
-// subtract 1 from the min-width breakpoints to mirror Tailwind's
-// `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`: ≥lg → 3, md–lg → 2, <md → 1.
+// react-masonry-css keys are max-widths, so subtract 1 to mirror Tailwind's
+// grid-cols-1 md:grid-cols-2 lg:grid-cols-3.
 const md = parseInt(screens.md, 10);
 const lg = parseInt(screens.lg, 10);
 const BREAKPOINT_COLS = { default: 3, [lg - 1]: 2, [md - 1]: 1 };
 
-/**
- * Row-order masonry layout for proposal/review cards. Preserves the server's
- * sort order left-to-right while packing variable-height cards into columns.
- * ponytail: react-masonry-css balances by item count, not measured height, so
- * column bottoms are ragged. Swap for `masonic` only if true packing matters.
- */
 export function ProposalMasonry({ children }: { children: ReactNode }) {
   return (
+    // -ml-6/pl-6 are the column gutter.
     <Masonry
       breakpointCols={BREAKPOINT_COLS}
-      className="flex gap-6"
-      columnClassName="flex min-w-0 flex-1 flex-col gap-6"
+      className="-ml-6 flex w-auto"
+      columnClassName="flex min-w-0 flex-col gap-6 bg-clip-padding pl-6"
     >
       {children}
     </Masonry>


### PR DESCRIPTION
- Single proposal rendered as one super-wide card; masonry now keeps it one column wide.
- Cause: `flex-1` on columns overrode react-masonry-css's per-column width, so the lone rendered column stretched to 100%.
- Fix: use the library's width + a negative-margin gutter (`-ml-6`/`pl-6`); no `flex-1`.