### PR TITLE
feat(decisions): highlight required proposal fields on failed submit

### DIFF
--- a/apps/app/src/components/collaboration/CollaborativeBudgetField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeBudgetField.tsx
@@ -4,7 +4,7 @@ import { useCollaborativeFragment } from '@/hooks/useCollaborativeFragment';
 import type { BudgetData } from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { NumberField } from '@op/ui/NumberField';
-import { cn } from '@op/ui/utils';
+import { cn, getInvalidAriaAttributes } from '@op/ui/utils';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -202,10 +202,10 @@ export function CollaborativeBudgetField({
           variant="pill"
           color="pill"
           onPress={handleStartEditing}
-          aria-invalid={isInvalid || undefined}
-          aria-describedby={
-            isInvalid ? getFieldErrorId(fragmentName) : undefined
-          }
+          {...getInvalidAriaAttributes({
+            isInvalid,
+            errorMessageId: getFieldErrorId(fragmentName),
+          })}
           className={cn(
             'justify-start text-start',
             isInvalid && INVALID_PILL_CLASS,

--- a/apps/app/src/components/collaboration/CollaborativeBudgetField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeBudgetField.tsx
@@ -10,9 +10,25 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from '@/lib/i18n';
 
 import { useCollaborativeDoc } from './CollaborativeDocContext';
-import { INVALID_PILL_CLASS } from './invalidFieldStyles';
+import { INVALID_PILL_CLASS, getFieldErrorId } from './invalidFieldStyles';
 
 const DEFAULT_CURRENCY = 'USD';
+
+/**
+ * Fragment text is legacy/shared collaborative data — a fragment that once
+ * belonged to a non-money field can hold non-JSON text, which must not crash
+ * the editor at render.
+ */
+function parseBudgetText(text: string): BudgetData | null {
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text) as BudgetData;
+  } catch {
+    return null;
+  }
+}
 
 const getCurrencySymbol = (currency: string) =>
   (0)
@@ -73,7 +89,7 @@ export function CollaborativeBudgetField({
     initialBudgetValue ? JSON.stringify(initialBudgetValue) : '',
   );
 
-  const budget = budgetText ? (JSON.parse(budgetText) as BudgetData) : null;
+  const budget = parseBudgetText(budgetText);
   const setBudget = (newBudget: BudgetData | null) =>
     setBudgetText(newBudget ? JSON.stringify(newBudget) : '');
 
@@ -138,7 +154,7 @@ export function CollaborativeBudgetField({
   };
 
   useEffect(() => {
-    const emitted = budgetText ? (JSON.parse(budgetText) as BudgetData) : null;
+    const emitted = parseBudgetText(budgetText);
     const key = emitted ? `${emitted.amount}:${emitted.currency}` : null;
 
     if (lastEmittedRef.current === key) {
@@ -186,6 +202,10 @@ export function CollaborativeBudgetField({
           variant="pill"
           color="pill"
           onPress={handleStartEditing}
+          aria-invalid={isInvalid || undefined}
+          aria-describedby={
+            isInvalid ? getFieldErrorId(fragmentName) : undefined
+          }
           className={cn(
             'justify-start text-start',
             isInvalid && INVALID_PILL_CLASS,

--- a/apps/app/src/components/collaboration/CollaborativeBudgetField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeBudgetField.tsx
@@ -4,11 +4,13 @@ import { useCollaborativeFragment } from '@/hooks/useCollaborativeFragment';
 import type { BudgetData } from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { NumberField } from '@op/ui/NumberField';
+import { cn } from '@op/ui/utils';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
 import { useCollaborativeDoc } from './CollaborativeDocContext';
+import { INVALID_PILL_CLASS } from './invalidFieldStyles';
 
 const DEFAULT_CURRENCY = 'USD';
 
@@ -28,6 +30,14 @@ interface CollaborativeBudgetFieldProps {
   minAmount?: number;
   maxAmount?: number;
   initialValue?: BudgetData | null;
+  /**
+   * Yjs fragment name to sync this field. Must match the field's template key
+   * — validation reads fragment text by key, so a custom money field syncing
+   * to the wrong fragment can never validate.
+   */
+  fragmentName?: string;
+  /** When true, renders the field in its validation-error state. */
+  isInvalid?: boolean;
   onChange?: (budget: BudgetData | null) => void;
 }
 
@@ -44,6 +54,8 @@ export function CollaborativeBudgetField({
   minAmount,
   maxAmount,
   initialValue = null,
+  fragmentName = 'budget',
+  isInvalid = false,
   onChange,
 }: CollaborativeBudgetFieldProps) {
   const t = useTranslations();
@@ -57,7 +69,7 @@ export function CollaborativeBudgetField({
 
   const [budgetText, setBudgetText] = useCollaborativeFragment(
     ydoc,
-    'budget',
+    fragmentName,
     initialBudgetValue ? JSON.stringify(initialBudgetValue) : '',
   );
 
@@ -174,7 +186,10 @@ export function CollaborativeBudgetField({
           variant="pill"
           color="pill"
           onPress={handleStartEditing}
-          className="justify-start text-start"
+          className={cn(
+            'justify-start text-start',
+            isInvalid && INVALID_PILL_CLASS,
+          )}
         >
           {budgetAmount !== null
             ? budgetAmount.toLocaleString(undefined, {

--- a/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
@@ -22,6 +22,8 @@ interface CollaborativeDropdownFieldProps {
   allowEmpty?: boolean;
   /** When true, sets `aria-required` on the select for assistive tech. */
   required?: boolean;
+  /** When true, renders the select in its validation-error state. */
+  isInvalid?: boolean;
 }
 
 /**
@@ -36,6 +38,7 @@ export function CollaborativeDropdownField({
   placeholder,
   allowEmpty = false,
   required = false,
+  isInvalid = false,
 }: CollaborativeDropdownFieldProps) {
   const t = useTranslations();
   const { ydoc } = useCollaborativeDoc();
@@ -86,6 +89,7 @@ export function CollaborativeDropdownField({
       variant="pill"
       size="medium"
       isRequired={required}
+      isInvalid={isInvalid}
       placeholder={placeholder ?? t('Select option')}
       selectedKey={selectedValue}
       onSelectionChange={handleSelectionChange}

--- a/apps/app/src/components/collaboration/CollaborativeEditor.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeEditor.tsx
@@ -30,6 +30,10 @@ export interface CollaborativeEditorProps {
   editorClassName?: string;
   /** When true, sets `aria-required` on the editable region for assistive tech. */
   required?: boolean;
+  /** When true, sets `aria-invalid` on the editable region. */
+  isInvalid?: boolean;
+  /** id of the error message element, set as `aria-describedby` while invalid. */
+  errorMessageId?: string;
 }
 
 /** Rich text editor with real-time collaboration via TipTap Cloud */
@@ -46,6 +50,8 @@ export const CollaborativeEditor = forwardRef<
       className = '',
       editorClassName = '',
       required = false,
+      isInvalid = false,
+      errorMessageId,
     },
     ref,
   ) => {
@@ -70,6 +76,8 @@ export const CollaborativeEditor = forwardRef<
       editorClassName,
       onEditorReady,
       required,
+      isInvalid,
+      errorMessageId,
     });
 
     useImperativeHandle(

--- a/apps/app/src/components/collaboration/CollaborativeLocationField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeLocationField.tsx
@@ -18,6 +18,8 @@ interface CollaborativeLocationFieldProps {
   profileId: string | null;
   /** Default map camera shown before a location is chosen (from the template). */
   defaultMapView?: MapDefaultView;
+  /** When true, renders the field in its validation-error state. */
+  isInvalid?: boolean;
   onChange?: (location: LocationData | null) => void;
 }
 
@@ -66,6 +68,7 @@ export function CollaborativeLocationField({
   initialValue = null,
   profileId,
   defaultMapView,
+  isInvalid = false,
   onChange,
 }: CollaborativeLocationFieldProps) {
   const { ydoc } = useCollaborativeDoc();
@@ -135,6 +138,7 @@ export function CollaborativeLocationField({
       value={location}
       profileId={profileId}
       defaultMapView={defaultMapView}
+      isInvalid={isInvalid}
       onChange={handleChange}
     />
   );

--- a/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
@@ -17,7 +17,7 @@ import { LuCheck } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 
 import { useCollaborativeDoc } from './CollaborativeDocContext';
-import { INVALID_PILL_CLASS } from './invalidFieldStyles';
+import { INVALID_PILL_CLASS, getFieldErrorId } from './invalidFieldStyles';
 
 interface CollaborativeMultiSelectFieldProps {
   options: Array<{ value: string; label: string }>;
@@ -115,6 +115,10 @@ export function CollaborativeMultiSelectField({
         <Button
           variant="pill"
           color="pill"
+          aria-invalid={isInvalid || undefined}
+          aria-describedby={
+            isInvalid ? getFieldErrorId(fragmentName) : undefined
+          }
           className={cn(
             'w-fit justify-start text-start pressed:bg-primary-tealWhite pressed:text-primary-teal pressed:!shadow-none',
             isInvalid && INVALID_PILL_CLASS,

--- a/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
@@ -7,7 +7,7 @@ import { DialogTrigger } from '@op/ui/Dialog';
 import { ListBox } from '@op/ui/ListBox';
 import { Popover } from '@op/ui/Popover';
 import { Tag, TagGroup } from '@op/ui/TagGroup';
-import { cn } from '@op/ui/utils';
+import { cn, getInvalidAriaAttributes } from '@op/ui/utils';
 import { useEffect, useMemo, useRef } from 'react';
 import type { Key } from 'react';
 import { Dialog, ListBoxItem } from 'react-aria-components';
@@ -115,10 +115,10 @@ export function CollaborativeMultiSelectField({
         <Button
           variant="pill"
           color="pill"
-          aria-invalid={isInvalid || undefined}
-          aria-describedby={
-            isInvalid ? getFieldErrorId(fragmentName) : undefined
-          }
+          {...getInvalidAriaAttributes({
+            isInvalid,
+            errorMessageId: getFieldErrorId(fragmentName),
+          })}
           className={cn(
             'w-fit justify-start text-start pressed:bg-primary-tealWhite pressed:text-primary-teal pressed:!shadow-none',
             isInvalid && INVALID_PILL_CLASS,

--- a/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
@@ -7,6 +7,7 @@ import { DialogTrigger } from '@op/ui/Dialog';
 import { ListBox } from '@op/ui/ListBox';
 import { Popover } from '@op/ui/Popover';
 import { Tag, TagGroup } from '@op/ui/TagGroup';
+import { cn } from '@op/ui/utils';
 import { useEffect, useMemo, useRef } from 'react';
 import type { Key } from 'react';
 import { Dialog, ListBoxItem } from 'react-aria-components';
@@ -16,6 +17,7 @@ import { LuCheck } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 
 import { useCollaborativeDoc } from './CollaborativeDocContext';
+import { INVALID_PILL_CLASS } from './invalidFieldStyles';
 
 interface CollaborativeMultiSelectFieldProps {
   options: Array<{ value: string; label: string }>;
@@ -25,6 +27,8 @@ interface CollaborativeMultiSelectFieldProps {
   fragmentName: string;
   /** Placeholder text shown when no value is selected. */
   placeholder?: string;
+  /** When true, renders the field in its validation-error state. */
+  isInvalid?: boolean;
 }
 
 /**
@@ -40,6 +44,7 @@ export function CollaborativeMultiSelectField({
   onChange,
   fragmentName,
   placeholder,
+  isInvalid = false,
 }: CollaborativeMultiSelectFieldProps) {
   const t = useTranslations();
   const { ydoc } = useCollaborativeDoc();
@@ -110,7 +115,10 @@ export function CollaborativeMultiSelectField({
         <Button
           variant="pill"
           color="pill"
-          className="w-fit justify-start text-start pressed:bg-primary-tealWhite pressed:text-primary-teal pressed:!shadow-none"
+          className={cn(
+            'w-fit justify-start text-start pressed:bg-primary-tealWhite pressed:text-primary-teal pressed:!shadow-none',
+            isInvalid && INVALID_PILL_CLASS,
+          )}
         >
           {buttonLabel}
         </Button>

--- a/apps/app/src/components/collaboration/CollaborativeTextField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTextField.tsx
@@ -8,6 +8,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { getProposalExtensions } from '../RichTextEditor';
 import { CollaborativeEditor } from './CollaborativeEditor';
+import { INVALID_EDITOR_CLASS, getFieldErrorId } from './invalidFieldStyles';
 
 /**
  * Props for the collaborative text field.
@@ -32,6 +33,8 @@ interface CollaborativeTextFieldProps {
   placeholder?: string;
   multiline?: boolean;
   maxLength?: number;
+  /** When true, renders the field in its validation-error state. */
+  isInvalid?: boolean;
   onChange?: (html: string) => void;
   onEditorFocus?: (editor: Editor) => void;
   onEditorBlur?: (editor: Editor) => void;
@@ -51,6 +54,7 @@ export function CollaborativeTextField({
   placeholder = 'Start typing...',
   multiline = false,
   maxLength,
+  isInvalid = false,
   onChange,
   onEditorFocus,
   onEditorBlur,
@@ -99,13 +103,25 @@ export function CollaborativeTextField({
       {(title || description) && (
         <div className="flex flex-col gap-2">
           {title && (
-            <span className="font-serif text-title-sm14 text-neutral-charcoal">
+            <span
+              className={cn(
+                'font-serif text-title-sm14 text-neutral-charcoal',
+                isInvalid && 'text-functional-red',
+              )}
+            >
               {title}
               {required && <RequiredAsterisk />}
             </span>
           )}
           {description && (
-            <p className="text-sm text-neutral-charcoal">{description}</p>
+            <p
+              className={cn(
+                'text-sm text-neutral-charcoal',
+                isInvalid && 'text-functional-red',
+              )}
+            >
+              {description}
+            </p>
           )}
         </div>
       )}
@@ -114,8 +130,11 @@ export function CollaborativeTextField({
         extensions={extensions}
         placeholder={placeholder}
         onEditorReady={handleEditorReady}
+        className={cn(isInvalid && INVALID_EDITOR_CLASS)}
         editorClassName={multiline ? 'min-h-32' : 'min-h-8'}
         required={required}
+        isInvalid={isInvalid}
+        errorMessageId={getFieldErrorId(fragmentName)}
       />
       {maxLength != null && (
         <div className="flex justify-end">

--- a/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Skeleton } from '@op/ui/Skeleton';
+import { cn } from '@op/ui/utils';
 import Collaboration from '@tiptap/extension-collaboration';
 import CollaborationCaret from '@tiptap/extension-collaboration-caret';
 import Document from '@tiptap/extension-document';
@@ -11,9 +12,12 @@ import { EditorContent, useEditor } from '@tiptap/react';
 import { useEffect, useMemo } from 'react';
 
 import { useCollaborativeDoc } from './CollaborativeDocContext';
+import { INVALID_EDITOR_CLASS, getFieldErrorId } from './invalidFieldStyles';
 
 interface CollaborativeTitleFieldProps {
   placeholder?: string;
+  /** When true, renders the field in its validation-error state. */
+  isInvalid?: boolean;
   onChange?: (text: string) => void;
 }
 
@@ -22,6 +26,7 @@ interface CollaborativeTitleFieldProps {
  */
 export function CollaborativeTitleField({
   placeholder = 'Untitled Proposal',
+  isInvalid = false,
   onChange,
 }: CollaborativeTitleFieldProps) {
   const { ydoc, provider, user } = useCollaborativeDoc();
@@ -49,13 +54,24 @@ export function CollaborativeTitleField({
     [ydoc, provider, user, placeholder],
   );
 
+  const editorAttributes = useMemo(
+    () => ({
+      class:
+        'h-auto border-0 p-0 font-serif text-title-lg text-neutral-charcoal outline-none',
+      ...(isInvalid
+        ? {
+            'aria-invalid': 'true',
+            'aria-describedby': getFieldErrorId('title'),
+          }
+        : {}),
+    }),
+    [isInvalid],
+  );
+
   const editor = useEditor({
     extensions,
     editorProps: {
-      attributes: {
-        class:
-          'h-auto border-0 p-0 font-serif text-title-lg text-neutral-charcoal outline-none',
-      },
+      attributes: editorAttributes,
       handleKeyDown: (_view, event) => {
         if (event.key === 'Enter') {
           return true;
@@ -65,6 +81,17 @@ export function CollaborativeTitleField({
     },
     immediatelyRender: false,
   });
+
+  // `useEditor` captures options at creation — push aria attribute changes
+  // (invalid toggling after a failed submit) into the live editor.
+  useEffect(() => {
+    editor?.setOptions({
+      editorProps: {
+        attributes: editorAttributes,
+        handleKeyDown: (_view, event) => event.key === 'Enter',
+      },
+    });
+  }, [editor, editorAttributes]);
 
   useEffect(() => {
     if (!editor || !onChange) {
@@ -87,6 +114,10 @@ export function CollaborativeTitleField({
   }
 
   return (
-    <EditorContent dir={editor.isEmpty ? undefined : 'auto'} editor={editor} />
+    <EditorContent
+      dir={editor.isEmpty ? undefined : 'auto'}
+      editor={editor}
+      className={cn(isInvalid && INVALID_EDITOR_CLASS)}
+    />
   );
 }

--- a/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
@@ -14,6 +14,11 @@ import { useEffect, useMemo } from 'react';
 import { useCollaborativeDoc } from './CollaborativeDocContext';
 import { INVALID_EDITOR_CLASS, getFieldErrorId } from './invalidFieldStyles';
 
+/** Titles are single-line — swallow Enter instead of inserting a paragraph. */
+function suppressEnterKey(_view: unknown, event: KeyboardEvent): boolean {
+  return event.key === 'Enter';
+}
+
 interface CollaborativeTitleFieldProps {
   placeholder?: string;
   /** When true, renders the field in its validation-error state. */
@@ -54,44 +59,30 @@ export function CollaborativeTitleField({
     [ydoc, provider, user, placeholder],
   );
 
-  const editorAttributes = useMemo(
+  // Memoized so `useEditor`'s per-render options diff only applies changes
+  // (aria-invalid toggling after a failed submit) when they actually change.
+  const editorProps = useMemo(
     () => ({
-      class:
-        'h-auto border-0 p-0 font-serif text-title-lg text-neutral-charcoal outline-none',
-      ...(isInvalid
-        ? {
-            'aria-invalid': 'true',
-            'aria-describedby': getFieldErrorId('title'),
-          }
-        : {}),
+      attributes: {
+        class:
+          'h-auto border-0 p-0 font-serif text-title-lg text-neutral-charcoal outline-none',
+        ...(isInvalid
+          ? {
+              'aria-invalid': 'true',
+              'aria-describedby': getFieldErrorId('title'),
+            }
+          : {}),
+      },
+      handleKeyDown: suppressEnterKey,
     }),
     [isInvalid],
   );
 
   const editor = useEditor({
     extensions,
-    editorProps: {
-      attributes: editorAttributes,
-      handleKeyDown: (_view, event) => {
-        if (event.key === 'Enter') {
-          return true;
-        }
-        return false;
-      },
-    },
+    editorProps,
     immediatelyRender: false,
   });
-
-  // `useEditor` captures options at creation — push aria attribute changes
-  // (invalid toggling after a failed submit) into the live editor.
-  useEffect(() => {
-    editor?.setOptions({
-      editorProps: {
-        attributes: editorAttributes,
-        handleKeyDown: (_view, event) => event.key === 'Enter',
-      },
-    });
-  }, [editor, editorAttributes]);
 
   useEffect(() => {
     if (!editor || !onChange) {

--- a/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Skeleton } from '@op/ui/Skeleton';
-import { cn } from '@op/ui/utils';
+import { cn, getInvalidAriaAttributes } from '@op/ui/utils';
 import Collaboration from '@tiptap/extension-collaboration';
 import CollaborationCaret from '@tiptap/extension-collaboration-caret';
 import Document from '@tiptap/extension-document';
@@ -66,12 +66,10 @@ export function CollaborativeTitleField({
       attributes: {
         class:
           'h-auto border-0 p-0 font-serif text-title-lg text-neutral-charcoal outline-none',
-        ...(isInvalid
-          ? {
-              'aria-invalid': 'true',
-              'aria-describedby': getFieldErrorId('title'),
-            }
-          : {}),
+        ...getInvalidAriaAttributes({
+          isInvalid,
+          errorMessageId: getFieldErrorId('title'),
+        }),
       },
       handleKeyDown: suppressEnterKey,
     }),

--- a/apps/app/src/components/collaboration/invalidFieldStyles.ts
+++ b/apps/app/src/components/collaboration/invalidFieldStyles.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared error-state visuals for proposal fields (Figma: red label +
+ * pink input surface for text editors, red outline for pill controls).
+ *
+ * No padding/size changes here on purpose — the error state must not shift
+ * layout, especially since it clears on the user's first keystroke.
+ */
+export const INVALID_EDITOR_CLASS = 'rounded-lg bg-functional-red-50';
+export const INVALID_PILL_CLASS = 'outline outline-1 outline-functional-red';
+
+/**
+ * DOM id of a field's rendered error message (see ProposalFormRenderer),
+ * used as the `aria-describedby` target on the field's input element.
+ */
+export function getFieldErrorId(key: string): string {
+  return `field-error-${key}`;
+}

--- a/apps/app/src/components/collaboration/invalidFieldStyles.ts
+++ b/apps/app/src/components/collaboration/invalidFieldStyles.ts
@@ -5,7 +5,7 @@
  * No padding/size changes here on purpose — the error state must not shift
  * layout, especially since it clears on the user's first keystroke.
  */
-export const INVALID_EDITOR_CLASS = 'rounded-lg bg-functional-red-50';
+export const INVALID_EDITOR_CLASS = 'bg-functional-red-50';
 export const INVALID_PILL_CLASS = 'outline outline-1 outline-functional-red';
 
 /**

--- a/apps/app/src/components/collaboration/invalidFieldStyles.ts
+++ b/apps/app/src/components/collaboration/invalidFieldStyles.ts
@@ -9,6 +9,14 @@ export const INVALID_EDITOR_CLASS = 'bg-functional-red-50';
 export const INVALID_PILL_CLASS = 'outline outline-1 outline-functional-red';
 
 /**
+ * DOM attribute carrying each field's key on its wrapper in
+ * ProposalFormRenderer. The editor uses it to locate and scroll to invalid
+ * fields after a failed submit; the wrapper also exposes `data-invalid` for
+ * tests.
+ */
+export const FIELD_ANCHOR_ATTR = 'data-field-anchor';
+
+/**
  * DOM id of a field's rendered error message (see ProposalFormRenderer),
  * used as the `aria-describedby` target on the field's input element.
  */

--- a/apps/app/src/components/decisions/forms/FieldHeader.tsx
+++ b/apps/app/src/components/decisions/forms/FieldHeader.tsx
@@ -1,5 +1,6 @@
 import { Header4 } from '@op/ui/Header';
 import { RequiredAsterisk } from '@op/ui/RequiredAsterisk';
+import { cn } from '@op/ui/utils';
 
 /** Renders title + description header for a form field. */
 export function FieldHeader({
@@ -7,6 +8,7 @@ export function FieldHeader({
   description,
   badge,
   required,
+  isInvalid,
   className = 'gap-2',
 }: {
   title?: string;
@@ -15,6 +17,8 @@ export function FieldHeader({
   badge?: React.ReactNode;
   /** When true, renders a red asterisk next to the title. */
   required?: boolean;
+  /** When true, renders the title + description in the error color. */
+  isInvalid?: boolean;
   className?: string;
 }) {
   if (!title && !description) {
@@ -25,7 +29,9 @@ export function FieldHeader({
     <div className={`flex flex-col ${className}`}>
       {title && (
         <div className="flex items-baseline justify-between gap-2">
-          <Header4 className="font-light">
+          <Header4
+            className={cn('font-light', isInvalid && 'text-functional-red')}
+          >
             {title}
             {required && <RequiredAsterisk />}
           </Header4>
@@ -35,7 +41,14 @@ export function FieldHeader({
         </div>
       )}
       {description && (
-        <p className="text-sm text-neutral-charcoal">{description}</p>
+        <p
+          className={cn(
+            'text-sm text-neutral-charcoal',
+            isInvalid && 'text-functional-red',
+          )}
+        >
+          {description}
+        </p>
       )}
     </div>
   );

--- a/apps/app/src/components/decisions/location/LocationMapField.tsx
+++ b/apps/app/src/components/decisions/location/LocationMapField.tsx
@@ -27,6 +27,8 @@ interface LocationMapFieldProps {
    * the map before the participant has chosen a location.
    */
   defaultMapView?: MapDefaultView;
+  /** When true, renders the field in its validation-error state. */
+  isInvalid?: boolean;
   onChange: (value: LocationData | null) => void;
 }
 
@@ -44,6 +46,7 @@ export function LocationMapField({
   value,
   profileId,
   defaultMapView,
+  isInvalid = false,
   onChange,
 }: LocationMapFieldProps) {
   const t = useTranslations();
@@ -155,7 +158,9 @@ export function LocationMapField({
 
       <div
         className={`overflow-hidden rounded-lg border ${
-          isWithinArea ? 'border-neutral-gray1' : 'border-functional-red'
+          isWithinArea && !isInvalid
+            ? 'border-neutral-gray1'
+            : 'border-functional-red'
         }`}
       >
         <MapCanvas

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -40,7 +40,10 @@ import { ProposalInfoModal } from '../ProposalInfoModal';
 import { compileProposalSchema } from '../forms/proposal';
 import { schemaHasOptions } from '../proposalTemplate';
 import { CustomFormModal, type CustomFormValues } from './CustomFormModal';
-import { ProposalFormRenderer } from './ProposalFormRenderer';
+import {
+  FIELD_ANCHOR_ATTR,
+  ProposalFormRenderer,
+} from './ProposalFormRenderer';
 import { RevisionFeedbackPanel } from './RevisionFeedbackPanel';
 import { useOptionalVersionPreview } from './VersionPreviewContext';
 import { handleMutationError } from './handleMutationError';
@@ -50,6 +53,62 @@ import { useProposalValidation } from './useProposalValidation';
 
 // Create a version snapshot after 60 seconds without local edits.
 const VERSION_INTERVAL_SECONDS = 60;
+
+/**
+ * Normalizes validator errors for field-level display. Nested errors are
+ * keyed by dot-path (e.g. `budget.amount`) — collapse to the top-level field
+ * key so they match rendered field anchors. First message per field wins.
+ */
+function normalizeFieldErrors(
+  errors: Record<string, string>,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, message] of Object.entries(errors)) {
+    const fieldKey = key.split('.')[0] ?? key;
+    normalized[fieldKey] ??= message;
+  }
+  return normalized;
+}
+
+/**
+ * Scrolls the first invalid field (in visual/DOM order) into view after a
+ * failed submit. Fields are anchored via {@link FIELD_ANCHOR_ATTR} in
+ * {@link ProposalFormRenderer}. Returns whether an invalid field was found —
+ * false means none of the invalid keys correspond to a rendered field.
+ */
+function scrollToFirstInvalidField(invalidKeys: string[]): boolean {
+  if (invalidKeys.length === 0) {
+    return false;
+  }
+
+  const keySet = new Set(invalidKeys);
+  const anchors = Array.from(
+    document.querySelectorAll(`[${FIELD_ANCHOR_ATTR}]`),
+  );
+
+  for (const anchor of anchors) {
+    const key = anchor.getAttribute(FIELD_ANCHOR_ATTR);
+    if (key && keySet.has(key)) {
+      const prefersReducedMotion = window.matchMedia(
+        '(prefers-reduced-motion: reduce)',
+      ).matches;
+      anchor.scrollIntoView({
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        block: 'center',
+      });
+      // Move keyboard/screen-reader focus to the invalid field, not just the
+      // viewport.
+      anchor
+        .querySelector<HTMLElement>(
+          '[contenteditable="true"], button, input, [tabindex]',
+        )
+        ?.focus({ preventScroll: true });
+      return true;
+    }
+  }
+
+  return false;
+}
 
 /**
  * Tracks which TipTap editor currently has focus.
@@ -236,6 +295,24 @@ function ProposalEditorInner({
     collaborationDocId,
   });
 
+  // Validation messages from the last failed submit, keyed by field. Cleared
+  // per-field as the user edits, and wholesale once a submit passes.
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const handleFieldChangeWithValidation = useCallback(
+    (key: string, value: unknown) => {
+      setFieldErrors((prev) => {
+        if (!(key in prev)) {
+          return prev;
+        }
+        const { [key]: _cleared, ...next } = prev;
+        return next;
+      });
+      handleFieldChange(key, value);
+    },
+    [handleFieldChange],
+  );
+
   // -- Schema compilation ----------------------------------------------------
 
   const templateRef = useRef(proposalTemplate);
@@ -257,14 +334,32 @@ function ProposalEditorInner({
 
   const { validate } = useProposalValidation(ydoc, proposalTemplate);
 
+  // Server-side validation rejections get the same field-level highlighting
+  // as client-side ones (the server is authoritative — e.g. it enforces the
+  // category requirement the client relaxes for location templates).
+  const handleServerFieldErrors = useCallback(
+    (serverFieldErrors: Record<string, string>) => {
+      const errors = normalizeFieldErrors(serverFieldErrors);
+      setFieldErrors(errors);
+      return scrollToFirstInvalidField(Object.keys(errors));
+    },
+    [],
+  );
+
   // -- Mutations -------------------------------------------------------------
 
   const submitProposalMutation = trpc.decision.submitProposal.useMutation({
-    onError: (error) => handleMutationError(error, 'submit', t),
+    onError: (error) =>
+      handleMutationError(error, 'submit', t, {
+        onFieldErrors: handleServerFieldErrors,
+      }),
   });
 
   const updateProposalMutation = trpc.decision.updateProposal.useMutation({
-    onError: (error) => handleMutationError(error, 'update', t),
+    onError: (error) =>
+      handleMutationError(error, 'update', t, {
+        onFieldErrors: handleServerFieldErrors,
+      }),
   });
 
   const submitCustomFormMutation = trpc.customForm.submit.useMutation({
@@ -344,13 +439,24 @@ function ProposalEditorInner({
     // -- Client-side schema validation (validates ALL template fields) --------
     const result = validate();
     if (!result.valid) {
-      toast.error({
-        title: t('Please fix the following issues:'),
-        message: Object.values(result.errors).join(', '),
-      });
+      const errors = normalizeFieldErrors(result.errors);
+      setFieldErrors(errors);
+      const didHighlight = scrollToFirstInvalidField(Object.keys(errors));
+      // When no invalid field is actually rendered (e.g. a required location
+      // field behind a disabled feature flag), highlighting alone would leave
+      // the user with no clue — fall back to listing the errors.
+      toast.error(
+        didHighlight
+          ? { title: t('Please fix the highlighted fields') }
+          : {
+              title: t('Please fix the following issues:'),
+              message: Object.values(result.errors).join(', '),
+            },
+      );
       return;
     }
 
+    setFieldErrors({});
     setIsSubmitting(true);
 
     try {
@@ -464,7 +570,8 @@ function ProposalEditorInner({
         fields={proposalFields}
         draft={draft}
         decisionProfileId={instance.profileId ?? null}
-        onFieldChange={handleFieldChange}
+        onFieldChange={handleFieldChangeWithValidation}
+        fieldErrors={fieldErrors}
         onEditorFocus={onEditorFocus}
         onEditorBlur={onEditorBlur}
         mode={isPreviewMode ? 'preview-version' : 'edit-collaborative'}

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -69,6 +69,19 @@ function normalizeFieldErrors(
 }
 
 /**
+ * Returns the subset of invalid keys that have a rendered field anchor
+ * ({@link FIELD_ANCHOR_ATTR} in {@link ProposalFormRenderer}). Keys without an
+ * anchor (e.g. a field behind a disabled feature flag) can't be highlighted.
+ */
+function getAnchoredFieldKeys(invalidKeys: string[]): string[] {
+  return invalidKeys.filter(
+    (key) =>
+      document.querySelector(`[${FIELD_ANCHOR_ATTR}="${CSS.escape(key)}"]`) !==
+      null,
+  );
+}
+
+/**
  * Scrolls the first invalid field (in visual/DOM order) into view after a
  * failed submit. Fields are anchored via {@link FIELD_ANCHOR_ATTR} in
  * {@link ProposalFormRenderer}. Returns whether an invalid field was found —
@@ -101,7 +114,7 @@ function scrollToFirstInvalidField(invalidKeys: string[]): boolean {
   // viewport.
   anchor
     .querySelector<HTMLElement>(
-      '[contenteditable="true"], button, input, [tabindex]',
+      '[contenteditable="true"], button, input, [tabindex]:not([tabindex="-1"])',
     )
     ?.focus({ preventScroll: true });
 
@@ -333,18 +346,34 @@ function ProposalEditorInner({
   const { validate } = useProposalValidation(ydoc, proposalTemplate);
 
   // Shared failure path for client- and server-side validation: highlight the
-  // fields, scroll to the first one, and toast. Falls back to listing the
-  // messages when no invalid field is actually rendered (e.g. a required
-  // location field behind a disabled feature flag), so the user isn't left
-  // with a toast pointing at nothing.
+  // fields, scroll to the first one, and toast. Errors on fields with no
+  // rendered control (e.g. a required location field behind a disabled feature
+  // flag) are listed in the toast instead, so no message is silently dropped.
   const reportFieldErrors = useCallback(
     (rawErrors: Record<string, string>) => {
       const errors = normalizeFieldErrors(rawErrors);
       setFieldErrors(errors);
-      const didHighlight = scrollToFirstInvalidField(Object.keys(errors));
+
+      const anchoredKeys = getAnchoredFieldKeys(Object.keys(errors));
+      if (anchoredKeys.length > 0) {
+        // Defer until the error state commits, so aria-invalid /
+        // aria-describedby and the inline message exist when focus lands —
+        // screen readers announce them at focus time.
+        requestAnimationFrame(() => scrollToFirstInvalidField(anchoredKeys));
+      }
+
+      const unanchoredMessages = Object.entries(errors)
+        .filter(([key]) => !anchoredKeys.includes(key))
+        .map(([, message]) => message);
+
       toast.error(
-        didHighlight
-          ? { title: t('Please fix the highlighted fields') }
+        anchoredKeys.length > 0
+          ? {
+              title: t('Please fix the highlighted fields'),
+              ...(unanchoredMessages.length > 0
+                ? { message: unanchoredMessages.join(', ') }
+                : {}),
+            }
           : {
               title: t('Please fix the following issues:'),
               message: Object.values(rawErrors).join(', '),

--- a/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalEditor.tsx
@@ -33,6 +33,7 @@ import {
   useCollaborativeDoc,
   useOptionalCollaborativeDoc,
 } from '../../collaboration';
+import { FIELD_ANCHOR_ATTR } from '../../collaboration/invalidFieldStyles';
 import { ProposalAttachments } from '../ProposalAttachments';
 import { ProposalEditorLayout } from '../ProposalEditorLayout';
 import { ProposalEditorSkeleton } from '../ProposalEditorSkeleton';
@@ -40,10 +41,7 @@ import { ProposalInfoModal } from '../ProposalInfoModal';
 import { compileProposalSchema } from '../forms/proposal';
 import { schemaHasOptions } from '../proposalTemplate';
 import { CustomFormModal, type CustomFormValues } from './CustomFormModal';
-import {
-  FIELD_ANCHOR_ATTR,
-  ProposalFormRenderer,
-} from './ProposalFormRenderer';
+import { ProposalFormRenderer } from './ProposalFormRenderer';
 import { RevisionFeedbackPanel } from './RevisionFeedbackPanel';
 import { useOptionalVersionPreview } from './VersionPreviewContext';
 import { handleMutationError } from './handleMutationError';
@@ -81,33 +79,33 @@ function scrollToFirstInvalidField(invalidKeys: string[]): boolean {
     return false;
   }
 
-  const keySet = new Set(invalidKeys);
-  const anchors = Array.from(
-    document.querySelectorAll(`[${FIELD_ANCHOR_ATTR}]`),
+  // Comma-joined selector: querySelector returns the first match in DOM order.
+  const anchor = document.querySelector(
+    invalidKeys
+      .map((key) => `[${FIELD_ANCHOR_ATTR}="${CSS.escape(key)}"]`)
+      .join(', '),
   );
 
-  for (const anchor of anchors) {
-    const key = anchor.getAttribute(FIELD_ANCHOR_ATTR);
-    if (key && keySet.has(key)) {
-      const prefersReducedMotion = window.matchMedia(
-        '(prefers-reduced-motion: reduce)',
-      ).matches;
-      anchor.scrollIntoView({
-        behavior: prefersReducedMotion ? 'auto' : 'smooth',
-        block: 'center',
-      });
-      // Move keyboard/screen-reader focus to the invalid field, not just the
-      // viewport.
-      anchor
-        .querySelector<HTMLElement>(
-          '[contenteditable="true"], button, input, [tabindex]',
-        )
-        ?.focus({ preventScroll: true });
-      return true;
-    }
+  if (!anchor) {
+    return false;
   }
 
-  return false;
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)',
+  ).matches;
+  anchor.scrollIntoView({
+    behavior: prefersReducedMotion ? 'auto' : 'smooth',
+    block: 'center',
+  });
+  // Move keyboard/screen-reader focus to the invalid field, not just the
+  // viewport.
+  anchor
+    .querySelector<HTMLElement>(
+      '[contenteditable="true"], button, input, [tabindex]',
+    )
+    ?.focus({ preventScroll: true });
+
+  return true;
 }
 
 /**
@@ -334,16 +332,26 @@ function ProposalEditorInner({
 
   const { validate } = useProposalValidation(ydoc, proposalTemplate);
 
-  // Server-side validation rejections get the same field-level highlighting
-  // as client-side ones (the server is authoritative — e.g. it enforces the
-  // category requirement the client relaxes for location templates).
-  const handleServerFieldErrors = useCallback(
-    (serverFieldErrors: Record<string, string>) => {
-      const errors = normalizeFieldErrors(serverFieldErrors);
+  // Shared failure path for client- and server-side validation: highlight the
+  // fields, scroll to the first one, and toast. Falls back to listing the
+  // messages when no invalid field is actually rendered (e.g. a required
+  // location field behind a disabled feature flag), so the user isn't left
+  // with a toast pointing at nothing.
+  const reportFieldErrors = useCallback(
+    (rawErrors: Record<string, string>) => {
+      const errors = normalizeFieldErrors(rawErrors);
       setFieldErrors(errors);
-      return scrollToFirstInvalidField(Object.keys(errors));
+      const didHighlight = scrollToFirstInvalidField(Object.keys(errors));
+      toast.error(
+        didHighlight
+          ? { title: t('Please fix the highlighted fields') }
+          : {
+              title: t('Please fix the following issues:'),
+              message: Object.values(rawErrors).join(', '),
+            },
+      );
     },
-    [],
+    [t],
   );
 
   // -- Mutations -------------------------------------------------------------
@@ -351,14 +359,14 @@ function ProposalEditorInner({
   const submitProposalMutation = trpc.decision.submitProposal.useMutation({
     onError: (error) =>
       handleMutationError(error, 'submit', t, {
-        onFieldErrors: handleServerFieldErrors,
+        onFieldErrors: reportFieldErrors,
       }),
   });
 
   const updateProposalMutation = trpc.decision.updateProposal.useMutation({
     onError: (error) =>
       handleMutationError(error, 'update', t, {
-        onFieldErrors: handleServerFieldErrors,
+        onFieldErrors: reportFieldErrors,
       }),
   });
 
@@ -439,20 +447,7 @@ function ProposalEditorInner({
     // -- Client-side schema validation (validates ALL template fields) --------
     const result = validate();
     if (!result.valid) {
-      const errors = normalizeFieldErrors(result.errors);
-      setFieldErrors(errors);
-      const didHighlight = scrollToFirstInvalidField(Object.keys(errors));
-      // When no invalid field is actually rendered (e.g. a required location
-      // field behind a disabled feature flag), highlighting alone would leave
-      // the user with no clue — fall back to listing the errors.
-      toast.error(
-        didHighlight
-          ? { title: t('Please fix the highlighted fields') }
-          : {
-              title: t('Please fix the following issues:'),
-              message: Object.values(result.errors).join(', '),
-            },
-      );
+      reportFieldErrors(result.errors);
       return;
     }
 
@@ -519,6 +514,7 @@ function ProposalEditorInner({
     draftRef,
     validate,
     finalizeSubmit,
+    reportFieldErrors,
   ]);
 
   const handleCustomFormSubmit = useCallback(

--- a/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
@@ -22,6 +22,7 @@ import {
   CollaborativeTextField,
   CollaborativeTitleField,
 } from '../../collaboration';
+import { getFieldErrorId } from '../../collaboration/invalidFieldStyles';
 import { FieldHeader } from '../forms/FieldHeader';
 import type { FieldDescriptor } from '../forms/types';
 import { LocationMapView } from '../location/LocationMapView';
@@ -56,6 +57,11 @@ interface ProposalFormRendererProps {
   decisionProfileId: string | null;
   /** Called when any system field value changes. */
   onFieldChange: (key: string, value: unknown) => void;
+  /**
+   * Validation messages keyed by field, from the last failed submit. Flagged
+   * fields render in their error state until the user edits them.
+   */
+  fieldErrors?: Record<string, string>;
   /** Called with the editor instance when a rich-text field gains focus. */
   onEditorFocus?: (editor: Editor) => void;
   /** Called with the editor instance when a rich-text field loses focus. */
@@ -65,6 +71,16 @@ interface ProposalFormRendererProps {
   /** Version preview content keyed by fragment name. */
   previewVersionFragmentContents?: Record<string, JSONContent | null>;
 }
+
+/** Stable empty object so an omitted `fieldErrors` prop doesn't churn renders. */
+const EMPTY_FIELD_ERRORS: Record<string, string> = {};
+
+/**
+ * DOM attribute carrying each field's key, used by the editor to locate and
+ * scroll to invalid fields after a failed submit. The anchor also exposes
+ * `data-invalid` for tests.
+ */
+export const FIELD_ANCHOR_ATTR = 'data-field-anchor';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -173,20 +189,33 @@ function getPreviewBudgetValue({
  * Renders a single field descriptor for collaborative editing or readonly
  * proposal preview modes.
  */
-function renderField(
-  field: FieldDescriptor,
-  draft: ProposalDraftFields,
-  decisionProfileId: string | null,
-  onFieldChange: (key: string, value: unknown) => void,
-  t: TranslateFn,
-  mode: 'edit-collaborative' | 'preview-version' | 'preview-template',
-  previewVersionFragmentContents: Record<string, JSONContent | null>,
-  onEditorFocus?: (editor: Editor) => void,
-  onEditorBlur?: (editor: Editor) => void,
-): React.ReactNode {
+function renderField({
+  field,
+  draft,
+  decisionProfileId,
+  onFieldChange,
+  t,
+  mode,
+  previewVersionFragmentContents,
+  fieldErrors,
+  onEditorFocus,
+  onEditorBlur,
+}: {
+  field: FieldDescriptor;
+  draft: ProposalDraftFields;
+  decisionProfileId: string | null;
+  onFieldChange: (key: string, value: unknown) => void;
+  t: TranslateFn;
+  mode: 'edit-collaborative' | 'preview-version' | 'preview-template';
+  previewVersionFragmentContents: Record<string, JSONContent | null>;
+  fieldErrors: Record<string, string>;
+  onEditorFocus?: (editor: Editor) => void;
+  onEditorBlur?: (editor: Editor) => void;
+}): React.ReactNode {
   const { key, format, schema } = field;
   const isReadonlyMode = mode !== 'edit-collaborative';
   const previewContent = previewVersionFragmentContents[key];
+  const isInvalid = key in fieldErrors;
 
   // -- Title ------------------------------------------------------------------
 
@@ -206,6 +235,7 @@ function renderField(
     return (
       <CollaborativeTitleField
         placeholder={t('Untitled Proposal')}
+        isInvalid={isInvalid}
         onChange={(value) => onFieldChange('title', value)}
       />
     );
@@ -255,6 +285,7 @@ function renderField(
             onChange={(value) => onFieldChange('category', value)}
             fragmentName="category"
             placeholder={t('Select category')}
+            isInvalid={isInvalid}
           />
         </div>
       );
@@ -268,6 +299,7 @@ function renderField(
         fragmentName="category"
         placeholder={t('Select category')}
         allowEmpty={!field.required}
+        isInvalid={isInvalid}
       />
     );
   }
@@ -293,6 +325,7 @@ function renderField(
         minAmount={schema.minimum}
         maxAmount={schema.maximum}
         initialValue={draft.budget}
+        isInvalid={isInvalid}
         onChange={(value) => onFieldChange('budget', value)}
       />
     );
@@ -329,6 +362,7 @@ function renderField(
           placeholder={placeholder}
           multiline={format === 'long-text'}
           maxLength={schema.maxLength}
+          isInvalid={isInvalid}
           onChange={(html) => onFieldChange(key, html)}
           onEditorFocus={onEditorFocus}
           onEditorBlur={onEditorBlur}
@@ -357,6 +391,8 @@ function renderField(
           minAmount={schema.minimum}
           maxAmount={schema.maximum}
           initialValue={null}
+          fragmentName={key}
+          isInvalid={isInvalid}
           onChange={(value) => onFieldChange(key, value)}
         />
       );
@@ -387,6 +423,7 @@ function renderField(
             title={schema.title}
             description={schema.description}
             required={field.required}
+            isInvalid={isInvalid}
           />
           <CollaborativeLocationField
             initialValue={
@@ -430,6 +467,7 @@ function renderField(
             title={schema.title}
             description={schema.description}
             required={field.required}
+            isInvalid={isInvalid}
           />
           <CollaborativeDropdownField
             options={options}
@@ -438,6 +476,7 @@ function renderField(
             fragmentName={key}
             allowEmpty={!field.required}
             required={field.required}
+            isInvalid={isInvalid}
           />
         </div>
       );
@@ -471,6 +510,7 @@ export function ProposalFormRenderer({
   draft,
   decisionProfileId,
   onFieldChange,
+  fieldErrors = EMPTY_FIELD_ERRORS,
   onEditorFocus,
   onEditorBlur,
   mode = 'edit-collaborative',
@@ -488,18 +528,38 @@ export function ProposalFormRenderer({
     (f) => !f.isSystem && (gisMapsEnabled || f.format !== 'location'),
   );
 
-  const render = (field: FieldDescriptor) =>
-    renderField(
-      field,
-      draft,
-      decisionProfileId,
-      onFieldChange,
-      t,
-      mode,
-      previewVersionFragmentContents,
-      onEditorFocus,
-      onEditorBlur,
+  const render = (field: FieldDescriptor) => {
+    const errorMessage = fieldErrors[field.key];
+
+    return (
+      <div
+        {...{ [FIELD_ANCHOR_ATTR]: field.key }}
+        data-invalid={errorMessage != null || undefined}
+        className="flex max-w-full min-w-0 flex-col gap-2"
+      >
+        {renderField({
+          field,
+          draft,
+          decisionProfileId,
+          onFieldChange,
+          t,
+          mode,
+          previewVersionFragmentContents,
+          fieldErrors,
+          onEditorFocus,
+          onEditorBlur,
+        })}
+        {errorMessage != null && (
+          <p
+            id={getFieldErrorId(field.key)}
+            className="text-sm text-functional-red"
+          >
+            {errorMessage}
+          </p>
+        )}
+      </div>
     );
+  };
 
   return (
     <div className={cn('flex flex-col', formGapClass)}>

--- a/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
@@ -22,7 +22,10 @@ import {
   CollaborativeTextField,
   CollaborativeTitleField,
 } from '../../collaboration';
-import { getFieldErrorId } from '../../collaboration/invalidFieldStyles';
+import {
+  FIELD_ANCHOR_ATTR,
+  getFieldErrorId,
+} from '../../collaboration/invalidFieldStyles';
 import { FieldHeader } from '../forms/FieldHeader';
 import type { FieldDescriptor } from '../forms/types';
 import { LocationMapView } from '../location/LocationMapView';
@@ -71,16 +74,6 @@ interface ProposalFormRendererProps {
   /** Version preview content keyed by fragment name. */
   previewVersionFragmentContents?: Record<string, JSONContent | null>;
 }
-
-/** Stable empty object so an omitted `fieldErrors` prop doesn't churn renders. */
-const EMPTY_FIELD_ERRORS: Record<string, string> = {};
-
-/**
- * DOM attribute carrying each field's key, used by the editor to locate and
- * scroll to invalid fields after a failed submit. The anchor also exposes
- * `data-invalid` for tests.
- */
-export const FIELD_ANCHOR_ATTR = 'data-field-anchor';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -197,7 +190,7 @@ function renderField({
   t,
   mode,
   previewVersionFragmentContents,
-  fieldErrors,
+  isInvalid,
   onEditorFocus,
   onEditorBlur,
 }: {
@@ -208,14 +201,13 @@ function renderField({
   t: TranslateFn;
   mode: 'edit-collaborative' | 'preview-version' | 'preview-template';
   previewVersionFragmentContents: Record<string, JSONContent | null>;
-  fieldErrors: Record<string, string>;
+  isInvalid: boolean;
   onEditorFocus?: (editor: Editor) => void;
   onEditorBlur?: (editor: Editor) => void;
 }): React.ReactNode {
   const { key, format, schema } = field;
   const isReadonlyMode = mode !== 'edit-collaborative';
   const previewContent = previewVersionFragmentContents[key];
-  const isInvalid = key in fieldErrors;
 
   // -- Title ------------------------------------------------------------------
 
@@ -510,7 +502,7 @@ export function ProposalFormRenderer({
   draft,
   decisionProfileId,
   onFieldChange,
-  fieldErrors = EMPTY_FIELD_ERRORS,
+  fieldErrors = {},
   onEditorFocus,
   onEditorBlur,
   mode = 'edit-collaborative',
@@ -545,7 +537,7 @@ export function ProposalFormRenderer({
           t,
           mode,
           previewVersionFragmentContents,
-          fieldErrors,
+          isInvalid: errorMessage != null,
           onEditorFocus,
           onEditorBlur,
         })}

--- a/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
@@ -423,6 +423,7 @@ function renderField({
             }
             profileId={decisionProfileId}
             defaultMapView={schema['x-map-default']}
+            isInvalid={isInvalid}
             onChange={(value) => onFieldChange(key, value)}
           />
         </div>
@@ -544,6 +545,9 @@ export function ProposalFormRenderer({
         {errorMessage != null && (
           <p
             id={getFieldErrorId(field.key)}
+            // Announce the error's appearance for fields whose control can't
+            // carry aria-describedby focus semantics (pills, map).
+            role="alert"
             className="text-sm text-functional-red"
           >
             {errorMessage}

--- a/apps/app/src/components/decisions/proposalEditor/handleMutationError.ts
+++ b/apps/app/src/components/decisions/proposalEditor/handleMutationError.ts
@@ -5,11 +5,19 @@ import type { TranslateFn } from '@/lib/i18n';
 /**
  * Handles tRPC validation errors from mutation responses.
  * Displays appropriate toast messages based on error shape.
+ *
+ * When `onFieldErrors` is provided, server-side validation errors are handed
+ * to it for field-level highlighting (mirroring the client-side validation
+ * UX). It returns whether any field was actually highlighted — when none was,
+ * this falls back to listing the messages in the toast.
  */
 export function handleMutationError(
   error: { data?: unknown; message?: string },
   operationType: 'create' | 'update' | 'submit',
   t: TranslateFn,
+  options?: {
+    onFieldErrors?: (fieldErrors: Record<string, string>) => boolean;
+  },
 ) {
   console.error(`Failed to ${operationType} proposal:`, error);
 
@@ -21,7 +29,11 @@ export function handleMutationError(
     const fieldErrors = errorData.cause.fieldErrors;
     const errorMessages = Object.values(fieldErrors);
 
-    if (errorMessages.length === 1) {
+    const didHighlight = options?.onFieldErrors?.(fieldErrors) ?? false;
+
+    if (didHighlight) {
+      toast.error({ title: t('Please fix the highlighted fields') });
+    } else if (errorMessages.length === 1) {
       toast.error({ message: errorMessages[0] });
     } else {
       toast.error({

--- a/apps/app/src/components/decisions/proposalEditor/handleMutationError.ts
+++ b/apps/app/src/components/decisions/proposalEditor/handleMutationError.ts
@@ -24,9 +24,11 @@ export function handleMutationError(
     | { cause?: { fieldErrors?: Record<string, string> } }
     | undefined;
 
-  if (errorData?.cause?.fieldErrors) {
-    const fieldErrors = errorData.cause.fieldErrors;
+  const fieldErrors = errorData?.cause?.fieldErrors;
 
+  // Empty fieldErrors carries nothing to highlight or list — treat it as a
+  // generic failure rather than toasting an empty message.
+  if (fieldErrors && Object.keys(fieldErrors).length > 0) {
     if (options?.onFieldErrors) {
       options.onFieldErrors(fieldErrors);
       return;

--- a/apps/app/src/components/decisions/proposalEditor/handleMutationError.ts
+++ b/apps/app/src/components/decisions/proposalEditor/handleMutationError.ts
@@ -6,17 +6,16 @@ import type { TranslateFn } from '@/lib/i18n';
  * Handles tRPC validation errors from mutation responses.
  * Displays appropriate toast messages based on error shape.
  *
- * When `onFieldErrors` is provided, server-side validation errors are handed
- * to it for field-level highlighting (mirroring the client-side validation
- * UX). It returns whether any field was actually highlighted — when none was,
- * this falls back to listing the messages in the toast.
+ * When `onFieldErrors` is provided, it owns the full validation-error UX
+ * (field highlighting + toast) and this function just extracts the errors
+ * and delegates. The toasts below are the no-handler fallback.
  */
 export function handleMutationError(
   error: { data?: unknown; message?: string },
   operationType: 'create' | 'update' | 'submit',
   t: TranslateFn,
   options?: {
-    onFieldErrors?: (fieldErrors: Record<string, string>) => boolean;
+    onFieldErrors?: (fieldErrors: Record<string, string>) => void;
   },
 ) {
   console.error(`Failed to ${operationType} proposal:`, error);
@@ -27,13 +26,14 @@ export function handleMutationError(
 
   if (errorData?.cause?.fieldErrors) {
     const fieldErrors = errorData.cause.fieldErrors;
+
+    if (options?.onFieldErrors) {
+      options.onFieldErrors(fieldErrors);
+      return;
+    }
+
     const errorMessages = Object.values(fieldErrors);
-
-    const didHighlight = options?.onFieldErrors?.(fieldErrors) ?? false;
-
-    if (didHighlight) {
-      toast.error({ title: t('Please fix the highlighted fields') });
-    } else if (errorMessages.length === 1) {
+    if (errorMessages.length === 1) {
       toast.error({ message: errorMessages[0] });
     } else {
       toast.error({

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -327,6 +327,7 @@
   "Failed to update proposal": "فشل تحديث المقترح",
   "Failed to submit proposal": "فشل تقديم المقترح",
   "Please fix the following issues:": "يرجى إصلاح المشكلات التالية:",
+  "Please fix the highlighted fields": "يرجى تصحيح الحقول المميّزة",
   "An unexpected error occurred": "حدث خطأ غير متوقع",
   "Anonymous": "مجهول",
   "Unknown": "غير معروف",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -382,6 +382,7 @@
   "Failed to update proposal": "প্রস্তাব আপডেট করতে ব্যর্থ",
   "Failed to submit proposal": "প্রস্তাব জমা দিতে ব্যর্থ",
   "Please fix the following issues:": "অনুগ্রহ করে নিম্নলিখিত সমস্যাগুলি সমাধান করুন:",
+  "Please fix the highlighted fields": "অনুগ্রহ করে চিহ্নিত ক্ষেত্রগুলি ঠিক করুন",
   "An unexpected error occurred": "একটি অপ্রত্যাশিত ত্রুটি ঘটেছে",
   "Anonymous": "বেনামী",
   "Unknown": "অজানা",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -345,6 +345,7 @@
   "Failed to update proposal": "Failed to update proposal",
   "Failed to submit proposal": "Failed to submit proposal",
   "Please fix the following issues:": "Please fix the following issues:",
+  "Please fix the highlighted fields": "Please fix the highlighted fields",
   "An unexpected error occurred": "An unexpected error occurred",
   "Anonymous": "Anonymous",
   "Unknown": "Unknown",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -382,6 +382,7 @@
   "Failed to update proposal": "Error al actualizar la propuesta",
   "Failed to submit proposal": "Error al enviar la propuesta",
   "Please fix the following issues:": "Por favor corrija los siguientes problemas:",
+  "Please fix the highlighted fields": "Corrige los campos resaltados",
   "An unexpected error occurred": "Ocurrió un error inesperado",
   "Anonymous": "Anónimo",
   "Unknown": "Desconocido",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -383,6 +383,7 @@
   "Failed to update proposal": "Échec de la mise à jour de la proposition",
   "Failed to submit proposal": "Échec de la soumission de la proposition",
   "Please fix the following issues:": "Veuillez corriger les problèmes suivants :",
+  "Please fix the highlighted fields": "Veuillez corriger les champs en surbrillance",
   "An unexpected error occurred": "Une erreur inattendue s'est produite",
   "Anonymous": "Anonyme",
   "Unknown": "Inconnu",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -383,6 +383,7 @@
   "Failed to update proposal": "Falha ao atualizar a proposta",
   "Failed to submit proposal": "Falha ao enviar a proposta",
   "Please fix the following issues:": "Por favor, corrija os seguintes problemas:",
+  "Please fix the highlighted fields": "Corrija os campos destacados",
   "An unexpected error occurred": "Ocorreu um erro inesperado",
   "Anonymous": "Anônimo",
   "Unknown": "Desconhecido",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -330,6 +330,7 @@
   "Failed to update proposal": "Ku guuldareystay cusboonaysiinta soo jeedinta",
   "Failed to submit proposal": "Ku guuldareystay gudbinta soo jeedinta",
   "Please fix the following issues:": "Fadlan hagaaji dhibaatooyinkaan soo socda:",
+  "Please fix the highlighted fields": "Fadlan saxi goobaha la iftiimiyay",
   "An unexpected error occurred": "Khalad aan la filayn ayaa dhacay",
   "Anonymous": "Aan la aqoon",
   "Unknown": "Aan la aqoon",

--- a/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
+++ b/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
@@ -20,6 +20,8 @@ export function useRichTextEditor({
   onEditorReady,
   editable = true,
   required = false,
+  isInvalid = false,
+  errorMessageId,
 }: {
   extensions?: Extensions;
   content?: Content;
@@ -41,6 +43,13 @@ export function useRichTextEditor({
   editable?: boolean;
   /** When true, sets `aria-required` on the editable region for assistive tech. */
   required?: boolean;
+  /** When true, sets `aria-invalid` on the editable region. Updates live. */
+  isInvalid?: boolean;
+  /**
+   * id of the element describing the validation error, set as
+   * `aria-describedby` on the editable region while `isInvalid` is true.
+   */
+  errorMessageId?: string;
 }) {
   // Append a single Placeholder extension when a top-level placeholder is asked
   // for OR the Details extension is present (it needs a per-node 'Summary' hint).
@@ -75,18 +84,27 @@ export function useRichTextEditor({
     ];
   }, [extensions, placeholder, summaryPlaceholder]);
 
+  const editorAttributes = useMemo(
+    () => ({
+      class: cn(
+        baseEditorStyles,
+        editorClassName || (editable ? 'min-h-96' : ''),
+      ),
+      ...(required ? { 'aria-required': 'true' } : {}),
+      ...(isInvalid ? { 'aria-invalid': 'true' } : {}),
+      ...(isInvalid && errorMessageId
+        ? { 'aria-describedby': errorMessageId }
+        : {}),
+    }),
+    [editorClassName, editable, required, isInvalid, errorMessageId],
+  );
+
   const editor = useEditor({
     extensions: resolvedExtensions,
     content,
     editable,
     editorProps: {
-      attributes: {
-        class: cn(
-          baseEditorStyles,
-          editorClassName || (editable ? 'min-h-96' : ''),
-        ),
-        ...(required ? { 'aria-required': 'true' } : {}),
-      },
+      attributes: editorAttributes,
     },
     onUpdate: ({ editor }) => {
       const html = editor.getHTML();
@@ -96,6 +114,12 @@ export function useRichTextEditor({
     },
     immediatelyRender: false,
   });
+
+  // `useEditor` captures options at creation — push attribute changes (e.g.
+  // aria-invalid toggling after a failed submit) into the live editor.
+  useEffect(() => {
+    editor?.setOptions({ editorProps: { attributes: editorAttributes } });
+  }, [editor, editorAttributes]);
 
   // Set initial content only once when editor is first created
   useEffect(() => {

--- a/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
+++ b/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
@@ -84,17 +84,22 @@ export function useRichTextEditor({
     ];
   }, [extensions, placeholder, summaryPlaceholder]);
 
-  const editorAttributes = useMemo(
+  // Memoized so `useEditor`'s per-render options diff only applies changes
+  // (e.g. aria-invalid toggling after a failed submit) when the attributes
+  // actually change — a fresh literal would trigger setOptions every render.
+  const editorProps = useMemo(
     () => ({
-      class: cn(
-        baseEditorStyles,
-        editorClassName || (editable ? 'min-h-96' : ''),
-      ),
-      ...(required ? { 'aria-required': 'true' } : {}),
-      ...(isInvalid ? { 'aria-invalid': 'true' } : {}),
-      ...(isInvalid && errorMessageId
-        ? { 'aria-describedby': errorMessageId }
-        : {}),
+      attributes: {
+        class: cn(
+          baseEditorStyles,
+          editorClassName || (editable ? 'min-h-96' : ''),
+        ),
+        ...(required ? { 'aria-required': 'true' } : {}),
+        ...(isInvalid ? { 'aria-invalid': 'true' } : {}),
+        ...(isInvalid && errorMessageId
+          ? { 'aria-describedby': errorMessageId }
+          : {}),
+      },
     }),
     [editorClassName, editable, required, isInvalid, errorMessageId],
   );
@@ -103,9 +108,7 @@ export function useRichTextEditor({
     extensions: resolvedExtensions,
     content,
     editable,
-    editorProps: {
-      attributes: editorAttributes,
-    },
+    editorProps,
     onUpdate: ({ editor }) => {
       const html = editor.getHTML();
       onUpdate?.(html);
@@ -114,12 +117,6 @@ export function useRichTextEditor({
     },
     immediatelyRender: false,
   });
-
-  // `useEditor` captures options at creation — push attribute changes (e.g.
-  // aria-invalid toggling after a failed submit) into the live editor.
-  useEffect(() => {
-    editor?.setOptions({ editorProps: { attributes: editorAttributes } });
-  }, [editor, editorAttributes]);
 
   // Set initial content only once when editor is first created
   useEffect(() => {

--- a/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
+++ b/packages/ui/src/components/RichTextEditor/useRichTextEditor.ts
@@ -4,7 +4,7 @@ import type { Content, Editor, Extensions } from '@tiptap/react';
 import { useEditor } from '@tiptap/react';
 import { useEffect, useMemo } from 'react';
 
-import { cn } from '../../lib/utils';
+import { cn, getInvalidAriaAttributes } from '../../lib/utils';
 import { defaultEditorExtensions } from './editorConfig';
 import { baseEditorStyles } from './viewerStyles';
 
@@ -95,10 +95,7 @@ export function useRichTextEditor({
           editorClassName || (editable ? 'min-h-96' : ''),
         ),
         ...(required ? { 'aria-required': 'true' } : {}),
-        ...(isInvalid ? { 'aria-invalid': 'true' } : {}),
-        ...(isInvalid && errorMessageId
-          ? { 'aria-describedby': errorMessageId }
-          : {}),
+        ...getInvalidAriaAttributes({ isInvalid, errorMessageId }),
       },
     }),
     [editorClassName, editable, required, isInvalid, errorMessageId],

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -103,7 +103,7 @@ export const Select = <T extends object, M extends SelectionMode = 'single'>({
     <AriaSelect
       {...props}
       isRequired={isRequired}
-      isInvalid={isInvalid ?? (!!errorMessage && errorMessage.length > 0)}
+      isInvalid={isInvalid ?? !!errorMessage}
       className={cn('group/select flex flex-col gap-1', props.className)}
     >
       {label && (

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -25,7 +25,7 @@ import type { PopoverProps } from './Popover';
 type SelectionMode = 'single' | 'multiple';
 
 const selectStyles = tv({
-  base: 'flex min-w-0 flex-row justify-between rounded-lg border text-base leading-none text-neutral-black outline outline-0 group-data-[invalid=true]:outline-1 group-data-[invalid=true]:outline-functional-red placeholder:text-neutral-gray4 hover:border-neutral-gray2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue active:border-neutral-gray4 active:outline disabled:border-neutral-gray2',
+  base: 'flex min-w-0 flex-row justify-between rounded-lg border text-base leading-none text-neutral-black outline outline-0 group-data-[invalid=true]/select:outline-1 group-data-[invalid=true]/select:outline-functional-red placeholder:text-neutral-gray4 hover:border-neutral-gray2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-data-blue active:border-neutral-gray4 active:outline disabled:border-neutral-gray2',
   variants: {
     isDisabled: {
       true: 'bg-neutral-gray1 text-neutral-gray4',
@@ -89,6 +89,7 @@ export const Select = <T extends object, M extends SelectionMode = 'single'>({
   children,
   items,
   isRequired,
+  isInvalid,
   variant = 'default',
   size,
   icon,
@@ -102,11 +103,11 @@ export const Select = <T extends object, M extends SelectionMode = 'single'>({
     <AriaSelect
       {...props}
       isRequired={isRequired}
-      isInvalid={!!errorMessage && errorMessage.length > 0}
-      className={cn('flex flex-col gap-1', props.className)}
+      isInvalid={isInvalid ?? (!!errorMessage && errorMessage.length > 0)}
+      className={cn('group/select flex flex-col gap-1', props.className)}
     >
       {label && (
-        <Label className="group-data-[invalid=true]:text-functional-red">
+        <Label className="group-data-[invalid=true]/select:text-functional-red">
           {label}{' '}
           {isRequired && <span className="text-functional-red"> *</span>}
         </Label>

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -6,6 +6,27 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * aria attributes tying a control in its validation-error state to the
+ * element that describes the error. Spread onto the interactive element
+ * (or a TipTap `editorProps.attributes` object); empty when valid.
+ */
+export function getInvalidAriaAttributes({
+  isInvalid,
+  errorMessageId,
+}: {
+  isInvalid: boolean;
+  errorMessageId?: string;
+}): { 'aria-invalid'?: 'true'; 'aria-describedby'?: string } {
+  if (!isInvalid) {
+    return {};
+  }
+  return {
+    'aria-invalid': 'true',
+    ...(errorMessageId ? { 'aria-describedby': errorMessageId } : {}),
+  };
+}
+
 export const GRADIENT_COLORS = [
   { gradient: 'bg-gradient', hex: '#1fa88f' },
   { gradient: 'bg-redTeal', hex: '#e86a4a' },

--- a/tests/e2e/tests/proposal-submit-validation.spec.ts
+++ b/tests/e2e/tests/proposal-submit-validation.spec.ts
@@ -152,31 +152,45 @@ test.describe('Proposal Submit Validation', () => {
       await authenticatedPage.waitForTimeout(360);
     };
 
+    // Helper: locator matching a field anchor currently flagged invalid.
+    // Invalid fields are marked with data-invalid on their data-field-anchor
+    // wrapper after a failed submit, and unflagged as the user edits them.
+    const invalidField = (key: string) =>
+      authenticatedPage.locator(
+        `[data-field-anchor="${key}"][data-invalid="true"]`,
+      );
+
     // =========================================================================
-    // Step 1: Submit with everything empty → expect 3 system field errors
-    // (Title, Budget, Category)
+    // Step 1: Submit with everything empty → every required field is
+    // highlighted as invalid
     // =========================================================================
 
     await submitButton.click();
 
     const errorToast = authenticatedPage
       .locator('[data-sonner-toast]')
-      .filter({ hasText: 'Please fix the following issues:' });
+      .filter({ hasText: 'Please fix the highlighted fields' });
 
     await expect(errorToast).toBeVisible({ timeout: 6_000 });
-    await expect(errorToast).toContainText('Title');
-    await expect(errorToast).toContainText('Budget');
-    await expect(errorToast).toContainText('Category');
+    for (const key of ALL_FIELDS_TEMPLATE.required) {
+      await expect(invalidField(key)).toBeVisible();
+    }
 
     await dismissToasts();
 
     // =========================================================================
-    // Step 2: Fill in Title → re-submit → expect 2 errors (Budget, Category)
+    // Step 2: Fill in Title → its error clears on edit (before resubmitting);
+    // re-submit → Budget and Category still invalid
     // =========================================================================
 
     const titleEditor = authenticatedPage.locator('.ProseMirror.text-title-lg');
     await titleEditor.click();
     await authenticatedPage.keyboard.type('My Test Proposal');
+
+    // Editing a flagged field clears its error immediately — no resubmit
+    await expect(invalidField('title')).toBeHidden();
+    // Untouched fields stay flagged
+    await expect(invalidField('budget')).toBeVisible();
 
     // Wait for debounced auto-save to fire
     await authenticatedPage.waitForTimeout(2_400);
@@ -185,12 +199,12 @@ test.describe('Proposal Submit Validation', () => {
 
     const errorToast2 = authenticatedPage
       .locator('[data-sonner-toast]')
-      .filter({ hasText: 'Please fix the following issues:' });
+      .filter({ hasText: 'Please fix the highlighted fields' });
 
     await expect(errorToast2).toBeVisible({ timeout: 6_000 });
-    await expect(errorToast2).not.toContainText('Title');
-    await expect(errorToast2).toContainText('Budget');
-    await expect(errorToast2).toContainText('Category');
+    await expect(invalidField('title')).toBeHidden();
+    await expect(invalidField('budget')).toBeVisible();
+    await expect(invalidField('category')).toBeVisible();
 
     await dismissToasts();
 
@@ -214,12 +228,12 @@ test.describe('Proposal Submit Validation', () => {
 
     const errorToast3 = authenticatedPage
       .locator('[data-sonner-toast]')
-      .filter({ hasText: 'Please fix the following issues:' });
+      .filter({ hasText: 'Please fix the highlighted fields' });
 
     await expect(errorToast3).toBeVisible({ timeout: 6_000 });
-    await expect(errorToast3).not.toContainText('Title');
-    await expect(errorToast3).not.toContainText('Budget');
-    await expect(errorToast3).toContainText('Category');
+    await expect(invalidField('title')).toBeHidden();
+    await expect(invalidField('budget')).toBeHidden();
+    await expect(invalidField('category')).toBeVisible();
 
     await dismissToasts();
 
@@ -247,17 +261,17 @@ test.describe('Proposal Submit Validation', () => {
     await submitButton.click();
 
     // After fixing all system fields, submission should be blocked by
-    // dynamic field validation. The toast should list the missing dynamic
-    // required fields.
+    // dynamic field validation — the remaining dynamic required fields are
+    // highlighted.
     const errorToast4 = authenticatedPage
       .locator('[data-sonner-toast]')
-      .filter({ hasText: 'Please fix the following issues:' });
+      .filter({ hasText: 'Please fix the highlighted fields' });
 
     await expect(errorToast4).toBeVisible({ timeout: 6_000 });
-    await expect(errorToast4).toContainText('Summary');
-    await expect(errorToast4).toContainText('Details');
-    await expect(errorToast4).toContainText('Priority Level');
-    await expect(errorToast4).toContainText('Region');
+    await expect(invalidField('summary')).toBeVisible();
+    await expect(invalidField('details')).toBeVisible();
+    await expect(invalidField('priority')).toBeVisible();
+    await expect(invalidField('region')).toBeVisible();
 
     await dismissToasts();
 
@@ -278,13 +292,13 @@ test.describe('Proposal Submit Validation', () => {
 
     const errorToast5 = authenticatedPage
       .locator('[data-sonner-toast]')
-      .filter({ hasText: 'Please fix the following issues:' });
+      .filter({ hasText: 'Please fix the highlighted fields' });
 
     await expect(errorToast5).toBeVisible({ timeout: 6_000 });
-    await expect(errorToast5).not.toContainText('Summary');
-    await expect(errorToast5).toContainText('Details');
-    await expect(errorToast5).toContainText('Priority Level');
-    await expect(errorToast5).toContainText('Region');
+    await expect(invalidField('summary')).toBeHidden();
+    await expect(invalidField('details')).toBeVisible();
+    await expect(invalidField('priority')).toBeVisible();
+    await expect(invalidField('region')).toBeVisible();
 
     await dismissToasts();
 
@@ -307,13 +321,13 @@ test.describe('Proposal Submit Validation', () => {
 
     const errorToast6 = authenticatedPage
       .locator('[data-sonner-toast]')
-      .filter({ hasText: 'Please fix the following issues:' });
+      .filter({ hasText: 'Please fix the highlighted fields' });
 
     await expect(errorToast6).toBeVisible({ timeout: 6_000 });
-    await expect(errorToast6).not.toContainText('Summary');
-    await expect(errorToast6).not.toContainText('Details');
-    await expect(errorToast6).toContainText('Priority Level');
-    await expect(errorToast6).toContainText('Region');
+    await expect(invalidField('summary')).toBeHidden();
+    await expect(invalidField('details')).toBeHidden();
+    await expect(invalidField('priority')).toBeVisible();
+    await expect(invalidField('region')).toBeVisible();
 
     await dismissToasts();
 
@@ -331,11 +345,11 @@ test.describe('Proposal Submit Validation', () => {
 
     const errorToast7 = authenticatedPage
       .locator('[data-sonner-toast]')
-      .filter({ hasText: 'Please fix the following issues:' });
+      .filter({ hasText: 'Please fix the highlighted fields' });
 
     await expect(errorToast7).toBeVisible({ timeout: 6_000 });
-    await expect(errorToast7).not.toContainText('Priority Level');
-    await expect(errorToast7).toContainText('Region');
+    await expect(invalidField('priority')).toBeHidden();
+    await expect(invalidField('region')).toBeVisible();
 
     await dismissToasts();
 
@@ -351,14 +365,17 @@ test.describe('Proposal Submit Validation', () => {
 
     await submitButton.click();
 
-    // Client-side validation should pass — no "required fields" toast.
-    // The server may still reject (TipTap mock doesn't have the typed
-    // content), but that's outside the scope of this test. We only care
-    // that the frontend schema validator accepted all fields.
+    // Client-side validation should pass — no validation toast and no field
+    // left highlighted. The server may still reject (TipTap mock doesn't have
+    // the typed content), but that's outside the scope of this test. We only
+    // care that the frontend schema validator accepted all fields.
     await expect(
       authenticatedPage
         .locator('[data-sonner-toast]')
-        .filter({ hasText: 'Please fix the following issues:' }),
+        .filter({ hasText: 'Please fix the highlighted fields' }),
     ).not.toBeVisible({ timeout: 6_000 });
+    await expect(
+      authenticatedPage.locator('[data-field-anchor][data-invalid="true"]'),
+    ).toHaveCount(0);
   });
 });

--- a/tests/e2e/tests/proposal-submit-validation.spec.ts
+++ b/tests/e2e/tests/proposal-submit-validation.spec.ts
@@ -176,6 +176,20 @@ test.describe('Proposal Submit Validation', () => {
       await expect(invalidField(key)).toBeVisible();
     }
 
+    // The accessible surface of the highlight: inline message rendered, the
+    // first invalid field's editor marked invalid, described by the message,
+    // and holding focus (focus is deferred until the error state commits).
+    await expect(authenticatedPage.locator('#field-error-title')).toBeVisible();
+    const invalidTitleEditor = authenticatedPage.locator(
+      '[data-field-anchor="title"] .ProseMirror',
+    );
+    await expect(invalidTitleEditor).toHaveAttribute('aria-invalid', 'true');
+    await expect(invalidTitleEditor).toHaveAttribute(
+      'aria-describedby',
+      'field-error-title',
+    );
+    await expect(invalidTitleEditor).toBeFocused();
+
     await dismissToasts();
 
     // =========================================================================
@@ -241,11 +255,8 @@ test.describe('Proposal Submit Validation', () => {
     // Step 4: Select Category → re-submit
     //
     // After fixing all 3 system fields, the client-side validation passes.
-    // The form should now also validate dynamic required fields (Summary,
-    // Details, Priority Level, Region) before allowing submission.
-    //
-    // This assertion will FAIL on the current implementation because
-    // client-side validation does not yet check dynamic required fields.
+    // The form now also validates dynamic required fields (Summary, Details,
+    // Priority Level, Region) before allowing submission.
     // =========================================================================
 
     const categoryButton = authenticatedPage.getByRole('button', {


### PR DESCRIPTION
Highlights required proposal fields on failed submit: invalid fields get red label/outline styling and an inline validation message, the first invalid field is scrolled into view and focused, and errors clear per-field as the user edits. Server-side validation failures reuse the same treatment. Includes aria wiring (`aria-invalid`, `aria-describedby`, `role="alert"`) and updated e2e coverage.

Also repoints custom money fields to sync to their own Yjs fragment (previously all custom money fields shared the system `budget` fragment). Required for this feature: validation reads fragments by template key, so a custom money field on the shared fragment could never clear its error state. Caveat: pre-deploy draft values for custom money fields remain in the old fragment and will render empty — those fields were effectively broken before, so exposure is near-zero.

Note: `Select`'s invalid styling previously never applied (the selector matched no ancestor group); the `group/select` scoping here activates it, and an explicit `isInvalid` prop was added.

## Follow-ups (out of scope)

- **i18n:** inline validation messages ("Title is required") are hardcoded English from `schemaValidator.ts` — needs message keys or client-side mapping.