### PR TITLE
fix(maps): update sticky margins and sizing

### DIFF
--- a/apps/app/src/components/decisions/ProposalsMapView.tsx
+++ b/apps/app/src/components/decisions/ProposalsMapView.tsx
@@ -175,7 +175,7 @@ export function ProposalsMapView({
           />
         ))}
       </ul>
-      <aside className="sticky top-20 hidden h-[calc(100dvh_-_9rem)] overflow-hidden rounded-lg border border-neutral-gray1 sm:block">
+      <aside className="sticky top-20 hidden h-[calc(100dvh_-_10rem)] overflow-hidden rounded-lg border border-neutral-gray1 sm:block">
         {map}
       </aside>
     </div>

--- a/apps/app/src/components/decisions/ProposalsMapView.tsx
+++ b/apps/app/src/components/decisions/ProposalsMapView.tsx
@@ -175,7 +175,7 @@ export function ProposalsMapView({
           />
         ))}
       </ul>
-      <aside className="sticky top-[8.25rem] hidden h-[calc(100dvh_-_9rem)] overflow-hidden rounded-lg border border-neutral-gray1 sm:block">
+      <aside className="sticky top-20 hidden h-[calc(100dvh_-_9rem)] overflow-hidden rounded-lg border border-neutral-gray1 sm:block">
         {map}
       </aside>
     </div>


### PR DESCRIPTION
Fixes the top and bottom sticky margins on the map in the proposal list
<img width="1159" height="1433" alt="Screenshot 2026-07-09 at 14 33 21" src="https://github.com/user-attachments/assets/25683977-7717-486b-b183-10a75edfb80e" />
