### PR TITLE
fix(hooks): eliminate hydration mismatches in useMediaQuery and useRelativeTime (React #418)

### DIFF
--- a/packages/hooks/src/useMediaQuery.tsx
+++ b/packages/hooks/src/useMediaQuery.tsx
@@ -1,47 +1,32 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 
 /**
  * Hook that returns true if the media query matches the current window state
  * @param query CSS media query string (e.g. '(max-width: 768px)')
  * @returns boolean indicating if the media query matches
+ *
+ * Implemented with useSyncExternalStore: the server snapshot is always false,
+ * so SSR HTML and the hydration render match (React #418), while components
+ * mounted after hydration read the real value synchronously — no false-frame
+ * flash on client-side navigations.
  */
 const useMediaQuery = (query: string): boolean => {
-  // Initialize with the current match state
-  const [matches, setMatches] = useState<boolean>(() => {
-    // Check if window is defined (client-side)
-    if (typeof window !== 'undefined') {
-      return window.matchMedia(query).matches;
-    }
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const mediaQuery = window.matchMedia(query);
+      mediaQuery.addEventListener('change', onStoreChange);
+      return () => mediaQuery.removeEventListener('change', onStoreChange);
+    },
+    [query],
+  );
 
-    return false; // Default to false on server-side
-  });
-
-  useEffect(() => {
-    // Return early if window is not defined (server-side)
-    if (typeof window === 'undefined') return () => {};
-
-    const mediaQuery = window.matchMedia(query);
-
-    // Update matches when the media query status changes
-    const updateMatches = (event: MediaQueryListEvent) => {
-      setMatches(event.matches);
-    };
-
-    // Set initial value
-    setMatches(mediaQuery.matches);
-
-    // Add event listener
-    mediaQuery.addEventListener('change', updateMatches);
-
-    // Cleanup
-    return () => {
-      mediaQuery.removeEventListener('change', updateMatches);
-    };
-  }, [query]);
-
-  return matches;
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => false,
+  );
 };
 
 export default useMediaQuery;

--- a/packages/hooks/src/useRelativeTime.tsx
+++ b/packages/hooks/src/useRelativeTime.tsx
@@ -22,6 +22,14 @@ export function useRelativeTime(
 
   const format = useFormatter();
   const [updateTrigger, setUpdateTrigger] = useState(0);
+  // Relative time depends on the wall clock, which differs between the server
+  // render and client hydration (React #418). Until mounted, render a
+  // deterministic absolute date instead; the relative string applies after.
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const adaptiveInterval =
     updateInterval ?? getAdaptiveUpdateInterval(dateTime);
@@ -41,6 +49,17 @@ export function useRelativeTime(
 
   return useMemo(() => {
     const date = new Date(dateTime);
+
+    if (!mounted) {
+      // Compact fallback keeps the width close to the post-mount relative
+      // string ("2m", "3d") to minimize layout shift when it swaps in.
+      return format.dateTime(date, {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      });
+    }
+
     let now = new Date();
 
     const diffMs = now.getTime() - date.getTime();
@@ -51,7 +70,7 @@ export function useRelativeTime(
     }
 
     return format.relativeTime(date, { now, style });
-  }, [dateTime, updateTrigger, format, style]);
+  }, [dateTime, updateTrigger, format, style, mounted]);
 }
 
 /**

--- a/packages/hooks/src/useRelativeTime.tsx
+++ b/packages/hooks/src/useRelativeTime.tsx
@@ -3,6 +3,8 @@
 import { useFormatter } from 'next-intl';
 import { useEffect, useMemo, useState } from 'react';
 
+import useMount from './useMount';
+
 /**
  * Returns a locale-aware relative time string with adaptive auto-updates.
  * Shows "now" for timestamps within ±5 seconds.
@@ -25,11 +27,7 @@ export function useRelativeTime(
   // Relative time depends on the wall clock, which differs between the server
   // render and client hydration (React #418). Until mounted, render a
   // deterministic absolute date instead; the relative string applies after.
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const { mounted } = useMount();
 
   const adaptiveInterval =
     updateInterval ?? getAdaptiveUpdateInterval(dateTime);


### PR DESCRIPTION
Fixes React minified error `#418` hydration mismatches caused by client-only values being read during the first render.

- `useMediaQuery`: reimplemented with `useSyncExternalStore` — the server snapshot is always `false` so SSR HTML matches the hydration render, while components mounted after hydration read `matchMedia` synchronously (no false-frame flash on client-side navigations)
- `useRelativeTime`: relative strings depend on the wall clock, which differs between server render and client hydration; render a deterministic compact absolute date until mounted, then swap in the live relative string

Date-formatting hydration fixes (UTC display of phase dates) are split into a separate PR for discussion.