### PR TITLE
refactor(decisions): standardize decision-process headings

### DIFF
--- a/apps/app/src/components/decisions/DecisionHero.tsx
+++ b/apps/app/src/components/decisions/DecisionHero.tsx
@@ -1,4 +1,4 @@
-import { GradientHeader, Header2 } from '@op/ui/Header';
+import { GradientHeader, Header1 } from '@op/ui/Header';
 import { cn } from '@op/ui/utils';
 import { ReactNode } from 'react';
 
@@ -19,15 +19,14 @@ export function DecisionHero({
   return (
     <div className="flex flex-col gap-2 text-center">
       {variant === 'results' ? (
-        <Header2 className="font-serif text-title-xxl font-light uppercase">
+        <Header1 className="font-serif font-light uppercase md:text-title-xxl">
           <bdi>{title}</bdi>
-        </Header2>
+        </Header1>
       ) : (
-        <GradientHeader
-          className="items-center align-middle uppercase"
-          gradient={gradient}
-        >
-          <bdi>{title}</bdi>
+        <GradientHeader className="uppercase" gradient={gradient}>
+          <Header1 className="md:text-title-xxl">
+            <bdi>{title}</bdi>
+          </Header1>
         </GradientHeader>
       )}
 

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -3,9 +3,10 @@
 import { useUser } from '@/utils/UserProvider';
 import { userCanInteract } from '@/utils/userCanInteract';
 import { ButtonLink } from '@op/ui/Button';
-import { Header1 } from '@op/ui/Header';
+import { Header2 } from '@op/ui/Header';
 import { IconButton } from '@op/ui/IconButton';
 import { MegaphoneIcon } from '@op/ui/MegaphoneIcon';
+import { cn } from '@op/ui/utils';
 import { useQueryState } from 'nuqs';
 import { type ReactNode, Suspense } from 'react';
 import { LuArrowLeft, LuSettings } from 'react-icons/lu';
@@ -70,9 +71,7 @@ export const DecisionInstanceHeader = ({
                 className="hidden h-6 w-px shrink-0 bg-neutral-gray2 md:block"
               />
             )}
-            <Header1 className="hidden truncate font-serif text-title-sm text-neutral-charcoal sm:text-title-sm md:block">
-              <bdi>{title}</bdi>
-            </Header1>
+            <DecisionTitle title={title} className="hidden md:block" />
           </>
         ) : null}
       </div>
@@ -81,14 +80,10 @@ export const DecisionInstanceHeader = ({
         {centerSlot ? (
           <>
             <div className="hidden md:flex">{centerSlot}</div>
-            <Header1 className="truncate font-serif text-title-sm text-neutral-charcoal md:hidden">
-              <bdi>{title}</bdi>
-            </Header1>
+            <DecisionTitle title={title} className="md:hidden" />
           </>
         ) : (
-          <Header1 className="truncate font-serif text-title-sm text-neutral-charcoal sm:text-title-sm">
-            <bdi>{title}</bdi>
-          </Header1>
+          <DecisionTitle title={title} />
         )}
       </div>
 
@@ -130,6 +125,23 @@ export const DecisionInstanceHeader = ({
     </header>
   );
 };
+
+const DecisionTitle = ({
+  title,
+  className,
+}: {
+  title: string;
+  className?: string;
+}) => (
+  <Header2
+    className={cn(
+      'truncate font-serif text-title-sm text-neutral-charcoal',
+      className,
+    )}
+  >
+    <bdi>{title}</bdi>
+  </Header2>
+);
 
 const DecisionUpdatesToggle = ({
   ariaLabel,

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -6,7 +6,7 @@ import { type ProcessInstance, type ProcessPhase } from '@op/api/encoders';
 import { Avatar } from '@op/ui/Avatar';
 import { Button, ButtonLink } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
-import { Header2, Header3 } from '@op/ui/Header';
+import { GradientHeader, Header1, Header3 } from '@op/ui/Header';
 import { Link } from '@op/ui/Link';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import he from 'he';
@@ -227,14 +227,15 @@ const OverviewHero = ({
     <section className="grid w-full grid-cols-1 justify-center border-b bg-neutral-offWhite md:grid-cols-12">
       <div className="mx-auto flex flex-col items-center gap-4 px-4 pt-16 pb-8 text-center sm:py-12 md:col-span-6 md:col-start-4 md:px-6">
         <div className="flex flex-col items-center gap-3">
-          {/* Brand teal→green gradient clipped to the title text. Rendered
-              as an <h2> because the sticky DecisionInstanceHeader already
-              carries the page's <h1> — keeping the hero a heading (one level
-              down) preserves the document outline while letting tests target
-              the banner h1 unambiguously with `level: 1`. */}
-          <Header2 className="bg-tealGreen bg-clip-text font-serif text-title-xl font-light text-balance text-transparent sm:text-title-xxl">
-            <bdi>{headline}</bdi>
-          </Header2>
+          {/* Brand teal→green gradient clipped to the title text. This hero is
+              the page's <h1>; the sticky DecisionInstanceHeader carries a
+              secondary <h2>, so there's exactly one <h1> and tests can target
+              the banner headline unambiguously with `level: 1`. */}
+          <GradientHeader>
+            <Header1 className="md:text-title-xxl">
+              <bdi>{headline}</bdi>
+            </Header1>
+          </GradientHeader>
           {stewardName || isPublic ? (
             <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-sm text-neutral-charcoal">
               {stewardName ? (

--- a/packages/styles/constants.ts
+++ b/packages/styles/constants.ts
@@ -15,7 +15,7 @@ export const screens = {
  * scanner picks them up.
  */
 export const headingClasses = {
-  h1: 'font-serif text-title-sm sm:text-title-lg',
+  h1: 'font-serif text-title-lg',
   h2: 'font-serif text-title-lg text-neutral-black',
   h3: 'font-serif text-title-base text-neutral-black',
   h4: 'font-serif text-title-sm14 text-neutral-black',

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -109,27 +109,27 @@
 
   /* Title sizes */
   --text-title-xxl: 3rem;
-  --text-title-xxl--line-height: 110%;
+  --text-title-xxl--line-height: 120%;
   --text-title-xxl--font-weight: 400;
   --text-title-xxl--letter-spacing: -0.075rem;
 
   --text-title-xl: 2.5rem;
-  --text-title-xl--line-height: 110%;
+  --text-title-xl--line-height: 120%;
   --text-title-xl--font-weight: 400;
   --text-title-xl--letter-spacing: -0.0625rem;
 
   --text-title-lg: 1.75rem;
-  --text-title-lg--line-height: 110%;
+  --text-title-lg--line-height: 120%;
   --text-title-lg--font-weight: 400;
   --text-title-lg--letter-spacing: -0.02625rem;
 
   --text-title-md: 1.5rem;
-  --text-title-md--line-height: 110%;
+  --text-title-md--line-height: 120%;
   --text-title-md--font-weight: 400;
   --text-title-md--letter-spacing: -0.0225rem;
 
   --text-title-base: 1.25rem;
-  --text-title-base--line-height: 110%;
+  --text-title-base--line-height: 120%;
   --text-title-base--font-weight: 400;
   --text-title-base--letter-spacing: -0.01875rem;
 

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -53,16 +53,14 @@ export const GradientHeader = ({
   gradient?: string;
 }) => {
   return (
-    <div className="flex w-full items-center justify-center text-transparent">
-      <div
-        className={cn(
-          'flex items-center bg-clip-text font-serif text-title-xxl',
-          gradient,
-          className,
-        )}
-      >
-        {children}
-      </div>
+    <div
+      className={cn(
+        'mx-auto flex w-fit items-center bg-clip-text font-serif text-title-xxl text-transparent',
+        gradient,
+        className,
+      )}
+    >
+      {children}
     </div>
   );
 };

--- a/tests/e2e/tests/decision-role-capabilities.spec.ts
+++ b/tests/e2e/tests/decision-role-capabilities.spec.ts
@@ -128,7 +128,7 @@ test.describe('Decision Role Capabilities', () => {
     });
 
     await expect(
-      memberPage.getByRole('heading', { name: instance.name, level: 1 }),
+      memberPage.getByRole('heading', { name: instance.name, level: 2 }),
     ).toBeVisible({ timeout: 15000 });
 
     await expect(
@@ -204,7 +204,7 @@ test.describe('Decision Role Capabilities', () => {
     });
 
     await expect(
-      memberPage.getByRole('heading', { name: instance.name, level: 1 }),
+      memberPage.getByRole('heading', { name: instance.name, level: 2 }),
     ).toBeVisible({ timeout: 15000 });
 
     await expect(
@@ -233,7 +233,7 @@ test.describe('Decision Role Capabilities', () => {
     });
 
     await expect(
-      authenticatedPage.getByRole('heading', { name: instance.name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name: instance.name, level: 2 }),
     ).toBeVisible({ timeout: 15000 });
 
     await expect(

--- a/tests/e2e/tests/decision-settings-permissions.spec.ts
+++ b/tests/e2e/tests/decision-settings-permissions.spec.ts
@@ -59,7 +59,7 @@ test.describe('Decision Settings Permissions', () => {
     });
 
     await expect(
-      memberPage.getByRole('heading', { name: instance.name, level: 1 }),
+      memberPage.getByRole('heading', { name: instance.name, level: 2 }),
     ).toBeVisible({ timeout: 15_000 });
 
     // 5. Assert the Settings button is NOT visible to the member
@@ -72,7 +72,7 @@ test.describe('Decision Settings Permissions', () => {
     });
 
     await expect(
-      authenticatedPage.getByRole('heading', { name: instance.name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name: instance.name, level: 2 }),
     ).toBeVisible({ timeout: 15_000 });
 
     const adminSettingsLink = authenticatedPage.getByRole('link', {

--- a/tests/e2e/tests/decisions.spec.ts
+++ b/tests/e2e/tests/decisions.spec.ts
@@ -27,7 +27,7 @@ test.describe('Decisions', () => {
     // 4. Wait for the page to load
     // The heading shows the instance name (which takes priority over template name)
     await expect(
-      authenticatedPage.getByRole('heading', { name: instance.name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name: instance.name, level: 2 }),
     ).toBeVisible({ timeout: 15000 });
 
     // 5. Click the "Start a proposal" button
@@ -88,7 +88,7 @@ test.describe('Decisions', () => {
     });
 
     await expect(
-      authenticatedPage.getByRole('heading', { name: instance.name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name: instance.name, level: 2 }),
     ).toBeVisible({ timeout: 15000 });
     await expect(authenticatedPage).toHaveURL(
       new RegExp(`/en/${instance.slug}(?:[/?#]|$)`),

--- a/tests/e2e/tests/default-hidden-proposals.spec.ts
+++ b/tests/e2e/tests/default-hidden-proposals.spec.ts
@@ -219,7 +219,7 @@ test.describe('Default Hidden Proposals', () => {
     });
 
     await expect(
-      authenticatedPage.getByRole('heading', { name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name, level: 2 }),
     ).toBeVisible({
       timeout: 30_000,
     });
@@ -279,7 +279,7 @@ test.describe('Default Hidden Proposals', () => {
     });
 
     await expect(
-      otherMemberPage.getByRole('heading', { name, level: 1 }),
+      otherMemberPage.getByRole('heading', { name, level: 2 }),
     ).toBeVisible({
       timeout: 30_000,
     });
@@ -367,7 +367,7 @@ test.describe('Default Hidden Proposals', () => {
     });
 
     await expect(
-      submitterPage.getByRole('heading', { name, level: 1 }),
+      submitterPage.getByRole('heading', { name, level: 2 }),
     ).toBeVisible({
       timeout: 30_000,
     });

--- a/tests/e2e/tests/proposal-listing-infinite-scroll.spec.ts
+++ b/tests/e2e/tests/proposal-listing-infinite-scroll.spec.ts
@@ -64,7 +64,7 @@ test.describe('Proposal Listing — Infinite Scroll', () => {
     });
 
     await expect(
-      authenticatedPage.getByRole('heading', { name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name, level: 2 }),
     ).toBeVisible({
       timeout: 30_000,
     });

--- a/tests/e2e/tests/proposal-listing-realtime-update.spec.ts
+++ b/tests/e2e/tests/proposal-listing-realtime-update.spec.ts
@@ -30,7 +30,7 @@ test.describe('Proposal Listing — update after create', () => {
       { waitUntil: 'domcontentloaded' },
     );
     await expect(
-      authenticatedPage.getByRole('heading', { name: instance.name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name: instance.name, level: 2 }),
     ).toBeVisible({ timeout: 30_000 });
     await expect(authenticatedPage.getByText('No proposals yet')).toBeVisible({
       timeout: 30_000,
@@ -53,7 +53,7 @@ test.describe('Proposal Listing — update after create', () => {
     // Return via client-side history — NOT a reload (which would mask the bug).
     await authenticatedPage.goBack({ waitUntil: 'commit' });
     await expect(
-      authenticatedPage.getByRole('heading', { name: instance.name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name: instance.name, level: 2 }),
     ).toBeVisible({ timeout: 15_000 });
 
     // The new draft must appear well within the 30s staleTime.

--- a/tests/e2e/tests/proposal-listing.spec.ts
+++ b/tests/e2e/tests/proposal-listing.spec.ts
@@ -240,7 +240,7 @@ test.describe('Proposal Listing', () => {
 
     // Decision heading renders
     await expect(
-      authenticatedPage.getByRole('heading', { name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name, level: 2 }),
     ).toBeVisible({
       timeout: 30_000,
     });
@@ -405,7 +405,7 @@ test.describe('Proposal Listing', () => {
 
     // Decision heading renders
     await expect(
-      authenticatedPage.getByRole('heading', { name, level: 1 }),
+      authenticatedPage.getByRole('heading', { name, level: 2 }),
     ).toBeVisible({
       timeout: 30_000,
     });


### PR DESCRIPTION
Cleanup + standardization of headings across decision processes.

- Consolidate three duplicate `Header` instances in `DecisionInstanceHeader` into one `DecisionTitle` helper.
- Collapse `GradientHeader`'s nested divs into a single `mx-auto`/`w-fit` element (gradient still maps across the text).
- Promote the overview hero to `h1` and demote the sticky header title to `h2` — page now has exactly one `h1`; stale heading-order comment updated.
- Align heading tokens: `h1` size, title line-heights 110%→120% (app-wide) to prevent text clipping.