### PR TITLE
fix(decisions): header size on promote account modal

### DIFF
--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -83,9 +83,7 @@ const PromoteAccountModalContent = ({
       <div className="flex flex-col items-center gap-4 text-center">
         <CheckIcon />
         <div className="flex flex-col gap-2">
-          <Header1 className="text-neutral-black">
-            {t('Your idea was submitted.')}
-          </Header1>
+          <Header1>{t('Your idea was submitted.')}</Header1>
           <p className="text-base text-neutral-charcoal">
             {t('Want to follow what happens next?')}
           </p>


### PR DESCRIPTION
Fix the header by removing a class that was clobbering the `text-title-lg` class on the header. 

<img width="1158" height="816" alt="before and after showing the header sizes (before: too small, after: perfect)" src="https://github.com/user-attachments/assets/f78c73b4-5bf7-4d40-9f4d-f71ec8eb6c24" />
