### PR TITLE
fix(a11y): always underline links in prose

### DIFF
--- a/apps/app/src/components/ColumbusAddendumContent/index.tsx
+++ b/apps/app/src/components/ColumbusAddendumContent/index.tsx
@@ -16,7 +16,7 @@ export const ColumbusAddendumContent = () => {
         <p className="mb-4">
           These Special Privacy Standards (Special Standards) supplement One
           Project’s{' '}
-          <a href="/info/privacy" className="text-primary-teal hover:underline">
+          <a href="/info/privacy" className="text-primary-teal underline">
             Privacy Notice
           </a>{' '}
           (the Privacy Notice or Notice), and dictate how One Project (One
@@ -28,7 +28,7 @@ export const ColumbusAddendumContent = () => {
         <p className="mb-4">
           These Special Standards accompany, modify, and expand on the
           information in the{' '}
-          <a href="/info/privacy" className="text-primary-teal hover:underline">
+          <a href="/info/privacy" className="text-primary-teal underline">
             Privacy Notice
           </a>
           . Unless otherwise noted, the terms in these Special Standards have
@@ -105,7 +105,7 @@ export const ColumbusAddendumContent = () => {
           See the{' '}
           <a
             href="/info/privacy#marketing-and-cookies"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             Privacy Notice
           </a>{' '}
@@ -120,7 +120,7 @@ export const ColumbusAddendumContent = () => {
         </Header3>
         <p className="mb-4">
           Our reasons for processing the data are listed in our{' '}
-          <a href="/info/privacy" className="text-primary-teal hover:underline">
+          <a href="/info/privacy" className="text-primary-teal underline">
             Privacy Notice
           </a>
           . We may also use this information for any other purpose to which you
@@ -191,7 +191,7 @@ export const ColumbusAddendumContent = () => {
           processing data contemplated in the{' '}
           <a
             href="/info/privacy#service-providers"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             Privacy Notice
           </a>
@@ -205,7 +205,7 @@ export const ColumbusAddendumContent = () => {
             see the{' '}
             <a
               href="https://supabase.com/privacy"
-              className="text-primary-teal hover:underline"
+              className="text-primary-teal underline"
             >
               https://supabase.com/privacy
             </a>
@@ -216,7 +216,7 @@ export const ColumbusAddendumContent = () => {
             how Vercel handles customer data, see the{' '}
             <a
               href="https://vercel.com/legal/dpa-sitecore"
-              className="text-primary-teal hover:underline"
+              className="text-primary-teal underline"
             >
               https://vercel.com/legal/dpa-sitecore
             </a>
@@ -252,7 +252,7 @@ export const ColumbusAddendumContent = () => {
         <p className="mb-4">
           We may also share information if we believe such disclosure is
           necessary to enforce or apply our{' '}
-          <a href="/info/tos" className="text-primary-teal hover:underline">
+          <a href="/info/tos" className="text-primary-teal underline">
             Terms of Service
           </a>
           , or if we believe disclosure is necessary or appropriate to protect
@@ -283,7 +283,7 @@ export const ColumbusAddendumContent = () => {
           Please see our{' '}
           <a
             href="/info/privacy#your-rights"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             Privacy Notice
           </a>{' '}
@@ -322,7 +322,7 @@ export const ColumbusAddendumContent = () => {
           or the Services more generally, please contact{' '}
           <a
             href="mailto:privacy@oneproject.org"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             privacy@oneproject.org
           </a>

--- a/apps/app/src/components/CommunityCommitmentsContent/index.tsx
+++ b/apps/app/src/components/CommunityCommitmentsContent/index.tsx
@@ -12,10 +12,7 @@ export const CommunityCommitmentsContent = () => {
           funders, and municipalities to democratically allocate resources—
           transparently, in any language, at any scale. Common’s users and
           community share these 10 core commitments and agree to abide by the{' '}
-          <a
-            href="#prohibited-content"
-            className="text-primary-teal hover:underline"
-          >
+          <a href="#prohibited-content" className="text-primary-teal underline">
             prohibited content policy
           </a>{' '}
           below.
@@ -151,7 +148,7 @@ export const CommunityCommitmentsContent = () => {
             processes and communities and can enforce their own rules, as long
             as those rules are not in contradiction with the Prohibited Content
             Policy, Community Commitments, and{' '}
-            <a href="/info/tos" className="text-primary-teal hover:underline">
+            <a href="/info/tos" className="text-primary-teal underline">
               Terms of Service
             </a>
             .
@@ -410,7 +407,7 @@ export const CommunityCommitmentsContent = () => {
           a user about an action and should be sent to{' '}
           <a
             href="mailto:support@oneproject.org"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             support@oneproject.org
           </a>

--- a/apps/app/src/components/PrivacyPolicyContent/index.tsx
+++ b/apps/app/src/components/PrivacyPolicyContent/index.tsx
@@ -95,7 +95,7 @@ export const PrivacyPolicyContent = () => {
           <li className="mb-2">
             <a
               href="/info/columbus-addendum"
-              className="text-primary-teal hover:underline"
+              className="text-primary-teal underline"
             >
               Special Privacy Standards for City of Columbus Participatory
               Budgeting Project
@@ -539,10 +539,7 @@ export const PrivacyPolicyContent = () => {
               services by declining to receive such emails when registering, in
               our subsequent communications by following opt-out or unsubscribe
               instructions included in the email, by{' '}
-              <a
-                href="#contact-us"
-                className="text-primary-teal hover:underline"
-              >
+              <a href="#contact-us" className="text-primary-teal underline">
                 contacting us
               </a>
               , or at other information collection points while using the
@@ -564,7 +561,7 @@ export const PrivacyPolicyContent = () => {
               href="http://www.allaboutcookies.org/manage-cookies/index.html"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary-teal hover:underline"
+              className="text-primary-teal underline"
             >
               http://www.allaboutcookies.org/manage-cookies/index.html
             </a>{' '}
@@ -689,7 +686,7 @@ export const PrivacyPolicyContent = () => {
             In the event you wish to make a right request, file a complaint
             about how we process your Personal Data, or appeal the denial of one
             of your requests, please{' '}
-            <a href="#contact-us" className="text-primary-teal hover:underline">
+            <a href="#contact-us" className="text-primary-teal underline">
               contact us
             </a>
             . Even if you make a complaint to us, you may also in some
@@ -816,7 +813,7 @@ export const PrivacyPolicyContent = () => {
             Email:{' '}
             <a
               href="mailto:privacy@oneproject.org"
-              className="text-primary-teal hover:underline"
+              className="text-primary-teal underline"
             >
               privacy@oneproject.org
             </a>

--- a/apps/app/src/components/ToSContent/index.tsx
+++ b/apps/app/src/components/ToSContent/index.tsx
@@ -102,7 +102,7 @@ export const ToSContent = () => {
           information, including, but not limited to, personal information. We
           will treat any personal information that you submit through the
           Services in accordance with our{' '}
-          <a href="/info/privacy" className="text-primary-teal hover:underline">
+          <a href="/info/privacy" className="text-primary-teal underline">
             Privacy Notice
           </a>
           . You may need to create an account with a user name and password to
@@ -132,7 +132,7 @@ export const ToSContent = () => {
           see our{' '}
           <a
             href="/info/community-commitments"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             Community Commitments
           </a>{' '}
@@ -296,7 +296,7 @@ export const ToSContent = () => {
             that violates our{' '}
             <a
               href="/info/community-commitments#prohibited-content"
-              className="text-primary-teal hover:underline"
+              className="text-primary-teal underline"
             >
               Prohibited Content Policy
             </a>
@@ -370,7 +370,7 @@ export const ToSContent = () => {
           that violates our{' '}
           <a
             href="/info/community-commitments#prohibited-content"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             Prohibited Content Policy
           </a>
@@ -398,7 +398,7 @@ export const ToSContent = () => {
           One Project’s Copyright Agent at{' '}
           <a
             href="mailto:privacy@oneproject.org"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             privacy@oneproject.org
           </a>{' '}
@@ -795,7 +795,7 @@ export const ToSContent = () => {
             href="https://www.jamsadr.com/rules-streamlined-arbitration/"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             https://www.jamsadr.com/rules-streamlined-arbitration/
           </a>
@@ -805,7 +805,7 @@ export const ToSContent = () => {
             href="https://www.jamsadr.com/consumer-minimum-standards/"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             https://www.jamsadr.com/consumer-minimum-standards/
           </a>
@@ -890,7 +890,7 @@ export const ToSContent = () => {
           notice sent to that address to{' '}
           <a
             href="mailto:support@oneproject.org"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             support@oneproject.org
           </a>
@@ -899,7 +899,7 @@ export const ToSContent = () => {
           of Service should be directed to:{' '}
           <a
             href="mailto:support@oneproject.org"
-            className="text-primary-teal hover:underline"
+            className="text-primary-teal underline"
           >
             support@oneproject.org
           </a>


### PR DESCRIPTION
Links in prose need some contrast with the surrounding text to be recognizable, especially when there isn't a ton of color contrast between the links and the rest of the text. 