### PR TITLE
feat(support): Show support link for anon users

### DIFF
--- a/apps/app/src/components/SupportLink/index.tsx
+++ b/apps/app/src/components/SupportLink/index.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useUser } from '@/utils/UserProvider';
+import { useMediaQuery } from '@op/hooks';
+import { screens } from '@op/styles/constants';
+import { Button } from '@op/ui/Button';
+import { IconButton } from '@op/ui/IconButton';
+import { LuCircleHelp } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+// Feature requests & support hub. Signed-in, non-anonymous users reach this from
+// the avatar menu; this button surfaces the same link for logged-out visitors
+// and anonymous accounts, who have no account menu to show it in.
+const SUPPORT_URL =
+  'https://oneprojectorg.notion.site/Common-Support-Hub-a9ef0b6622538269927c01e51045638b';
+
+export const SupportLink = () => {
+  const t = useTranslations();
+  const isMobile = useMediaQuery(`(max-width: ${screens.sm})`);
+  const { user } = useUser();
+
+  // Non-anonymous signed-in users already have this link in their avatar menu.
+  if (user && !user.isAnonymous) {
+    return null;
+  }
+
+  const openSupport = () => {
+    window.open(SUPPORT_URL, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <>
+      <IconButton
+        aria-label={t('Feature Requests & Support')}
+        variant="outline"
+        size="medium"
+        className="hidden sm:flex"
+        onPress={openSupport}
+      >
+        <LuCircleHelp className="size-4" />
+      </IconButton>
+      {isMobile ? (
+        <Button
+          color="neutral"
+          unstyled
+          variant="icon"
+          aria-label={t('Feature Requests & Support')}
+          className="flex size-8 items-center justify-center rounded-full bg-neutral-offWhite sm:hidden"
+          onPress={openSupport}
+        >
+          <LuCircleHelp className="size-4" />
+        </Button>
+      ) : null}
+    </>
+  );
+};

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -124,8 +124,8 @@ export const DecisionInstanceHeader = ({
               <LuSettings className="size-4" />
             </ButtonLink>
           )}
-          <LocaleChooser />
           <SupportLink />
+          <LocaleChooser />
           <HeaderUserMenu />
         </div>
       </div>

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -16,6 +16,7 @@ import { Link } from '@/lib/i18n/routing';
 
 import { LocaleChooser } from '../LocaleChooser';
 import { HeaderUserMenu } from '../SiteHeader';
+import { SupportLink } from '../SupportLink';
 import { panelStateParser } from './panelState';
 
 export const DecisionInstanceHeader = ({
@@ -124,6 +125,7 @@ export const DecisionInstanceHeader = ({
             </ButtonLink>
           )}
           <LocaleChooser />
+          <SupportLink />
           <HeaderUserMenu />
         </div>
       </div>


### PR DESCRIPTION
Shows a support link in the header for users who don't have the AvatarMenu because they aren't yet logged in.