### PR TITLE
feat(decisions): render per-phase banners on phase pages

### DIFF
--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -8,6 +8,7 @@ import {
   type ProcessInstance,
   type ProcessPhase,
 } from '@op/api/encoders';
+import { usePathname } from 'next/navigation';
 import { type ReactNode } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -114,18 +115,25 @@ function DecisionHeaderView({
   phases,
   currentStateId,
   heroImagePath,
+  phaseHeroImagePath,
 }: StandardDecisionHeaderProps & {
   title: string;
   phases: ProcessPhase[];
   currentStateId: string;
   /** Stored overview hero image path, for the admin Edit-banner controls. */
   heroImagePath?: string;
+  /** Stored hero image path of the current phase, for the phase tab's control. */
+  phaseHeroImagePath?: string;
 }) {
   // Admin banner controls live in the header so they persist across the
   // overview/current-phase tabs: a desktop "Edit banner" button and, on mobile,
   // a full-width admin bar that opens a bottom sheet.
   const currentPhase = phases.find((p) => p.id === currentStateId);
   const showAdminControls = isAdmin === true && Boolean(decisionSlug);
+  // One shared header spans both tabs; scope the mobile bar's banner action to
+  // whichever tab is active. The current-phase tab lives at `/…/current`.
+  const pathname = usePathname();
+  const isPhaseView = pathname.includes('/current');
 
   return (
     <>
@@ -141,7 +149,8 @@ function DecisionHeaderView({
             <AdminOverviewBar
               instanceId={instanceId}
               decisionSlug={decisionSlug}
-              heroImagePath={heroImagePath}
+              phaseId={isPhaseView ? currentStateId : undefined}
+              heroImagePath={isPhaseView ? phaseHeroImagePath : heroImagePath}
               phaseName={currentPhase?.name || undefined}
               phaseEndDate={currentPhase?.phase?.endDate}
             />
@@ -180,6 +189,11 @@ function DecisionHeaderContent(props: StandardDecisionHeaderProps) {
       phases={toProcessPhases(instance.instanceData)}
       currentStateId={instance.currentStateId || ''}
       heroImagePath={instance.instanceData?.overview?.heroImage}
+      phaseHeroImagePath={
+        instance.instanceData?.phases?.find(
+          (p) => p.phaseId === instance.currentStateId,
+        )?.heroImage
+      }
     />
   );
 }
@@ -204,6 +218,11 @@ function DecisionHeaderFromProps(
       phases={toProcessPhases(instance.instanceData)}
       currentStateId={instance.currentStateId || ''}
       heroImagePath={instance.instanceData?.overview?.heroImage}
+      phaseHeroImagePath={
+        instance.instanceData?.phases?.find(
+          (p) => p.phaseId === instance.currentStateId,
+        )?.heroImage
+      }
     />
   );
 }

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -103,6 +103,15 @@ function toProcessPhases(
   }));
 }
 
+/** Hero image path of the instance's current phase, if any. */
+function currentPhaseHeroImage(
+  instanceData: InstanceData | undefined,
+  currentStateId: string | null | undefined,
+): string | undefined {
+  return instanceData?.phases?.find((p) => p.phaseId === currentStateId)
+    ?.heroImage;
+}
+
 /** Presentational header bar + optional stepper, fed by either variant below. */
 function DecisionHeaderView({
   instanceId,
@@ -189,11 +198,10 @@ function DecisionHeaderContent(props: StandardDecisionHeaderProps) {
       phases={toProcessPhases(instance.instanceData)}
       currentStateId={instance.currentStateId || ''}
       heroImagePath={instance.instanceData?.overview?.heroImage}
-      phaseHeroImagePath={
-        instance.instanceData?.phases?.find(
-          (p) => p.phaseId === instance.currentStateId,
-        )?.heroImage
-      }
+      phaseHeroImagePath={currentPhaseHeroImage(
+        instance.instanceData,
+        instance.currentStateId,
+      )}
     />
   );
 }
@@ -218,11 +226,10 @@ function DecisionHeaderFromProps(
       phases={toProcessPhases(instance.instanceData)}
       currentStateId={instance.currentStateId || ''}
       heroImagePath={instance.instanceData?.overview?.heroImage}
-      phaseHeroImagePath={
-        instance.instanceData?.phases?.find(
-          (p) => p.phaseId === instance.currentStateId,
-        )?.heroImage
-      }
+      phaseHeroImagePath={currentPhaseHeroImage(
+        instance.instanceData,
+        instance.currentStateId,
+      )}
     />
   );
 }

--- a/apps/app/src/components/decisions/PhaseHeroBanner.tsx
+++ b/apps/app/src/components/decisions/PhaseHeroBanner.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import type { InstancePhaseData } from '@op/api/encoders';
+import { cn } from '@op/ui/utils';
+import type { ReactNode } from 'react';
+
+import { DecisionHeroBanner } from './DecisionHeroBanner';
+import { EditBannerModal } from './EditBannerModal';
+
+/**
+ * Phase-page hero banner: shows the phase's own hero image, falling back to the
+ * decision's overview banner, and gives admins the "Edit banner" control
+ * (scoped to the phase). Wraps the DecisionHeroBanner chrome so the standard /
+ * voting / review pages don't each re-derive the fallback + wrapper.
+ *
+ * `children` is a render prop receiving whether a banner image is showing, so
+ * the hero content (DecisionHero, facepile, ...) can switch to white text
+ * without recomputing the fallback.
+ */
+export function PhaseHeroBanner({
+  instanceId,
+  phase,
+  overviewImagePath,
+  isAdmin = false,
+  className,
+  children,
+}: {
+  instanceId: string;
+  /** Current phase; supplies the per-phase image + id (the edit target). */
+  phase?: InstancePhaseData;
+  /** Overview banner, shown when the phase has no image of its own. */
+  overviewImagePath?: string;
+  isAdmin?: boolean;
+  /** Extra classes for the inner max-w container (e.g. `items-center`). */
+  className?: string;
+  children: (hasImage: boolean) => ReactNode;
+}) {
+  const phaseImagePath = phase?.heroImage;
+  const heroImagePath = phaseImagePath ?? overviewImagePath;
+  const hasImage = Boolean(heroImagePath);
+
+  return (
+    <div className="relative">
+      {isAdmin && phase?.phaseId ? (
+        <EditBannerModal
+          instanceId={instanceId}
+          phaseId={phase.phaseId}
+          heroImagePath={phaseImagePath}
+        />
+      ) : null}
+      <DecisionHeroBanner heroImagePath={heroImagePath}>
+        <div
+          className={cn(
+            'mx-auto flex max-w-3xl flex-col justify-center gap-4 px-4 pt-16 pb-8 md:pb-16',
+            className,
+          )}
+        >
+          {children(hasImage)}
+        </div>
+      </DecisionHeroBanner>
+    </div>
+  );
+}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -17,6 +17,7 @@ import { LuTrash2 } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 
 import { RichTextEditorWithToolbar } from '@/components/RichTextEditor/RichTextEditorWithToolbar';
+import { HeroImageField } from '@/components/decisions/HeroImageField';
 
 import { useProcessBuilderAutosave } from '../../ProcessBuilderAutosaveContext';
 import { SaveStatusIndicator } from '../../components/SaveStatusIndicator';
@@ -110,6 +111,13 @@ function PhaseDetailForm({
 
   const initialPhase = allPhases.find((p) => p.id === phaseId);
   const [phase, setPhase] = useState<PhaseDefinition | undefined>(initialPhase);
+
+  // Hero image is owned by the dedicated upload endpoints (not the phase
+  // autosave), so read its stored path straight from instanceData rather than
+  // the local phase state.
+  const heroImagePath = instancePhases?.find(
+    (p) => p.phaseId === phaseId,
+  )?.heroImage;
 
   const allPhasesRef = useRef(allPhases);
   allPhasesRef.current = allPhases;
@@ -271,6 +279,11 @@ function PhaseDetailForm({
           errorMessage={getErrorMessage('headline')}
           description={t('This text appears as the header of the page.')}
           maxLength={50}
+        />
+        <HeroImageField
+          instanceId={instanceId}
+          phaseId={phaseId}
+          initialPath={heroImagePath}
         />
         <TextField
           label={t('Description')}

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -16,6 +16,7 @@ import { DecisionActionBar } from '../DecisionActionBar';
 import { DecisionHero } from '../DecisionHero';
 import { DecisionHeroBanner } from '../DecisionHeroBanner';
 import { useDecisionTranslation } from '../DecisionTranslationContext';
+import { EditBannerModal } from '../EditBannerModal';
 import { ProposalListSkeleton } from '../ProposalListSkeleton';
 import { ProposalsList } from '../ProposalsList';
 import { ReviewProgressStats } from '../Review/ReviewProgressStats';
@@ -61,49 +62,62 @@ export function ReviewPage({
   const actionBarLabel = phaseAdditionalInfo
     ? t('About this phase')
     : undefined;
-  const heroImagePath = instance.instanceData?.overview?.heroImage;
+  // Per-phase banner, falling back to the decision's overview banner.
+  const phaseImagePath = currentPhase.heroImage;
+  const heroImagePath =
+    phaseImagePath ?? instance.instanceData?.overview?.heroImage;
   const hasHeroImage = Boolean(heroImagePath);
 
   return (
     <div className="min-h-full">
-      <DecisionHeroBanner heroImagePath={heroImagePath}>
-        <div className="mx-auto flex max-w-3xl flex-col items-center justify-center gap-4 px-4 pt-16 pb-8 md:pb-16">
-          <DecisionHero
-            title={
-              isAdmin ? (
-                <TranslatedText text="Review Progress" />
+      <div className="relative">
+        {isAdmin ? (
+          <EditBannerModal
+            instanceId={instance.id}
+            phaseId={currentPhase.phaseId}
+            heroImagePath={phaseImagePath}
+            hideOnMobile
+          />
+        ) : null}
+        <DecisionHeroBanner heroImagePath={heroImagePath}>
+          <div className="mx-auto flex max-w-3xl flex-col items-center justify-center gap-4 px-4 pt-16 pb-8 md:pb-16">
+            <DecisionHero
+              title={
+                isAdmin ? (
+                  <TranslatedText text="Review Progress" />
+                ) : (
+                  (currentPhase.headline ?? (
+                    <TranslatedText text="REVIEW PROPOSALS." />
+                  ))
+                )
+              }
+              description={
+                !isAdmin && currentPhase.description ? (
+                  <p>{currentPhase.description}</p>
+                ) : undefined
+              }
+              variant="standard"
+              hasImage={hasHeroImage}
+            >
+              {isAdmin ? (
+                <ReviewProgressStats
+                  processInstanceId={instance.id}
+                  phaseId={currentPhase.phaseId}
+                  hasImage={hasHeroImage}
+                />
               ) : (
-                (currentPhase.headline ?? (
-                  <TranslatedText text="REVIEW PROPOSALS." />
-                ))
-              )
-            }
-            description={
-              !isAdmin && currentPhase.description ? (
-                <p>{currentPhase.description}</p>
-              ) : undefined
-            }
-            variant="standard"
-            hasImage={hasHeroImage}
-          >
-            {isAdmin ? (
-              <ReviewProgressStats
-                processInstanceId={instance.id}
-                phaseId={currentPhase.phaseId}
-                hasImage={hasHeroImage}
-              />
-            ) : (
-              <DecisionActionBar
-                instanceId={instance.id}
-                description={actionBarDescription}
-                label={actionBarLabel}
-                markup={!!translation?.additionalInfo}
-                showSubmitButton={false}
-              />
-            )}
-          </DecisionHero>
-        </div>
-      </DecisionHeroBanner>
+                <DecisionActionBar
+                  instanceId={instance.id}
+                  description={actionBarDescription}
+                  label={actionBarLabel}
+                  markup={!!translation?.additionalInfo}
+                  showSubmitButton={false}
+                />
+              )}
+            </DecisionHero>
+          </div>
+        </DecisionHeroBanner>
+      </div>
 
       <div className="flex w-full justify-center bg-white">
         <div className="w-full p-4 sm:max-w-6xl sm:p-8">

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -14,9 +14,8 @@ import { TranslatedText } from '@/components/TranslatedText';
 
 import { DecisionActionBar } from '../DecisionActionBar';
 import { DecisionHero } from '../DecisionHero';
-import { DecisionHeroBanner } from '../DecisionHeroBanner';
 import { useDecisionTranslation } from '../DecisionTranslationContext';
-import { EditBannerModal } from '../EditBannerModal';
+import { PhaseHeroBanner } from '../PhaseHeroBanner';
 import { ProposalListSkeleton } from '../ProposalListSkeleton';
 import { ProposalsList } from '../ProposalsList';
 import { ReviewProgressStats } from '../Review/ReviewProgressStats';
@@ -62,61 +61,53 @@ export function ReviewPage({
   const actionBarLabel = phaseAdditionalInfo
     ? t('About this phase')
     : undefined;
-  // Per-phase banner, falling back to the decision's overview banner.
-  const phaseImagePath = currentPhase.heroImage;
-  const heroImagePath =
-    phaseImagePath ?? instance.instanceData?.overview?.heroImage;
-  const hasHeroImage = Boolean(heroImagePath);
 
   return (
     <div className="min-h-full">
-      <div className="relative">
-        {isAdmin ? (
-          <EditBannerModal
-            instanceId={instance.id}
-            phaseId={currentPhase.phaseId}
-            heroImagePath={phaseImagePath}
-          />
-        ) : null}
-        <DecisionHeroBanner heroImagePath={heroImagePath}>
-          <div className="mx-auto flex max-w-3xl flex-col items-center justify-center gap-4 px-4 pt-16 pb-8 md:pb-16">
-            <DecisionHero
-              title={
-                isAdmin ? (
-                  <TranslatedText text="Review Progress" />
-                ) : (
-                  (currentPhase.headline ?? (
-                    <TranslatedText text="REVIEW PROPOSALS." />
-                  ))
-                )
-              }
-              description={
-                !isAdmin && currentPhase.description ? (
-                  <p>{currentPhase.description}</p>
-                ) : undefined
-              }
-              variant="standard"
-              hasImage={hasHeroImage}
-            >
-              {isAdmin ? (
-                <ReviewProgressStats
-                  processInstanceId={instance.id}
-                  phaseId={currentPhase.phaseId}
-                  hasImage={hasHeroImage}
-                />
+      <PhaseHeroBanner
+        instanceId={instance.id}
+        phase={currentPhase}
+        overviewImagePath={instance.instanceData?.overview?.heroImage}
+        isAdmin={isAdmin}
+        className="items-center"
+      >
+        {(hasImage) => (
+          <DecisionHero
+            title={
+              isAdmin ? (
+                <TranslatedText text="Review Progress" />
               ) : (
-                <DecisionActionBar
-                  instanceId={instance.id}
-                  description={actionBarDescription}
-                  label={actionBarLabel}
-                  markup={!!translation?.additionalInfo}
-                  showSubmitButton={false}
-                />
-              )}
-            </DecisionHero>
-          </div>
-        </DecisionHeroBanner>
-      </div>
+                (currentPhase.headline ?? (
+                  <TranslatedText text="REVIEW PROPOSALS." />
+                ))
+              )
+            }
+            description={
+              !isAdmin && currentPhase.description ? (
+                <p>{currentPhase.description}</p>
+              ) : undefined
+            }
+            variant="standard"
+            hasImage={hasImage}
+          >
+            {isAdmin ? (
+              <ReviewProgressStats
+                processInstanceId={instance.id}
+                phaseId={currentPhase.phaseId}
+                hasImage={hasImage}
+              />
+            ) : (
+              <DecisionActionBar
+                instanceId={instance.id}
+                description={actionBarDescription}
+                label={actionBarLabel}
+                markup={!!translation?.additionalInfo}
+                showSubmitButton={false}
+              />
+            )}
+          </DecisionHero>
+        )}
+      </PhaseHeroBanner>
 
       <div className="flex w-full justify-center bg-white">
         <div className="w-full p-4 sm:max-w-6xl sm:p-8">

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -76,7 +76,6 @@ export function ReviewPage({
             instanceId={instance.id}
             phaseId={currentPhase.phaseId}
             heroImagePath={phaseImagePath}
-            hideOnMobile
           />
         ) : null}
         <DecisionHeroBanner heroImagePath={heroImagePath}>

--- a/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
+++ b/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
@@ -12,12 +12,11 @@ import { useTranslations } from '@/lib/i18n/routing';
 
 import { DecisionActionBar } from '../DecisionActionBar';
 import { DecisionHero } from '../DecisionHero';
-import { DecisionHeroBanner } from '../DecisionHeroBanner';
 import { useDecisionTranslation } from '../DecisionTranslationContext';
-import { EditBannerModal } from '../EditBannerModal';
 import { HiddenProposalsBanner } from '../HiddenProposalsBanner';
 import { ManualSelectionList } from '../ManualSelectionList';
 import { MemberParticipationFacePile } from '../MemberParticipationFacePile';
+import { PhaseHeroBanner } from '../PhaseHeroBanner';
 import { ProposalListSkeleton } from '../ProposalListSkeleton';
 import { ProposalsList } from '../ProposalsList';
 
@@ -77,37 +76,30 @@ export function StandardDecisionPage({
     currentPhase?.additionalInfo ??
     translation?.description ??
     description;
-  // Per-phase banner, falling back to the decision's overview banner.
-  const phaseImagePath = currentPhase?.heroImage;
-  const heroImagePath =
-    phaseImagePath ?? instance.instanceData?.overview?.heroImage;
-  const hasHeroImage = Boolean(heroImagePath);
 
   return (
     <div className="min-h-full">
-      <div className="relative">
-        {isAdmin && currentPhase?.phaseId ? (
-          <EditBannerModal
-            instanceId={instanceId}
-            phaseId={currentPhase.phaseId}
-            heroImagePath={phaseImagePath}
-          />
-        ) : null}
-        <DecisionHeroBanner heroImagePath={heroImagePath}>
-          <div className="mx-auto flex max-w-3xl flex-col justify-center gap-4 px-4 pt-16 pb-8 md:pb-16">
+      <PhaseHeroBanner
+        instanceId={instanceId}
+        phase={currentPhase}
+        overviewImagePath={instance.instanceData?.overview?.heroImage}
+        isAdmin={isAdmin}
+      >
+        {(hasImage) => (
+          <>
             <DecisionHero
               title={heroTitle}
               description={
                 heroDescription ? <p>{heroDescription}</p> : undefined
               }
               variant="standard"
-              hasImage={hasHeroImage}
+              hasImage={hasImage}
             />
 
             <MemberParticipationFacePile
               submitters={submitters}
               total={total}
-              hasImage={hasHeroImage}
+              hasImage={hasImage}
             />
 
             <DecisionActionBar
@@ -116,9 +108,9 @@ export function StandardDecisionPage({
               markup={!!translation?.additionalInfo}
               showSubmitButton={allowProposals && canSubmitProposal}
             />
-          </div>
-        </DecisionHeroBanner>
-      </div>
+          </>
+        )}
+      </PhaseHeroBanner>
 
       <div className="flex w-full flex-col items-center border-t bg-white">
         {proposalsHidden && (

--- a/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
+++ b/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
@@ -14,6 +14,7 @@ import { DecisionActionBar } from '../DecisionActionBar';
 import { DecisionHero } from '../DecisionHero';
 import { DecisionHeroBanner } from '../DecisionHeroBanner';
 import { useDecisionTranslation } from '../DecisionTranslationContext';
+import { EditBannerModal } from '../EditBannerModal';
 import { HiddenProposalsBanner } from '../HiddenProposalsBanner';
 import { ManualSelectionList } from '../ManualSelectionList';
 import { MemberParticipationFacePile } from '../MemberParticipationFacePile';
@@ -76,34 +77,49 @@ export function StandardDecisionPage({
     currentPhase?.additionalInfo ??
     translation?.description ??
     description;
-  const heroImagePath = instance.instanceData?.overview?.heroImage;
+  // Per-phase banner, falling back to the decision's overview banner.
+  const phaseImagePath = currentPhase?.heroImage;
+  const heroImagePath =
+    phaseImagePath ?? instance.instanceData?.overview?.heroImage;
   const hasHeroImage = Boolean(heroImagePath);
 
   return (
     <div className="min-h-full">
-      <DecisionHeroBanner heroImagePath={heroImagePath}>
-        <div className="mx-auto flex max-w-3xl flex-col justify-center gap-4 px-4 pt-16 pb-8 md:pb-16">
-          <DecisionHero
-            title={heroTitle}
-            description={heroDescription ? <p>{heroDescription}</p> : undefined}
-            variant="standard"
-            hasImage={hasHeroImage}
-          />
-
-          <MemberParticipationFacePile
-            submitters={submitters}
-            total={total}
-            hasImage={hasHeroImage}
-          />
-
-          <DecisionActionBar
+      <div className="relative">
+        {isAdmin && currentPhase?.phaseId ? (
+          <EditBannerModal
             instanceId={instanceId}
-            description={actionBarDescription}
-            markup={!!translation?.additionalInfo}
-            showSubmitButton={allowProposals && canSubmitProposal}
+            phaseId={currentPhase.phaseId}
+            heroImagePath={phaseImagePath}
+            hideOnMobile
           />
-        </div>
-      </DecisionHeroBanner>
+        ) : null}
+        <DecisionHeroBanner heroImagePath={heroImagePath}>
+          <div className="mx-auto flex max-w-3xl flex-col justify-center gap-4 px-4 pt-16 pb-8 md:pb-16">
+            <DecisionHero
+              title={heroTitle}
+              description={
+                heroDescription ? <p>{heroDescription}</p> : undefined
+              }
+              variant="standard"
+              hasImage={hasHeroImage}
+            />
+
+            <MemberParticipationFacePile
+              submitters={submitters}
+              total={total}
+              hasImage={hasHeroImage}
+            />
+
+            <DecisionActionBar
+              instanceId={instanceId}
+              description={actionBarDescription}
+              markup={!!translation?.additionalInfo}
+              showSubmitButton={allowProposals && canSubmitProposal}
+            />
+          </div>
+        </DecisionHeroBanner>
+      </div>
 
       <div className="flex w-full flex-col items-center border-t bg-white">
         {proposalsHidden && (

--- a/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
+++ b/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
@@ -91,7 +91,6 @@ export function StandardDecisionPage({
             instanceId={instanceId}
             phaseId={currentPhase.phaseId}
             heroImagePath={phaseImagePath}
-            hideOnMobile
           />
         ) : null}
         <DecisionHeroBanner heroImagePath={heroImagePath}>

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -11,6 +11,7 @@ import { DecisionActionBar } from '../DecisionActionBar';
 import { DecisionHero } from '../DecisionHero';
 import { DecisionHeroBanner } from '../DecisionHeroBanner';
 import { useDecisionTranslation } from '../DecisionTranslationContext';
+import { EditBannerModal } from '../EditBannerModal';
 import { MemberParticipationFacePile } from '../MemberParticipationFacePile';
 import { ProposalListSkeleton } from '../ProposalListSkeleton';
 import { ProposalsList } from '../ProposalsList';
@@ -80,34 +81,50 @@ export function VotingPage({
     currentPhase?.additionalInfo ??
     translation?.description ??
     description;
-  const heroImagePath = instance.instanceData?.overview?.heroImage;
+  const isAdmin = Boolean(instance.access?.admin);
+  // Per-phase banner, falling back to the decision's overview banner.
+  const phaseImagePath = currentPhase?.heroImage;
+  const heroImagePath =
+    phaseImagePath ?? instance.instanceData?.overview?.heroImage;
   const hasHeroImage = Boolean(heroImagePath);
 
   return (
     <div className="min-h-full">
-      <DecisionHeroBanner heroImagePath={heroImagePath}>
-        <div className="mx-auto flex max-w-3xl flex-col justify-center gap-4 px-4 pt-16 pb-8 md:pb-16">
-          <DecisionHero
-            title={heroTitle}
-            description={heroDescription ? <p>{heroDescription}</p> : undefined}
-            variant="standard"
-            hasImage={hasHeroImage}
-          />
-
-          <MemberParticipationFacePile
-            submitters={submitters}
-            total={total}
-            hasImage={hasHeroImage}
-          />
-
-          <DecisionActionBar
+      <div className="relative">
+        {isAdmin && currentPhase?.phaseId ? (
+          <EditBannerModal
             instanceId={instanceId}
-            markup={!!translation?.additionalInfo}
-            description={actionBarDescription}
-            showSubmitButton={false}
+            phaseId={currentPhase.phaseId}
+            heroImagePath={phaseImagePath}
+            hideOnMobile
           />
-        </div>
-      </DecisionHeroBanner>
+        ) : null}
+        <DecisionHeroBanner heroImagePath={heroImagePath}>
+          <div className="mx-auto flex max-w-3xl flex-col justify-center gap-4 px-4 pt-16 pb-8 md:pb-16">
+            <DecisionHero
+              title={heroTitle}
+              description={
+                heroDescription ? <p>{heroDescription}</p> : undefined
+              }
+              variant="standard"
+              hasImage={hasHeroImage}
+            />
+
+            <MemberParticipationFacePile
+              submitters={submitters}
+              total={total}
+              hasImage={hasHeroImage}
+            />
+
+            <DecisionActionBar
+              instanceId={instanceId}
+              markup={!!translation?.additionalInfo}
+              description={actionBarDescription}
+              showSubmitButton={false}
+            />
+          </div>
+        </DecisionHeroBanner>
+      </div>
 
       <div className="flex w-full justify-center border-t bg-white">
         <div className="w-full p-4 sm:max-w-6xl sm:p-8">

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -9,10 +9,9 @@ import { useTranslations } from '@/lib/i18n/routing';
 
 import { DecisionActionBar } from '../DecisionActionBar';
 import { DecisionHero } from '../DecisionHero';
-import { DecisionHeroBanner } from '../DecisionHeroBanner';
 import { useDecisionTranslation } from '../DecisionTranslationContext';
-import { EditBannerModal } from '../EditBannerModal';
 import { MemberParticipationFacePile } from '../MemberParticipationFacePile';
+import { PhaseHeroBanner } from '../PhaseHeroBanner';
 import { ProposalListSkeleton } from '../ProposalListSkeleton';
 import { ProposalsList } from '../ProposalsList';
 
@@ -82,37 +81,30 @@ export function VotingPage({
     translation?.description ??
     description;
   const isAdmin = Boolean(instance.access?.admin);
-  // Per-phase banner, falling back to the decision's overview banner.
-  const phaseImagePath = currentPhase?.heroImage;
-  const heroImagePath =
-    phaseImagePath ?? instance.instanceData?.overview?.heroImage;
-  const hasHeroImage = Boolean(heroImagePath);
 
   return (
     <div className="min-h-full">
-      <div className="relative">
-        {isAdmin && currentPhase?.phaseId ? (
-          <EditBannerModal
-            instanceId={instanceId}
-            phaseId={currentPhase.phaseId}
-            heroImagePath={phaseImagePath}
-          />
-        ) : null}
-        <DecisionHeroBanner heroImagePath={heroImagePath}>
-          <div className="mx-auto flex max-w-3xl flex-col justify-center gap-4 px-4 pt-16 pb-8 md:pb-16">
+      <PhaseHeroBanner
+        instanceId={instanceId}
+        phase={currentPhase}
+        overviewImagePath={instance.instanceData?.overview?.heroImage}
+        isAdmin={isAdmin}
+      >
+        {(hasImage) => (
+          <>
             <DecisionHero
               title={heroTitle}
               description={
                 heroDescription ? <p>{heroDescription}</p> : undefined
               }
               variant="standard"
-              hasImage={hasHeroImage}
+              hasImage={hasImage}
             />
 
             <MemberParticipationFacePile
               submitters={submitters}
               total={total}
-              hasImage={hasHeroImage}
+              hasImage={hasImage}
             />
 
             <DecisionActionBar
@@ -121,9 +113,9 @@ export function VotingPage({
               description={actionBarDescription}
               showSubmitButton={false}
             />
-          </div>
-        </DecisionHeroBanner>
-      </div>
+          </>
+        )}
+      </PhaseHeroBanner>
 
       <div className="flex w-full justify-center border-t bg-white">
         <div className="w-full p-4 sm:max-w-6xl sm:p-8">

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -96,7 +96,6 @@ export function VotingPage({
             instanceId={instanceId}
             phaseId={currentPhase.phaseId}
             heroImagePath={phaseImagePath}
-            hideOnMobile
           />
         ) : null}
         <DecisionHeroBanner heroImagePath={heroImagePath}>


### PR DESCRIPTION
Live render layer for per-phase hero banners (top of the stack).

- Standard / voting / review phase pages show the per-phase image, falling back to the decision's overview banner, via DecisionHeroBanner + DecisionHero hasImage.
- Admin Add/Edit banner control on the phase hero (desktop) and the mobile admin bar, which DecisionHeader scopes to the active tab (phase vs overview).
- Phase editor upload field (HeroImageField).

Stack: PR 3 of 3. Base: `phase-hero-refactor` (#1528).