### PR TITLE
refactor(editor): buildBaseExtensions factory replaces name-string filtering

### DIFF
--- a/apps/app/src/components/RichTextEditor/editorConfig.ts
+++ b/apps/app/src/components/RichTextEditor/editorConfig.ts
@@ -1,20 +1,8 @@
-import { defaultEditorExtensions } from '@op/ui/RichTextEditor';
-import Link from '@tiptap/extension-link';
+import { buildBaseExtensions } from '@op/ui/RichTextEditor';
 import type { AnyExtension } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
 
 import { IframelyExtension } from '../decisions/IframelyExtension';
 import { SlashCommands } from '../decisions/SlashCommands';
-
-/**
- * Base extensions from @op/ui, minus StarterKit and Link (we configure both
- * ourselves — leaving the base Link in would register the extension twice).
- */
-function getBaseExtensions(): AnyExtension[] {
-  return defaultEditorExtensions.filter(
-    (ext) => ext.name !== 'starterKit' && ext.name !== 'link',
-  ) as AnyExtension[];
-}
 
 export interface EditorExtensionOptions {
   slashCommands?: boolean;
@@ -33,20 +21,13 @@ export function getProposalExtensions(
     collaborative = false,
   } = options;
 
-  const extensions: AnyExtension[] = [
-    // heading/link disabled to match @op/ui's base config — StyledHeading and
-    // our own Link.configure below take their place.
-    StarterKit.configure({
-      undoRedo: collaborative ? false : undefined,
-      heading: false,
-      link: false,
-    }),
-    ...getBaseExtensions(),
-    Link.configure({
+  const extensions: AnyExtension[] = buildBaseExtensions({
+    collaborative,
+    link: {
       openOnClick: false,
       linkOnPaste: false, // Disable auto-linking on paste to let Iframely extension handle it
-    }),
-  ];
+    },
+  });
 
   if (linkEmbeds) {
     extensions.push(IframelyExtension as AnyExtension);
@@ -61,14 +42,7 @@ export function getProposalExtensions(
 /** Viewer extensions for read-only proposal display */
 export function getViewerExtensions(): AnyExtension[] {
   return [
-    StarterKit.configure({
-      heading: false,
-      link: false,
-    }),
-    ...getBaseExtensions(),
-    Link.configure({
-      openOnClick: true,
-    }),
+    ...buildBaseExtensions({ link: { openOnClick: true } }),
     IframelyExtension as AnyExtension,
   ];
 }

--- a/apps/app/src/components/RichTextEditor/editorConfig.ts
+++ b/apps/app/src/components/RichTextEditor/editorConfig.ts
@@ -6,10 +6,13 @@ import StarterKit from '@tiptap/starter-kit';
 import { IframelyExtension } from '../decisions/IframelyExtension';
 import { SlashCommands } from '../decisions/SlashCommands';
 
-/** Base extensions from @op/ui, minus StarterKit (we configure it ourselves) */
+/**
+ * Base extensions from @op/ui, minus StarterKit and Link (we configure both
+ * ourselves — leaving the base Link in would register the extension twice).
+ */
 function getBaseExtensions(): AnyExtension[] {
   return defaultEditorExtensions.filter(
-    (ext) => ext.name !== 'starterKit',
+    (ext) => ext.name !== 'starterKit' && ext.name !== 'link',
   ) as AnyExtension[];
 }
 
@@ -31,8 +34,12 @@ export function getProposalExtensions(
   } = options;
 
   const extensions: AnyExtension[] = [
+    // heading/link disabled to match @op/ui's base config — StyledHeading and
+    // our own Link.configure below take their place.
     StarterKit.configure({
       undoRedo: collaborative ? false : undefined,
+      heading: false,
+      link: false,
     }),
     ...getBaseExtensions(),
     Link.configure({
@@ -54,7 +61,10 @@ export function getProposalExtensions(
 /** Viewer extensions for read-only proposal display */
 export function getViewerExtensions(): AnyExtension[] {
   return [
-    StarterKit,
+    StarterKit.configure({
+      heading: false,
+      link: false,
+    }),
     ...getBaseExtensions(),
     Link.configure({
       openOnClick: true,

--- a/apps/app/src/components/collaboration/CollaborativeTextField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTextField.tsx
@@ -2,7 +2,6 @@
 
 import { RequiredAsterisk } from '@op/ui/RequiredAsterisk';
 import { cn } from '@op/ui/utils';
-import Placeholder from '@tiptap/extension-placeholder';
 import type { Editor } from '@tiptap/react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
@@ -57,16 +56,11 @@ export function CollaborativeTextField({
 }: CollaborativeTextFieldProps) {
   const [charCount, setCharCount] = useState(0);
 
+  // No Placeholder extension here — useRichTextEditor registers one from the
+  // `placeholder` prop below; adding our own would duplicate the extension.
   const extensions = useMemo(
-    () => [
-      ...getProposalExtensions({ collaborative: true }),
-      Placeholder.configure({
-        placeholder,
-        emptyEditorClass:
-          'before:content-[attr(data-placeholder)] before:text-neutral-gray3 before:float-start before:h-0 before:pointer-events-none',
-      }),
-    ],
-    [placeholder],
+    () => getProposalExtensions({ collaborative: true }),
+    [],
   );
 
   // Stable refs so the onEditorReady callback doesn't re-trigger on identity changes

--- a/packages/common/src/services/decision/tiptapExtensions.test.ts
+++ b/packages/common/src/services/decision/tiptapExtensions.test.ts
@@ -1,0 +1,19 @@
+import { resolveExtensions } from '@tiptap/core';
+import { describe, expect, it } from 'vitest';
+
+import { serverExtensions } from './tiptapExtensions';
+
+/**
+ * Duplicate extension names are more than a console warning: tiptap keeps both
+ * copies, so both register their ProseMirror plugins/keymaps while only the
+ * last one defines the schema. StarterKit bundles more extensions on major
+ * upgrades (v3 added `link` and `underline`), which silently turned our
+ * explicit registrations into duplicates. This guards the next bump.
+ */
+describe('serverExtensions', () => {
+  it('has no duplicate extension names', () => {
+    const names = resolveExtensions(serverExtensions).map((ext) => ext.name);
+    const duplicates = names.filter((name, i) => names.indexOf(name) !== i);
+    expect([...new Set(duplicates)]).toEqual([]);
+  });
+});

--- a/packages/common/src/services/decision/tiptapExtensions.ts
+++ b/packages/common/src/services/decision/tiptapExtensions.ts
@@ -4,7 +4,6 @@ import Heading from '@tiptap/extension-heading';
 import Image from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
 import TextAlign from '@tiptap/extension-text-align';
-import Underline from '@tiptap/extension-underline';
 import StarterKit from '@tiptap/starter-kit';
 
 /**
@@ -158,8 +157,11 @@ const DetailsContentServerNode = Node.create({
  * @see apps/app/src/components/decisions/IframelyExtension.tsx (client version)
  */
 export const serverExtensions = [
+  // StarterKit bundles underline; link is disabled so our configured Link
+  // below is the only registration (duplicate names trigger a tiptap warning).
   StarterKit.configure({
     heading: false,
+    link: false,
   }),
   // Must match the editor (@op/ui editorConfig allows 1-4). TipTap's
   // Heading.renderHTML falls back to levels[0] for any out-of-range level, so a
@@ -174,7 +176,6 @@ export const serverExtensions = [
     inline: true,
     allowBase64: true,
   }),
-  Underline,
   Link.configure({
     openOnClick: false,
   }),

--- a/packages/ui/src/components/RichTextEditor/editorConfig.ts
+++ b/packages/ui/src/components/RichTextEditor/editorConfig.ts
@@ -1,5 +1,5 @@
 import { headingClasses } from '@op/styles/constants';
-import { Extension, mergeAttributes } from '@tiptap/core';
+import { type AnyExtension, Extension, mergeAttributes } from '@tiptap/core';
 import {
   Details,
   DetailsContent,
@@ -71,53 +71,69 @@ const DetailsFocus = Extension.create({
   },
 });
 
+export interface BaseExtensionOptions {
+  /** Disables local undo/redo so Yjs collaboration can own history. */
+  collaborative?: boolean;
+  link?: {
+    openOnClick?: boolean;
+    linkOnPaste?: boolean;
+  };
+}
+
 /**
- * Base extensions shared by both editor and viewer
+ * The single source for the shared editor/viewer extension set. Every
+ * extension (including StarterKit and Link) is registered exactly once —
+ * consumers layer their own extensions on top of the returned array instead
+ * of filtering or re-registering, which is how duplicate-extension bugs
+ * happen.
  */
-const baseExtensions = [
-  // StarterKit already bundles underline, strike, blockquote and
-  // horizontalRule — don't re-add them or tiptap warns about duplicate
-  // extension names. heading/link are disabled because we register our own
-  // configured versions below.
-  StarterKit.configure({
-    heading: false,
-    link: false,
-  }),
-  DetailsFocus,
-  TextAlign.configure({
-    types: ['heading', 'paragraph'],
-  }),
-  Image.configure({
-    inline: true,
-    allowBase64: true,
-  }),
-  StyledHeading.configure({
-    levels: [1, 2, 3, 4],
-  }),
-  // Vanilla Details extension — its built-in node view provides the toggle
-  // button + `is-open` class; all chrome is styled via `.details` CSS in
-  // @op/styles. `persist` stores the open state in the doc.
-  Details.configure({ persist: true, HTMLAttributes: { class: 'details' } }),
-  DetailsSummary,
-  DetailsContent,
-];
+export function buildBaseExtensions(
+  options: BaseExtensionOptions = {},
+): AnyExtension[] {
+  const { collaborative = false, link } = options;
+
+  return [
+    // StarterKit already bundles underline, strike, blockquote and
+    // horizontalRule — don't re-add them or tiptap warns about duplicate
+    // extension names. heading/link are disabled because we register our own
+    // configured versions below.
+    StarterKit.configure({
+      heading: false,
+      link: false,
+      undoRedo: collaborative ? false : undefined,
+    }),
+    DetailsFocus,
+    TextAlign.configure({
+      types: ['heading', 'paragraph'],
+    }),
+    Image.configure({
+      inline: true,
+      allowBase64: true,
+    }),
+    StyledHeading.configure({
+      levels: [1, 2, 3, 4],
+    }),
+    // Vanilla Details extension — its built-in node view provides the toggle
+    // button + `is-open` class; all chrome is styled via `.details` CSS in
+    // @op/styles. `persist` stores the open state in the doc.
+    Details.configure({ persist: true, HTMLAttributes: { class: 'details' } }),
+    DetailsSummary,
+    DetailsContent,
+    Link.configure({
+      openOnClick: false,
+      ...link,
+    }),
+  ];
+}
 
 /**
  * Default editor extensions for editable content
  */
-export const defaultEditorExtensions = [
-  ...baseExtensions,
-  Link.configure({
-    openOnClick: false,
-  }),
-];
+export const defaultEditorExtensions = buildBaseExtensions();
 
 /**
  * Default viewer extensions for read-only content (links open on click)
  */
-export const defaultViewerExtensions = [
-  ...baseExtensions,
-  Link.configure({
-    openOnClick: true, // Allow clicking links in view mode
-  }),
-];
+export const defaultViewerExtensions = buildBaseExtensions({
+  link: { openOnClick: true },
+});

--- a/packages/ui/src/components/RichTextEditor/editorConfig.ts
+++ b/packages/ui/src/components/RichTextEditor/editorConfig.ts
@@ -1,18 +1,14 @@
 import { headingClasses } from '@op/styles/constants';
 import { Extension, mergeAttributes } from '@tiptap/core';
-import Blockquote from '@tiptap/extension-blockquote';
 import {
   Details,
   DetailsContent,
   DetailsSummary,
 } from '@tiptap/extension-details';
 import Heading from '@tiptap/extension-heading';
-import HorizontalRule from '@tiptap/extension-horizontal-rule';
 import Image from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
-import Strike from '@tiptap/extension-strike';
 import TextAlign from '@tiptap/extension-text-align';
-import Underline from '@tiptap/extension-underline';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import StarterKit from '@tiptap/starter-kit';
@@ -79,7 +75,14 @@ const DetailsFocus = Extension.create({
  * Base extensions shared by both editor and viewer
  */
 const baseExtensions = [
-  StarterKit,
+  // StarterKit already bundles underline, strike, blockquote and
+  // horizontalRule — don't re-add them or tiptap warns about duplicate
+  // extension names. heading/link are disabled because we register our own
+  // configured versions below.
+  StarterKit.configure({
+    heading: false,
+    link: false,
+  }),
   DetailsFocus,
   TextAlign.configure({
     types: ['heading', 'paragraph'],
@@ -91,10 +94,6 @@ const baseExtensions = [
   StyledHeading.configure({
     levels: [1, 2, 3, 4],
   }),
-  Underline,
-  Strike,
-  Blockquote,
-  HorizontalRule,
   // Vanilla Details extension — its built-in node view provides the toggle
   // button + `is-open` class; all chrome is styled via `.details` CSS in
   // @op/styles. `persist` stores the open state in the doc.

--- a/packages/ui/src/components/RichTextEditor/index.ts
+++ b/packages/ui/src/components/RichTextEditor/index.ts
@@ -4,6 +4,8 @@ export { RichTextEditorSkeleton } from './RichTextEditorSkeleton';
 export { StyledRichTextContent } from './StyledRichTextContent';
 export { useRichTextEditor } from './useRichTextEditor';
 export {
+  buildBaseExtensions,
+  type BaseExtensionOptions,
   defaultEditorExtensions,
   defaultViewerExtensions,
   StyledHeading,

--- a/tests/e2e/tests/proposal-editor-toolbar.spec.ts
+++ b/tests/e2e/tests/proposal-editor-toolbar.spec.ts
@@ -81,6 +81,16 @@ test.describe('Proposal Editor Toolbar', () => {
 
     // -- Navigate to editor --------------------------------------------------
 
+    // Guard against duplicate tiptap extension registrations (e.g. StarterKit
+    // majors bundling extensions we also add explicitly). Duplicates register
+    // their ProseMirror plugins/keymaps twice and tiptap warns on the console.
+    const tiptapWarnings: string[] = [];
+    authenticatedPage.on('console', (message) => {
+      if (message.text().includes('[tiptap warn]')) {
+        tiptapWarnings.push(message.text());
+      }
+    });
+
     await authenticatedPage.goto(
       `/en/decisions/${instance.slug}/proposal/${proposal.profileId}/edit`,
       { waitUntil: 'domcontentloaded' },
@@ -175,5 +185,9 @@ test.describe('Proposal Editor Toolbar', () => {
     await expect(
       summarySection.locator('strong', { hasText: 'Summary bold text' }),
     ).toBeVisible();
+
+    // -- No duplicate tiptap extension registrations --------------------------
+
+    expect(tiptapWarnings).toEqual([]);
   });
 });

--- a/tests/e2e/tests/proposal-view.spec.ts
+++ b/tests/e2e/tests/proposal-view.spec.ts
@@ -128,6 +128,15 @@ test.describe('Proposal View', () => {
       },
     });
 
+    // Guard against duplicate tiptap extension registrations in the viewer /
+    // RichTextRenderer path (serverExtensions) — tiptap warns on the console.
+    const tiptapWarnings: string[] = [];
+    authenticatedPage.on('console', (message) => {
+      if (message.text().includes('[tiptap warn]')) {
+        tiptapWarnings.push(message.text());
+      }
+    });
+
     await authenticatedPage.goto(
       `/en/decisions/${instance.slug}/proposal/${proposal.profileId}`,
     );
@@ -186,6 +195,9 @@ test.describe('Proposal View', () => {
     await expect(
       authenticatedPage.getByText('Region', { exact: true }).first(),
     ).toBeVisible();
+
+    // No duplicate tiptap extension registrations.
+    expect(tiptapWarnings).toEqual([]);
   });
 
   test('renders legacy HTML description when no collaborationDocId exists', async ({


### PR DESCRIPTION
Stacked on #1529.

- `@op/ui` exposes `buildBaseExtensions({ collaborative, link })` — the one place the shared extension set (StarterKit options included) is assembled; `defaultEditorExtensions`/`defaultViewerExtensions` become thin wrappers
- `apps/app` `getProposalExtensions`/`getViewerExtensions` layer Iframely/SlashCommands on top instead of filtering `@op/ui`'s defaults by extension name (`'starterKit'`, `'link'`) and re-registering StarterKit and Link