### PR TITLE
feat(decisions): match decision-view loading skeletons to the real layouts

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/loading.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/current/loading.tsx
@@ -1,0 +1,8 @@
+import { DecisionContentSkeleton } from '@/components/skeletons/DecisionSkeleton';
+
+// Matches the hero + action bar + proposal list DecisionStateRouter renders;
+// same skeleton the page's own Suspense fallback uses. Without this file the
+// overview-shaped skeleton from the parent segment would show here instead.
+export default function Loading() {
+  return <DecisionContentSkeleton />;
+}

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -37,6 +37,9 @@ const DecisionViewLayout = ({
           and confines the scrollbar to the content row. The content row is the
           scroll container the proposals filter bar pins inside. */}
       <div className="grid h-dvh grid-rows-[auto_1fr]">
+        {/* Grid contract: this Suspense (and the resolved header) must stay a
+            single grid item — a second top-level element (e.g. flipping
+            showStepper back on) would steal the 1fr row from the content. */}
         <Suspense fallback={<DecisionHeaderBarSkeleton />}>
           <DecisionViewHeader params={params} />
         </Suspense>

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -6,57 +6,40 @@ import { DecisionTranslationProvider } from '@/components/decisions/DecisionTran
 import { DecisionViewToggle } from '@/components/decisions/DecisionViewToggle';
 import { PromoteAccountModal } from '@/components/decisions/PromoteAccountModal';
 import { hasFirstPhaseStarted } from '@/components/decisions/hasFirstPhaseStarted';
+import { DecisionHeaderBarSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
 import { loadDecision } from './loadDecision';
+
+type DecisionViewParams = Promise<{ slug: string; locale: string }>;
 
 /**
  * Shared shell for the overview and current-phase tabs. Living in a layout
  * means the header, the Overview / Current Phase toggle, and the updates side
  * panel persist across tab switches — the tab content is the only thing that
- * swaps, which is what makes the switch feel like a single page. The header and
- * toggle read everything they need from `loadDecision` (the single slug fetch,
- * enriched with `access` + encoded `instanceData`), so the layout makes no
- * separate `getInstance` call. The /current tab seeds its own `getInstance`
- * cache in its page.
+ * swaps, which is what makes the switch feel like a single page.
+ *
+ * The layout itself awaits nothing, so the shell (and each tab's loading.tsx
+ * skeleton) paints immediately on first navigation. The header and side panel
+ * each await `loadDecision` inside their own Suspense below — that's the same
+ * React-cached slug fetch the page makes, so everything still rides on one
+ * request and streams in together when it resolves.
  */
-const DecisionViewLayout = async ({
+const DecisionViewLayout = ({
   children,
   params,
 }: {
   children: ReactNode;
-  params: Promise<{ slug: string; locale: string }>;
+  params: DecisionViewParams;
 }) => {
-  const { slug } = await params;
-
-  const { decisionProfile, instanceId } = await loadDecision(slug);
-  const instance = decisionProfile.processInstance;
-
-  // The process is "active" once its first phase begins — read from the phases
-  // loadDecision already returned (no separate getInstance fetch).
-  const isActive = hasFirstPhaseStarted(instance?.instanceData?.phases);
-  const access = instance?.access;
-
   return (
     <DecisionTranslationProvider>
       {/* Fixed header + scrolling content: the grid keeps the header in place
           and confines the scrollbar to the content row. The content row is the
           scroll container the proposals filter bar pins inside. */}
       <div className="grid h-dvh grid-rows-[auto_1fr]">
-        <DecisionHeader
-          instanceId={instanceId}
-          decisionSlug={slug}
-          isAdmin={access?.admin}
-          canReadUpdates={access?.admin === true || access?.read === true}
-          profileName={decisionProfile.name}
-          // Pass the instance so the header renders from props (no client
-          // getInstance query on this route).
-          processInstance={instance}
-          showStepper={false}
-          // Hidden until the first phase begins.
-          centerSlot={
-            isActive ? <DecisionViewToggle decisionSlug={slug} /> : undefined
-          }
-        />
+        <Suspense fallback={<DecisionHeaderBarSkeleton />}>
+          <DecisionViewHeader params={params} />
+        </Suspense>
         {/* overflow-x-clip: the bar's full-bleed `w-screen` chrome is 100vw,
             which exceeds the content width by the scrollbar on desktop and would
             otherwise add a few px of horizontal scroll. */}
@@ -64,16 +47,14 @@ const DecisionViewLayout = async ({
       </div>
       {/*
        * Like the header's updates toggle, the side panel reads the `panel`
-       * search param (nuqs/useSearchParams). It lives in this layout, which
-       * Next prerenders as the route's static shell (see loading.tsx), so the
-       * read would happen outside a request scope and throw. Suspense defers
-       * it out of the shell; the panel is closed by default, so null fallback.
+       * search param (nuqs/useSearchParams), which must stay out of the
+       * route's static shell (the read would happen outside a request scope
+       * and throw). Suspense defers it — and lets the loader await
+       * loadDecision without blocking the shell; the panel is closed by
+       * default, so null fallback.
        */}
       <Suspense fallback={null}>
-        <DecisionSidePanel
-          decisionProfileId={decisionProfile.id}
-          access={access}
-        />
+        <DecisionSidePanelLoader params={params} />
       </Suspense>
       {/*
        * Post-anon-submit promote modal. Mounted here (not on the deleted
@@ -86,6 +67,62 @@ const DecisionViewLayout = async ({
         <PromoteAccountModal />
       </Suspense>
     </DecisionTranslationProvider>
+  );
+};
+
+/**
+ * Header + view toggle, streamed in once loadDecision resolves. Reads
+ * everything it needs from the single slug fetch (enriched with `access` +
+ * encoded `instanceData`), so no separate `getInstance` call. The /current tab
+ * seeds its own `getInstance` cache in its page.
+ */
+const DecisionViewHeader = async ({
+  params,
+}: {
+  params: DecisionViewParams;
+}) => {
+  const { slug } = await params;
+  const { decisionProfile, instanceId } = await loadDecision(slug);
+  const instance = decisionProfile.processInstance;
+
+  // The process is "active" once its first phase begins — read from the phases
+  // loadDecision already returned (no separate getInstance fetch).
+  const isActive = hasFirstPhaseStarted(instance?.instanceData?.phases);
+  const access = instance?.access;
+
+  return (
+    <DecisionHeader
+      instanceId={instanceId}
+      decisionSlug={slug}
+      isAdmin={access?.admin}
+      canReadUpdates={access?.admin === true || access?.read === true}
+      profileName={decisionProfile.name}
+      // Pass the instance so the header renders from props (no client
+      // getInstance query on this route).
+      processInstance={instance}
+      showStepper={false}
+      // Hidden until the first phase begins.
+      centerSlot={
+        isActive ? <DecisionViewToggle decisionSlug={slug} /> : undefined
+      }
+    />
+  );
+};
+
+/** Awaits the shared loadDecision fetch for the updates side panel. */
+const DecisionSidePanelLoader = async ({
+  params,
+}: {
+  params: DecisionViewParams;
+}) => {
+  const { slug } = await params;
+  const { decisionProfile } = await loadDecision(slug);
+
+  return (
+    <DecisionSidePanel
+      decisionProfileId={decisionProfile.id}
+      access={decisionProfile.processInstance?.access}
+    />
   );
 };
 

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -6,43 +6,57 @@ import { DecisionTranslationProvider } from '@/components/decisions/DecisionTran
 import { DecisionViewToggle } from '@/components/decisions/DecisionViewToggle';
 import { PromoteAccountModal } from '@/components/decisions/PromoteAccountModal';
 import { hasFirstPhaseStarted } from '@/components/decisions/hasFirstPhaseStarted';
-import { DecisionHeaderBarSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
 import { loadDecision } from './loadDecision';
-
-type DecisionViewParams = Promise<{ slug: string; locale: string }>;
 
 /**
  * Shared shell for the overview and current-phase tabs. Living in a layout
  * means the header, the Overview / Current Phase toggle, and the updates side
  * panel persist across tab switches — the tab content is the only thing that
- * swaps, which is what makes the switch feel like a single page.
- *
- * The layout itself awaits nothing, so the shell (and each tab's loading.tsx
- * skeleton) paints immediately on first navigation. The header and side panel
- * each await `loadDecision` inside their own Suspense below — that's the same
- * React-cached slug fetch the page makes, so everything still rides on one
- * request and streams in together when it resolves.
+ * swaps, which is what makes the switch feel like a single page. The header and
+ * toggle read everything they need from `loadDecision` (the single slug fetch,
+ * enriched with `access` + encoded `instanceData`), so the layout makes no
+ * separate `getInstance` call. The /current tab seeds its own `getInstance`
+ * cache in its page.
  */
-const DecisionViewLayout = ({
+const DecisionViewLayout = async ({
   children,
   params,
 }: {
   children: ReactNode;
-  params: DecisionViewParams;
+  params: Promise<{ slug: string; locale: string }>;
 }) => {
+  const { slug } = await params;
+
+  const { decisionProfile, instanceId } = await loadDecision(slug);
+  const instance = decisionProfile.processInstance;
+
+  // The process is "active" once its first phase begins — read from the phases
+  // loadDecision already returned (no separate getInstance fetch).
+  const isActive = hasFirstPhaseStarted(instance?.instanceData?.phases);
+  const access = instance?.access;
+
   return (
     <DecisionTranslationProvider>
       {/* Fixed header + scrolling content: the grid keeps the header in place
           and confines the scrollbar to the content row. The content row is the
           scroll container the proposals filter bar pins inside. */}
       <div className="grid h-dvh grid-rows-[auto_1fr]">
-        {/* Grid contract: this Suspense (and the resolved header) must stay a
-            single grid item — a second top-level element (e.g. flipping
-            showStepper back on) would steal the 1fr row from the content. */}
-        <Suspense fallback={<DecisionHeaderBarSkeleton />}>
-          <DecisionViewHeader params={params} />
-        </Suspense>
+        <DecisionHeader
+          instanceId={instanceId}
+          decisionSlug={slug}
+          isAdmin={access?.admin}
+          canReadUpdates={access?.admin === true || access?.read === true}
+          profileName={decisionProfile.name}
+          // Pass the instance so the header renders from props (no client
+          // getInstance query on this route).
+          processInstance={instance}
+          showStepper={false}
+          // Hidden until the first phase begins.
+          centerSlot={
+            isActive ? <DecisionViewToggle decisionSlug={slug} /> : undefined
+          }
+        />
         {/* overflow-x-clip: the bar's full-bleed `w-screen` chrome is 100vw,
             which exceeds the content width by the scrollbar on desktop and would
             otherwise add a few px of horizontal scroll. */}
@@ -50,14 +64,16 @@ const DecisionViewLayout = ({
       </div>
       {/*
        * Like the header's updates toggle, the side panel reads the `panel`
-       * search param (nuqs/useSearchParams), which must stay out of the
-       * route's static shell (the read would happen outside a request scope
-       * and throw). Suspense defers it — and lets the loader await
-       * loadDecision without blocking the shell; the panel is closed by
-       * default, so null fallback.
+       * search param (nuqs/useSearchParams). It lives in this layout, which
+       * Next prerenders as the route's static shell (see loading.tsx), so the
+       * read would happen outside a request scope and throw. Suspense defers
+       * it out of the shell; the panel is closed by default, so null fallback.
        */}
       <Suspense fallback={null}>
-        <DecisionSidePanelLoader params={params} />
+        <DecisionSidePanel
+          decisionProfileId={decisionProfile.id}
+          access={access}
+        />
       </Suspense>
       {/*
        * Post-anon-submit promote modal. Mounted here (not on the deleted
@@ -70,62 +86,6 @@ const DecisionViewLayout = ({
         <PromoteAccountModal />
       </Suspense>
     </DecisionTranslationProvider>
-  );
-};
-
-/**
- * Header + view toggle, streamed in once loadDecision resolves. Reads
- * everything it needs from the single slug fetch (enriched with `access` +
- * encoded `instanceData`), so no separate `getInstance` call. The /current tab
- * seeds its own `getInstance` cache in its page.
- */
-const DecisionViewHeader = async ({
-  params,
-}: {
-  params: DecisionViewParams;
-}) => {
-  const { slug } = await params;
-  const { decisionProfile, instanceId } = await loadDecision(slug);
-  const instance = decisionProfile.processInstance;
-
-  // The process is "active" once its first phase begins — read from the phases
-  // loadDecision already returned (no separate getInstance fetch).
-  const isActive = hasFirstPhaseStarted(instance?.instanceData?.phases);
-  const access = instance?.access;
-
-  return (
-    <DecisionHeader
-      instanceId={instanceId}
-      decisionSlug={slug}
-      isAdmin={access?.admin}
-      canReadUpdates={access?.admin === true || access?.read === true}
-      profileName={decisionProfile.name}
-      // Pass the instance so the header renders from props (no client
-      // getInstance query on this route).
-      processInstance={instance}
-      showStepper={false}
-      // Hidden until the first phase begins.
-      centerSlot={
-        isActive ? <DecisionViewToggle decisionSlug={slug} /> : undefined
-      }
-    />
-  );
-};
-
-/** Awaits the shared loadDecision fetch for the updates side panel. */
-const DecisionSidePanelLoader = async ({
-  params,
-}: {
-  params: DecisionViewParams;
-}) => {
-  const { slug } = await params;
-  const { decisionProfile } = await loadDecision(slug);
-
-  return (
-    <DecisionSidePanel
-      decisionProfileId={decisionProfile.id}
-      access={decisionProfile.processInstance?.access}
-    />
   );
 };
 

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/loading.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/loading.tsx
@@ -1,7 +1,8 @@
-import { DecisionContentSkeleton } from '@/components/skeletons/DecisionSkeleton';
+import { OverviewSkeleton } from '@/components/skeletons/DecisionSkeleton';
 
-// Content-only: the header + tabs live in the persisted layout, so a tab
-// switch should skeleton just the swapping content, not the whole page.
+// This boundary belongs to the overview page (this segment's page.tsx); the
+// header + tabs live in the persisted layout, so only the swapping content
+// skeletons. /current has its own loading.tsx with the proposal-list shape.
 export default function Loading() {
-  return <DecisionContentSkeleton />;
+  return <OverviewSkeleton />;
 }

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/loading.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/loading.tsx
@@ -1,5 +1,0 @@
-import { DecisionPageSkeleton } from '@/components/skeletons/DecisionSkeleton';
-
-export default function Loading() {
-  return <DecisionPageSkeleton />;
-}

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/loading.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/loading.tsx
@@ -1,0 +1,18 @@
+import {
+  DecisionHeaderBarSkeleton,
+  OverviewSkeleton,
+} from '@/components/skeletons/DecisionSkeleton';
+
+// First-load skeleton for /decisions/[slug]: header bar (no stepper — the
+// decision-view layout renders showStepper={false}) + overview-shaped content,
+// since the overview is the canonical tab. Direct loads of /current briefly
+// show this overview shape too; tab switches use the per-tab loading files
+// inside (decision-view), which the persisted layout keeps mounted.
+export default function Loading() {
+  return (
+    <div className="flex min-h-dvh flex-col">
+      <DecisionHeaderBarSkeleton />
+      <OverviewSkeleton />
+    </div>
+  );
+}

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/loading.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/loading.tsx
@@ -8,11 +8,17 @@ import {
 // since the overview is the canonical tab. Direct loads of /current briefly
 // show this overview shape too; tab switches use the per-tab loading files
 // inside (decision-view), which the persisted layout keeps mounted.
+//
+// The shell mirrors the (decision-view) layout's grid — h-dvh with scroll
+// confined to the content row — so the scrollbar lives in the same place
+// during load and after resolve (no gutter shift, no scroll-position reset).
 export default function Loading() {
   return (
-    <div className="flex min-h-dvh flex-col">
+    <div className="grid h-dvh grid-rows-[auto_1fr]">
       <DecisionHeaderBarSkeleton />
-      <OverviewSkeleton />
+      <div className="overflow-x-clip overflow-y-auto">
+        <OverviewSkeleton />
+      </div>
     </div>
   );
 }

--- a/apps/app/src/components/skeletons/DecisionSkeleton.tsx
+++ b/apps/app/src/components/skeletons/DecisionSkeleton.tsx
@@ -72,6 +72,81 @@ export const DecisionContentSkeleton = () => {
 };
 
 /**
+ * Skeleton for the decision header bar only (no stepper). Mirrors
+ * DecisionInstanceHeader's fixed-height sticky bar so the real header swaps in
+ * without shifting the layout: same sticky/border/height classes, with chips
+ * where the back link, view toggle, and user controls land.
+ */
+export const DecisionHeaderBarSkeleton = () => {
+  return (
+    <header className="sticky top-0 z-30 border-b bg-white">
+      <div className="grid h-12 grid-cols-[auto_1fr_auto] items-center px-4 sm:grid-cols-3 md:h-14 md:px-6">
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-6 rounded md:size-4" />
+          <Skeleton className="hidden h-5 w-24 md:block" />
+        </div>
+        <div className="flex justify-center">
+          <Skeleton className="h-8 w-44 rounded-full" />
+        </div>
+        <div className="flex items-center justify-end gap-2 md:gap-4">
+          <Skeleton className="h-7 w-7 rounded" />
+          <Skeleton className="h-8 w-8 rounded-full" />
+        </div>
+      </div>
+    </header>
+  );
+};
+
+/**
+ * Skeleton for the decision overview tab. Mirrors DecisionOverview's real
+ * layout — full-bleed hero band, then the 12-col grid with the phase timeline
+ * sidebar and the About body — so the resolved page lands without a layout
+ * shift.
+ */
+export const OverviewSkeleton = () => {
+  return (
+    <div className="flex w-full flex-col">
+      {/* Hero band: title, meta row, subhead, CTA chips */}
+      <div className="border-b bg-neutral-offWhite">
+        <div className="mx-auto flex max-w-2xl flex-col items-center gap-4 px-4 pt-16 pb-8 text-center md:px-6 md:pb-16">
+          <div className="flex w-full flex-col items-center gap-3">
+            <Skeleton className="h-12 w-3/4 sm:h-14" />
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-5 w-1/2" />
+          </div>
+          <div className="flex w-full flex-col items-center gap-4 md:flex-row md:justify-center">
+            <Skeleton className="h-10 w-full md:w-40" />
+            <Skeleton className="h-10 w-full md:w-40" />
+          </div>
+        </div>
+      </div>
+      {/* Sidebar (phase timeline) + About body grid */}
+      <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-4 py-6 md:grid-cols-12 md:gap-x-6 md:px-6 md:py-12">
+        <div className="flex flex-col gap-4 md:col-span-4">
+          <Skeleton className="h-4 w-32" />
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="flex gap-3">
+              <Skeleton className="size-5 shrink-0 rounded-full" />
+              <div className="flex w-full flex-col gap-2">
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex min-w-0 flex-col gap-3 md:col-span-7 md:col-start-6">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-11/12" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-4/5" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
  * Full page skeleton for decision pages.
  * Includes header, hero, action bar, and content area.
  */

--- a/apps/app/src/components/skeletons/DecisionSkeleton.tsx
+++ b/apps/app/src/components/skeletons/DecisionSkeleton.tsx
@@ -85,11 +85,14 @@ export const DecisionHeaderBarSkeleton = () => {
           <Skeleton className="size-6 rounded md:size-4" />
           <Skeleton className="hidden h-5 w-24 md:block" />
         </div>
+        {/* Mobile centers the decision title (the toggle floats below the bar);
+            md+ shows the view-toggle pill in the center column. */}
         <div className="flex justify-center">
-          <Skeleton className="h-8 w-44 rounded-full" />
+          <Skeleton className="h-5 w-32 rounded md:h-8 md:w-44 md:rounded-full" />
         </div>
         <div className="flex items-center justify-end gap-2 md:gap-4">
-          <Skeleton className="h-7 w-7 rounded" />
+          <Skeleton className="h-8 w-8 rounded-md" />
+          <Skeleton className="h-8 w-8 rounded-md" />
           <Skeleton className="h-8 w-8 rounded-full" />
         </div>
       </div>
@@ -106,11 +109,12 @@ export const DecisionHeaderBarSkeleton = () => {
 export const OverviewSkeleton = () => {
   return (
     <div className="flex w-full flex-col">
-      {/* Hero band: title, meta row, subhead, CTA chips */}
-      <div className="border-b bg-neutral-offWhite">
-        <div className="mx-auto flex max-w-2xl flex-col items-center gap-4 px-4 pt-16 pb-8 text-center md:px-6 md:pb-16">
+      {/* Hero band: same 12-col grid as OverviewHero so the content column
+          width (and therefore text wrap + band height) matches on resolve. */}
+      <div className="grid w-full grid-cols-1 justify-center border-b bg-neutral-offWhite md:grid-cols-12">
+        <div className="mx-auto flex w-full flex-col items-center gap-4 px-4 pt-16 pb-8 text-center md:col-span-6 md:col-start-4 md:px-6 md:pb-16">
           <div className="flex w-full flex-col items-center gap-3">
-            <Skeleton className="h-12 w-3/4 sm:h-14" />
+            <Skeleton className="h-8 w-3/4 md:h-14" />
             <Skeleton className="h-5 w-40" />
             <Skeleton className="h-5 w-1/2" />
           </div>
@@ -124,15 +128,16 @@ export const OverviewSkeleton = () => {
       <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-4 py-6 md:grid-cols-12 md:gap-x-6 md:px-6 md:py-12">
         <div className="flex flex-col gap-4 md:col-span-4">
           <Skeleton className="h-4 w-32" />
-          {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="flex gap-3">
-              <Skeleton className="size-5 shrink-0 rounded-full" />
-              <div className="flex w-full flex-col gap-2">
-                <Skeleton className="h-4 w-2/3" />
-                <Skeleton className="h-3 w-1/2" />
+          {/* Mirrors DecisionPhaseTimeline: a gap-6 list of left-bordered
+              PhaseCards (date row + serif name), not dot rows. */}
+          <div className="flex flex-col gap-6">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="flex flex-col gap-2 border-s px-4 py-2">
+                <Skeleton className="h-4 w-1/2" />
+                <Skeleton className="h-6 w-2/3" />
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
         <div className="flex min-w-0 flex-col gap-3 md:col-span-7 md:col-start-6">
           <Skeleton className="h-4 w-full" />


### PR DESCRIPTION
- The decision overview's loading skeleton rendered the current-phase layout (proposal list + a stepper the page never shows). Replaced with skeletons that mirror the real components: a header-bar skeleton matching `DecisionInstanceHeader`'s dimensions and an `OverviewSkeleton` matching the hero + phase-timeline/About grid.
- `[slug]/loading.tsx` now renders header bar + overview-shaped content for first loads; tab switches get per-tab skeletons via `(decision-view)/loading.tsx` (overview) and a new `current/loading.tsx` (proposal list).