### PR TITLE
fix(app): render decision phase dates deterministically across SSR and hydration (React #418)

### DIFF
--- a/apps/app/src/components/decisions/AdminOverviewBar.tsx
+++ b/apps/app/src/components/decisions/AdminOverviewBar.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@op/ui/Button';
 import { Menu, MenuItem } from '@op/ui/Menu';
 import { Sheet, SheetBody } from '@op/ui/Sheet';
+import { formatPhaseDate } from '@op/ui/utils/formatting';
 import { useLocale } from 'next-intl';
 import { useState } from 'react';
 import { LuEye } from 'react-icons/lu';
@@ -39,10 +40,11 @@ export function AdminOverviewBar({
 
   const endsLabel = phaseEndDate
     ? t('ends {date}', {
-        date: new Date(phaseEndDate).toLocaleDateString(locale, {
-          month: 'long',
-          day: 'numeric',
-        }),
+        date: formatPhaseDate(
+          phaseEndDate,
+          { month: 'long', day: 'numeric' },
+          locale,
+        ),
       })
     : null;
 

--- a/apps/app/src/components/decisions/DecisionListItem.tsx
+++ b/apps/app/src/components/decisions/DecisionListItem.tsx
@@ -8,6 +8,7 @@ import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
 import { OptionMenu } from '@op/ui/OptionMenu';
 import { toast } from '@op/ui/Toast';
 import { cn } from '@op/ui/utils';
+import { formatPhaseDate } from '@op/ui/utils/formatting';
 import { useLocale } from 'next-intl';
 import { useState } from 'react';
 import { LuCalendar } from 'react-icons/lu';
@@ -20,14 +21,12 @@ import { TranslatedText } from '../TranslatedText';
 import { DecisionCardHeader } from './DecisionCardHeader';
 import { DuplicateProcessModal } from './DuplicateProcessModal';
 
-const formatDateShort = (dateString: string, locale: string) => {
-  const date = new Date(dateString);
-  return date.toLocaleDateString(locale, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-};
+const formatDateShort = (dateString: string, locale: string) =>
+  formatPhaseDate(
+    dateString,
+    { month: 'short', day: 'numeric', year: 'numeric' },
+    locale,
+  );
 
 const isClosingSoon = (dateString: string) => {
   const date = new Date(dateString);

--- a/apps/app/src/components/decisions/HiddenProposalsBanner.tsx
+++ b/apps/app/src/components/decisions/HiddenProposalsBanner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { formatDate } from '@/utils/formatting';
 import { AlertBanner } from '@op/ui/AlertBanner';
+import { formatPhaseDate } from '@op/ui/utils/formatting';
 import { useLocale } from 'next-intl';
 import { LuLock } from 'react-icons/lu';
 
@@ -20,10 +20,11 @@ export function HiddenProposalsBanner({
   const locale = useLocale();
 
   const formattedDate = currentPhaseEndDate
-    ? formatDate(currentPhaseEndDate, locale, {
-        month: 'short',
-        day: 'numeric',
-      })
+    ? formatPhaseDate(
+        currentPhaseEndDate,
+        { month: 'short', day: 'numeric' },
+        locale,
+      )
     : undefined;
 
   const message =

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -217,6 +217,11 @@ function PhaseDetailForm({
   const getErrorMessage = (field: string) =>
     touchedFields.has(field) ? errors[field] : undefined;
 
+  // Serializes the picked calendar day as the author's local midnight, which
+  // discards the author's timezone. Display sides compensate with the ±12h
+  // heuristic in formatPhaseDate (@op/ui/utils/formatting).
+  // TODO: store a timezone at the process level (or store phase dates as plain
+  // calendar dates) so the picked day survives without that heuristic.
   const formatDateValue = (date: {
     year: number;
     month: number;

--- a/apps/app/src/components/decisions/VoteSuccessModal.tsx
+++ b/apps/app/src/components/decisions/VoteSuccessModal.tsx
@@ -7,6 +7,7 @@ import { DialogTrigger } from '@op/ui/Dialog';
 import { Header1, Header3 } from '@op/ui/Header';
 import { Modal } from '@op/ui/Modal';
 import { Skeleton } from '@op/ui/Skeleton';
+import { useLocale } from 'next-intl';
 import { Suspense } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -26,6 +27,7 @@ const VoteSuccessModalSuspense = ({
   instanceId,
 }: VoteSuccessModalProps) => {
   const t = useTranslations();
+  const locale = useLocale();
 
   const [processInstance] = trpc.decision.getInstance.useSuspenseQuery({
     instanceId,
@@ -75,7 +77,7 @@ const VoteSuccessModalSuspense = ({
                     {nextSteps.map((step) => (
                       <li key={step.id} className="flex items-start gap-2">
                         <span>•</span>
-                        <span>{formatStepForDisplay(step)}</span>
+                        <span>{formatStepForDisplay(step, locale)}</span>
                       </li>
                     ))}
                   </ul>

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -2,6 +2,7 @@
 
 import { trpc } from '@op/api/client';
 import { type InstancePhaseData } from '@op/api/encoders';
+import { formatPhaseDate } from '@op/ui/utils/formatting';
 import { useLocale } from 'next-intl';
 import { Suspense } from 'react';
 
@@ -63,10 +64,11 @@ export function VotingPage({
     : (translation?.headline ?? currentPhase?.headline ?? t('TIME TO VOTE.'));
 
   const resultsDate = nextPhase?.startDate
-    ? new Date(nextPhase.startDate).toLocaleDateString(locale, {
-        month: 'long',
-        day: 'numeric',
-      })
+    ? formatPhaseDate(
+        nextPhase.startDate,
+        { month: 'long', day: 'numeric' },
+        locale,
+      )
     : undefined;
 
   const heroDescription = hasVoted

--- a/apps/app/src/components/decisions/utils/processSteps.ts
+++ b/apps/app/src/components/decisions/utils/processSteps.ts
@@ -1,3 +1,5 @@
+import { formatPhaseDate } from '@op/ui/utils/formatting';
+
 export interface NextStep {
   id: string;
   name: string;
@@ -42,17 +44,16 @@ export function getNextSteps(
   return upcomingPhases;
 }
 
-export function formatStepForDisplay(step: NextStep): string {
+export function formatStepForDisplay(step: NextStep, locale: string): string {
   if (!step.startDate) {
     return step.name;
   }
 
-  const date = new Date(step.startDate);
-  const formattedDate = date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  const formattedDate = formatPhaseDate(
+    step.startDate,
+    { month: 'short', day: 'numeric', year: 'numeric' },
+    locale,
+  );
 
   return `${step.name} on ${formattedDate}`;
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -93,6 +93,7 @@
     "build": "storybook build",
     "dev": "storybook dev -p 3600 --no-open",
     "format:check": "oxfmt --check",
+    "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
@@ -151,6 +152,7 @@
     "storybook": "^10.1.11",
     "tailwindcss": "4.1.18",
     "typescript": "5.7.3",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/ui/src/utils/formatting.test.ts
+++ b/packages/ui/src/utils/formatting.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDate, formatDateRange, formatPhaseDate } from './formatting';
+
+/**
+ * Phase dates are stored as the author's local midnight serialized to ISO
+ * (ProcessBuilder's `formatDateValue`), so each case below is "author in
+ * timezone X picked July 15, 2026" expressed as the instant that gets stored.
+ */
+describe('formatPhaseDate', () => {
+  it('recovers the picked day for an author east of UTC (Berlin, UTC+2)', () => {
+    expect(formatPhaseDate('2026-07-14T22:00:00.000Z')).toBe('Jul 15');
+  });
+
+  it('recovers the picked day for an author west of UTC (New York, UTC-4)', () => {
+    expect(formatPhaseDate('2026-07-15T04:00:00.000Z')).toBe('Jul 15');
+  });
+
+  it('recovers the picked day for a UTC author', () => {
+    expect(formatPhaseDate('2026-07-15T00:00:00.000Z')).toBe('Jul 15');
+  });
+
+  it('recovers the picked day at the eastern edge (Auckland winter, UTC+12)', () => {
+    expect(formatPhaseDate('2026-07-14T12:00:00.000Z')).toBe('Jul 15');
+  });
+
+  it('recovers the picked day at the western edge (Pago Pago, UTC-11)', () => {
+    expect(formatPhaseDate('2026-07-15T11:00:00.000Z')).toBe('Jul 15');
+  });
+
+  it('passes formatting options through', () => {
+    expect(
+      formatPhaseDate('2026-07-14T22:00:00.000Z', {
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    ).toBe('July 15, 2026');
+  });
+
+  it('formats in the requested locale', () => {
+    expect(
+      formatPhaseDate(
+        '2026-07-14T22:00:00.000Z',
+        { month: 'long', day: 'numeric' },
+        'es-ES',
+      ),
+    ).toContain('julio');
+  });
+
+  // Documents the known ceiling of the ±12h heuristic (see TODO in
+  // formatPhaseDate): an author at UTC+13 (e.g. New Zealand during DST,
+  // picking Jan 15) still renders the previous day. If this assertion starts
+  // failing, the heuristic changed — update the TODO and the docs with it.
+  it('KNOWN LIMITATION: shows the previous day for authors at UTC+13/+14', () => {
+    expect(formatPhaseDate('2026-01-14T11:00:00.000Z')).toBe('Jan 14');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats the UTC calendar day regardless of environment timezone', () => {
+    // 23:30 UTC — already "tomorrow" east of UTC, still "today" west of it.
+    // Pinning to UTC keeps SSR and client output identical (React #418).
+    expect(formatDate('2026-07-06T23:30:00.000Z')).toBe('Jul 6');
+  });
+
+  it('lets callers override the timezone', () => {
+    expect(
+      formatDate('2026-07-07T00:30:00.000Z', {
+        timeZone: 'America/New_York',
+        month: 'short',
+        day: 'numeric',
+      }),
+    ).toBe('Jul 6');
+  });
+});
+
+describe('formatDateRange', () => {
+  it('applies the phase-date shift to both ends', () => {
+    expect(
+      formatDateRange('2026-07-14T22:00:00.000Z', '2026-07-28T22:00:00.000Z'),
+    ).toBe('Jul 15 - Jul 29');
+  });
+
+  it('formats a lone start or end date', () => {
+    expect(formatDateRange('2026-07-14T22:00:00.000Z', undefined)).toBe(
+      'Jul 15',
+    );
+    expect(formatDateRange(undefined, '2026-07-28T22:00:00.000Z')).toBe(
+      'Jul 29',
+    );
+  });
+
+  it('returns an empty string when both dates are missing', () => {
+    expect(formatDateRange(undefined, undefined)).toBe('');
+  });
+});

--- a/packages/ui/src/utils/formatting.ts
+++ b/packages/ui/src/utils/formatting.ts
@@ -4,7 +4,9 @@
  */
 
 /**
- * Format a date string for display in the user's local timezone.
+ * Format a date string for display. Rendered in UTC so server-rendered HTML
+ * matches the client during hydration — a viewer-local timezone would shift
+ * the displayed day near midnight and mismatch the SSR output (React #418).
  */
 export function formatDate(
   dateString: string,
@@ -12,7 +14,28 @@ export function formatDate(
   locale: string = 'en-US',
 ): string {
   const date = new Date(dateString);
-  return date.toLocaleDateString(locale, options);
+  return date.toLocaleDateString(locale, { timeZone: 'UTC', ...options });
+}
+
+/**
+ * Format a process phase date for display.
+ *
+ * Phase dates are stored as the author's local midnight serialized to ISO
+ * (see ProcessBuilder's `formatDateValue`), so the instant's UTC calendar day
+ * can be one day earlier than the day the author picked. Shifting to the
+ * middle of the stored day before formatting in UTC recovers the intended
+ * day for any author timezone within UTC±12, while staying deterministic
+ * across SSR and hydration (React #418).
+ */
+const HALF_DAY_MS = 12 * 60 * 60 * 1000;
+
+export function formatPhaseDate(
+  dateString: string,
+  options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' },
+  locale: string = 'en-US',
+): string {
+  const shifted = new Date(new Date(dateString).getTime() + HALF_DAY_MS);
+  return shifted.toLocaleDateString(locale, { timeZone: 'UTC', ...options });
 }
 
 /**
@@ -28,13 +51,17 @@ export function formatDateRange(
   }
 
   if (startDate && endDate) {
-    return `${formatDate(startDate, { month: 'short', day: 'numeric' }, locale)} - ${formatDate(endDate, { month: 'short', day: 'numeric' }, locale)}`;
+    return `${formatPhaseDate(startDate, { month: 'short', day: 'numeric' }, locale)} - ${formatPhaseDate(endDate, { month: 'short', day: 'numeric' }, locale)}`;
   }
   if (startDate) {
-    return formatDate(startDate, { month: 'short', day: 'numeric' }, locale);
+    return formatPhaseDate(
+      startDate,
+      { month: 'short', day: 'numeric' },
+      locale,
+    );
   }
   if (endDate) {
-    return formatDate(endDate, { month: 'short', day: 'numeric' }, locale);
+    return formatPhaseDate(endDate, { month: 'short', day: 'numeric' }, locale);
   }
   return '';
 }

--- a/packages/ui/src/utils/formatting.ts
+++ b/packages/ui/src/utils/formatting.ts
@@ -26,6 +26,10 @@ export function formatDate(
  * middle of the stored day before formatting in UTC recovers the intended
  * day for any author timezone within UTC±12, while staying deterministic
  * across SSR and hydration (React #418).
+ *
+ * TODO: store a timezone at the process level (or store phase dates as plain
+ * calendar dates) so display doesn't rely on this ±12h heuristic — authors at
+ * UTC+13/+14 (e.g. New Zealand during DST) still see the previous day.
  */
 const HALF_DAY_MS = 12 * 60 * 60 * 1000;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1239,6 +1239,9 @@ importers:
       vite:
         specifier: ^6.2.0
         version: 6.2.0(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(happy-dom@20.5.3)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
   services/api:
     dependencies:
@@ -9265,10 +9268,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -10988,7 +10987,7 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
@@ -11011,7 +11010,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-joda/core@5.7.0': {}
 
@@ -12856,7 +12855,7 @@ snapshots:
       enhanced-resolve: 5.18.4
       jiti: 2.4.2
       lightningcss: 1.30.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       source-map-js: 1.2.1
       tailwindcss: 4.1.8
 
@@ -13732,7 +13731,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 6.2.0(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
 
@@ -13801,7 +13800,7 @@ snapshots:
       '@vue/compiler-ssr': 3.5.13
       '@vue/shared': 3.5.13
       estree-walker: 2.0.2
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       postcss: 8.5.3
       source-map-js: 1.2.1
 
@@ -17690,8 +17689,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.2: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
@@ -18037,7 +18034,7 @@ snapshots:
       picomatch: 4.0.3
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
+      tinyexec: 1.2.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
       vite: 6.2.0(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.85.1)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)


### PR DESCRIPTION
**Scope: display only.** This PR makes decision phase dates render identically for every viewer (and identically between server and client, fixing the React #418 hydration errors). It does not change when phases actually open or close — there are real underlying date/time semantics issues for phases that still need to be addressed (below).

**What it does**
- Phase dates are stored as the author's local midnight serialized to ISO (`formatDateValue`), so an author in UTC+2 picking July 15 stores `2026-07-14T22:00Z`. Viewer-local rendering hydration-mismatched; plain UTC rendering shows July 14 to everyone.
- New `formatPhaseDate` in `@op/ui`: shifts the stored instant +12h and formats in UTC — deterministic across SSR/hydration, and shows the author's intended day for any author timezone within UTC±12. All phase-date call sites use it (AdminOverviewBar, VotingPage, DecisionListItem, HiddenProposalsBanner, VoteSuccessModal, PhaseCard/PhaseStepper via `formatDateRange`).
- `formatDate` now defaults to UTC so created-at style dates ("Submitted on", "Added") are hydration-safe too.
- Tests cover day recovery across author offsets (UTC−11..+12), locale/options, and pin the known limitation below.

**Known limitation (documented + tested):** authors at UTC+13/+14 (e.g. New Zealand during DST) still display the previous day. TODO comments point at the real fix.

**Underlying issues NOT fixed here (need a team decision)**
- The stored "end date" instant is the *start* of the picked day, and the phase transition fires at exactly that instant — so a phase "ending Sep 24" actually closes the moment Sep 24 begins (author time). Participants west of the author lose even more: for a Berlin process, submissions close 3pm the day *before* in Los Angeles, while the UI says "Closes Sep 24".
- Plan: store a timezone at the process level, and decide deadline semantics (inclusive end-of-day in process timezone vs anywhere-on-Earth). Until then this PR only guarantees everyone sees the same calendar day — not that the day is honored as a deadline.