### PR TITLE
feat(decisions): per-phase hero image API

### DIFF
--- a/packages/common/src/services/decision/applyPhaseHeroImage.ts
+++ b/packages/common/src/services/decision/applyPhaseHeroImage.ts
@@ -1,0 +1,55 @@
+import { db, eq } from '@op/db/client';
+import { processInstances } from '@op/db/schema';
+
+import { CommonError } from '../../utils';
+import { deleteStorageObject } from '../../utils/deleteStorageObject';
+import { invalidateDecisionInstance } from './decisionCache';
+import type { DecisionInstanceData } from './schemas/instanceData';
+
+/**
+ * Persists a phase's hero image path into `instanceData.phases[i].heroImage`
+ * and runs the shared post-write cleanup (cache bust + best-effort delete of
+ * the replaced object). Writes `instanceData` directly so sibling phases and
+ * transitions are untouched. Callers own the admin assert, phase lookup, and
+ * (for uploads) the storage trust-boundary check. Shared by
+ * {@link updatePhaseHeroImage} and {@link removePhaseHeroImage}.
+ */
+export async function applyPhaseHeroImage({
+  instanceId,
+  instanceData,
+  phaseId,
+  heroImage,
+  previousPath,
+}: {
+  instanceId: string;
+  instanceData: DecisionInstanceData;
+  phaseId: string;
+  /** New stored path, or '' to clear. */
+  heroImage: string;
+  /** Prior stored path, deleted from the bucket once the write lands. */
+  previousPath?: string;
+}): Promise<void> {
+  const updatedInstanceData: DecisionInstanceData = {
+    ...instanceData,
+    phases: instanceData.phases.map((phase) =>
+      phase.phaseId === phaseId ? { ...phase, heroImage } : phase,
+    ),
+  };
+
+  const [updated] = await db
+    .update(processInstances)
+    .set({ instanceData: updatedInstanceData })
+    .where(eq(processInstances.id, instanceId))
+    .returning({ id: processInstances.id });
+  if (!updated) {
+    throw new CommonError('Failed to update decision process instance');
+  }
+
+  // Cache bust and dropping the replaced object are independent — run together.
+  await Promise.all([
+    invalidateDecisionInstance(instanceId),
+    previousPath && previousPath !== heroImage
+      ? deleteStorageObject({ path: previousPath })
+      : Promise.resolve(),
+  ]);
+}

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -14,6 +14,12 @@ export * from './removeOverviewHeroImage';
 export * from './signOverviewHeroImageUploadUrl';
 export * from './updateOverviewHeroImage';
 
+// Phase hero-image signed-URL upload flow
+export * from './phaseHeroImageStorage';
+export * from './removePhaseHeroImage';
+export * from './signPhaseHeroImageUploadUrl';
+export * from './updatePhaseHeroImage';
+
 // Instance management
 export * from './createInstanceFromTemplate';
 export * from './duplicateInstance';

--- a/packages/common/src/services/decision/phaseHeroImageStorage.ts
+++ b/packages/common/src/services/decision/phaseHeroImageStorage.ts
@@ -1,0 +1,9 @@
+// Phase hero-image upload flow: storage path prefix. Bucket, sanitizer, MIME
+// allowlist, size cap (IMAGE_UPLOAD_SIZE_LIMIT), and the upload trust-boundary
+// check all live in `utils/storage.ts`, shared with the overview hero, proposal
+// attachments, and resource documents so the features can't drift. Scoped per
+// phase so each phase's banner lives under its own folder (mirrors the
+// `${instanceId}/overview/` overview prefix).
+
+export const phaseHeroImagePathPrefix = (instanceId: string, phaseId: string) =>
+  `${instanceId}/phase/${phaseId}/`;

--- a/packages/common/src/services/decision/removePhaseHeroImage.ts
+++ b/packages/common/src/services/decision/removePhaseHeroImage.ts
@@ -1,0 +1,86 @@
+import { db, eq } from '@op/db/client';
+import { processInstances } from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+import { permission } from 'access-zones';
+
+import { CommonError, NotFoundError } from '../../utils';
+import { deleteStorageObject } from '../../utils/deleteStorageObject';
+import { assertProfileAccess } from '../assert';
+import { invalidateDecisionInstance } from './decisionCache';
+import type { DecisionInstanceData } from './schemas/instanceData';
+
+export interface RemovePhaseHeroImageInput {
+  instanceId: string;
+  phaseId: string;
+}
+
+export interface RemovePhaseHeroImageResult {
+  heroImage: '';
+}
+
+/**
+ * Clears a decision phase's hero image: admin-only, drops the stored path
+ * (`instanceData.phases[i].heroImage`) and deletes the underlying storage
+ * object so it doesn't leak in the shared assets bucket. Setting the image goes
+ * through {@link updatePhaseHeroImage}; both write `instanceData.phases`
+ * directly so the generic `updateDecisionInstance` mutation never has to accept
+ * a raw path.
+ */
+export async function removePhaseHeroImage({
+  input,
+  user,
+}: {
+  input: RemovePhaseHeroImageInput;
+  user: User;
+}): Promise<RemovePhaseHeroImageResult> {
+  const { instanceId, phaseId } = input;
+
+  const instance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+    columns: { profileId: true, instanceData: true },
+  });
+  if (!instance?.profileId) {
+    throw new NotFoundError('Process instance', instanceId);
+  }
+
+  await assertProfileAccess({
+    user: { id: user.id },
+    profileId: instance.profileId,
+    permissions: { decisions: permission.ADMIN },
+  });
+
+  const instanceData = instance.instanceData as DecisionInstanceData;
+  const phases = instanceData?.phases ?? [];
+  const targetPhase = phases.find((phase) => phase.phaseId === phaseId);
+  if (!targetPhase) {
+    throw new NotFoundError('Phase', phaseId);
+  }
+
+  const previousPath = targetPhase.heroImage;
+
+  // Nothing stored — no write or cleanup needed.
+  if (!previousPath) {
+    return { heroImage: '' };
+  }
+
+  const updatedInstanceData: DecisionInstanceData = {
+    ...instanceData,
+    phases: phases.map((phase) =>
+      phase.phaseId === phaseId ? { ...phase, heroImage: '' } : phase,
+    ),
+  };
+
+  const [updated] = await db
+    .update(processInstances)
+    .set({ instanceData: updatedInstanceData })
+    .where(eq(processInstances.id, instanceId))
+    .returning({ id: processInstances.id });
+  if (!updated) {
+    throw new CommonError('Failed to update decision process instance');
+  }
+
+  await invalidateDecisionInstance(instanceId);
+  await deleteStorageObject({ path: previousPath });
+
+  return { heroImage: '' };
+}

--- a/packages/common/src/services/decision/removePhaseHeroImage.ts
+++ b/packages/common/src/services/decision/removePhaseHeroImage.ts
@@ -1,12 +1,10 @@
-import { db, eq } from '@op/db/client';
-import { processInstances } from '@op/db/schema';
+import { db } from '@op/db/client';
 import type { User } from '@op/supabase/lib';
 import { permission } from 'access-zones';
 
-import { CommonError, NotFoundError } from '../../utils';
-import { deleteStorageObject } from '../../utils/deleteStorageObject';
+import { NotFoundError } from '../../utils';
 import { assertProfileAccess } from '../assert';
-import { invalidateDecisionInstance } from './decisionCache';
+import { applyPhaseHeroImage } from './applyPhaseHeroImage';
 import type { DecisionInstanceData } from './schemas/instanceData';
 
 export interface RemovePhaseHeroImageInput {
@@ -56,31 +54,18 @@ export async function removePhaseHeroImage({
     throw new NotFoundError('Phase', phaseId);
   }
 
-  const previousPath = targetPhase.heroImage;
-
   // Nothing stored — no write or cleanup needed.
-  if (!previousPath) {
+  if (!targetPhase.heroImage) {
     return { heroImage: '' };
   }
 
-  const updatedInstanceData: DecisionInstanceData = {
-    ...instanceData,
-    phases: phases.map((phase) =>
-      phase.phaseId === phaseId ? { ...phase, heroImage: '' } : phase,
-    ),
-  };
-
-  const [updated] = await db
-    .update(processInstances)
-    .set({ instanceData: updatedInstanceData })
-    .where(eq(processInstances.id, instanceId))
-    .returning({ id: processInstances.id });
-  if (!updated) {
-    throw new CommonError('Failed to update decision process instance');
-  }
-
-  await invalidateDecisionInstance(instanceId);
-  await deleteStorageObject({ path: previousPath });
+  await applyPhaseHeroImage({
+    instanceId,
+    instanceData,
+    phaseId,
+    heroImage: '',
+    previousPath: targetPhase.heroImage,
+  });
 
   return { heroImage: '' };
 }

--- a/packages/common/src/services/decision/schemas/instanceData.ts
+++ b/packages/common/src/services/decision/schemas/instanceData.ts
@@ -42,6 +42,14 @@ export interface PhaseInstanceData {
   startDate?: string;
   endDate?: string;
   settings?: Record<string, unknown>;
+  /**
+   * Storage object path (bucket-relative) of the phase's hero background image,
+   * resolved to a URL via `getPublicUrl`. Empty/undefined falls back to the
+   * gradient banner. Admins upload it from the Process Builder phase editor.
+   * Set/cleared only via the dedicated updatePhaseHeroImage/removePhaseHeroImage
+   * services, never through the generic updateDecisionInstance mutation.
+   */
+  heroImage?: string;
 }
 
 /** Public-facing overview content (headline, short description, rich text body) */

--- a/packages/common/src/services/decision/signPhaseHeroImageUploadUrl.ts
+++ b/packages/common/src/services/decision/signPhaseHeroImageUploadUrl.ts
@@ -1,0 +1,56 @@
+import { db } from '@op/db/client';
+import type { User } from '@op/supabase/lib';
+import { permission } from 'access-zones';
+
+import { NotFoundError } from '../../utils';
+import { signStorageUploadUrl } from '../../utils/signStorageUploadUrl';
+import { assertProfileAccess } from '../assert';
+import { phaseHeroImagePathPrefix } from './phaseHeroImageStorage';
+
+export interface SignPhaseHeroImageUploadUrlInput {
+  instanceId: string;
+  phaseId: string;
+  fileName: string;
+}
+
+export interface SignPhaseHeroImageUploadUrlResult {
+  storagePath: string;
+  signedUrl: string;
+  token: string;
+}
+
+/**
+ * Issues a Supabase signed upload URL for a decision phase's hero image.
+ * Admin-only: the caller must hold decisions ADMIN on the instance's profile,
+ * asserted before any storage access so non-admins can't mint upload URLs. The
+ * client PUTs the file binary straight to storage, then calls
+ * `updatePhaseHeroImage` to validate + persist the path — the same signed-URL
+ * flow the overview hero uses, so large photos never round-trip through the
+ * tRPC body.
+ */
+export async function signPhaseHeroImageUploadUrl({
+  input,
+  user,
+}: {
+  input: SignPhaseHeroImageUploadUrlInput;
+  user: User;
+}): Promise<SignPhaseHeroImageUploadUrlResult> {
+  const instance = await db.query.processInstances.findFirst({
+    where: { id: input.instanceId },
+    columns: { profileId: true },
+  });
+  if (!instance?.profileId) {
+    throw new NotFoundError('Process instance', input.instanceId);
+  }
+
+  await assertProfileAccess({
+    user: { id: user.id },
+    profileId: instance.profileId,
+    permissions: { decisions: permission.ADMIN },
+  });
+
+  return signStorageUploadUrl({
+    pathPrefix: phaseHeroImagePathPrefix(input.instanceId, input.phaseId),
+    fileName: input.fileName,
+  });
+}

--- a/packages/common/src/services/decision/updatePhaseHeroImage.ts
+++ b/packages/common/src/services/decision/updatePhaseHeroImage.ts
@@ -1,0 +1,117 @@
+import { db, eq } from '@op/db/client';
+import { processInstances } from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+import { permission } from 'access-zones';
+
+import { CommonError, NotFoundError, ValidationError } from '../../utils';
+import { deleteStorageObject } from '../../utils/deleteStorageObject';
+import {
+  IMAGE_UPLOAD_SIZE_LIMIT,
+  assertUploadedStorageObject,
+} from '../../utils/storage';
+import { getStorageObjectByPath } from '../../utils/storageObject';
+import { assertProfileAccess } from '../assert';
+import { invalidateDecisionInstance } from './decisionCache';
+import { phaseHeroImagePathPrefix } from './phaseHeroImageStorage';
+import type { DecisionInstanceData } from './schemas/instanceData';
+
+export interface UpdatePhaseHeroImageInput {
+  instanceId: string;
+  phaseId: string;
+  /** Path of the storage object the client just uploaded into. */
+  storagePath: string;
+  /** Client-declared MIME type; must match what storage recorded on PUT. */
+  mimeType: string;
+}
+
+export interface UpdatePhaseHeroImageResult {
+  heroImage: string;
+}
+
+/**
+ * Records the hero image a client uploaded directly to storage via a signed
+ * URL (see {@link signPhaseHeroImageUploadUrl}). Re-asserts admin, then runs the
+ * shared storage trust-boundary check (path prefix, stored Content-Type on the
+ * allowlist matching the declared type, size cap) and requires the object to be
+ * an image before persisting its path into the phase's `heroImage`.
+ *
+ * Writes `instanceData.phases[i].heroImage` directly rather than going through
+ * `updateDecisionInstance`, because that mutation replaces the whole phases
+ * array (dropping siblings) and recomputes transitions — neither of which we
+ * want for a single image change. The read-modify-write shares the same
+ * (admin-only, debounced) race window as the phase autosave; the autosave's
+ * per-phase merge spreads `...existing`, so a stored heroImage is preserved
+ * across unrelated field saves. Clearing goes through {@link removePhaseHeroImage}.
+ */
+export async function updatePhaseHeroImage({
+  input,
+  user,
+}: {
+  input: UpdatePhaseHeroImageInput;
+  user: User;
+}): Promise<UpdatePhaseHeroImageResult> {
+  const { instanceId, phaseId, storagePath, mimeType } = input;
+
+  const instance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+    columns: { profileId: true, instanceData: true },
+  });
+  if (!instance?.profileId) {
+    throw new NotFoundError('Process instance', instanceId);
+  }
+
+  await assertProfileAccess({
+    user: { id: user.id },
+    profileId: instance.profileId,
+    permissions: { decisions: permission.ADMIN },
+  });
+
+  const instanceData = instance.instanceData as DecisionInstanceData;
+  const phases = instanceData?.phases ?? [];
+  const targetPhase = phases.find((phase) => phase.phaseId === phaseId);
+  if (!targetPhase) {
+    throw new NotFoundError('Phase', phaseId);
+  }
+
+  const storageObject = await getStorageObjectByPath({ path: storagePath });
+  const { storedMimeType } = assertUploadedStorageObject({
+    storageObject,
+    storagePath,
+    requiredPathPrefix: phaseHeroImagePathPrefix(instanceId, phaseId),
+    declaredMimeType: mimeType,
+    maxFileSize: IMAGE_UPLOAD_SIZE_LIMIT,
+  });
+  // The shared allowlist also permits PDFs / office docs; the hero is
+  // image-only, so reject anything that isn't an image.
+  if (!storedMimeType.startsWith('image/')) {
+    throw new ValidationError('Hero image must be an image file');
+  }
+
+  // Previous object, so we can drop it once the new path is persisted (a
+  // replaced hero image would otherwise leak in the shared assets bucket).
+  const previousPath = targetPhase.heroImage;
+
+  const updatedInstanceData: DecisionInstanceData = {
+    ...instanceData,
+    phases: phases.map((phase) =>
+      phase.phaseId === phaseId ? { ...phase, heroImage: storagePath } : phase,
+    ),
+  };
+
+  const [updated] = await db
+    .update(processInstances)
+    .set({ instanceData: updatedInstanceData })
+    .where(eq(processInstances.id, instanceId))
+    .returning({ id: processInstances.id });
+  if (!updated) {
+    throw new CommonError('Failed to update decision process instance');
+  }
+
+  await invalidateDecisionInstance(instanceId);
+
+  if (previousPath && previousPath !== storagePath) {
+    await deleteStorageObject({ path: previousPath });
+  }
+
+  return { heroImage: storagePath };
+}

--- a/packages/common/src/services/decision/updatePhaseHeroImage.ts
+++ b/packages/common/src/services/decision/updatePhaseHeroImage.ts
@@ -1,17 +1,15 @@
-import { db, eq } from '@op/db/client';
-import { processInstances } from '@op/db/schema';
+import { db } from '@op/db/client';
 import type { User } from '@op/supabase/lib';
 import { permission } from 'access-zones';
 
-import { CommonError, NotFoundError, ValidationError } from '../../utils';
-import { deleteStorageObject } from '../../utils/deleteStorageObject';
+import { NotFoundError, ValidationError } from '../../utils';
 import {
   IMAGE_UPLOAD_SIZE_LIMIT,
   assertUploadedStorageObject,
 } from '../../utils/storage';
 import { getStorageObjectByPath } from '../../utils/storageObject';
 import { assertProfileAccess } from '../assert';
-import { invalidateDecisionInstance } from './decisionCache';
+import { applyPhaseHeroImage } from './applyPhaseHeroImage';
 import { phaseHeroImagePathPrefix } from './phaseHeroImageStorage';
 import type { DecisionInstanceData } from './schemas/instanceData';
 
@@ -87,31 +85,14 @@ export async function updatePhaseHeroImage({
     throw new ValidationError('Hero image must be an image file');
   }
 
-  // Previous object, so we can drop it once the new path is persisted (a
-  // replaced hero image would otherwise leak in the shared assets bucket).
-  const previousPath = targetPhase.heroImage;
-
-  const updatedInstanceData: DecisionInstanceData = {
-    ...instanceData,
-    phases: phases.map((phase) =>
-      phase.phaseId === phaseId ? { ...phase, heroImage: storagePath } : phase,
-    ),
-  };
-
-  const [updated] = await db
-    .update(processInstances)
-    .set({ instanceData: updatedInstanceData })
-    .where(eq(processInstances.id, instanceId))
-    .returning({ id: processInstances.id });
-  if (!updated) {
-    throw new CommonError('Failed to update decision process instance');
-  }
-
-  await invalidateDecisionInstance(instanceId);
-
-  if (previousPath && previousPath !== storagePath) {
-    await deleteStorageObject({ path: previousPath });
-  }
+  await applyPhaseHeroImage({
+    instanceId,
+    instanceData,
+    phaseId,
+    heroImage: storagePath,
+    // Drop the replaced object so it doesn't leak in the shared assets bucket.
+    previousPath: targetPhase.heroImage,
+  });
 
   return { heroImage: storagePath };
 }

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -192,6 +192,10 @@ export const instancePhaseDataEncoder = z.object({
   selectionPipeline: selectionPipelineEncoder.optional(),
   settingsSchema: jsonSchemaEncoder.optional(),
   settings: z.record(z.string(), z.unknown()).optional(),
+  // Bucket-relative storage path of the phase's hero image. Set/cleared only
+  // via the dedicated updatePhaseHeroImage/removePhaseHeroImage endpoints, so
+  // it's read-only here and omitted from the update input encoder below.
+  heroImage: z.string().optional(),
 });
 
 /**
@@ -517,10 +521,12 @@ export const createInstanceFromTemplateInputSchema = z.object({
 });
 
 /** Input schema for phase overrides with datetime validation */
-const instancePhaseDataInputEncoder = instancePhaseDataEncoder.extend({
-  startDate: z.string().datetime({ offset: true }).optional(),
-  endDate: z.string().datetime({ offset: true }).optional(),
-});
+const instancePhaseDataInputEncoder = instancePhaseDataEncoder
+  .omit({ heroImage: true })
+  .extend({
+    startDate: z.string().datetime({ offset: true }).optional(),
+    endDate: z.string().datetime({ offset: true }).optional(),
+  });
 
 export const updateDecisionInstanceInputSchema = z.object({
   instanceId: z.uuid(),

--- a/services/api/src/routers/decision/instances/index.ts
+++ b/services/api/src/routers/decision/instances/index.ts
@@ -11,11 +11,14 @@ import { listLegacyInstancesRouter } from './listLegacyInstances';
 import { listProposalSubmittersRouter } from './listProposalSubmitters';
 import { listSelectionCandidatesRouter } from './listSelectionCandidates';
 import { removeOverviewHeroImageRouter } from './removeOverviewHeroImage';
+import { removePhaseHeroImageRouter } from './removePhaseHeroImage';
 import { signOverviewHeroImageUploadUrlRouter } from './signOverviewHeroImageUploadUrl';
+import { signPhaseHeroImageUploadUrlRouter } from './signPhaseHeroImageUploadUrl';
 import { submitManualSelectionRouter } from './submitManualSelection';
 import { transitionFromPhaseRouter } from './transitionFromPhase';
 import { updateDecisionInstanceRouter } from './updateDecisionInstance';
 import { updateOverviewHeroImageRouter } from './updateOverviewHeroImage';
+import { updatePhaseHeroImageRouter } from './updatePhaseHeroImage';
 
 export const instancesRouter = mergeRouters(
   createInstanceFromTemplateRouter,
@@ -25,6 +28,9 @@ export const instancesRouter = mergeRouters(
   signOverviewHeroImageUploadUrlRouter,
   updateOverviewHeroImageRouter,
   removeOverviewHeroImageRouter,
+  signPhaseHeroImageUploadUrlRouter,
+  updatePhaseHeroImageRouter,
+  removePhaseHeroImageRouter,
   transitionFromPhaseRouter,
   listLegacyInstancesRouter,
   getInstanceRouter,

--- a/services/api/src/routers/decision/instances/phaseHeroImage.test.ts
+++ b/services/api/src/routers/decision/instances/phaseHeroImage.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  accessTierGatingCell,
+  describeDecisionAccessTierGating,
+  expectFailsAccessTierGate,
+  expectPassesAccessTierGate,
+} from '../../../test/helpers/gating/decision';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+const NIL_UUID = '00000000-0000-0000-0000-000000000000';
+// Phase id seeded by TestDecisionsDataManager.createDecisionSetup.
+const PHASE_ID = 'initial';
+
+describe.concurrent('signPhaseHeroImageUploadUrl', () => {
+  it('should reject a non-admin caller before signing', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instance;
+
+    const memberUser = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const nonAdminCaller = await createAuthenticatedCaller(memberUser.email);
+
+    await expect(
+      nonAdminCaller.decision.signPhaseHeroImageUploadUrl({
+        instanceId: instance.instance.id,
+        phaseId: PHASE_ID,
+        fileName: 'hero.png',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should require authentication', async () => {
+    const caller = createCaller({
+      session: null,
+      user: null,
+    } as never);
+
+    await expect(
+      caller.decision.signPhaseHeroImageUploadUrl({
+        instanceId: NIL_UUID,
+        phaseId: PHASE_ID,
+        fileName: 'hero.png',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should return 404 for a non-existent instance', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 0,
+      grantAccess: true,
+    });
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.signPhaseHeroImageUploadUrl({
+        instanceId: NIL_UUID,
+        phaseId: PHASE_ID,
+        fileName: 'hero.png',
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+});
+
+describe.concurrent('updatePhaseHeroImage', () => {
+  it('should reject a non-admin caller', async ({ task, onTestFinished }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instance;
+
+    const memberUser = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const nonAdminCaller = await createAuthenticatedCaller(memberUser.email);
+
+    await expect(
+      nonAdminCaller.decision.updatePhaseHeroImage({
+        instanceId: instance.instance.id,
+        phaseId: PHASE_ID,
+        storagePath: `${instance.instance.id}/phase/${PHASE_ID}/does-not-exist.png`,
+        mimeType: 'image/png',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should return 404 for a non-existent instance', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 0,
+      grantAccess: true,
+    });
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.updatePhaseHeroImage({
+        instanceId: NIL_UUID,
+        phaseId: PHASE_ID,
+        storagePath: `${NIL_UUID}/phase/${PHASE_ID}/hero.png`,
+        mimeType: 'image/png',
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('should return 404 for a non-existent phase', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      adminCaller.decision.updatePhaseHeroImage({
+        instanceId: setup.instance.instance.id,
+        phaseId: 'no-such-phase',
+        storagePath: `${setup.instance.instance.id}/phase/no-such-phase/hero.png`,
+        mimeType: 'image/png',
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('should reject a storage path with no uploaded object', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+
+    // Admin passes the gate and the phase exists; the storage object was never
+    // uploaded, so the trust-boundary check rejects it.
+    await expect(
+      adminCaller.decision.updatePhaseHeroImage({
+        instanceId: setup.instance.instance.id,
+        phaseId: PHASE_ID,
+        storagePath: `${setup.instance.instance.id}/phase/${PHASE_ID}/never-uploaded.png`,
+        mimeType: 'image/png',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe.concurrent('removePhaseHeroImage', () => {
+  it('should reject a non-admin caller', async ({ task, onTestFinished }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instance;
+
+    const memberUser = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const nonAdminCaller = await createAuthenticatedCaller(memberUser.email);
+
+    await expect(
+      nonAdminCaller.decision.removePhaseHeroImage({
+        instanceId: instance.instance.id,
+        phaseId: PHASE_ID,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should be a no-op for a phase with no hero image', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await adminCaller.decision.removePhaseHeroImage({
+      instanceId: setup.instance.instance.id,
+      phaseId: PHASE_ID,
+    });
+    expect(result.heroImage).toBe('');
+  });
+});
+
+describeDecisionAccessTierGating('signPhaseHeroImageUploadUrl', {
+  noJwtNonPublic: accessTierGatingCell(
+    'rejects no-JWT caller on non-public instance',
+    async ({ task, onTestFinished, callers }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const caller = await callers.noJwt();
+
+      await expectFailsAccessTierGate(
+        caller.decision.signPhaseHeroImageUploadUrl({
+          instanceId: setup.instance.instance.id,
+          phaseId: PHASE_ID,
+          fileName: 'hero.png',
+        }),
+        'none',
+      );
+    },
+  ),
+
+  anonJwtNonPublic: accessTierGatingCell(
+    'rejects anon-JWT caller on non-public instance',
+    async ({ task, onTestFinished, callers }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const caller = await callers.anonJwt();
+
+      await expectFailsAccessTierGate(
+        caller.decision.signPhaseHeroImageUploadUrl({
+          instanceId: setup.instance.instance.id,
+          phaseId: PHASE_ID,
+          fileName: 'hero.png',
+        }),
+        'anon',
+      );
+    },
+  ),
+
+  userJwtNonPublic: accessTierGatingCell(
+    'admits confirmed user-JWT caller past the tier gate',
+    async ({ task, onTestFinished, callers }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const caller = await callers.userJwt();
+
+      // Past the tier gate; the deeper admin assertion still rejects a
+      // non-admin caller (that's not a tier failure).
+      await expectPassesAccessTierGate(
+        caller.decision.signPhaseHeroImageUploadUrl({
+          instanceId: setup.instance.instance.id,
+          phaseId: PHASE_ID,
+          fileName: 'hero.png',
+        }),
+      );
+    },
+  ),
+
+  networkJwtNonPublic: accessTierGatingCell(
+    'admits network-JWT caller past the tier gate',
+    async ({ task, onTestFinished, callers }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const caller = await callers.networkJwt(setup.userEmail);
+
+      await expectPassesAccessTierGate(
+        caller.decision.signPhaseHeroImageUploadUrl({
+          instanceId: setup.instance.instance.id,
+          phaseId: PHASE_ID,
+          fileName: 'hero.png',
+        }),
+      );
+    },
+  ),
+});

--- a/services/api/src/routers/decision/instances/removePhaseHeroImage.ts
+++ b/services/api/src/routers/decision/instances/removePhaseHeroImage.ts
@@ -1,0 +1,34 @@
+import {
+  Channels,
+  removePhaseHeroImage as removePhaseHeroImageService,
+} from '@op/common';
+import { z } from 'zod';
+
+import { authenticatedConfirmedProcedure, router } from '../../../trpcFactory';
+
+/**
+ * Clears a decision phase's hero image (and deletes the storage object). Thin
+ * wrapper: the admin assertion, path clear, and object cleanup live in the
+ * @op/common service; the router registers the realtime channel so subscribers
+ * re-read the now-empty image.
+ */
+export const removePhaseHeroImageRouter = router({
+  removePhaseHeroImage: authenticatedConfirmedProcedure()
+    .input(
+      z.object({
+        instanceId: z.string().uuid(),
+        phaseId: z.string().min(1),
+      }),
+    )
+    .output(z.object({ heroImage: z.literal('') }))
+    .mutation(async ({ input, ctx }) => {
+      const result = await removePhaseHeroImageService({
+        input,
+        user: ctx.user,
+      });
+      ctx.registerMutationChannels([
+        Channels.decisionInstance(input.instanceId),
+      ]);
+      return result;
+    }),
+});

--- a/services/api/src/routers/decision/instances/signPhaseHeroImageUploadUrl.ts
+++ b/services/api/src/routers/decision/instances/signPhaseHeroImageUploadUrl.ts
@@ -1,0 +1,29 @@
+import { signPhaseHeroImageUploadUrl as signPhaseHeroImageUploadUrlService } from '@op/common';
+import { z } from 'zod';
+
+import { authenticatedConfirmedProcedure, router } from '../../../trpcFactory';
+
+/**
+ * Mints a signed upload URL for a decision phase hero image. Thin wrapper:
+ * the admin assertion + signing live in the @op/common service.
+ */
+export const signPhaseHeroImageUploadUrlRouter = router({
+  signPhaseHeroImageUploadUrl: authenticatedConfirmedProcedure()
+    .input(
+      z.object({
+        instanceId: z.string().uuid(),
+        phaseId: z.string().min(1),
+        fileName: z.string().min(1).max(255),
+      }),
+    )
+    .output(
+      z.object({
+        storagePath: z.string(),
+        signedUrl: z.string().url(),
+        token: z.string(),
+      }),
+    )
+    .mutation(({ input, ctx }) =>
+      signPhaseHeroImageUploadUrlService({ input, user: ctx.user }),
+    ),
+});

--- a/services/api/src/routers/decision/instances/updatePhaseHeroImage.ts
+++ b/services/api/src/routers/decision/instances/updatePhaseHeroImage.ts
@@ -1,0 +1,36 @@
+import {
+  Channels,
+  updatePhaseHeroImage as updatePhaseHeroImageService,
+} from '@op/common';
+import { z } from 'zod';
+
+import { authenticatedConfirmedProcedure, router } from '../../../trpcFactory';
+
+/**
+ * Records a phase hero image the client uploaded via a signed URL. Thin
+ * wrapper: the admin assertion, storage trust-boundary check, and persistence
+ * live in the @op/common service; the router registers the realtime channel so
+ * subscribers re-read the new image.
+ */
+export const updatePhaseHeroImageRouter = router({
+  updatePhaseHeroImage: authenticatedConfirmedProcedure()
+    .input(
+      z.object({
+        instanceId: z.string().uuid(),
+        phaseId: z.string().min(1),
+        storagePath: z.string(),
+        mimeType: z.string(),
+      }),
+    )
+    .output(z.object({ heroImage: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      const result = await updatePhaseHeroImageService({
+        input,
+        user: ctx.user,
+      });
+      ctx.registerMutationChannels([
+        Channels.decisionInstance(input.instanceId),
+      ]);
+      return result;
+    }),
+});


### PR DESCRIPTION
Backend for admin-uploadable per-phase hero banners. No UI (that's stacked on top).

- Signed-URL upload flow per phase: `signPhaseHeroImageUploadUrl` / `updatePhaseHeroImage` / `removePhaseHeroImage` (services + tRPC routers).
- Storage prefix `${instanceId}/phase/${phaseId}/`; trust-boundary validation (stored MIME/size/prefix, image-only) + previous-object cleanup.
- `heroImage` on the phase schema + read encoder; omitted from the generic update input (set only via the dedicated endpoints).
- Gating + validation tests.

Stack: this is PR 1 of 3 (API → component refactor → live render).