### PR TITLE
fix(auth): redirect back to current page after header login

### DIFF
--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -489,7 +489,11 @@ export const HeaderUserMenu = ({ className }: { className?: string }) => {
       color="primary"
       size="small"
       className={className}
-      onPress={() => window.location.assign('/login')}
+      onPress={() =>
+        window.location.assign(
+          `/login?redirect=${encodeURIComponent(window.location.pathname + window.location.search)}`,
+        )
+      }
     >
       {t('Log in')}
     </Button>


### PR DESCRIPTION
- Header "Log in" button now passes the current path+query as a `redirect` param
- Matches existing walled-garden protected-route behavior; `getSafeRedirectPath` sanitizes it on the login side