### PR TITLE
refactor(decisions): extract shared TranslationNotice component

### DIFF
--- a/apps/app/src/components/Bullet/index.tsx
+++ b/apps/app/src/components/Bullet/index.tsx
@@ -1,1 +1,7 @@
-export const Bullet = () => <span className="text-neutral-gray4">•</span>;
+// Decorative separator between inline metadata. aria-hidden so screen readers
+// don't announce "bullet" mid-sentence.
+export const Bullet = () => (
+  <span aria-hidden className="text-neutral-gray4">
+    •
+  </span>
+);

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -20,7 +20,6 @@ import { LuBookOpen, LuTriangleAlert } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
-import { Bullet } from '../Bullet';
 import { DecisionHeroBackgroundImage } from './DecisionHeroBanner';
 import { DecisionPhaseTimeline } from './DecisionPhaseTimeline';
 import { useDecisionTranslation } from './DecisionTranslationContext';
@@ -32,6 +31,7 @@ import {
 } from './OverviewPinnedResources';
 import { ProposalHtmlContent } from './ProposalHtmlContent';
 import { TranslateBanner } from './TranslateBanner';
+import { TranslationNotice } from './TranslationNotice';
 import { getOverviewDetectionText } from './translationDetectionText';
 import { useCreateProposal } from './useCreateProposal';
 import { useTranslateDecision } from './useTranslateDecision';
@@ -234,19 +234,11 @@ function DecisionOverviewContent({
         </div>
         <div className="min-w-0 md:col-span-7 md:col-start-6">
           {decisionTranslation.translationState ? (
-            <p className="mb-4 text-sm text-neutral-gray4">
-              {t('Translated from {language}', {
-                language: decisionTranslation.sourceLanguageName,
-              })}
-              <Bullet />{' '}
-              <Button
-                variant="link"
-                onPress={decisionTranslation.handleViewOriginal}
-                className="inline h-auto p-0 text-sm sm:text-sm"
-              >
-                {t('View original')}
-              </Button>
-            </p>
+            <TranslationNotice
+              sourceLanguageName={decisionTranslation.sourceLanguageName}
+              onViewOriginal={decisionTranslation.handleViewOriginal}
+              className="mb-4"
+            />
           ) : null}
           <OverviewAbout
             bodySlot={translatedAbout ?? aboutSlot}

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -12,7 +12,6 @@ import {
 } from '@op/common/client';
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Header1, Header3 } from '@op/ui/Header';
-import { Link } from '@op/ui/Link';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Tag, TagGroup } from '@op/ui/TagGroup';
 import type { ReactNode } from 'react';
@@ -33,6 +32,7 @@ import { DocumentNotAvailable } from './DocumentNotAvailable';
 import { ProposalAttachmentViewList } from './ProposalAttachmentViewList';
 import { ProposalContentRenderer } from './ProposalContentRenderer';
 import { ProposalHtmlContent } from './ProposalHtmlContent';
+import { TranslationNotice } from './TranslationNotice';
 import { resolveProposalSystemFields } from './proposalContentUtils';
 
 export type ProposalTranslation = {
@@ -139,18 +139,10 @@ export function ProposalPreview({
 
         {/* Translation attribution */}
         {translation && (
-          <p className="text-sm text-neutral-gray3">
-            {t('Translated from {language}', {
-              language: translation.sourceLanguageName,
-            })}{' '}
-            &middot;{' '}
-            <Link
-              onPress={translation.onViewOriginal}
-              className="text-sm font-semibold"
-            >
-              {t('View original')}
-            </Link>
-          </p>
+          <TranslationNotice
+            sourceLanguageName={translation.sourceLanguageName}
+            onViewOriginal={translation.onViewOriginal}
+          />
         )}
 
         <div className="space-y-6">

--- a/apps/app/src/components/decisions/TranslationNotice.tsx
+++ b/apps/app/src/components/decisions/TranslationNotice.tsx
@@ -24,9 +24,11 @@ export const TranslationNotice = ({
   const t = useTranslations();
 
   return (
-    <p className={cn('text-sm text-neutral-gray4', className)}>
-      {t('Translated from {language}', { language: sourceLanguageName })}
-      <Bullet />{' '}
+    <div className="flex gap-1">
+      <p className={cn('text-sm text-neutral-gray4', className)}>
+        {t('Translated from {language}', { language: sourceLanguageName })}
+      </p>
+      <Bullet />
       <Button
         variant="link"
         onPress={onViewOriginal}
@@ -34,6 +36,6 @@ export const TranslationNotice = ({
       >
         {t('View original')}
       </Button>
-    </p>
+    </div>
   );
 };

--- a/apps/app/src/components/decisions/TranslationNotice.tsx
+++ b/apps/app/src/components/decisions/TranslationNotice.tsx
@@ -1,25 +1,39 @@
 'use client';
 
-import { Link } from '@op/ui/Link';
+import { Button } from '@op/ui/Button';
+import { cn } from '@op/ui/utils';
 
 import { useTranslations } from '@/lib/i18n';
 
+import { Bullet } from '../Bullet';
+
+/**
+ * "Translated from {language} · View original" attribution shown above
+ * machine-translated content — the proposal view, the proposal list, and the
+ * decision overview all render this same notice.
+ */
 export const TranslationNotice = ({
   sourceLanguageName,
   onViewOriginal,
+  className,
 }: {
   sourceLanguageName: string;
   onViewOriginal: () => void;
+  className?: string;
 }) => {
   const t = useTranslations();
 
   return (
-    <p className="text-sm text-neutral-gray3">
-      {t('Translated from {language}', { language: sourceLanguageName })}{' '}
-      &middot;{' '}
-      <Link onPress={onViewOriginal} className="text-sm font-semibold">
+    <p className={cn('text-sm text-neutral-gray4', className)}>
+      {t('Translated from {language}', { language: sourceLanguageName })}
+      <Bullet />{' '}
+      <Button
+        variant="link"
+        onPress={onViewOriginal}
+        className="inline h-auto p-0 text-sm sm:text-sm"
+      >
         {t('View original')}
-      </Link>
+      </Button>
     </p>
   );
 };

--- a/apps/app/src/components/decisions/TranslationNotice.tsx
+++ b/apps/app/src/components/decisions/TranslationNotice.tsx
@@ -24,7 +24,7 @@ export const TranslationNotice = ({
   const t = useTranslations();
 
   return (
-    <div className="flex gap-1">
+    <div className="flex items-center gap-1">
       <p className={cn('text-sm text-neutral-gray4', className)}>
         {t('Translated from {language}', { language: sourceLanguageName })}
       </p>

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -80,7 +80,7 @@ const buttonStyle = tv({
       variant: 'link',
       unstyled: false,
       className:
-        'bg-transparent text-primary-teal shadow-none hover:bg-transparent pressed:bg-transparent pressed:text-primary-teal pressed:!shadow-none',
+        'bg-transparent text-primary-teal shadow-none hover:bg-transparent hover:underline pressed:bg-transparent pressed:text-primary-teal pressed:!shadow-none',
     },
   ],
 

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -80,7 +80,7 @@ const buttonStyle = tv({
       variant: 'link',
       unstyled: false,
       className:
-        'bg-transparent text-primary-teal shadow-none hover:bg-transparent hover:underline pressed:bg-transparent pressed:text-primary-teal pressed:!shadow-none',
+        'bg-transparent text-primary-teal shadow-none hover:bg-transparent pressed:bg-transparent pressed:text-primary-teal pressed:!shadow-none',
     },
   ],
 


### PR DESCRIPTION
Three copies of the "Translated from {language} · View original" notice (`ProposalPreview`, `ProposalsList`, `DecisionOverview`) had drifted apart. Extract one `TranslationNotice` and converge all three on the bullet + link-button style.

<img width="700" height="226" alt="Screenshot showing the before and after of the component. It lacked contrast before. Now it is legible and matches the design in Figma." src="https://github.com/user-attachments/assets/37598563-3310-492a-9eae-fc9a78d620bf" />
