### PR TITLE
feat(decisions): add join/claim-account flow for public decision processes

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -36,6 +36,9 @@ const DecisionViewLayout = async ({
   // loadDecision already returned (no separate getInstance fetch).
   const isActive = hasFirstPhaseStarted(instance?.instanceData?.phases);
   const access = instance?.access;
+  // A viewer who can submit proposals without an account is on a "public"
+  // process — the header offers Join (account claim) instead of Log in.
+  const canJoin = access?.submitProposals === true;
 
   return (
     <DecisionTranslationProvider>
@@ -48,10 +51,7 @@ const DecisionViewLayout = async ({
           decisionSlug={slug}
           isAdmin={access?.admin}
           canReadUpdates={access?.admin === true || access?.read === true}
-          // A viewer who can submit proposals without an account is on a
-          // "public" process — the header offers Join (account claim) instead
-          // of Log in. Full accounts still get the avatar menu.
-          canJoin={access?.submitProposals === true}
+          canJoin={canJoin}
           profileName={decisionProfile.name}
           // Pass the instance so the header renders from props (no client
           // getInstance query on this route).
@@ -96,7 +96,7 @@ const DecisionViewLayout = async ({
        * the param via nuqs, hence the Suspense (see the side panel comment).
        */}
       <Suspense fallback={null}>
-        <JoinAccountModal canJoin={access?.submitProposals === true} />
+        <JoinAccountModal canJoin={canJoin} />
       </Suspense>
     </DecisionTranslationProvider>
   );

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -94,10 +94,14 @@ const DecisionViewLayout = async ({
        * Header "Join" modal (account claim on public processes). Mounted in the
        * layout like PromoteAccountModal so `?join=1` works on both tabs; reads
        * the param via nuqs, hence the Suspense (see the side panel comment).
+       * Only mounted when the process is public — non-public pages hydrate
+       * nothing.
        */}
-      <Suspense fallback={null}>
-        <JoinAccountModal canJoin={canJoin} />
-      </Suspense>
+      {canJoin ? (
+        <Suspense fallback={null}>
+          <JoinAccountModal />
+        </Suspense>
+      ) : null}
     </DecisionTranslationProvider>
   );
 };

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -51,7 +51,6 @@ const DecisionViewLayout = async ({
           decisionSlug={slug}
           isAdmin={access?.admin}
           canReadUpdates={access?.admin === true || access?.read === true}
-          canJoin={canJoin}
           profileName={decisionProfile.name}
           // Pass the instance so the header renders from props (no client
           // getInstance query on this route).

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/(decision-view)/layout.tsx
@@ -4,6 +4,7 @@ import { DecisionHeader } from '@/components/decisions/DecisionHeader';
 import { DecisionSidePanel } from '@/components/decisions/DecisionSidePanel';
 import { DecisionTranslationProvider } from '@/components/decisions/DecisionTranslationContext';
 import { DecisionViewToggle } from '@/components/decisions/DecisionViewToggle';
+import { JoinAccountModal } from '@/components/decisions/JoinAccountModal';
 import { PromoteAccountModal } from '@/components/decisions/PromoteAccountModal';
 import { hasFirstPhaseStarted } from '@/components/decisions/hasFirstPhaseStarted';
 
@@ -47,6 +48,10 @@ const DecisionViewLayout = async ({
           decisionSlug={slug}
           isAdmin={access?.admin}
           canReadUpdates={access?.admin === true || access?.read === true}
+          // A viewer who can submit proposals without an account is on a
+          // "public" process — the header offers Join (account claim) instead
+          // of Log in. Full accounts still get the avatar menu.
+          canJoin={access?.submitProposals === true}
           profileName={decisionProfile.name}
           // Pass the instance so the header renders from props (no client
           // getInstance query on this route).
@@ -84,6 +89,14 @@ const DecisionViewLayout = async ({
        */}
       <Suspense fallback={null}>
         <PromoteAccountModal />
+      </Suspense>
+      {/*
+       * Header "Join" modal (account claim on public processes). Mounted in the
+       * layout like PromoteAccountModal so `?join=1` works on both tabs; reads
+       * the param via nuqs, hence the Suspense (see the side panel comment).
+       */}
+      <Suspense fallback={null}>
+        <JoinAccountModal canJoin={access?.submitProposals === true} />
       </Suspense>
     </DecisionTranslationProvider>
   );

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/ProposalViewClient.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/ProposalViewClient.tsx
@@ -56,7 +56,6 @@ function ProposalViewPageContent({
     <ProposalView
       proposal={proposal}
       canSeeRevisions={canSeeRevisions}
-      canJoin={instance.access?.submitProposals === true}
       decisionRoot={`/decisions/${slug}`}
       selection={selection ?? null}
     />

--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/ProposalViewClient.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/ProposalViewClient.tsx
@@ -56,6 +56,7 @@ function ProposalViewPageContent({
     <ProposalView
       proposal={proposal}
       canSeeRevisions={canSeeRevisions}
+      canJoin={instance.access?.submitProposals === true}
       decisionRoot={`/decisions/${slug}`}
       selection={selection ?? null}
     />

--- a/apps/app/src/components/AuthPanel.tsx
+++ b/apps/app/src/components/AuthPanel.tsx
@@ -138,12 +138,14 @@ export const AuthEmailField = ({
   isDisabled,
   onChange,
   onSubmit,
+  placeholder = 'admin@yourorganization.org',
 }: {
   label: string;
   value: string;
   isDisabled: boolean;
   onChange: (value: string) => void;
   onSubmit: () => void;
+  placeholder?: string;
 }) => {
   const t = useTranslations();
 
@@ -162,7 +164,7 @@ export const AuthEmailField = ({
           isRequired
           type="email"
           inputProps={{
-            placeholder: 'admin@yourorganization.org',
+            placeholder,
             spellCheck: false,
           }}
           autoFocus

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { useClaimAccount } from '@/hooks/useClaimAccount';
 import { isSafeRedirectPath } from '@op/common/client';
 import { useMount } from '@op/hooks';
-import { createSBBrowserClient } from '@op/supabase/client';
 import { Button } from '@op/ui/Button';
 import { CheckIcon } from '@op/ui/CheckIcon';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
@@ -29,8 +29,9 @@ import {
  * TODO(anon-upgrade): Google identity linking is deferred; email + OTP only.
  */
 export const LinkAccountPanel = () => {
-  const supabase = createSBBrowserClient();
   const t = useTranslations();
+  const { requestEmailCode, verifyEmailCode, goToOnboarding } =
+    useClaimAccount();
 
   const { mounted } = useMount();
   const searchParams = useSearchParams();
@@ -65,15 +66,12 @@ export const LinkAccountPanel = () => {
   // After linking, route through onboarding with the page to return to.
   // `redirectParam` carries the locale prefix the locale-less /login route lacks.
   const goAfterLink = useCallback(() => {
-    const dest = isSafeRedirectPath(redirectParam) ? redirectParam : '/';
-    const locale = dest.split('/')[1] || 'en';
-    window.location.href = `/${locale}/start?promote=1&redirect=${encodeURIComponent(dest)}`;
-  }, [redirectParam]);
+    goToOnboarding(redirectParam);
+  }, [goToOnboarding, redirectParam]);
 
-  // `updateUser({ email })` attaches the email to the anon user. With email
-  // confirmations on it sends an OTP (→ code screen); with them off the change
-  // applies immediately, so we refresh the session and continue.
-  const requestEmailCode = async () => {
+  // Attach the email to the anon user (see useClaimAccount). OTP sent → code
+  // screen; applied immediately (confirmations off) → straight to onboarding.
+  const submitEmail = async () => {
     if (isSubmitting) {
       return;
     }
@@ -82,18 +80,12 @@ export const LinkAccountPanel = () => {
     setLinkError(undefined);
 
     try {
-      // TODO(anon-upgrade): updateUser fails if this email already belongs to
-      // another account; we surface the raw Supabase error for now.
-      // Productionize with a friendly "that account already exists" path.
-      const { data, error } = await supabase.auth.updateUser({ email });
-      if (error) {
-        setLinkError(error.message);
+      const result = await requestEmailCode(email);
+      if (!result.ok) {
+        setLinkError(result.message);
         return;
       }
-      // No pending change + email already set ⇒ applied immediately (no OTP).
-      if (data.user?.email === email && !data.user?.new_email) {
-        // Refresh so the token drops its stale anonymous claims before we nav.
-        await supabase.auth.refreshSession();
+      if (!result.needsOtp) {
         goAfterLink();
         return;
       }
@@ -110,23 +102,25 @@ export const LinkAccountPanel = () => {
 
     setIsSubmitting(true);
     try {
-      // Link mode confirms an email *change* on the anon user.
-      const { data, error } = await supabase.auth.verifyOtp({
-        email,
-        token,
-        type: 'email_change',
-      });
-
-      if (data.user && data.session && data.user.role === 'authenticated') {
+      const result = await verifyEmailCode({ email, token });
+      if (result.ok) {
         // Freshly upgraded from anonymous — send them through onboarding.
         goAfterLink();
         return;
       }
-      setTokenError(error?.message ?? t('Failed to verify code'));
+      setTokenError(result.message ?? t('Failed to verify code'));
     } finally {
       setIsSubmitting(false);
     }
-  }, [email, token, isSubmitting, goAfterLink, setTokenError, supabase, t]);
+  }, [
+    email,
+    token,
+    isSubmitting,
+    goAfterLink,
+    setTokenError,
+    verifyEmailCode,
+    t,
+  ]);
 
   // "Go back" from the code screen returns to email entry without losing the
   // anon session (only the success/token state is cleared).
@@ -256,7 +250,7 @@ export const LinkAccountPanel = () => {
             setEmail(val);
           }}
           onSubmit={() => {
-            void requestEmailCode();
+            void submitEmail();
           }}
         />
         <Button
@@ -264,7 +258,7 @@ export const LinkAccountPanel = () => {
           className="flex w-full items-center justify-center"
           isDisabled={isSubmitting || !emailIsValid}
           onPress={() => {
-            void requestEmailCode();
+            void submitEmail();
           }}
         >
           {isSubmitting ? <LoadingSpinner /> : t('Continue')}

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { useClaimAccount } from '@/hooks/useClaimAccount';
+import {
+  getClaimEmailErrorMessage,
+  goToOnboarding,
+  useClaimAccount,
+} from '@/hooks/useClaimAccount';
 import { isSafeRedirectPath } from '@op/common/client';
 import { useMount } from '@op/hooks';
 import { Button } from '@op/ui/Button';
@@ -30,8 +34,7 @@ import {
  */
 export const LinkAccountPanel = () => {
   const t = useTranslations();
-  const { requestEmailCode, verifyEmailCode, goToOnboarding } =
-    useClaimAccount();
+  const { requestEmailCode, verifyEmailCode } = useClaimAccount();
 
   const { mounted } = useMount();
   const searchParams = useSearchParams();
@@ -67,7 +70,7 @@ export const LinkAccountPanel = () => {
   // `redirectParam` carries the locale prefix the locale-less /login route lacks.
   const goAfterLink = useCallback(() => {
     goToOnboarding(redirectParam);
-  }, [goToOnboarding, redirectParam]);
+  }, [redirectParam]);
 
   // Attach the email to the anon user (see useClaimAccount). OTP sent → code
   // screen; applied immediately (confirmations off) → straight to onboarding.
@@ -84,11 +87,7 @@ export const LinkAccountPanel = () => {
     try {
       const result = await requestEmailCode(email);
       if (!result.ok) {
-        setLinkError(
-          result.alreadySignedIn
-            ? t("You're already signed in. Reload the page to continue.")
-            : (result.message ?? t("That didn't work")),
-        );
+        setLinkError(getClaimEmailErrorMessage(result, t));
         setIsSubmitting(false);
         return;
       }

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -12,7 +12,6 @@ import { CheckIcon } from '@op/ui/CheckIcon';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { useSearchParams } from 'next/navigation';
 import React, { useCallback, useState } from 'react';
-import { z } from 'zod';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -23,6 +22,7 @@ import {
   isValidOtpLength,
   useAuthPanelStore,
 } from './AuthPanel';
+import { isValidEmail } from './decisions/emailUtils';
 
 /**
  * Account-upgrade panel for an anonymous visitor ("link mode"), reached via
@@ -57,8 +57,6 @@ export const LinkAccountPanel = () => {
     loginSuccess,
     setLoginSuccess,
   } = useAuthPanelStore();
-
-  const emailParser = z.email();
 
   // "Already have an account? Log in" — a real full account can't be linked
   // onto the anon user, so that path drops link mode and goes to normal login.
@@ -256,7 +254,7 @@ export const LinkAccountPanel = () => {
           value={email}
           isDisabled={isSubmitting}
           onChange={(val) => {
-            setEmailIsValid(emailParser.safeParse(val).success);
+            setEmailIsValid(isValidEmail(val));
             setEmail(val);
           }}
           onSubmit={() => {

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -79,10 +79,17 @@ export const LinkAccountPanel = () => {
     setIsSubmitting(true);
     setLinkError(undefined);
 
+    // isSubmitting stays true through goAfterLink so the form can't be
+    // re-submitted while window.location is unloading the page.
     try {
       const result = await requestEmailCode(email);
       if (!result.ok) {
-        setLinkError(result.message);
+        setLinkError(
+          result.alreadySignedIn
+            ? t("You're already signed in. Reload the page to continue.")
+            : (result.message ?? t("That didn't work")),
+        );
+        setIsSubmitting(false);
         return;
       }
       if (!result.needsOtp) {
@@ -90,7 +97,9 @@ export const LinkAccountPanel = () => {
         return;
       }
       setLoginSuccess(true);
-    } finally {
+      setIsSubmitting(false);
+    } catch {
+      setLinkError(t("That didn't work"));
       setIsSubmitting(false);
     }
   };
@@ -105,13 +114,15 @@ export const LinkAccountPanel = () => {
       const result = await verifyEmailCode({ email, token });
       if (result.ok) {
         // Freshly upgraded from anonymous — send them through onboarding.
+        // isSubmitting stays true while the page unloads.
         goAfterLink();
         return;
       }
       setTokenError(result.message ?? t('Failed to verify code'));
-    } finally {
-      setIsSubmitting(false);
+    } catch {
+      setTokenError(t('Failed to verify code'));
     }
+    setIsSubmitting(false);
   }, [
     email,
     token,

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -30,6 +30,12 @@ interface StandardDecisionHeaderProps extends DecisionHeaderBaseProps {
   useLegacy?: false;
   /** Whether the current user can read decision updates */
   canReadUpdates?: boolean;
+  /**
+   * Public process (viewer can submit proposals without an account): the
+   * header offers "Join" (account claim) instead of "Log in" to logged-out
+   * and anonymous visitors.
+   */
+  canJoin?: boolean;
   /** Center-column content, e.g. the Overview / Current Phase toggle */
   centerSlot?: ReactNode;
   /** Whether to render the phase stepper below the header bar (default true) */
@@ -108,6 +114,7 @@ function DecisionHeaderView({
   decisionSlug,
   isAdmin,
   canReadUpdates,
+  canJoin,
   centerSlot,
   showStepper = true,
   title,
@@ -135,6 +142,7 @@ function DecisionHeaderView({
         decisionSlug={decisionSlug}
         isAdmin={isAdmin}
         canReadUpdates={canReadUpdates}
+        canJoin={canJoin}
         centerSlot={centerSlot}
         mobileAdminBar={
           showAdminControls && decisionSlug ? (
@@ -170,6 +178,7 @@ function DecisionHeaderContent(props: StandardDecisionHeaderProps) {
   return (
     <DecisionHeaderView
       {...props}
+      canJoin={props.canJoin ?? instance.access?.submitProposals === true}
       title={
         props.profileName ||
         instance.name ||

--- a/apps/app/src/components/decisions/DecisionHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionHeader.tsx
@@ -30,12 +30,6 @@ interface StandardDecisionHeaderProps extends DecisionHeaderBaseProps {
   useLegacy?: false;
   /** Whether the current user can read decision updates */
   canReadUpdates?: boolean;
-  /**
-   * Public process (viewer can submit proposals without an account): the
-   * header offers "Join" (account claim) instead of "Log in" to logged-out
-   * and anonymous visitors.
-   */
-  canJoin?: boolean;
   /** Center-column content, e.g. the Overview / Current Phase toggle */
   centerSlot?: ReactNode;
   /** Whether to render the phase stepper below the header bar (default true) */
@@ -125,6 +119,12 @@ function DecisionHeaderView({
   title: string;
   phases: ProcessPhase[];
   currentStateId: string;
+  /**
+   * Public process (viewer can submit proposals without an account): the
+   * header offers "Join" (account claim) instead of "Log in" to logged-out
+   * and anonymous visitors. Derived from the instance by both variants.
+   */
+  canJoin: boolean;
   /** Stored overview hero image path, for the admin Edit-banner controls. */
   heroImagePath?: string;
 }) {
@@ -178,7 +178,7 @@ function DecisionHeaderContent(props: StandardDecisionHeaderProps) {
   return (
     <DecisionHeaderView
       {...props}
-      canJoin={props.canJoin ?? instance.access?.submitProposals === true}
+      canJoin={instance.access?.submitProposals === true}
       title={
         props.profileName ||
         instance.name ||
@@ -203,6 +203,7 @@ function DecisionHeaderFromProps(
   return (
     <DecisionHeaderView
       {...props}
+      canJoin={instance.access?.submitProposals === true}
       title={
         props.profileName ||
         instance.name ||

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useUser } from '@/utils/UserProvider';
 import { userCanInteract } from '@/utils/userCanInteract';
-import { Button, ButtonLink } from '@op/ui/Button';
+import { ButtonLink } from '@op/ui/Button';
 import { Header2 } from '@op/ui/Header';
 import { IconButton } from '@op/ui/IconButton';
 import { MegaphoneIcon } from '@op/ui/MegaphoneIcon';
@@ -17,7 +17,10 @@ import { Link } from '@/lib/i18n/routing';
 import { LocaleChooser } from '../LocaleChooser';
 import { HeaderUserMenu } from '../SiteHeader';
 import { SupportLink } from '../SupportLink';
-import { JoinDecisionButton } from './JoinAccountModal';
+import {
+  JoinDecisionButton,
+  JoinDecisionButtonFallback,
+} from './JoinAccountModal';
 import { panelStateParser } from './panelState';
 
 export const DecisionInstanceHeader = ({
@@ -136,15 +139,7 @@ export const DecisionInstanceHeader = ({
           {canJoin && (!user || user.isAnonymous) ? (
             // The button reads/writes `?join` via nuqs (useSearchParams), so it
             // needs the same Suspense treatment as the updates toggle above.
-            // The fallback is an inert copy so the static shell shows the same
-            // button.
-            <Suspense
-              fallback={
-                <Button color="primary" size="small">
-                  {t('Join')}
-                </Button>
-              }
-            >
+            <Suspense fallback={<JoinDecisionButtonFallback />}>
               <JoinDecisionButton />
             </Suspense>
           ) : (

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -15,12 +15,8 @@ import { useTranslations } from '@/lib/i18n';
 import { Link } from '@/lib/i18n/routing';
 
 import { LocaleChooser } from '../LocaleChooser';
-import { HeaderUserMenu } from '../SiteHeader';
 import { SupportLink } from '../SupportLink';
-import {
-  JoinDecisionButton,
-  JoinDecisionButtonFallback,
-} from './JoinAccountModal';
+import { JoinOrUserMenu } from './JoinAccountModal';
 import { panelStateParser } from './panelState';
 
 export const DecisionInstanceHeader = ({
@@ -136,15 +132,7 @@ export const DecisionInstanceHeader = ({
           )}
           <SupportLink />
           <LocaleChooser />
-          {canJoin && (!user || user.isAnonymous) ? (
-            // The button reads/writes `?join` via nuqs (useSearchParams), so it
-            // needs the same Suspense treatment as the updates toggle above.
-            <Suspense fallback={<JoinDecisionButtonFallback />}>
-              <JoinDecisionButton />
-            </Suspense>
-          ) : (
-            <HeaderUserMenu />
-          )}
+          <JoinOrUserMenu canJoin={canJoin} />
         </div>
       </div>
 

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useUser } from '@/utils/UserProvider';
 import { userCanInteract } from '@/utils/userCanInteract';
-import { ButtonLink } from '@op/ui/Button';
+import { Button, ButtonLink } from '@op/ui/Button';
 import { Header2 } from '@op/ui/Header';
 import { IconButton } from '@op/ui/IconButton';
 import { MegaphoneIcon } from '@op/ui/MegaphoneIcon';
@@ -17,6 +17,7 @@ import { Link } from '@/lib/i18n/routing';
 import { LocaleChooser } from '../LocaleChooser';
 import { HeaderUserMenu } from '../SiteHeader';
 import { SupportLink } from '../SupportLink';
+import { JoinDecisionButton } from './JoinAccountModal';
 import { panelStateParser } from './panelState';
 
 export const DecisionInstanceHeader = ({
@@ -25,6 +26,7 @@ export const DecisionInstanceHeader = ({
   decisionSlug,
   isAdmin,
   canReadUpdates = false,
+  canJoin = false,
   centerSlot,
   mobileAdminBar,
 }: {
@@ -36,6 +38,11 @@ export const DecisionInstanceHeader = ({
   decisionSlug?: string;
   isAdmin?: boolean;
   canReadUpdates?: boolean;
+  /**
+   * Public process: offer "Join" (account claim, see JoinAccountModal) instead
+   * of "Log in" to logged-out and anonymous visitors.
+   */
+  canJoin?: boolean;
   /**
    * Optional content for the header's center column (e.g. the Overview /
    * Current Phase toggle). When provided, on md+ the title moves beside the
@@ -126,7 +133,23 @@ export const DecisionInstanceHeader = ({
           )}
           <SupportLink />
           <LocaleChooser />
-          <HeaderUserMenu />
+          {canJoin && (!user || user.isAnonymous) ? (
+            // The button reads/writes `?join` via nuqs (useSearchParams), so it
+            // needs the same Suspense treatment as the updates toggle above.
+            // The fallback is an inert copy so the static shell shows the same
+            // button.
+            <Suspense
+              fallback={
+                <Button color="primary" size="small">
+                  {t('Join')}
+                </Button>
+              }
+            >
+              <JoinDecisionButton />
+            </Suspense>
+          ) : (
+            <HeaderUserMenu />
+          )}
         </div>
       </div>
 

--- a/apps/app/src/components/decisions/JoinAccountModal.tsx
+++ b/apps/app/src/components/decisions/JoinAccountModal.tsx
@@ -56,7 +56,7 @@ export const JoinAccountModal = () => {
       onOpenChange={(open) => (open ? null : close())}
       isDismissable
       surface="flat"
-      className="sm:max-w-[29rem]"
+      className="sm:max-w-128"
     >
       <JoinAccountModalContent />
     </Modal>

--- a/apps/app/src/components/decisions/JoinAccountModal.tsx
+++ b/apps/app/src/components/decisions/JoinAccountModal.tsx
@@ -58,7 +58,7 @@ export const JoinAccountModal = () => {
 
 /** Header button that opens the modal. Reads/writes `?join` via nuqs, so any
  * mount point must sit under a Suspense boundary (useSearchParams). */
-export const JoinDecisionButton = () => {
+export const JoinDecisionButton = ({ className }: { className?: string }) => {
   const t = useTranslations();
   const [, setJoin] = useQueryState('join');
 
@@ -66,6 +66,7 @@ export const JoinDecisionButton = () => {
     <Button
       color="primary"
       size="small"
+      className={className}
       onPress={() => {
         void setJoin('1');
       }}

--- a/apps/app/src/components/decisions/JoinAccountModal.tsx
+++ b/apps/app/src/components/decisions/JoinAccountModal.tsx
@@ -58,7 +58,7 @@ export const JoinAccountModal = () => {
 
 /** Header button that opens the modal. Reads/writes `?join` via nuqs, so any
  * mount point must sit under a Suspense boundary (useSearchParams). */
-export const JoinDecisionButton = ({ className }: { className?: string }) => {
+export const JoinDecisionButton = () => {
   const t = useTranslations();
   const [, setJoin] = useQueryState('join');
 
@@ -66,7 +66,6 @@ export const JoinDecisionButton = ({ className }: { className?: string }) => {
     <Button
       color="primary"
       size="small"
-      className={className}
       onPress={() => {
         void setJoin('1');
       }}

--- a/apps/app/src/components/decisions/JoinAccountModal.tsx
+++ b/apps/app/src/components/decisions/JoinAccountModal.tsx
@@ -6,6 +6,7 @@ import {
   useClaimAccount,
 } from '@/hooks/useClaimAccount';
 import { useUser } from '@/utils/UserProvider';
+import type { CommonUser } from '@op/api/encoders';
 import { headingClasses } from '@op/styles/constants';
 import { Button, ButtonLink } from '@op/ui/Button';
 import { IconButton } from '@op/ui/IconButton';
@@ -13,13 +14,14 @@ import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Modal } from '@op/ui/Modal';
 import { usePathname } from 'next/navigation';
 import { useQueryState } from 'nuqs';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, Suspense, useState } from 'react';
 import { Heading } from 'react-aria-components';
 import { LuX } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
 import { AuthCodeField, AuthEmailField, isValidOtpLength } from '../AuthPanel';
+import { HeaderUserMenu } from '../SiteHeader';
 import { isValidEmail } from './emailUtils';
 
 /**
@@ -34,11 +36,19 @@ import { isValidEmail } from './emailUtils';
  * won't open for one.
  */
 
+/**
+ * Who may claim: logged-out visitors and anonymous accounts. NOT the same as
+ * `!userCanInteract` — a full account without a currentProfile must see the
+ * user menu, not Join.
+ */
+export const isJoinEligible = (user: CommonUser | null | undefined): boolean =>
+  !user || user.isAnonymous;
+
 export const JoinAccountModal = () => {
   const { user } = useUser();
   const [join, setJoin] = useQueryState('join');
 
-  const isOpen = (!user || user.isAnonymous) && join === '1';
+  const isOpen = isJoinEligible(user) && join === '1';
 
   const close = () => {
     void setJoin(null);
@@ -58,7 +68,12 @@ export const JoinAccountModal = () => {
 
 /** Header button that opens the modal. Reads/writes `?join` via nuqs, so any
  * mount point must sit under a Suspense boundary (useSearchParams). */
-export const JoinDecisionButton = () => {
+export const JoinDecisionButton = ({
+  ariaDescribedBy,
+}: {
+  /** Id of an element giving the bare "Join" label its context (a11y). */
+  ariaDescribedBy?: string;
+}) => {
   const t = useTranslations();
   const [, setJoin] = useQueryState('join');
 
@@ -66,6 +81,7 @@ export const JoinDecisionButton = () => {
     <Button
       color="primary"
       size="small"
+      aria-describedby={ariaDescribedBy}
       onPress={() => {
         void setJoin('1');
       }}
@@ -87,6 +103,33 @@ export const JoinDecisionButtonFallback = () => {
       {t('Join')}
     </ButtonLink>
   );
+};
+
+/**
+ * Header account control: Join (account claim) for join-eligible visitors on
+ * public processes, the avatar menu / Log in otherwise. Owns the eligibility
+ * check and the Suspense treatment JoinDecisionButton's nuqs read requires, so
+ * every header renders the same behavior.
+ */
+export const JoinOrUserMenu = ({
+  canJoin,
+  userMenuClassName,
+}: {
+  canJoin: boolean;
+  /** Passed to HeaderUserMenu only — lets headers keep the avatar sm-gated
+   * while Join stays visible at all widths. */
+  userMenuClassName?: string;
+}) => {
+  const { user } = useUser();
+
+  if (canJoin && isJoinEligible(user)) {
+    return (
+      <Suspense fallback={<JoinDecisionButtonFallback />}>
+        <JoinDecisionButton />
+      </Suspense>
+    );
+  }
+  return <HeaderUserMenu className={userMenuClassName} />;
 };
 
 const JoinAccountModalContent = ({ onClose }: { onClose: () => void }) => {

--- a/apps/app/src/components/decisions/JoinAccountModal.tsx
+++ b/apps/app/src/components/decisions/JoinAccountModal.tsx
@@ -2,13 +2,15 @@
 
 import { useClaimAccount } from '@/hooks/useClaimAccount';
 import { useUser } from '@/utils/UserProvider';
-import { Button } from '@op/ui/Button';
-import { Header1 } from '@op/ui/Header';
+import { headingClasses } from '@op/styles/constants';
+import { Button, ButtonLink } from '@op/ui/Button';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Modal } from '@op/ui/Modal';
 import { usePathname } from 'next/navigation';
 import { useQueryState } from 'nuqs';
 import { type ReactNode, useState } from 'react';
+import { Heading } from 'react-aria-components';
+import { LuX } from 'react-icons/lu';
 import { z } from 'zod';
 
 import { useTranslations } from '@/lib/i18n';
@@ -40,16 +42,17 @@ export const JoinAccountModal = ({ canJoin }: { canJoin: boolean }) => {
     <Modal
       isOpen={isOpen}
       onOpenChange={(open) => (open ? null : close())}
+      isDismissable
       className="sm:max-w-[29rem]"
     >
-      <JoinAccountModalContent />
+      <JoinAccountModalContent onClose={close} />
     </Modal>
   );
 };
 
 /** Header button that opens the modal. Reads/writes `?join` via nuqs, so any
  * mount point must sit under a Suspense boundary (useSearchParams). */
-export const JoinDecisionButton = ({ className }: { className?: string }) => {
+export const JoinDecisionButton = () => {
   const t = useTranslations();
   const [, setJoin] = useQueryState('join');
 
@@ -57,7 +60,6 @@ export const JoinDecisionButton = ({ className }: { className?: string }) => {
     <Button
       color="primary"
       size="small"
-      className={className}
       onPress={() => {
         void setJoin('1');
       }}
@@ -67,9 +69,23 @@ export const JoinDecisionButton = ({ className }: { className?: string }) => {
   );
 };
 
+/**
+ * Suspense fallback for JoinDecisionButton in the prerendered shell: a plain
+ * link so the button works even before hydration (nuqs takes over after).
+ */
+export const JoinDecisionButtonFallback = () => {
+  const t = useTranslations();
+
+  return (
+    <ButtonLink href="?join=1" color="primary" size="small">
+      {t('Join')}
+    </ButtonLink>
+  );
+};
+
 const emailParser = z.email();
 
-const JoinAccountModalContent = () => {
+const JoinAccountModalContent = ({ onClose }: { onClose: () => void }) => {
   const t = useTranslations();
   const { requestEmailCode, verifyEmailCode, goToOnboarding } =
     useClaimAccount();
@@ -98,10 +114,17 @@ const JoinAccountModalContent = () => {
     setIsSubmitting(true);
     setError(undefined);
 
+    // Deliberately left submitting through the success-navigation path so the
+    // form can't be re-submitted while window.location is unloading the page.
     try {
-      const result = await requestEmailCode(email);
+      const result = await requestEmailCode(email, { mintAnonSession: true });
       if (!result.ok) {
-        setError(result.message);
+        setError(
+          result.alreadySignedIn
+            ? t("You're already signed in. Reload the page to continue.")
+            : (result.message ?? t("That didn't work")),
+        );
+        setIsSubmitting(false);
         return;
       }
       if (!result.needsOtp) {
@@ -109,7 +132,9 @@ const JoinAccountModalContent = () => {
         return;
       }
       setOtpSent(true);
-    } finally {
+      setIsSubmitting(false);
+    } catch {
+      setError(t("That didn't work"));
       setIsSubmitting(false);
     }
   };
@@ -129,9 +154,10 @@ const JoinAccountModalContent = () => {
         return;
       }
       setError(result.message ?? t('Failed to verify code'));
-    } finally {
-      setIsSubmitting(false);
+    } catch {
+      setError(t('Failed to verify code'));
     }
+    setIsSubmitting(false);
   };
 
   const goBack = () => {
@@ -145,11 +171,26 @@ const JoinAccountModalContent = () => {
   const loginHref = `/login?redirect=${encodeURIComponent(pathname)}`;
 
   return (
-    <div className="flex flex-col gap-6 p-8 text-center sm:px-12 sm:py-12">
+    <div className="relative flex flex-col gap-6 p-8 text-center sm:px-12 sm:py-12">
+      <button
+        type="button"
+        aria-label={t('Close')}
+        onClick={onClose}
+        className="absolute end-4 top-4 flex size-6 cursor-pointer items-center justify-center rounded-md text-neutral-charcoal outline-hidden hover:bg-neutral-gray1 focus-visible:ring-2 focus-visible:ring-primary-teal focus-visible:ring-offset-2"
+      >
+        <LuX className="size-5" aria-hidden />
+      </button>
+
       <div className="flex flex-col gap-2">
-        <Header1>
+        {/* RAC Heading wires the dialog's accessible name (aria-labelledby);
+            level 2 avoids a second h1 on the page. */}
+        <Heading
+          slot="title"
+          level={2}
+          className={`${headingClasses.h1} text-neutral-black`}
+        >
           {otpSent ? t('Email sent!') : t('Claim your account')}
-        </Header1>
+        </Heading>
         <p className="text-base text-neutral-charcoal">
           {otpSent
             ? t(
@@ -162,7 +203,13 @@ const JoinAccountModalContent = () => {
         </p>
       </div>
 
-      {error ? <p className="text-sm text-functional-red">{error}</p> : null}
+      {/* role="alert" so async claim errors are announced while focus stays on
+          the submit button. */}
+      {error ? (
+        <p role="alert" className="text-sm text-functional-red">
+          {error}
+        </p>
+      ) : null}
 
       {otpSent ? (
         <div className="flex flex-col gap-3 text-start">
@@ -194,6 +241,7 @@ const JoinAccountModalContent = () => {
           <div className="text-start">
             <AuthEmailField
               label={t('Email')}
+              // Example-email placeholders are deliberately untranslated.
               placeholder="your@email.com"
               value={email}
               isDisabled={isSubmitting}

--- a/apps/app/src/components/decisions/JoinAccountModal.tsx
+++ b/apps/app/src/components/decisions/JoinAccountModal.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useClaimAccount } from '@/hooks/useClaimAccount';
+import { useUser } from '@/utils/UserProvider';
+import { Button } from '@op/ui/Button';
+import { Header1 } from '@op/ui/Header';
+import { LoadingSpinner } from '@op/ui/LoadingSpinner';
+import { Modal } from '@op/ui/Modal';
+import { usePathname } from 'next/navigation';
+import { useQueryState } from 'nuqs';
+import { type ReactNode, useState } from 'react';
+import { z } from 'zod';
+
+import { useTranslations } from '@/lib/i18n';
+
+import { AuthCodeField, AuthEmailField, isValidOtpLength } from '../AuthPanel';
+
+/**
+ * "Join" flow for public decision processes: claims a full account for the
+ * current visitor (see useClaimAccount) directly in a modal — email, then OTP,
+ * then the promote onboarding at /start. Opened by JoinDecisionButton (the
+ * header's replacement for "Log in" on public processes) via `?join=1`.
+ *
+ * Only meaningful for logged-out and anonymous visitors; a full account never
+ * sees the Join button and the modal won't open for one.
+ */
+
+export const JoinAccountModal = ({ canJoin }: { canJoin: boolean }) => {
+  const { user } = useUser();
+  const [join, setJoin] = useQueryState('join');
+
+  const isOpen =
+    canJoin && (!user || Boolean(user.isAnonymous)) && join === '1';
+
+  const close = () => {
+    void setJoin(null);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => (open ? null : close())}
+      className="sm:max-w-[29rem]"
+    >
+      <JoinAccountModalContent />
+    </Modal>
+  );
+};
+
+/** Header button that opens the modal. Reads/writes `?join` via nuqs, so any
+ * mount point must sit under a Suspense boundary (useSearchParams). */
+export const JoinDecisionButton = ({ className }: { className?: string }) => {
+  const t = useTranslations();
+  const [, setJoin] = useQueryState('join');
+
+  return (
+    <Button
+      color="primary"
+      size="small"
+      className={className}
+      onPress={() => {
+        void setJoin('1');
+      }}
+    >
+      {t('Join')}
+    </Button>
+  );
+};
+
+const emailParser = z.email();
+
+const JoinAccountModalContent = () => {
+  const t = useTranslations();
+  const { requestEmailCode, verifyEmailCode, goToOnboarding } =
+    useClaimAccount();
+  // next/navigation (not the i18n router): the locale prefix must stay — the
+  // promote-onboarding redirect and the locale-less /login route both need it.
+  const pathname = usePathname();
+
+  const [email, setEmail] = useState('');
+  const [emailIsValid, setEmailIsValid] = useState(false);
+  const [token, setToken] = useState<string | undefined>();
+  const [otpSent, setOtpSent] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Return to this decision page after onboarding. Query params are dropped
+  // deliberately — `join=1` must not re-open the modal on the way back.
+  const goAfterClaim = () => {
+    goToOnboarding(pathname);
+  };
+
+  const submitEmail = async () => {
+    if (isSubmitting || !emailIsValid) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(undefined);
+
+    try {
+      const result = await requestEmailCode(email);
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      if (!result.needsOtp) {
+        goAfterClaim();
+        return;
+      }
+      setOtpSent(true);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const submitToken = async () => {
+    if (!token || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(undefined);
+
+    try {
+      const result = await verifyEmailCode({ email, token });
+      if (result.ok) {
+        goAfterClaim();
+        return;
+      }
+      setError(result.message ?? t('Failed to verify code'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const goBack = () => {
+    setOtpSent(false);
+    setToken(undefined);
+    setError(undefined);
+  };
+
+  // Native anchor: /login is outside the [locale] tree, so a RAC link 404s at
+  // /en/login (same as HeaderUserMenu).
+  const loginHref = `/login?redirect=${encodeURIComponent(pathname)}`;
+
+  return (
+    <div className="flex flex-col gap-6 p-8 text-center sm:px-12 sm:py-12">
+      <div className="flex flex-col gap-2">
+        <Header1>
+          {otpSent ? t('Email sent!') : t('Claim your account')}
+        </Header1>
+        <p className="text-base text-neutral-charcoal">
+          {otpSent
+            ? t(
+                'A code was sent to {email}. Type the code below to create your profile.',
+                { email },
+              )
+            : t(
+                'Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.',
+              )}
+        </p>
+      </div>
+
+      {error ? <p className="text-sm text-functional-red">{error}</p> : null}
+
+      {otpSent ? (
+        <div className="flex flex-col gap-3 text-start">
+          <AuthCodeField
+            value={token}
+            isDisabled={isSubmitting}
+            onChange={setToken}
+            onSubmit={submitToken}
+          />
+          <Button
+            className="flex w-full items-center justify-center"
+            isDisabled={isSubmitting || !isValidOtpLength(token)}
+            onPress={() => {
+              void submitToken();
+            }}
+          >
+            {isSubmitting ? <LoadingSpinner /> : t('Create profile')}
+          </Button>
+          <Button
+            color="secondary"
+            className="flex w-full items-center justify-center"
+            onPress={goBack}
+          >
+            {t('Go back')}
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <div className="text-start">
+            <AuthEmailField
+              label={t('Email')}
+              placeholder="your@email.com"
+              value={email}
+              isDisabled={isSubmitting}
+              onChange={(val) => {
+                setEmailIsValid(emailParser.safeParse(val).success);
+                setEmail(val);
+              }}
+              onSubmit={() => {
+                void submitEmail();
+              }}
+            />
+          </div>
+          <Button
+            className="flex w-full items-center justify-center"
+            isDisabled={isSubmitting || !emailIsValid}
+            onPress={() => {
+              void submitEmail();
+            }}
+          >
+            {isSubmitting ? <LoadingSpinner /> : t('Join')}
+          </Button>
+          <p className="text-sm text-neutral-charcoal">
+            {t.rich('Already have an account? <login>Log in</login>', {
+              login: (chunks: ReactNode) => (
+                <a href={loginHref} className="text-primary-teal underline">
+                  {chunks}
+                </a>
+              ),
+            })}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/app/src/components/decisions/JoinAccountModal.tsx
+++ b/apps/app/src/components/decisions/JoinAccountModal.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { useClaimAccount } from '@/hooks/useClaimAccount';
+import {
+  getClaimEmailErrorMessage,
+  goToOnboarding,
+  useClaimAccount,
+} from '@/hooks/useClaimAccount';
 import { useUser } from '@/utils/UserProvider';
 import { headingClasses } from '@op/styles/constants';
 import { Button, ButtonLink } from '@op/ui/Button';
+import { IconButton } from '@op/ui/IconButton';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Modal } from '@op/ui/Modal';
 import { usePathname } from 'next/navigation';
@@ -11,11 +16,11 @@ import { useQueryState } from 'nuqs';
 import { type ReactNode, useState } from 'react';
 import { Heading } from 'react-aria-components';
 import { LuX } from 'react-icons/lu';
-import { z } from 'zod';
 
 import { useTranslations } from '@/lib/i18n';
 
 import { AuthCodeField, AuthEmailField, isValidOtpLength } from '../AuthPanel';
+import { isValidEmail } from './emailUtils';
 
 /**
  * "Join" flow for public decision processes: claims a full account for the
@@ -23,16 +28,17 @@ import { AuthCodeField, AuthEmailField, isValidOtpLength } from '../AuthPanel';
  * then the promote onboarding at /start. Opened by JoinDecisionButton (the
  * header's replacement for "Log in" on public processes) via `?join=1`.
  *
- * Only meaningful for logged-out and anonymous visitors; a full account never
- * sees the Join button and the modal won't open for one.
+ * Mounted only on public processes (the decision-view layout gates on the
+ * viewer's submitProposals access) and only meaningful for logged-out and
+ * anonymous visitors; a full account never sees the Join button and the modal
+ * won't open for one.
  */
 
-export const JoinAccountModal = ({ canJoin }: { canJoin: boolean }) => {
+export const JoinAccountModal = () => {
   const { user } = useUser();
   const [join, setJoin] = useQueryState('join');
 
-  const isOpen =
-    canJoin && (!user || Boolean(user.isAnonymous)) && join === '1';
+  const isOpen = (!user || user.isAnonymous) && join === '1';
 
   const close = () => {
     void setJoin(null);
@@ -83,22 +89,20 @@ export const JoinDecisionButtonFallback = () => {
   );
 };
 
-const emailParser = z.email();
-
 const JoinAccountModalContent = ({ onClose }: { onClose: () => void }) => {
   const t = useTranslations();
-  const { requestEmailCode, verifyEmailCode, goToOnboarding } =
-    useClaimAccount();
+  const { requestEmailCode, verifyEmailCode } = useClaimAccount();
   // next/navigation (not the i18n router): the locale prefix must stay — the
   // promote-onboarding redirect and the locale-less /login route both need it.
   const pathname = usePathname();
 
   const [email, setEmail] = useState('');
-  const [emailIsValid, setEmailIsValid] = useState(false);
   const [token, setToken] = useState<string | undefined>();
   const [otpSent, setOtpSent] = useState(false);
   const [error, setError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const emailIsValid = isValidEmail(email);
 
   // Return to this decision page after onboarding. Query params are dropped
   // deliberately — `join=1` must not re-open the modal on the way back.
@@ -119,11 +123,7 @@ const JoinAccountModalContent = ({ onClose }: { onClose: () => void }) => {
     try {
       const result = await requestEmailCode(email, { mintAnonSession: true });
       if (!result.ok) {
-        setError(
-          result.alreadySignedIn
-            ? t("You're already signed in. Reload the page to continue.")
-            : (result.message ?? t("That didn't work")),
-        );
+        setError(getClaimEmailErrorMessage(result, t));
         setIsSubmitting(false);
         return;
       }
@@ -172,23 +172,19 @@ const JoinAccountModalContent = ({ onClose }: { onClose: () => void }) => {
 
   return (
     <div className="relative flex flex-col gap-6 p-8 text-center sm:px-12 sm:py-12">
-      <button
-        type="button"
+      <IconButton
+        size="small"
         aria-label={t('Close')}
-        onClick={onClose}
-        className="absolute end-4 top-4 flex size-6 cursor-pointer items-center justify-center rounded-md text-neutral-charcoal outline-hidden hover:bg-neutral-gray1 focus-visible:ring-2 focus-visible:ring-primary-teal focus-visible:ring-offset-2"
+        onPress={onClose}
+        className="absolute end-4 top-4"
       >
         <LuX className="size-5" aria-hidden />
-      </button>
+      </IconButton>
 
       <div className="flex flex-col gap-2">
         {/* RAC Heading wires the dialog's accessible name (aria-labelledby);
             level 2 avoids a second h1 on the page. */}
-        <Heading
-          slot="title"
-          level={2}
-          className={`${headingClasses.h1} text-neutral-black`}
-        >
+        <Heading slot="title" level={2} className={headingClasses.h2}>
           {otpSent ? t('Email sent!') : t('Claim your account')}
         </Heading>
         <p className="text-base text-neutral-charcoal">
@@ -245,10 +241,7 @@ const JoinAccountModalContent = ({ onClose }: { onClose: () => void }) => {
               placeholder="your@email.com"
               value={email}
               isDisabled={isSubmitting}
-              onChange={(val) => {
-                setEmailIsValid(emailParser.safeParse(val).success);
-                setEmail(val);
-              }}
+              onChange={setEmail}
               onSubmit={() => {
                 void submitEmail();
               }}

--- a/apps/app/src/components/decisions/JoinAccountModal.tsx
+++ b/apps/app/src/components/decisions/JoinAccountModal.tsx
@@ -7,16 +7,12 @@ import {
 } from '@/hooks/useClaimAccount';
 import { useUser } from '@/utils/UserProvider';
 import type { CommonUser } from '@op/api/encoders';
-import { headingClasses } from '@op/styles/constants';
 import { Button, ButtonLink } from '@op/ui/Button';
-import { IconButton } from '@op/ui/IconButton';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
-import { Modal } from '@op/ui/Modal';
+import { Modal, ModalBody, ModalHeader } from '@op/ui/Modal';
 import { usePathname } from 'next/navigation';
 import { useQueryState } from 'nuqs';
 import { type ReactNode, Suspense, useState } from 'react';
-import { Heading } from 'react-aria-components';
-import { LuX } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -59,9 +55,10 @@ export const JoinAccountModal = () => {
       isOpen={isOpen}
       onOpenChange={(open) => (open ? null : close())}
       isDismissable
+      surface="flat"
       className="sm:max-w-[29rem]"
     >
-      <JoinAccountModalContent onClose={close} />
+      <JoinAccountModalContent />
     </Modal>
   );
 };
@@ -132,7 +129,7 @@ export const JoinOrUserMenu = ({
   return <HeaderUserMenu className={userMenuClassName} />;
 };
 
-const JoinAccountModalContent = ({ onClose }: { onClose: () => void }) => {
+const JoinAccountModalContent = () => {
   const t = useTranslations();
   const { requestEmailCode, verifyEmailCode } = useClaimAccount();
   // next/navigation (not the i18n router): the locale prefix must stay — the
@@ -214,22 +211,14 @@ const JoinAccountModalContent = ({ onClose }: { onClose: () => void }) => {
   const loginHref = `/login?redirect=${encodeURIComponent(pathname)}`;
 
   return (
-    <div className="relative flex flex-col gap-6 p-8 text-center sm:px-12 sm:py-12">
-      <IconButton
-        size="small"
-        aria-label={t('Close')}
-        onPress={onClose}
-        className="absolute end-4 top-4"
-      >
-        <LuX className="size-5" aria-hidden />
-      </IconButton>
-
-      <div className="flex flex-col gap-2">
-        {/* RAC Heading wires the dialog's accessible name (aria-labelledby);
-            level 2 avoids a second h1 on the page. */}
-        <Heading slot="title" level={2} className={headingClasses.h2}>
-          {otpSent ? t('Email sent!') : t('Claim your account')}
-        </Heading>
+    <>
+      {/* ModalHeader renders the dismiss X (Modal's isDismissable) and a
+          slot="title" heading that names the dialog. pt compensates for the
+          flat surface's built-in pt-6 to hit p-8 / sm:pt-12 overall. */}
+      <ModalHeader className="pt-2 text-title-lg text-neutral-black sm:pt-6 sm:text-title-lg">
+        {otpSent ? t('Email sent!') : t('Claim your account')}
+      </ModalHeader>
+      <ModalBody className="gap-6 px-8 pt-2 pb-8 text-center sm:px-12 sm:pb-12">
         <p className="text-base text-neutral-charcoal">
           {otpSent
             ? t(
@@ -240,76 +229,72 @@ const JoinAccountModalContent = ({ onClose }: { onClose: () => void }) => {
                 'Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.',
               )}
         </p>
-      </div>
 
-      {/* role="alert" so async claim errors are announced while focus stays on
+        {/* role="alert" so async claim errors are announced while focus stays on
           the submit button. */}
-      {error ? (
-        <p role="alert" className="text-sm text-functional-red">
-          {error}
-        </p>
-      ) : null}
+        {error ? (
+          <p role="alert" className="text-sm text-functional-red">
+            {error}
+          </p>
+        ) : null}
 
-      {otpSent ? (
-        <div className="flex flex-col gap-3 text-start">
-          <AuthCodeField
-            value={token}
-            isDisabled={isSubmitting}
-            onChange={setToken}
-            onSubmit={submitToken}
-          />
-          <Button
-            className="flex w-full items-center justify-center"
-            isDisabled={isSubmitting || !isValidOtpLength(token)}
-            onPress={() => {
-              void submitToken();
-            }}
-          >
-            {isSubmitting ? <LoadingSpinner /> : t('Create profile')}
-          </Button>
-          <Button
-            color="secondary"
-            className="flex w-full items-center justify-center"
-            onPress={goBack}
-          >
-            {t('Go back')}
-          </Button>
-        </div>
-      ) : (
-        <div className="flex flex-col gap-4">
-          <div className="text-start">
-            <AuthEmailField
-              label={t('Email')}
-              // Example-email placeholders are deliberately untranslated.
-              placeholder="your@email.com"
-              value={email}
+        {otpSent ? (
+          <div className="flex flex-col gap-3 text-start">
+            <AuthCodeField
+              value={token}
               isDisabled={isSubmitting}
-              onChange={setEmail}
-              onSubmit={() => {
+              onChange={setToken}
+              onSubmit={submitToken}
+            />
+            <Button
+              className="w-full"
+              isDisabled={isSubmitting || !isValidOtpLength(token)}
+              onPress={() => {
+                void submitToken();
+              }}
+            >
+              {isSubmitting ? <LoadingSpinner /> : t('Create profile')}
+            </Button>
+            <Button color="secondary" className="w-full" onPress={goBack}>
+              {t('Go back')}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <div className="text-start">
+              <AuthEmailField
+                label={t('Email')}
+                // Example-email placeholders are deliberately untranslated.
+                placeholder="your@email.com"
+                value={email}
+                isDisabled={isSubmitting}
+                onChange={setEmail}
+                onSubmit={() => {
+                  void submitEmail();
+                }}
+              />
+            </div>
+            <Button
+              className="w-full"
+              isDisabled={isSubmitting || !emailIsValid}
+              onPress={() => {
                 void submitEmail();
               }}
-            />
+            >
+              {isSubmitting ? <LoadingSpinner /> : t('Join')}
+            </Button>
+            <p className="text-neutral-charcoal">
+              {t.rich('Already have an account? <login>Log in</login>', {
+                login: (chunks: ReactNode) => (
+                  <a href={loginHref} className="text-primary-teal underline">
+                    {chunks}
+                  </a>
+                ),
+              })}
+            </p>
           </div>
-          <Button
-            className="flex w-full items-center justify-center"
-            isDisabled={isSubmitting || !emailIsValid}
-            onPress={() => {
-              void submitEmail();
-            }}
-          >
-            {isSubmitting ? <LoadingSpinner /> : t('Join')}
-          </Button>
-          <p className="text-sm text-neutral-charcoal">
-            {t.rich('Already have an account? <login>Log in</login>', {
-              login: (chunks: ReactNode) => (
-                <a href={loginHref} className="text-primary-teal underline">
-                  {chunks}
-                </a>
-              ),
-            })}
-          </p>
-        </div>
-      )}
-    </div>
+        )}
+      </ModalBody>
+    </>
   );
 };

--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -41,10 +41,11 @@ export function ProposalComments({
   const canInteract = userCanInteract(user);
   const readOnly = readOnlyProp || !canInteract || !canSubmitProposal;
   // A visitor on a public process who could comment with an account gets an
-  // account-claim prompt where the composer would be. The opening button
-  // relies on JoinAccountModal being mounted by ProposalViewLayout; the other
-  // ProposalComments surface (ReviewProposalPane) only renders for reviewers,
-  // who always pass userCanInteract.
+  // account-claim prompt where the composer would be. ProposalViewLayout
+  // mounts the JoinAccountModal this opens, keyed to the same
+  // proposal.access bit; the other ProposalComments surface
+  // (ReviewProposalPane) only renders for reviewers, who always pass
+  // userCanInteract.
   const showJoinPrompt = !readOnlyProp && !canInteract && canSubmitProposal;
 
   const scrollToComments = useCallback(() => {
@@ -81,11 +82,15 @@ export function ProposalComments({
 
         {showJoinPrompt && (
           <div className="mb-8">
-            <Surface className="flex flex-col items-center gap-3 border-0 p-0 text-center sm:border sm:p-6">
-              <p className="text-base text-neutral-charcoal">
+            {/* sm:p-4 matches the composer Surface this slot-replaces. */}
+            <Surface className="flex flex-col items-center gap-3 border-0 p-0 text-center sm:border sm:p-4">
+              <p
+                id="join-to-comment-prompt"
+                className="text-base text-neutral-charcoal"
+              >
                 {t('Join Common to comment on this proposal.')}
               </p>
-              <JoinDecisionButton />
+              <JoinDecisionButton ariaDescribedBy="join-to-comment-prompt" />
             </Surface>
           </div>
         )}

--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -12,6 +12,7 @@ import { useTranslations } from '@/lib/i18n';
 
 import { PostFeed, PostItem, usePostFeedActions } from '../PostFeed';
 import { PostUpdate } from '../PostUpdate';
+import { JoinDecisionButton } from './JoinAccountModal';
 
 export function ProposalComments({
   proposal,
@@ -37,7 +38,14 @@ export function ProposalComments({
   // SUBMIT_PROPOSALS on the decision profile). Showing the post box to users
   // who'd get rejected on submit surfaces as a "Not authorized" toast.
   const canSubmitProposal = proposal.access?.submitProposals === true;
-  const readOnly = readOnlyProp || !userCanInteract(user) || !canSubmitProposal;
+  const canInteract = userCanInteract(user);
+  const readOnly = readOnlyProp || !canInteract || !canSubmitProposal;
+  // A visitor on a public process who could comment with an account gets an
+  // account-claim prompt where the composer would be. The opening button
+  // relies on JoinAccountModal being mounted by ProposalViewLayout; the other
+  // ProposalComments surface (ReviewProposalPane) only renders for reviewers,
+  // who always pass userCanInteract.
+  const showJoinPrompt = !readOnlyProp && !canInteract && canSubmitProposal;
 
   const scrollToComments = useCallback(() => {
     setTimeout(() => {
@@ -67,6 +75,17 @@ export function ProposalComments({
                 proposalId={proposal.id}
                 processInstanceId={proposal.processInstanceId}
               />
+            </Surface>
+          </div>
+        )}
+
+        {showJoinPrompt && (
+          <div className="mb-8">
+            <Surface className="flex flex-col items-center gap-3 border-0 p-0 text-center sm:border sm:p-6">
+              <p className="text-base text-neutral-charcoal">
+                {t('Join Common to comment on this proposal.')}
+              </p>
+              <JoinDecisionButton />
             </Surface>
           </div>
         )}

--- a/apps/app/src/components/decisions/ProposalComments.tsx
+++ b/apps/app/src/components/decisions/ProposalComments.tsx
@@ -4,9 +4,11 @@ import { useUser } from '@/utils/UserProvider';
 import { userCanInteract } from '@/utils/userCanInteract';
 import { trpc } from '@op/api/client';
 import type { Proposal } from '@op/common/client';
+import { EmptyState } from '@op/ui/EmptyState';
 import { Header3 } from '@op/ui/Header';
 import { Surface } from '@op/ui/Surface';
 import { useCallback, useRef } from 'react';
+import { LuUserRoundPlus } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -81,18 +83,18 @@ export function ProposalComments({
         )}
 
         {showJoinPrompt && (
-          <div className="mb-8">
-            {/* sm:p-4 matches the composer Surface this slot-replaces. */}
-            <Surface className="flex flex-col items-center gap-3 border-0 p-0 text-center sm:border sm:p-4">
-              <p
-                id="join-to-comment-prompt"
-                className="text-base text-neutral-charcoal"
-              >
-                {t('Join Common to comment on this proposal.')}
-              </p>
-              <JoinDecisionButton ariaDescribedBy="join-to-comment-prompt" />
-            </Surface>
-          </div>
+          <EmptyState
+            icon={<LuUserRoundPlus className="size-6" />}
+            className="mb-8"
+          >
+            <p
+              id="join-to-comment-prompt"
+              className="text-base text-neutral-charcoal"
+            >
+              {t('Join Common to comment on this proposal.')}
+            </p>
+            <JoinDecisionButton ariaDescribedBy="join-to-comment-prompt" />
+          </EmptyState>
         )}
 
         {commentsLoading ? (

--- a/apps/app/src/components/decisions/ProposalEditorHeader.tsx
+++ b/apps/app/src/components/decisions/ProposalEditorHeader.tsx
@@ -12,6 +12,7 @@ import { useRouter, useTranslations } from '@/lib/i18n';
 
 import { LocaleChooser } from '../LocaleChooser';
 import { UserAvatarMenu } from '../SiteHeader';
+import { JoinAccountModal, JoinDecisionButton } from './JoinAccountModal';
 
 interface ProposalEditorHeaderProps {
   backHref: string;
@@ -120,10 +121,22 @@ export function ProposalEditorHeader({
               </Button>
             )}
             <LocaleChooser />
-            {/* No avatar or login for visitors/anonymous. */}
             {userCanInteract(user) ? (
               <UserAvatarMenu className="hidden sm:block" />
-            ) : null}
+            ) : (
+              /*
+               * The only non-interactive viewer who can reach the editor is an
+               * anonymous drafter on a public process (logged-out visitors 403
+               * at getProposal), so no canJoin plumbing is needed here. The
+               * claim links the email onto their existing anon session, which
+               * owns this draft — the proposal follows to the new account
+               * automatically.
+               */
+              <>
+                <JoinDecisionButton className="hidden sm:block" />
+                <JoinAccountModal />
+              </>
+            )}
           </>
         )}
       </div>

--- a/apps/app/src/components/decisions/ProposalEditorHeader.tsx
+++ b/apps/app/src/components/decisions/ProposalEditorHeader.tsx
@@ -12,7 +12,6 @@ import { useRouter, useTranslations } from '@/lib/i18n';
 
 import { LocaleChooser } from '../LocaleChooser';
 import { UserAvatarMenu } from '../SiteHeader';
-import { JoinAccountModal, JoinDecisionButton } from './JoinAccountModal';
 
 interface ProposalEditorHeaderProps {
   backHref: string;
@@ -121,22 +120,10 @@ export function ProposalEditorHeader({
               </Button>
             )}
             <LocaleChooser />
+            {/* No avatar or login for visitors/anonymous. */}
             {userCanInteract(user) ? (
               <UserAvatarMenu className="hidden sm:block" />
-            ) : (
-              /*
-               * The only non-interactive viewer who can reach the editor is an
-               * anonymous drafter on a public process (logged-out visitors 403
-               * at getProposal), so no canJoin plumbing is needed here. The
-               * claim links the email onto their existing anon session, which
-               * owns this draft — the proposal follows to the new account
-               * automatically.
-               */
-              <>
-                <JoinDecisionButton className="hidden sm:block" />
-                <JoinAccountModal />
-              </>
-            )}
+            ) : null}
           </>
         )}
       </div>

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -48,11 +48,14 @@ export type ProposalDocumentState = 'ready' | 'pending' | 'error';
 export function ProposalView({
   proposal: initialProposal,
   canSeeRevisions,
+  canJoin = false,
   decisionRoot,
   selection,
 }: {
   proposal: Proposal;
   canSeeRevisions: boolean;
+  /** Public process: the header offers Join instead of Log in (see ProposalViewLayout). */
+  canJoin?: boolean;
   decisionRoot: string;
   selection: ProposalSelection | null;
 }) {
@@ -268,6 +271,7 @@ export function ProposalView({
       isLoading={isLoading}
       editHref={editHref}
       canEdit={canEdit}
+      canJoin={canJoin}
       revisionToggle={
         firstRevisionRequestId
           ? {

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -48,14 +48,11 @@ export type ProposalDocumentState = 'ready' | 'pending' | 'error';
 export function ProposalView({
   proposal: initialProposal,
   canSeeRevisions,
-  canJoin = false,
   decisionRoot,
   selection,
 }: {
   proposal: Proposal;
   canSeeRevisions: boolean;
-  /** Public process: the header offers Join instead of Log in (see ProposalViewLayout). */
-  canJoin?: boolean;
   decisionRoot: string;
   selection: ProposalSelection | null;
 }) {
@@ -271,7 +268,11 @@ export function ProposalView({
       isLoading={isLoading}
       editHref={editHref}
       canEdit={canEdit}
-      canJoin={canJoin}
+      // Same viewer-access bit the comments prompt reads (getProposal mirrors
+      // the decision profile's SUBMIT_PROPOSALS grant onto proposal.access),
+      // so the Join button, the modal mount, and the prompt can't diverge —
+      // on any route that renders a proposal, including the legacy one.
+      canJoin={currentProposal.access?.submitProposals === true}
       revisionToggle={
         firstRevisionRequestId
           ? {

--- a/apps/app/src/components/decisions/ProposalViewLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalViewLayout.tsx
@@ -149,7 +149,7 @@ export function ProposalViewLayout({
               <Tooltip>{revisionRequestLabel}</Tooltip>
             </TooltipTrigger>
           )}
-          <div className="hidden sm:flex">
+          <div className="hidden sm:block">
             <LocaleChooser />
           </div>
           {/* Outside the sm-only cluster: Join stays visible on mobile (the

--- a/apps/app/src/components/decisions/ProposalViewLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalViewLayout.tsx
@@ -18,6 +18,7 @@ import { useRouter } from '@/lib/i18n/routing';
 
 import { LocaleChooser } from '../LocaleChooser';
 import { HeaderUserMenu } from '../SiteHeader';
+import { JoinAccountModal, JoinDecisionButton } from './JoinAccountModal';
 import { ReportProposalDialog } from './ReportProposalDialog';
 
 export function ProposalViewLayout({
@@ -31,6 +32,7 @@ export function ProposalViewLayout({
   isLoading = false,
   editHref,
   canEdit = false,
+  canJoin = false,
   reportProposalId,
   revisionToggle,
 }: {
@@ -44,6 +46,12 @@ export function ProposalViewLayout({
   isLoading?: boolean;
   editHref?: string;
   canEdit?: boolean;
+  /**
+   * Public process (viewer can submit proposals without an account): the
+   * header offers "Join" (account claim, see JoinAccountModal) instead of
+   * "Log in" to logged-out and anonymous visitors.
+   */
+  canJoin?: boolean;
   /** When set, renders the "Report" action (opens the report dialog) for the
    *  proposal with this id. */
   reportProposalId?: string;
@@ -144,12 +152,20 @@ export function ProposalViewLayout({
           )}
           <div className="hidden gap-4 sm:flex">
             <LocaleChooser />
-            <HeaderUserMenu />
+            {canJoin && (!user || user.isAnonymous) ? (
+              <JoinDecisionButton />
+            ) : (
+              <HeaderUserMenu />
+            )}
           </div>
         </div>
       </div>
 
       <div className="relative min-h-0 overflow-y-auto">{children}</div>
+
+      {/* Mounted outside the sm-only header cluster so a `?join=1` deep link
+          still opens the modal on mobile. */}
+      {canJoin ? <JoinAccountModal /> : null}
     </div>
   );
 }

--- a/apps/app/src/components/decisions/ProposalViewLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalViewLayout.tsx
@@ -17,8 +17,7 @@ import { useTranslations } from '@/lib/i18n';
 import { useRouter } from '@/lib/i18n/routing';
 
 import { LocaleChooser } from '../LocaleChooser';
-import { HeaderUserMenu } from '../SiteHeader';
-import { JoinAccountModal, JoinDecisionButton } from './JoinAccountModal';
+import { JoinAccountModal, JoinOrUserMenu } from './JoinAccountModal';
 import { ReportProposalDialog } from './ReportProposalDialog';
 
 export function ProposalViewLayout({
@@ -150,14 +149,15 @@ export function ProposalViewLayout({
               <Tooltip>{revisionRequestLabel}</Tooltip>
             </TooltipTrigger>
           )}
-          <div className="hidden gap-4 sm:flex">
+          <div className="hidden sm:flex">
             <LocaleChooser />
-            {canJoin && (!user || user.isAnonymous) ? (
-              <JoinDecisionButton />
-            ) : (
-              <HeaderUserMenu />
-            )}
           </div>
+          {/* Outside the sm-only cluster: Join stays visible on mobile (the
+              avatar keeps its desktop-only treatment via userMenuClassName). */}
+          <JoinOrUserMenu
+            canJoin={canJoin}
+            userMenuClassName="hidden sm:block"
+          />
         </div>
       </div>
 

--- a/apps/app/src/hooks/useClaimAccount.ts
+++ b/apps/app/src/hooks/useClaimAccount.ts
@@ -7,6 +7,7 @@ import { createSBBrowserClient } from '@op/supabase/client';
 import { useCallback } from 'react';
 
 import { i18nConfig } from '@/lib/i18n/config';
+import type { TranslateFn } from '@/lib/i18n/routing';
 
 /**
  * Claim a full account by linking an email identity (via OTP) onto the
@@ -25,12 +26,11 @@ export type ClaimEmailResult =
   | { ok: true; needsOtp: boolean }
   | {
       ok: false;
-      message: string | undefined;
+      message?: string;
       /**
        * The current session already belongs to a full account (e.g. the user
        * signed in from another tab while a stale Join button was showing).
-       * Consumers translate this into their own copy — proceeding would have
-       * started a real email change on the full account.
+       * Proceeding would have started a real email change on the full account.
        */
       alreadySignedIn?: boolean;
     };
@@ -38,6 +38,33 @@ export type ClaimEmailResult =
 export type ClaimVerifyResult =
   | { ok: true }
   | { ok: false; message: string | undefined };
+
+/** Shared flag→copy mapping for failed `requestEmailCode` results. */
+export function getClaimEmailErrorMessage(
+  result: Extract<ClaimEmailResult, { ok: false }>,
+  t: TranslateFn,
+): string {
+  if (result.alreadySignedIn) {
+    return t("You're already signed in. Reload the page to continue.");
+  }
+  return result.message ?? t("That didn't work");
+}
+
+/**
+ * After linking, route through promote onboarding (personal details + ToS),
+ * returning to `dest` when done. `dest` must carry the locale prefix — the
+ * locale-less /login route and the modal both pass a localized pathname.
+ */
+export function goToOnboarding(dest: string | null) {
+  const safeDest = dest && isSafeRedirectPath(dest) ? dest : '/';
+  // A safe path isn't necessarily locale-prefixed (e.g. /info/tos), so
+  // validate the first segment before building the /start URL from it.
+  const firstSegment = safeDest.split('/')[1] ?? '';
+  const locale = SUPPORTED_LOCALES.some((l) => l === firstSegment)
+    ? firstSegment
+    : i18nConfig.defaultLocale;
+  window.location.href = `/${locale}/start?promote=1&redirect=${encodeURIComponent(safeDest)}`;
+}
 
 export function useClaimAccount() {
   const supabase = createSBBrowserClient();
@@ -65,7 +92,7 @@ export function useClaimAccount() {
       // real email change on it. Reachable via a stale-cache Join button
       // (cross-tab sign-in within getMyAccount's staleTime).
       if (sessionData.session && !sessionData.session.user.is_anonymous) {
-        return { ok: false, message: undefined, alreadySignedIn: true };
+        return { ok: false, alreadySignedIn: true };
       }
       if (!sessionData.session && mintAnonSession) {
         // Mint an anonymous user to link onto (same as useCreateProposal
@@ -75,7 +102,9 @@ export function useClaimAccount() {
           return { ok: false, message: error.message };
         }
         // The new session isn't reflected in the cached account query.
-        await utils.account.getMyAccount.invalidate();
+        // Fire-and-forget: the refetch only matters if the modal is abandoned,
+        // and both success paths end in a full navigation anyway.
+        void utils.account.getMyAccount.invalidate();
       }
 
       // TODO(anon-upgrade): updateUser fails if this email already belongs to
@@ -123,21 +152,5 @@ export function useClaimAccount() {
     [supabase],
   );
 
-  /**
-   * After linking, route through promote onboarding (personal details + ToS),
-   * returning to `dest` when done. `dest` must carry the locale prefix — the
-   * locale-less /login route and the modal both pass a localized pathname.
-   */
-  const goToOnboarding = useCallback((dest: string | null) => {
-    const safeDest = dest && isSafeRedirectPath(dest) ? dest : '/';
-    // A safe path isn't necessarily locale-prefixed (e.g. /info/tos), so
-    // validate the first segment before building the /start URL from it.
-    const firstSegment = safeDest.split('/')[1] ?? '';
-    const locale = SUPPORTED_LOCALES.some((l) => l === firstSegment)
-      ? firstSegment
-      : i18nConfig.defaultLocale;
-    window.location.href = `/${locale}/start?promote=1&redirect=${encodeURIComponent(safeDest)}`;
-  }, []);
-
-  return { requestEmailCode, verifyEmailCode, goToOnboarding };
+  return { requestEmailCode, verifyEmailCode };
 }

--- a/apps/app/src/hooks/useClaimAccount.ts
+++ b/apps/app/src/hooks/useClaimAccount.ts
@@ -2,15 +2,19 @@
 
 import { trpc } from '@op/api/client';
 import { isSafeRedirectPath } from '@op/common/client';
+import { SUPPORTED_LOCALES } from '@op/common/locales';
 import { createSBBrowserClient } from '@op/supabase/client';
+import { useCallback } from 'react';
+
+import { i18nConfig } from '@/lib/i18n/config';
 
 /**
  * Claim a full account by linking an email identity (via OTP) onto the
  * visitor's anonymous Supabase user, so anything they created while anonymous
- * stays theirs. A visitor with no session at all gets an anonymous user minted
- * first, making this also the signup path for public decision processes — it
- * deliberately never touches `account.login`, so the invite-only allowList
- * gate does not apply.
+ * stays theirs. With `mintAnonSession`, a visitor with no session at all gets
+ * an anonymous user minted first, making this also the signup path for public
+ * decision processes — it deliberately never touches `account.login`, so the
+ * invite-only allowList gate does not apply.
  *
  * Consumed by `LinkAccountPanel` (/login?link=1) and `JoinAccountModal` (the
  * header "Join" button on public decisions). UI state (steps, errors, i18n)
@@ -19,7 +23,17 @@ import { createSBBrowserClient } from '@op/supabase/client';
 
 export type ClaimEmailResult =
   | { ok: true; needsOtp: boolean }
-  | { ok: false; message: string };
+  | {
+      ok: false;
+      message: string | undefined;
+      /**
+       * The current session already belongs to a full account (e.g. the user
+       * signed in from another tab while a stale Join button was showing).
+       * Consumers translate this into their own copy — proceeding would have
+       * started a real email change on the full account.
+       */
+      alreadySignedIn?: boolean;
+    };
 
 export type ClaimVerifyResult =
   | { ok: true }
@@ -34,65 +48,96 @@ export function useClaimAccount() {
    * an OTP when email confirmations are on (`needsOtp: true`); with them off
    * the change applies immediately and the session is refreshed so the token
    * drops its stale anonymous claims (`needsOtp: false`).
+   *
+   * `mintAnonSession` signs in anonymously first when there is no session
+   * (the Join modal's public-visitor path). LinkAccountPanel leaves it off:
+   * its route requires an anon session at render, and if that session died
+   * before submit the claim must fail loudly rather than silently linking the
+   * email onto a fresh empty account (orphaning the visitor's proposal).
    */
-  const requestEmailCode = async (email: string): Promise<ClaimEmailResult> => {
-    // A plain visitor has no session to link onto — mint an anonymous user
-    // first (same as useCreateProposal before attributing a draft).
-    const { data: sessionData } = await supabase.auth.getSession();
-    if (!sessionData.session) {
-      const { error } = await supabase.auth.signInAnonymously();
+  const requestEmailCode = useCallback(
+    async (
+      email: string,
+      { mintAnonSession = false }: { mintAnonSession?: boolean } = {},
+    ): Promise<ClaimEmailResult> => {
+      const { data: sessionData } = await supabase.auth.getSession();
+      // A full account has nothing to claim — updateUser here would start a
+      // real email change on it. Reachable via a stale-cache Join button
+      // (cross-tab sign-in within getMyAccount's staleTime).
+      if (sessionData.session && !sessionData.session.user.is_anonymous) {
+        return { ok: false, message: undefined, alreadySignedIn: true };
+      }
+      if (!sessionData.session && mintAnonSession) {
+        // Mint an anonymous user to link onto (same as useCreateProposal
+        // before attributing a draft).
+        const { error } = await supabase.auth.signInAnonymously();
+        if (error) {
+          return { ok: false, message: error.message };
+        }
+        // The new session isn't reflected in the cached account query.
+        await utils.account.getMyAccount.invalidate();
+      }
+
+      // TODO(anon-upgrade): updateUser fails if this email already belongs to
+      // another account; we surface the raw Supabase error for now.
+      // Productionize with a friendly "that account already exists" path.
+      const { data, error } = await supabase.auth.updateUser({ email });
       if (error) {
         return { ok: false, message: error.message };
       }
-      // The new session isn't reflected in the cached account query.
-      await utils.account.getMyAccount.invalidate();
-    }
-
-    // TODO(anon-upgrade): updateUser fails if this email already belongs to
-    // another account; we surface the raw Supabase error for now.
-    // Productionize with a friendly "that account already exists" path.
-    const { data, error } = await supabase.auth.updateUser({ email });
-    if (error) {
-      return { ok: false, message: error.message };
-    }
-    // No pending change + email already set ⇒ applied immediately (no OTP).
-    if (data.user?.email === email && !data.user?.new_email) {
-      await supabase.auth.refreshSession();
-      return { ok: true, needsOtp: false };
-    }
-    return { ok: true, needsOtp: true };
-  };
+      // No pending change + email already set ⇒ applied immediately (no OTP).
+      // GoTrue lowercases the stored email, so compare case-insensitively or a
+      // mixed-case entry would dead-end on an OTP screen with no code sent.
+      if (
+        data.user?.email === email.trim().toLowerCase() &&
+        !data.user?.new_email
+      ) {
+        await supabase.auth.refreshSession();
+        return { ok: true, needsOtp: false };
+      }
+      return { ok: true, needsOtp: true };
+    },
+    [supabase, utils],
+  );
 
   /** Confirm the OTP — the claim is an email *change* on the anon user. */
-  const verifyEmailCode = async ({
-    email,
-    token,
-  }: {
-    email: string;
-    token: string;
-  }): Promise<ClaimVerifyResult> => {
-    const { data, error } = await supabase.auth.verifyOtp({
+  const verifyEmailCode = useCallback(
+    async ({
       email,
       token,
-      type: 'email_change',
-    });
+    }: {
+      email: string;
+      token: string;
+    }): Promise<ClaimVerifyResult> => {
+      const { data, error } = await supabase.auth.verifyOtp({
+        email,
+        token,
+        type: 'email_change',
+      });
 
-    if (data.user && data.session && data.user.role === 'authenticated') {
-      return { ok: true };
-    }
-    return { ok: false, message: error?.message };
-  };
+      if (data.user && data.session && data.user.role === 'authenticated') {
+        return { ok: true };
+      }
+      return { ok: false, message: error?.message };
+    },
+    [supabase],
+  );
 
   /**
    * After linking, route through promote onboarding (personal details + ToS),
    * returning to `dest` when done. `dest` must carry the locale prefix — the
    * locale-less /login route and the modal both pass a localized pathname.
    */
-  const goToOnboarding = (dest: string | null) => {
+  const goToOnboarding = useCallback((dest: string | null) => {
     const safeDest = dest && isSafeRedirectPath(dest) ? dest : '/';
-    const locale = safeDest.split('/')[1] || 'en';
+    // A safe path isn't necessarily locale-prefixed (e.g. /info/tos), so
+    // validate the first segment before building the /start URL from it.
+    const firstSegment = safeDest.split('/')[1] ?? '';
+    const locale = SUPPORTED_LOCALES.some((l) => l === firstSegment)
+      ? firstSegment
+      : i18nConfig.defaultLocale;
     window.location.href = `/${locale}/start?promote=1&redirect=${encodeURIComponent(safeDest)}`;
-  };
+  }, []);
 
   return { requestEmailCode, verifyEmailCode, goToOnboarding };
 }

--- a/apps/app/src/hooks/useClaimAccount.ts
+++ b/apps/app/src/hooks/useClaimAccount.ts
@@ -53,6 +53,8 @@ export function getClaimEmailErrorMessage(
       'An account with this email already exists. Try logging in instead.',
     );
   }
+  // The user sees localized generic copy; keep the raw cause findable.
+  console.error('claim: requestEmailCode failed', result);
   return t("That didn't work");
 }
 

--- a/apps/app/src/hooks/useClaimAccount.ts
+++ b/apps/app/src/hooks/useClaimAccount.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { trpc } from '@op/api/client';
+import { isSafeRedirectPath } from '@op/common/client';
+import { createSBBrowserClient } from '@op/supabase/client';
+
+/**
+ * Claim a full account by linking an email identity (via OTP) onto the
+ * visitor's anonymous Supabase user, so anything they created while anonymous
+ * stays theirs. A visitor with no session at all gets an anonymous user minted
+ * first, making this also the signup path for public decision processes — it
+ * deliberately never touches `account.login`, so the invite-only allowList
+ * gate does not apply.
+ *
+ * Consumed by `LinkAccountPanel` (/login?link=1) and `JoinAccountModal` (the
+ * header "Join" button on public decisions). UI state (steps, errors, i18n)
+ * stays in the consumers; this hook only owns the Supabase calls.
+ */
+
+export type ClaimEmailResult =
+  | { ok: true; needsOtp: boolean }
+  | { ok: false; message: string };
+
+export type ClaimVerifyResult =
+  | { ok: true }
+  | { ok: false; message: string | undefined };
+
+export function useClaimAccount() {
+  const supabase = createSBBrowserClient();
+  const utils = trpc.useUtils();
+
+  /**
+   * Attach `email` to the visitor's anon user. `updateUser({ email })` sends
+   * an OTP when email confirmations are on (`needsOtp: true`); with them off
+   * the change applies immediately and the session is refreshed so the token
+   * drops its stale anonymous claims (`needsOtp: false`).
+   */
+  const requestEmailCode = async (email: string): Promise<ClaimEmailResult> => {
+    // A plain visitor has no session to link onto — mint an anonymous user
+    // first (same as useCreateProposal before attributing a draft).
+    const { data: sessionData } = await supabase.auth.getSession();
+    if (!sessionData.session) {
+      const { error } = await supabase.auth.signInAnonymously();
+      if (error) {
+        return { ok: false, message: error.message };
+      }
+      // The new session isn't reflected in the cached account query.
+      await utils.account.getMyAccount.invalidate();
+    }
+
+    // TODO(anon-upgrade): updateUser fails if this email already belongs to
+    // another account; we surface the raw Supabase error for now.
+    // Productionize with a friendly "that account already exists" path.
+    const { data, error } = await supabase.auth.updateUser({ email });
+    if (error) {
+      return { ok: false, message: error.message };
+    }
+    // No pending change + email already set ⇒ applied immediately (no OTP).
+    if (data.user?.email === email && !data.user?.new_email) {
+      await supabase.auth.refreshSession();
+      return { ok: true, needsOtp: false };
+    }
+    return { ok: true, needsOtp: true };
+  };
+
+  /** Confirm the OTP — the claim is an email *change* on the anon user. */
+  const verifyEmailCode = async ({
+    email,
+    token,
+  }: {
+    email: string;
+    token: string;
+  }): Promise<ClaimVerifyResult> => {
+    const { data, error } = await supabase.auth.verifyOtp({
+      email,
+      token,
+      type: 'email_change',
+    });
+
+    if (data.user && data.session && data.user.role === 'authenticated') {
+      return { ok: true };
+    }
+    return { ok: false, message: error?.message };
+  };
+
+  /**
+   * After linking, route through promote onboarding (personal details + ToS),
+   * returning to `dest` when done. `dest` must carry the locale prefix — the
+   * locale-less /login route and the modal both pass a localized pathname.
+   */
+  const goToOnboarding = (dest: string | null) => {
+    const safeDest = dest && isSafeRedirectPath(dest) ? dest : '/';
+    const locale = safeDest.split('/')[1] || 'en';
+    window.location.href = `/${locale}/start?promote=1&redirect=${encodeURIComponent(safeDest)}`;
+  };
+
+  return { requestEmailCode, verifyEmailCode, goToOnboarding };
+}

--- a/apps/app/src/hooks/useClaimAccount.ts
+++ b/apps/app/src/hooks/useClaimAccount.ts
@@ -26,6 +26,9 @@ export type ClaimEmailResult =
   | { ok: true; needsOtp: boolean }
   | {
       ok: false;
+      /** Supabase error code (e.g. 'email_exists') — for copy mapping. */
+      code?: string;
+      /** Raw Supabase message. Not for display: English-only. */
       message?: string;
       /**
        * The current session already belongs to a full account (e.g. the user
@@ -45,7 +48,12 @@ export function getClaimEmailErrorMessage(
   if (result.alreadySignedIn) {
     return t("You're already signed in. Reload the page to continue.");
   }
-  return result.message ?? t("That didn't work");
+  if (result.code === 'email_exists') {
+    return t(
+      'An account with this email already exists. Try logging in instead.',
+    );
+  }
+  return t("That didn't work");
 }
 
 /**
@@ -97,7 +105,7 @@ export function useClaimAccount() {
         // before attributing a draft).
         const { error } = await supabase.auth.signInAnonymously();
         if (error) {
-          return { ok: false, message: error.message };
+          return { ok: false, code: error.code, message: error.message };
         }
         // The new session isn't reflected in the cached account query.
         // Fire-and-forget: the refetch only matters if the modal is abandoned,
@@ -105,12 +113,12 @@ export function useClaimAccount() {
         void utils.account.getMyAccount.invalidate();
       }
 
-      // TODO(anon-upgrade): updateUser fails if this email already belongs to
-      // another account; we surface the raw Supabase error for now.
-      // Productionize with a friendly "that account already exists" path.
+      // updateUser fails with code 'email_exists' when the email already
+      // belongs to another account — mapped to friendly copy in
+      // getClaimEmailErrorMessage.
       const { data, error } = await supabase.auth.updateUser({ email });
       if (error) {
-        return { ok: false, message: error.message };
+        return { ok: false, code: error.code, message: error.message };
       }
       // No pending change + email already set ⇒ applied immediately (no OTP).
       // GoTrue lowercases the stored email, so compare case-insensitively or a

--- a/apps/app/src/hooks/useClaimAccount.ts
+++ b/apps/app/src/hooks/useClaimAccount.ts
@@ -35,9 +35,7 @@ export type ClaimEmailResult =
       alreadySignedIn?: boolean;
     };
 
-export type ClaimVerifyResult =
-  | { ok: true }
-  | { ok: false; message: string | undefined };
+export type ClaimVerifyResult = { ok: true } | { ok: false; message?: string };
 
 /** Shared flag→copy mapping for failed `requestEmailCode` results. */
 export function getClaimEmailErrorMessage(

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1390,5 +1390,6 @@
   "Remove image": "إزالة الصورة",
   "Claim your account": "احصل على حسابك",
   "Join": "انضم",
-  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "انضم إلى Common لتتمكن من الإعجاب بأي فكرة والتعليق عليها ومتابعتها، ولتعديل مساهماتك وتلقي التحديثات بشأنها."
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "انضم إلى Common لتتمكن من الإعجاب بأي فكرة والتعليق عليها ومتابعتها، ولتعديل مساهماتك وتلقي التحديثات بشأنها.",
+  "You're already signed in. Reload the page to continue.": "لقد سجّلت الدخول بالفعل. أعد تحميل الصفحة للمتابعة."
 }

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1387,5 +1387,8 @@
   "Admin options": "خيارات المسؤول",
   "Process settings": "إعدادات العملية",
   "ends {date}": "ينتهي في {date}",
-  "Remove image": "إزالة الصورة"
+  "Remove image": "إزالة الصورة",
+  "Claim your account": "احصل على حسابك",
+  "Join": "انضم",
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "انضم إلى Common لتتمكن من الإعجاب بأي فكرة والتعليق عليها ومتابعتها، ولتعديل مساهماتك وتلقي التحديثات بشأنها."
 }

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1392,5 +1392,6 @@
   "Join": "انضم",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "انضم إلى Common لتتمكن من الإعجاب بأي فكرة والتعليق عليها ومتابعتها، ولتعديل مساهماتك وتلقي التحديثات بشأنها.",
   "You're already signed in. Reload the page to continue.": "لقد سجّلت الدخول بالفعل. أعد تحميل الصفحة للمتابعة.",
+  "An account with this email already exists. Try logging in instead.": "يوجد حساب بهذا البريد الإلكتروني بالفعل. حاول تسجيل الدخول بدلاً من ذلك.",
   "Join Common to comment on this proposal.": "انضم إلى Common للتعليق على هذا المقترح."
 }

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1391,5 +1391,6 @@
   "Claim your account": "احصل على حسابك",
   "Join": "انضم",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "انضم إلى Common لتتمكن من الإعجاب بأي فكرة والتعليق عليها ومتابعتها، ولتعديل مساهماتك وتلقي التحديثات بشأنها.",
-  "You're already signed in. Reload the page to continue.": "لقد سجّلت الدخول بالفعل. أعد تحميل الصفحة للمتابعة."
+  "You're already signed in. Reload the page to continue.": "لقد سجّلت الدخول بالفعل. أعد تحميل الصفحة للمتابعة.",
+  "Join Common to comment on this proposal.": "انضم إلى Common للتعليق على هذا المقترح."
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1393,5 +1393,6 @@
   "Remove image": "ছবি সরান",
   "Claim your account": "আপনার অ্যাকাউন্ট দাবি করুন",
   "Join": "যোগ দিন",
-  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "যেকোনো আইডিয়া লাইক, কমেন্ট ও ফলো করতে এবং আপনার নিজের জমা দেওয়া আইডিয়া সম্পাদনা ও সেগুলোর আপডেট পেতে Common-এ যোগ দিন।"
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "যেকোনো আইডিয়া লাইক, কমেন্ট ও ফলো করতে এবং আপনার নিজের জমা দেওয়া আইডিয়া সম্পাদনা ও সেগুলোর আপডেট পেতে Common-এ যোগ দিন।",
+  "You're already signed in. Reload the page to continue.": "আপনি ইতিমধ্যে সাইন ইন করেছেন। চালিয়ে যেতে পৃষ্ঠাটি পুনরায় লোড করুন।"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1390,5 +1390,8 @@
   "Admin options": "অ্যাডমিন বিকল্প",
   "Process settings": "প্রক্রিয়া সেটিংস",
   "ends {date}": "{date} তারিখে শেষ হয়",
-  "Remove image": "ছবি সরান"
+  "Remove image": "ছবি সরান",
+  "Claim your account": "আপনার অ্যাকাউন্ট দাবি করুন",
+  "Join": "যোগ দিন",
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "যেকোনো আইডিয়া লাইক, কমেন্ট ও ফলো করতে এবং আপনার নিজের জমা দেওয়া আইডিয়া সম্পাদনা ও সেগুলোর আপডেট পেতে Common-এ যোগ দিন।"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1395,5 +1395,6 @@
   "Join": "যোগ দিন",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "যেকোনো আইডিয়া লাইক, কমেন্ট ও ফলো করতে এবং আপনার নিজের জমা দেওয়া আইডিয়া সম্পাদনা ও সেগুলোর আপডেট পেতে Common-এ যোগ দিন।",
   "You're already signed in. Reload the page to continue.": "আপনি ইতিমধ্যে সাইন ইন করেছেন। চালিয়ে যেতে পৃষ্ঠাটি পুনরায় লোড করুন।",
+  "An account with this email already exists. Try logging in instead.": "এই ইমেল দিয়ে ইতিমধ্যে একটি অ্যাকাউন্ট রয়েছে। পরিবর্তে লগ ইন করার চেষ্টা করুন।",
   "Join Common to comment on this proposal.": "এই প্রস্তাবে মন্তব্য করতে Common-এ যোগ দিন।"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1394,5 +1394,6 @@
   "Claim your account": "আপনার অ্যাকাউন্ট দাবি করুন",
   "Join": "যোগ দিন",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "যেকোনো আইডিয়া লাইক, কমেন্ট ও ফলো করতে এবং আপনার নিজের জমা দেওয়া আইডিয়া সম্পাদনা ও সেগুলোর আপডেট পেতে Common-এ যোগ দিন।",
-  "You're already signed in. Reload the page to continue.": "আপনি ইতিমধ্যে সাইন ইন করেছেন। চালিয়ে যেতে পৃষ্ঠাটি পুনরায় লোড করুন।"
+  "You're already signed in. Reload the page to continue.": "আপনি ইতিমধ্যে সাইন ইন করেছেন। চালিয়ে যেতে পৃষ্ঠাটি পুনরায় লোড করুন।",
+  "Join Common to comment on this proposal.": "এই প্রস্তাবে মন্তব্য করতে Common-এ যোগ দিন।"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1400,5 +1400,6 @@
   "Claim your account": "Claim your account",
   "Join": "Join",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.",
-  "You're already signed in. Reload the page to continue.": "You're already signed in. Reload the page to continue."
+  "You're already signed in. Reload the page to continue.": "You're already signed in. Reload the page to continue.",
+  "Join Common to comment on this proposal.": "Join Common to comment on this proposal."
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1399,5 +1399,6 @@
   "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.",
   "Claim your account": "Claim your account",
   "Join": "Join",
-  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions."
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.",
+  "You're already signed in. Reload the page to continue.": "You're already signed in. Reload the page to continue."
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1396,5 +1396,8 @@
   "Already have an account? <login>Log in</login>": "Already have an account? <login>Log in</login>",
   "A code was sent to {email}. Type the code below to create your profile.": "A code was sent to {email}. Type the code below to create your profile.",
   "Create profile": "Create profile",
-  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>."
+  "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.": "I agree to the <tos>Terms of Service</tos> and <privacy>Privacy Policy</privacy>.",
+  "Claim your account": "Claim your account",
+  "Join": "Join",
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions."
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1401,5 +1401,6 @@
   "Join": "Join",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.",
   "You're already signed in. Reload the page to continue.": "You're already signed in. Reload the page to continue.",
+  "An account with this email already exists. Try logging in instead.": "An account with this email already exists. Try logging in instead.",
   "Join Common to comment on this proposal.": "Join Common to comment on this proposal."
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1390,5 +1390,6 @@
   "Remove image": "Eliminar imagen",
   "Claim your account": "Reclama tu cuenta",
   "Join": "Únete",
-  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Únete a Common para dar me gusta, comentar y seguir cualquier idea, y para editar y recibir novedades sobre tus propias propuestas."
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Únete a Common para dar me gusta, comentar y seguir cualquier idea, y para editar y recibir novedades sobre tus propias propuestas.",
+  "You're already signed in. Reload the page to continue.": "Ya has iniciado sesión. Recarga la página para continuar."
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1392,5 +1392,6 @@
   "Join": "Únete",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Únete a Common para dar me gusta, comentar y seguir cualquier idea, y para editar y recibir novedades sobre tus propias propuestas.",
   "You're already signed in. Reload the page to continue.": "Ya has iniciado sesión. Recarga la página para continuar.",
+  "An account with this email already exists. Try logging in instead.": "Ya existe una cuenta con este correo electrónico. Intenta iniciar sesión.",
   "Join Common to comment on this proposal.": "Únete a Common para comentar esta propuesta."
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1391,5 +1391,6 @@
   "Claim your account": "Reclama tu cuenta",
   "Join": "Únete",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Únete a Common para dar me gusta, comentar y seguir cualquier idea, y para editar y recibir novedades sobre tus propias propuestas.",
-  "You're already signed in. Reload the page to continue.": "Ya has iniciado sesión. Recarga la página para continuar."
+  "You're already signed in. Reload the page to continue.": "Ya has iniciado sesión. Recarga la página para continuar.",
+  "Join Common to comment on this proposal.": "Únete a Common para comentar esta propuesta."
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1387,5 +1387,8 @@
   "Admin options": "Opciones de administrador",
   "Process settings": "Configuración del proceso",
   "ends {date}": "finaliza el {date}",
-  "Remove image": "Eliminar imagen"
+  "Remove image": "Eliminar imagen",
+  "Claim your account": "Reclama tu cuenta",
+  "Join": "Únete",
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Únete a Common para dar me gusta, comentar y seguir cualquier idea, y para editar y recibir novedades sobre tus propias propuestas."
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1387,5 +1387,8 @@
   "Admin options": "Options d'administration",
   "Process settings": "Paramètres du processus",
   "ends {date}": "se termine le {date}",
-  "Remove image": "Supprimer l'image"
+  "Remove image": "Supprimer l'image",
+  "Claim your account": "Réclamez votre compte",
+  "Join": "Rejoindre",
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Rejoignez Common pour aimer, commenter et suivre n'importe quelle idée, et pour modifier vos propres contributions et recevoir des mises à jour à leur sujet."
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1392,5 +1392,6 @@
   "Join": "Rejoindre",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Rejoignez Common pour aimer, commenter et suivre n'importe quelle idée, et pour modifier vos propres contributions et recevoir des mises à jour à leur sujet.",
   "You're already signed in. Reload the page to continue.": "Vous êtes déjà connecté. Rechargez la page pour continuer.",
+  "An account with this email already exists. Try logging in instead.": "Un compte avec cet e-mail existe déjà. Essayez plutôt de vous connecter.",
   "Join Common to comment on this proposal.": "Rejoignez Common pour commenter cette proposition."
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1390,5 +1390,6 @@
   "Remove image": "Supprimer l'image",
   "Claim your account": "Réclamez votre compte",
   "Join": "Rejoindre",
-  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Rejoignez Common pour aimer, commenter et suivre n'importe quelle idée, et pour modifier vos propres contributions et recevoir des mises à jour à leur sujet."
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Rejoignez Common pour aimer, commenter et suivre n'importe quelle idée, et pour modifier vos propres contributions et recevoir des mises à jour à leur sujet.",
+  "You're already signed in. Reload the page to continue.": "Vous êtes déjà connecté. Rechargez la page pour continuer."
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1391,5 +1391,6 @@
   "Claim your account": "Réclamez votre compte",
   "Join": "Rejoindre",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Rejoignez Common pour aimer, commenter et suivre n'importe quelle idée, et pour modifier vos propres contributions et recevoir des mises à jour à leur sujet.",
-  "You're already signed in. Reload the page to continue.": "Vous êtes déjà connecté. Rechargez la page pour continuer."
+  "You're already signed in. Reload the page to continue.": "Vous êtes déjà connecté. Rechargez la page pour continuer.",
+  "Join Common to comment on this proposal.": "Rejoignez Common pour commenter cette proposition."
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1392,5 +1392,6 @@
   "Join": "Participar",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Junte-se ao Common para curtir, comentar e seguir qualquer ideia, e para editar e receber atualizações sobre suas próprias contribuições.",
   "You're already signed in. Reload the page to continue.": "Você já está com a sessão iniciada. Recarregue a página para continuar.",
+  "An account with this email already exists. Try logging in instead.": "Já existe uma conta com este e-mail. Tente fazer login.",
   "Join Common to comment on this proposal.": "Junte-se ao Common para comentar esta proposta."
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1391,5 +1391,6 @@
   "Claim your account": "Reivindique sua conta",
   "Join": "Participar",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Junte-se ao Common para curtir, comentar e seguir qualquer ideia, e para editar e receber atualizações sobre suas próprias contribuições.",
-  "You're already signed in. Reload the page to continue.": "Você já está com a sessão iniciada. Recarregue a página para continuar."
+  "You're already signed in. Reload the page to continue.": "Você já está com a sessão iniciada. Recarregue a página para continuar.",
+  "Join Common to comment on this proposal.": "Junte-se ao Common para comentar esta proposta."
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1390,5 +1390,6 @@
   "Remove image": "Remover imagem",
   "Claim your account": "Reivindique sua conta",
   "Join": "Participar",
-  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Junte-se ao Common para curtir, comentar e seguir qualquer ideia, e para editar e receber atualizações sobre suas próprias contribuições."
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Junte-se ao Common para curtir, comentar e seguir qualquer ideia, e para editar e receber atualizações sobre suas próprias contribuições.",
+  "You're already signed in. Reload the page to continue.": "Você já está com a sessão iniciada. Recarregue a página para continuar."
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1387,5 +1387,8 @@
   "Admin options": "Opções de administrador",
   "Process settings": "Configurações do processo",
   "ends {date}": "termina em {date}",
-  "Remove image": "Remover imagem"
+  "Remove image": "Remover imagem",
+  "Claim your account": "Reivindique sua conta",
+  "Join": "Participar",
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Junte-se ao Common para curtir, comentar e seguir qualquer ideia, e para editar e receber atualizações sobre suas próprias contribuições."
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1393,5 +1393,6 @@
   "Claim your account": "Sheegso akoonkaaga",
   "Join": "Ku biir",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Ku biir Common si aad u jeclaysato, uga faallooto, oo aad u raacdo fikrad kasta, iyo si aad u tafatirto oo aad u hesho war-bixinta fikradahaaga aad gudbisay.",
-  "You're already signed in. Reload the page to continue.": "Horeyba waad u soo gashay. Dib u shub bogga si aad u sii wadato."
+  "You're already signed in. Reload the page to continue.": "Horeyba waad u soo gashay. Dib u shub bogga si aad u sii wadato.",
+  "Join Common to comment on this proposal.": "Ku biir Common si aad faallo uga bixiso soo-jeedintan."
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1394,5 +1394,6 @@
   "Join": "Ku biir",
   "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Ku biir Common si aad u jeclaysato, uga faallooto, oo aad u raacdo fikrad kasta, iyo si aad u tafatirto oo aad u hesho war-bixinta fikradahaaga aad gudbisay.",
   "You're already signed in. Reload the page to continue.": "Horeyba waad u soo gashay. Dib u shub bogga si aad u sii wadato.",
+  "An account with this email already exists. Try logging in instead.": "Akoon leh emailkan ayaa horey u jiray. Isku day inaad gasho.",
   "Join Common to comment on this proposal.": "Ku biir Common si aad faallo uga bixiso soo-jeedintan."
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1392,5 +1392,6 @@
   "Remove image": "Ka saar sawirka",
   "Claim your account": "Sheegso akoonkaaga",
   "Join": "Ku biir",
-  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Ku biir Common si aad u jeclaysato, uga faallooto, oo aad u raacdo fikrad kasta, iyo si aad u tafatirto oo aad u hesho war-bixinta fikradahaaga aad gudbisay."
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Ku biir Common si aad u jeclaysato, uga faallooto, oo aad u raacdo fikrad kasta, iyo si aad u tafatirto oo aad u hesho war-bixinta fikradahaaga aad gudbisay.",
+  "You're already signed in. Reload the page to continue.": "Horeyba waad u soo gashay. Dib u shub bogga si aad u sii wadato."
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1389,5 +1389,8 @@
   "Admin options": "Doorashooyinka maamulaha",
   "Process settings": "Dejinta habka",
   "ends {date}": "wuxuu dhammaanayaa {date}",
-  "Remove image": "Ka saar sawirka"
+  "Remove image": "Ka saar sawirka",
+  "Claim your account": "Sheegso akoonkaaga",
+  "Join": "Ku biir",
+  "Join Common to like, comment on, and follow any idea — and to edit and get updates about your own submissions.": "Ku biir Common si aad u jeclaysato, uga faallooto, oo aad u raacdo fikrad kasta, iyo si aad u tafatirto oo aad u hesho war-bixinta fikradahaaga aad gudbisay."
 }

--- a/services/api/src/routers/account/updateUserProfile.test.ts
+++ b/services/api/src/routers/account/updateUserProfile.test.ts
@@ -1,9 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../test/helpers/TestDecisionsDataManager';
 import {
   accessTierGatingCell,
   describeAccessTierGating,
   expectFailsAccessTierGate,
   expectPassesAccessTierGate,
 } from '../../test/helpers/gating';
+import { createAuthenticatedCaller } from '../../test/supabase-utils';
+
+describe.concurrent('updateUserProfile', () => {
+  it('busts the cached user so getMyAccount serves the update immediately', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({ grantAccess: true });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    // Warm the type:'user' cache, then mutate: updateUserProfile must
+    // invalidate it or the next getMyAccount serves the stale profile name
+    // (the "Logged in as <old name>" bug).
+    const before = await caller.account.getMyAccount();
+    expect(before?.profile?.name).toBeDefined();
+
+    const newName = `Renamed ${task.id}`;
+    await caller.account.updateUserProfile({ name: newName });
+
+    const after = await caller.account.getMyAccount();
+    expect(after?.profile?.name).toBe(newName);
+  });
+});
 
 describeAccessTierGating('account.updateUserProfile', {
   noJwt: accessTierGatingCell('rejects no-JWT caller', async ({ callers }) => {

--- a/services/api/src/routers/account/updateUserProfile.ts
+++ b/services/api/src/routers/account/updateUserProfile.ts
@@ -1,3 +1,4 @@
+import { invalidate } from '@op/cache';
 import { updateUserProfile as updateUserProfileService } from '@op/common';
 
 import { encodeUser, userEncoder } from '../../encoders';
@@ -16,6 +17,14 @@ const updateUserProfile = router({
       const result = await updateUserProfileService({
         input,
         user,
+      });
+
+      // getMyAccount serves the cached user (with profile/currentProfile
+      // names); without this, "Logged in as" and the comment-box placeholder
+      // keep the old name until the cache expires.
+      await invalidate({
+        type: 'user',
+        params: [user.id],
       });
 
       return encodeUser({ user: result, authUser: user });

--- a/tests/e2e/tests/join-account-flow.spec.ts
+++ b/tests/e2e/tests/join-account-flow.spec.ts
@@ -144,8 +144,9 @@ test.describe('Join account flow (public decision header)', () => {
     });
 
     // Anchor on the decision header being rendered before asserting absences.
+    // .first(): the header renders the title twice (responsive md variants).
     await expect(
-      page.getByRole('heading', { name: instance.name }),
+      page.getByRole('heading', { name: instance.name }).first(),
     ).toBeVisible({ timeout: 15000 });
 
     await expect(

--- a/tests/e2e/tests/join-account-flow.spec.ts
+++ b/tests/e2e/tests/join-account-flow.spec.ts
@@ -1,5 +1,7 @@
+import { ProposalStatus } from '@op/db/schema';
 import {
   createDecisionInstance,
+  createProposal,
   getSeededTemplate,
   makeDecisionPublic,
 } from '@op/test';
@@ -75,6 +77,52 @@ test.describe('Join account flow (public decision header)', () => {
 
     // Confirmations are off in e2e, so submitting the email claims the account
     // immediately and navigates to the promote onboarding.
+    await dialog.getByRole('button', { name: 'Join' }).click();
+    await page.waitForURL(/\/start\?.*promote=1/, { timeout: 20000 });
+    await expect(
+      page.getByText('You do not have permission to view this page'),
+    ).not.toBeVisible();
+  });
+
+  test('logged-out visitor joins from the proposal view page', async ({
+    page,
+  }) => {
+    const { org, instance } = await seedPublicDecision('join-prop');
+    const proposal = await createProposal({
+      processInstanceId: instance.instance.id,
+      submittedByProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      proposalData: {
+        title: `Join prompt proposal ${randomUUID().slice(0, 6)}`,
+      },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    await page.goto(
+      `/en/decisions/${instance.slug}/proposal/${proposal.profileId}`,
+      { waitUntil: 'networkidle' },
+    );
+
+    // The comments composer slot shows the claim prompt for visitors; the
+    // header offers Join rather than Log in.
+    await expect(
+      page.getByText('Join Common to comment on this proposal.'),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByRole('button', { name: 'Log in' }),
+    ).not.toBeVisible();
+
+    // Either Join button (header or prompt) opens the claim modal mounted by
+    // the proposal view layout.
+    await page.getByRole('button', { name: 'Join' }).first().click();
+    await expect(
+      page.getByRole('heading', { name: 'Claim your account' }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const email = `join-${randomUUID().slice(0, 8)}@example.com`;
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel('Email').fill(email);
     await dialog.getByRole('button', { name: 'Join' }).click();
     await page.waitForURL(/\/start\?.*promote=1/, { timeout: 20000 });
     await expect(

--- a/tests/e2e/tests/join-account-flow.spec.ts
+++ b/tests/e2e/tests/join-account-flow.spec.ts
@@ -1,0 +1,108 @@
+import {
+  createDecisionInstance,
+  getSeededTemplate,
+  makeDecisionPublic,
+} from '@op/test';
+import { randomUUID } from 'node:crypto';
+
+import {
+  TEST_USER_DEFAULT_PASSWORD,
+  authenticateAsUser,
+  createOrganization,
+  createSupabaseAdminClient,
+  expect,
+  test,
+} from '../fixtures/index.js';
+
+/**
+ * Header "Join" flow on public decisions: the header swaps "Log in" for
+ * "Join" when the viewer can submit proposals without an account, and the
+ * JoinAccountModal claims a full account inline (email → promote onboarding),
+ * minting an anonymous Supabase user on demand for no-session visitors.
+ *
+ * Note: e2e Supabase has email confirmations off, so entering the email
+ * applies immediately (no OTP screen) and navigates straight to
+ * /start?promote=1. The OTP branch is not coverable here.
+ *
+ * The logged-out + non-public case isn't asserted: a no-session visitor on a
+ * non-public decision gets the forbidden screen, which doesn't render the
+ * decision header at all.
+ */
+test.describe('Join account flow (public decision header)', () => {
+  // Start with no session; tests establish their own auth state.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  const admin = createSupabaseAdminClient();
+
+  async function seedPublicDecision(testIdPrefix: string) {
+    const org = await createOrganization({
+      testId: `${testIdPrefix}-${randomUUID().slice(0, 6)}`,
+      supabaseAdmin: admin,
+      users: { admin: 1, member: 0 },
+    });
+    const template = await getSeededTemplate();
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: template.processSchema,
+    });
+    // Public grant includes SUBMIT_PROPOSALS, which is what makes the header
+    // offer Join instead of Log in.
+    await makeDecisionPublic({ profileId: instance.profileId });
+    return { org, instance };
+  }
+
+  test('logged-out visitor claims an account via the header Join modal', async ({
+    page,
+  }) => {
+    const { instance } = await seedPublicDecision('join');
+
+    // No session at all — the modal mints the anonymous user itself.
+    await page.goto(`/en/decisions/${instance.slug}`, {
+      waitUntil: 'networkidle',
+    });
+
+    await page.getByRole('button', { name: 'Join' }).click();
+    await expect(
+      page.getByRole('heading', { name: 'Claim your account' }),
+    ).toBeVisible({ timeout: 15000 });
+
+    const email = `join-${randomUUID().slice(0, 8)}@example.com`;
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel('Email').fill(email);
+
+    // Confirmations are off in e2e, so submitting the email claims the account
+    // immediately and navigates to the promote onboarding.
+    await dialog.getByRole('button', { name: 'Join' }).click();
+    await page.waitForURL(/\/start\?.*promote=1/, { timeout: 20000 });
+    await expect(
+      page.getByText('You do not have permission to view this page'),
+    ).not.toBeVisible();
+  });
+
+  test('a full account sees the user menu, not Join, and ?join=1 opens nothing', async ({
+    page,
+  }) => {
+    const { org, instance } = await seedPublicDecision('nojoin');
+
+    await authenticateAsUser(page, {
+      email: org.adminUser.email,
+      password: TEST_USER_DEFAULT_PASSWORD,
+    });
+    await page.goto(`/en/decisions/${instance.slug}?join=1`, {
+      waitUntil: 'networkidle',
+    });
+
+    // Anchor on the decision header being rendered before asserting absences.
+    await expect(
+      page.getByRole('heading', { name: instance.name }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await expect(
+      page.getByRole('heading', { name: 'Claim your account' }),
+    ).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Join' })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Adds a "Join" account-claim flow for public decision processes (viewer resolves `submitProposals` without an account via the Public role — today: `columbus`). Three surfaces, one modal:

- **Decision header** and **proposal view header** swap "Log in" for "Join" for logged-out and anonymous visitors (`JoinOrUserMenu`).
- **Proposal comments** show a "Join Common to comment on this proposal" block where the composer would be.
- `JoinAccountModal` (`?join=1`): email → OTP claim inline, then the existing `/start?promote=1` promote onboarding, returning to the page the visitor left. No-session visitors get an anonymous user minted on submit; an existing anon session (e.g. a proposal author) is upgraded in place, so their data follows the claim.

The claim calls `supabase.auth.updateUser` on the anon session and never touches `account.login` — deliberately bypassing the invite-only allowList for public processes. Claim logic is extracted from `LinkAccountPanel` into a shared `useClaimAccount` hook (the panel is refactored onto it).

Also rides along (found dogfooding): `updateUserProfile` never invalidated the cached `getMyAccount` user, so freshly claimed accounts kept their old anonymous name in "Logged in as …" and the comment-box placeholder. Now invalidated, pinned by a test.

Tests: e2e for the decision-header and proposal-page join paths + full-account denial; vitest for the cache invalidation. Copy is placeholder pending a copy pass.

Note: liking/following as a claimed account also needs #1580 (relationship mutations were closed-network-gated).

Follow-up (separate PR): move the promote onboarding steps into the modal and converge `PromoteAccountModal` on the same in-modal flow.
