### PR TITLE
refactor(editor): single shared tiptap base for editors and server rendering

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -10,6 +10,7 @@
     "./validation": "./src/utils/validation.ts",
     "./realtime": "./src/realtime/index.ts",
     "./client": "./src/client.ts",
+    "./tiptap": "./src/services/decision/tiptapBase.ts",
     "./src/services/access": "./src/services/access/index.ts",
     "./src/services/decision": "./src/services/decision/index.ts",
     "./locales": "./src/services/translation/locales.ts",

--- a/packages/common/src/services/decision/tiptapBase.ts
+++ b/packages/common/src/services/decision/tiptapBase.ts
@@ -1,0 +1,84 @@
+import { headingClasses } from '@op/styles/constants';
+import { type AnyExtension, mergeAttributes } from '@tiptap/core';
+import Heading from '@tiptap/extension-heading';
+import Image from '@tiptap/extension-image';
+import Link from '@tiptap/extension-link';
+import TextAlign from '@tiptap/extension-text-align';
+import StarterKit from '@tiptap/starter-kit';
+
+/**
+ * TipTap heading extension that bakes the design-system `headingClasses` onto
+ * each rendered `<h1>`–`<h4>` tag, keeping editor output visually identical to
+ * the `Header1/2/3/4` components in `@op/ui`. Any level without a mapped class
+ * renders without a baked class.
+ *
+ * The single definition shared by the live editors (via `@op/ui`'s
+ * `buildBaseExtensions`) and the server-side renderers (`serverExtensions`),
+ * so editor output and generated HTML can't drift.
+ */
+export const StyledHeading = Heading.extend({
+  renderHTML({ node, HTMLAttributes }) {
+    const level = node.attrs.level as 1 | 2 | 3 | 4;
+    const className =
+      headingClasses[`h${level}` as keyof typeof headingClasses];
+    return [
+      `h${level}`,
+      mergeAttributes(
+        this.options.HTMLAttributes,
+        HTMLAttributes,
+        className ? { class: className } : {},
+      ),
+      0,
+    ];
+  },
+});
+
+export interface SharedTiptapBaseOptions {
+  /** Disables local undo/redo so Yjs collaboration can own history. */
+  collaborative?: boolean;
+  link?: {
+    openOnClick?: boolean;
+    linkOnPaste?: boolean;
+  };
+}
+
+/**
+ * The canonical shared TipTap extension set: everything that both the live
+ * editors/viewers (`@op/ui` layers client-only extensions on top) and the
+ * server-side renderers (`serverExtensions` layers schema-only node stubs on
+ * top) must agree on. Every extension — StarterKit options included — is
+ * registered exactly once here; consumers append, never filter or
+ * re-register.
+ *
+ * StarterKit already bundles underline, strike, blockquote and horizontalRule
+ * — don't re-add them or tiptap warns about duplicate extension names.
+ * heading/link are disabled in StarterKit because the configured
+ * StyledHeading/Link below take their place.
+ */
+export function buildSharedTiptapBase(
+  options: SharedTiptapBaseOptions = {},
+): AnyExtension[] {
+  const { collaborative = false, link } = options;
+
+  return [
+    StarterKit.configure({
+      heading: false,
+      link: false,
+      undoRedo: collaborative ? false : undefined,
+    }),
+    TextAlign.configure({
+      types: ['heading', 'paragraph'],
+    }),
+    Image.configure({
+      inline: true,
+      allowBase64: true,
+    }),
+    StyledHeading.configure({
+      levels: [1, 2, 3, 4],
+    }),
+    Link.configure({
+      openOnClick: false,
+      ...link,
+    }),
+  ];
+}

--- a/packages/common/src/services/decision/tiptapExtensions.test.ts
+++ b/packages/common/src/services/decision/tiptapExtensions.test.ts
@@ -1,6 +1,7 @@
-import { resolveExtensions } from '@tiptap/core';
+import { getSchema, resolveExtensions } from '@tiptap/core';
 import { describe, expect, it } from 'vitest';
 
+import { buildSharedTiptapBase } from './tiptapBase';
 import { serverExtensions } from './tiptapExtensions';
 
 /**
@@ -10,10 +11,42 @@ import { serverExtensions } from './tiptapExtensions';
  * upgrades (v3 added `link` and `underline`), which silently turned our
  * explicit registrations into duplicates. This guards the next bump.
  */
+/**
+ * Node types the client editors register beyond the shared base
+ * (React/PM-plugin extensions living in @op/ui and apps/app). Their
+ * schema-only server stubs must exist in `serverExtensions`, or content using
+ * them is silently dropped by `generateHTML()` — and JSON loaded back into an
+ * editor with an unknown type blanks the whole doc.
+ */
+const CLIENT_ONLY_NODE_NAMES = [
+  'details',
+  'detailsSummary',
+  'detailsContent',
+  'iframely',
+];
+
 describe('serverExtensions', () => {
   it('has no duplicate extension names', () => {
     const names = resolveExtensions(serverExtensions).map((ext) => ext.name);
     const duplicates = names.filter((name, i) => names.indexOf(name) !== i);
     expect([...new Set(duplicates)]).toEqual([]);
+  });
+
+  it('covers every node and mark the editors can produce', () => {
+    const serverSchema = getSchema(serverExtensions);
+    const serverNames = new Set([
+      ...Object.keys(serverSchema.nodes),
+      ...Object.keys(serverSchema.marks),
+    ]);
+
+    const editorBaseSchema = getSchema(buildSharedTiptapBase());
+    const requiredNames = [
+      ...Object.keys(editorBaseSchema.nodes),
+      ...Object.keys(editorBaseSchema.marks),
+      ...CLIENT_ONLY_NODE_NAMES,
+    ];
+
+    const missing = requiredNames.filter((name) => !serverNames.has(name));
+    expect(missing).toEqual([]);
   });
 });

--- a/packages/common/src/services/decision/tiptapExtensions.ts
+++ b/packages/common/src/services/decision/tiptapExtensions.ts
@@ -1,31 +1,6 @@
-import { headingClasses } from '@op/styles/constants';
 import { Node, mergeAttributes } from '@tiptap/core';
-import Heading from '@tiptap/extension-heading';
-import Image from '@tiptap/extension-image';
-import Link from '@tiptap/extension-link';
-import TextAlign from '@tiptap/extension-text-align';
-import StarterKit from '@tiptap/starter-kit';
 
-/**
- * Server-side mirror of the `StyledHeading` extension in `@op/ui`. Bakes the
- * shared `headingClasses` onto each rendered heading tag so `generateHTML()`
- * output matches the live editor and the `Header1/2/3` design-system
- * components exactly.
- */
-const StyledHeading = Heading.extend({
-  renderHTML({ node, HTMLAttributes }) {
-    const level = node.attrs.level as 1 | 2 | 3;
-    const className =
-      headingClasses[`h${level}` as keyof typeof headingClasses];
-    return [
-      `h${level}`,
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
-        class: className,
-      }),
-      0,
-    ];
-  },
-});
+import { buildSharedTiptapBase } from './tiptapBase';
 
 /**
  * Server-safe Iframely node extension for `generateHTML()`.
@@ -157,28 +132,9 @@ const DetailsContentServerNode = Node.create({
  * @see apps/app/src/components/decisions/IframelyExtension.tsx (client version)
  */
 export const serverExtensions = [
-  // StarterKit bundles underline; link is disabled so our configured Link
-  // below is the only registration (duplicate names trigger a tiptap warning).
-  StarterKit.configure({
-    heading: false,
-    link: false,
-  }),
-  // Must match the editor (@op/ui editorConfig allows 1-4). TipTap's
-  // Heading.renderHTML falls back to levels[0] for any out-of-range level, so a
-  // narrower list here silently renders a stored H4 as H1.
-  StyledHeading.configure({
-    levels: [1, 2, 3, 4],
-  }),
-  TextAlign.configure({
-    types: ['heading', 'paragraph'],
-  }),
-  Image.configure({
-    inline: true,
-    allowBase64: true,
-  }),
-  Link.configure({
-    openOnClick: false,
-  }),
+  // The shared base (`tiptapBase.ts`) is the same set the live editors build
+  // on, so the schema here can't drift from what the editor can produce.
+  ...buildSharedTiptapBase(),
   IframelyServerNode,
   DetailsServerNode,
   DetailsSummaryServerNode,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -100,6 +100,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@internationalized/date": "catalog:",
+    "@op/common": "workspace:*",
     "@op/core": "workspace:*",
     "@op/hooks": "workspace:*",
     "@op/styles": "workspace:*",

--- a/packages/ui/src/components/RichTextEditor/editorConfig.ts
+++ b/packages/ui/src/components/RichTextEditor/editorConfig.ts
@@ -1,40 +1,17 @@
-import { headingClasses } from '@op/styles/constants';
-import { type AnyExtension, Extension, mergeAttributes } from '@tiptap/core';
+import {
+  type SharedTiptapBaseOptions,
+  buildSharedTiptapBase,
+} from '@op/common/tiptap';
+import { type AnyExtension, Extension } from '@tiptap/core';
 import {
   Details,
   DetailsContent,
   DetailsSummary,
 } from '@tiptap/extension-details';
-import Heading from '@tiptap/extension-heading';
-import Image from '@tiptap/extension-image';
-import Link from '@tiptap/extension-link';
-import TextAlign from '@tiptap/extension-text-align';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
-import StarterKit from '@tiptap/starter-kit';
 
-/**
- * TipTap heading extension that bakes the design-system `headingClasses` onto
- * each rendered `<h1>`–`<h4>` tag, keeping editor output visually identical to
- * the `Header1/2/3/4` components in `@op/ui`. Any level without a mapped class
- * renders without a baked class.
- */
-export const StyledHeading = Heading.extend({
-  renderHTML({ node, HTMLAttributes }) {
-    const level = node.attrs.level as 1 | 2 | 3 | 4;
-    const className =
-      headingClasses[`h${level}` as keyof typeof headingClasses];
-    return [
-      `h${level}`,
-      mergeAttributes(
-        this.options.HTMLAttributes,
-        HTMLAttributes,
-        className ? { class: className } : {},
-      ),
-      0,
-    ];
-  },
-});
+export { StyledHeading } from '@op/common/tiptap';
 
 /**
  * Adds an `is-focused` class to the `details` node that currently contains the
@@ -71,58 +48,28 @@ const DetailsFocus = Extension.create({
   },
 });
 
-export interface BaseExtensionOptions {
-  /** Disables local undo/redo so Yjs collaboration can own history. */
-  collaborative?: boolean;
-  link?: {
-    openOnClick?: boolean;
-    linkOnPaste?: boolean;
-  };
-}
+export type BaseExtensionOptions = SharedTiptapBaseOptions;
 
 /**
- * The single source for the shared editor/viewer extension set. Every
- * extension (including StarterKit and Link) is registered exactly once —
- * consumers layer their own extensions on top of the returned array instead
- * of filtering or re-registering, which is how duplicate-extension bugs
- * happen.
+ * The shared editor/viewer extension set: the canonical base from
+ * `@op/common/tiptap` (the same base `serverExtensions` renders with) plus
+ * the client-only extensions that need a live editor. Every extension is
+ * registered exactly once — consumers layer their own extensions on top of
+ * the returned array instead of filtering or re-registering, which is how
+ * duplicate-extension bugs happen.
  */
 export function buildBaseExtensions(
   options: BaseExtensionOptions = {},
 ): AnyExtension[] {
-  const { collaborative = false, link } = options;
-
   return [
-    // StarterKit already bundles underline, strike, blockquote and
-    // horizontalRule — don't re-add them or tiptap warns about duplicate
-    // extension names. heading/link are disabled because we register our own
-    // configured versions below.
-    StarterKit.configure({
-      heading: false,
-      link: false,
-      undoRedo: collaborative ? false : undefined,
-    }),
+    ...buildSharedTiptapBase(options),
     DetailsFocus,
-    TextAlign.configure({
-      types: ['heading', 'paragraph'],
-    }),
-    Image.configure({
-      inline: true,
-      allowBase64: true,
-    }),
-    StyledHeading.configure({
-      levels: [1, 2, 3, 4],
-    }),
     // Vanilla Details extension — its built-in node view provides the toggle
     // button + `is-open` class; all chrome is styled via `.details` CSS in
     // @op/styles. `persist` stores the open state in the doc.
     Details.configure({ persist: true, HTMLAttributes: { class: 'details' } }),
     DetailsSummary,
     DetailsContent,
-    Link.configure({
-      openOnClick: false,
-      ...link,
-    }),
   ];
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,7 +648,7 @@ importers:
         version: 16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1)
       next-intl:
         specifier: ^4.8.3
-        version: 4.8.3(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3)
+        version: 4.8.3(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3)
       nuqs:
         specifier: ^2.8.5
         version: 2.8.6(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)
@@ -930,7 +930,7 @@ importers:
         version: 3.0.5
       next-intl:
         specifier: ^4.8.3
-        version: 4.8.3(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3)
+        version: 4.8.3(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3)
       react:
         specifier: ^19.0.1
         version: 19.2.1
@@ -1091,6 +1091,9 @@ importers:
       '@internationalized/date':
         specifier: 'catalog:'
         version: 3.12.1
+      '@op/common':
+        specifier: workspace:*
+        version: link:../common
       '@op/core':
         specifier: workspace:*
         version: link:../core
@@ -16180,7 +16183,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.8.3: {}
 
-  next-intl@4.8.3(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3):
+  next-intl@4.8.3(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1))(react@19.2.1)(typescript@5.7.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@parcel/watcher': 2.5.1


### PR DESCRIPTION
Stacked on #1530 (which stacks on #1529).

- `@op/common/tiptap` (new export) holds `buildSharedTiptapBase` + the single `StyledHeading` — the canonical set both the live editors and the server renderers build on
- `@op/ui` `buildBaseExtensions` = shared base + client-only extensions (DetailsFocus, Details node views); `serverExtensions` = shared base + schema-only server stubs, deleting its drifted private StyledHeading copy
- Schema-superset test: `serverExtensions` must cover every node/mark the editors can produce — guards the silent-content-drop / doc-blanking failure mode
- **New workspace dependency `@op/ui` → `@op/common`** — flagging for review; the base is React-free and neither package depended on the other before. Alternative considered: a tiny standalone `@op/tiptap` package (more setup, cleaner layering) — happy to switch if preferred