### PR TITLE
fix(decisions): strip /current from promote-account redirect url

### DIFF
--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -71,7 +71,8 @@ const PromoteAccountModalContent = ({
   // collision error in LinkAccountPanel — route "Log in" to /login and handle the
   // abandoned anon draft.
   const goToLogin = () => {
-    const base = window.location.pathname;
+    // Proposal routes hang off /decisions/[slug], not the /current tab.
+    const base = window.location.pathname.replace(/\/current$/, '');
     const redirect = proposalId ? `${base}/proposal/${proposalId}` : base;
     window.location.assign(
       `/login?link=1&redirect=${encodeURIComponent(redirect)}`,

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -72,7 +72,9 @@ const PromoteAccountModalContent = ({
   // abandoned anon draft.
   const goToLogin = () => {
     // Proposal routes hang off /decisions/[slug], not the /current tab.
-    const base = window.location.pathname.replace(/\/current$/, '');
+    const base = window.location.pathname
+      .replace(/\/+$/, '')
+      .replace(/\/current$/, '');
     const redirect = proposalId ? `${base}/proposal/${proposalId}` : base;
     window.location.assign(
       `/login?link=1&redirect=${encodeURIComponent(redirect)}`,


### PR DESCRIPTION
- The promote-account modal built its post-login redirect from `window.location.pathname`, which includes the `/current` tab segment, producing `/decisions/[slug]/current/proposal/[id]` instead of `/decisions/[slug]/proposal/[id]`.
- Strip a trailing `/current` before appending the proposal path.