### PR TITLE
fix(decisions): enable infinite scroll for the map view proposal list

### DIFF
--- a/apps/app/src/components/Organizations/AllOrganizations/index.tsx
+++ b/apps/app/src/components/Organizations/AllOrganizations/index.tsx
@@ -57,10 +57,7 @@ export const AllOrganizationsSuspense = ({
     <div className="flex flex-col gap-4">
       <ProfileSummaryList profiles={allProfiles} />
       {shouldShowTrigger && (
-        <div
-          ref={ref as React.RefObject<HTMLDivElement>}
-          className="flex justify-center py-4"
-        >
+        <div ref={ref} className="flex justify-center py-4">
           {isFetchingNextPage ? (
             <div className="text-sm text-neutral-gray4">
               <SkeletonLine lines={3} />

--- a/apps/app/src/components/Profile/ProfileFeed/index.tsx
+++ b/apps/app/src/components/Profile/ProfileFeed/index.tsx
@@ -12,7 +12,7 @@ import { useInfiniteScroll } from '@op/hooks';
 import { HorizontalList, HorizontalListItem } from '@op/ui/HorizontalList';
 import { SkeletonLine } from '@op/ui/Skeleton';
 import { cn } from '@op/ui/utils';
-import { Fragment, type RefObject, useCallback } from 'react';
+import { Fragment, type RefCallback, useCallback } from 'react';
 
 import {
   DiscussionModalContainer,
@@ -32,7 +32,7 @@ export type ProfileFeedRenderProps = {
   posts: PostToOrganization[];
   isEmpty: boolean;
   user: CommonUser;
-  infiniteScrollRef: RefObject<HTMLElement | null>;
+  infiniteScrollRef: RefCallback<HTMLElement>;
   shouldShowTrigger: boolean;
   isFetchingNextPage: boolean;
   handleReactionClick: (postId: string, emoji: string) => void;
@@ -154,7 +154,7 @@ export const ProfileFeedCards = ({
         )}
         {shouldShowTrigger && (
           <HorizontalListItem>
-            <div ref={infiniteScrollRef as React.RefObject<HTMLDivElement>}>
+            <div ref={infiniteScrollRef}>
               {isFetchingNextPage ? (
                 <div className="text-sm text-neutral-gray4">
                   <SkeletonLine lines={2} />
@@ -211,10 +211,7 @@ export const ProfileFeedList = ({
         />
       </PostFeed>
       {shouldShowTrigger && (
-        <div
-          ref={infiniteScrollRef as React.RefObject<HTMLDivElement>}
-          className="flex justify-center py-4"
-        >
+        <div ref={infiniteScrollRef} className="flex justify-center py-4">
           {isFetchingNextPage ? (
             <div className="text-sm text-neutral-gray4">
               <SkeletonLine lines={2} />

--- a/apps/app/src/components/decisions/AllDecisions/index.tsx
+++ b/apps/app/src/components/decisions/AllDecisions/index.tsx
@@ -98,10 +98,7 @@ const DecisionsListSuspense = ({
         <DecisionListItem key={item.id} item={item} />
       ))}
       {shouldShowTrigger && (
-        <div
-          ref={ref as React.RefObject<HTMLDivElement>}
-          className="flex justify-center py-4"
-        >
+        <div ref={ref} className="flex justify-center py-4">
           {isFetchingNextPage ? <DecisionListItemSkeleton /> : null}
         </div>
       )}

--- a/apps/app/src/components/decisions/ProfileUsersAccess.tsx
+++ b/apps/app/src/components/decisions/ProfileUsersAccess.tsx
@@ -147,10 +147,7 @@ export const ProfileUsersAccess = ({
         />
 
         {shouldShowTrigger && (
-          <div
-            ref={scrollTriggerRef as React.RefObject<HTMLDivElement>}
-            className="flex justify-center py-4"
-          >
+          <div ref={scrollTriggerRef} className="flex justify-center py-4">
             {isFetchingNextPage && <SkeletonLine lines={3} />}
           </div>
         )}

--- a/apps/app/src/components/decisions/ProposalListSkeleton.tsx
+++ b/apps/app/src/components/decisions/ProposalListSkeleton.tsx
@@ -1,17 +1,6 @@
 import { Skeleton } from '@op/ui/Skeleton';
 import { Surface } from '@op/ui/Surface';
 
-/** Loading state for the map view's list column — mirrors the map view's
- * grid template so the skeleton cards line up under the list, not the map. */
-export const ProposalMapListSkeleton = () => (
-  <div className="grid grid-cols-1 gap-6 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
-    <div className="flex min-w-0 flex-col gap-6">
-      <ProposalCardSkeleton />
-      <ProposalCardSkeleton />
-    </div>
-  </div>
-);
-
 export const ProposalListSkeletonGrid = () => (
   <div className="columns-1 gap-6 md:columns-2 lg:columns-3 [&>*]:mb-6 [&>*]:break-inside-avoid">
     {Array.from({ length: 6 }).map((_, index) => (
@@ -40,7 +29,7 @@ export const ProposalListSkeleton = () => {
   );
 };
 
-const ProposalCardSkeleton = () => {
+export const ProposalCardSkeleton = () => {
   return (
     <Surface className="relative w-full space-y-3 p-4 pb-4">
       {/* Header with title and budget skeleton */}

--- a/apps/app/src/components/decisions/ProposalListSkeleton.tsx
+++ b/apps/app/src/components/decisions/ProposalListSkeleton.tsx
@@ -1,6 +1,17 @@
 import { Skeleton } from '@op/ui/Skeleton';
 import { Surface } from '@op/ui/Surface';
 
+/** Loading state for the map view's list column — mirrors the map view's
+ * grid template so the skeleton cards line up under the list, not the map. */
+export const ProposalMapListSkeleton = () => (
+  <div className="grid grid-cols-1 gap-6 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
+    <div className="flex min-w-0 flex-col gap-6">
+      <ProposalCardSkeleton />
+      <ProposalCardSkeleton />
+    </div>
+  </div>
+);
+
 export const ProposalListSkeletonGrid = () => (
   <div className="columns-1 gap-6 md:columns-2 lg:columns-3 [&>*]:mb-6 [&>*]:break-inside-avoid">
     {Array.from({ length: 6 }).map((_, index) => (

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -435,6 +435,20 @@ const ProposalsListContent = ({
 
   const hideFilters = !!proposalsHidden && !canManageProposals;
 
+  // One sentinel definition for both views — map mode renders it inside the
+  // list column (via listFooter), grid mode below the grid. Only the loading
+  // skeleton differs.
+  const renderScrollSentinel = (skeleton: React.ReactNode) =>
+    shouldShowTrigger ? (
+      <div
+        ref={infiniteScrollRef}
+        className="py-4"
+        data-testid="proposals-infinite-scroll-sentinel"
+      >
+        {isFetchingNextPage ? skeleton : null}
+      </div>
+    ) : null;
+
   return (
     <div
       className={cn(
@@ -490,17 +504,7 @@ const ProposalsListContent = ({
               decisionSlug={decisionSlug}
               permissions={permissions}
               mapView={mapView}
-              listFooter={
-                shouldShowTrigger ? (
-                  <div
-                    ref={infiniteScrollRef}
-                    className="py-4"
-                    data-testid="proposals-infinite-scroll-sentinel"
-                  >
-                    {isFetchingNextPage ? <ProposalCardSkeleton /> : null}
-                  </div>
-                ) : null
-              }
+              listFooter={renderScrollSentinel(<ProposalCardSkeleton />)}
             />
           ) : (
             // Local boundaries keep the pin query from suspending / erroring
@@ -532,17 +536,7 @@ const ProposalsListContent = ({
                     votedByProfileId: queryParams.votedByProfileId,
                     status: queryParams.status,
                   }}
-                  listFooter={
-                    shouldShowTrigger ? (
-                      <div
-                        ref={infiniteScrollRef}
-                        className="py-4"
-                        data-testid="proposals-infinite-scroll-sentinel"
-                      >
-                        {isFetchingNextPage ? <ProposalCardSkeleton /> : null}
-                      </div>
-                    ) : null
-                  }
+                  listFooter={renderScrollSentinel(<ProposalCardSkeleton />)}
                 />
               </Suspense>
             </APIErrorBoundary>
@@ -568,15 +562,7 @@ const ProposalsListContent = ({
         )}
       </ProposalTranslationProvider>
 
-      {!isMapMode && shouldShowTrigger && (
-        <div
-          ref={infiniteScrollRef}
-          className="py-4"
-          data-testid="proposals-infinite-scroll-sentinel"
-        >
-          {isFetchingNextPage ? <ProposalListSkeletonGrid /> : null}
-        </div>
-      )}
+      {!isMapMode && renderScrollSentinel(<ProposalListSkeletonGrid />)}
 
       {translation.showBanner && (
         <TranslateBanner

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -25,7 +25,10 @@ import { type RefObject, Suspense, useCallback, useMemo } from 'react';
 import { useTranslations } from '@/lib/i18n';
 
 import { MobileViewSwitch } from './MobileViewSwitch';
-import { ProposalListSkeletonGrid } from './ProposalListSkeleton';
+import {
+  ProposalListSkeletonGrid,
+  ProposalMapListSkeleton,
+} from './ProposalListSkeleton';
 import { ProposalTranslationProvider } from './ProposalTranslationContext';
 import { PROPOSAL_VIEWS, type ProposalView } from './ProposalViewToggle';
 import { ProposalsGrid } from './ProposalsGrid';
@@ -543,13 +546,21 @@ const ProposalsListContent = ({
         )}
       </ProposalTranslationProvider>
 
-      {!isMapMode && shouldShowTrigger && (
+      {shouldShowTrigger && (
         <div
           ref={infiniteScrollRef}
-          className="py-4"
+          // Mobile map view is a fullscreen map with no list — hide the
+          // sentinel there so it can't add stray space or fetch unseen pages.
+          className={cn('py-4', isMapMode && 'max-sm:hidden')}
           data-testid="proposals-infinite-scroll-sentinel"
         >
-          {isFetchingNextPage ? <ProposalListSkeletonGrid /> : null}
+          {isFetchingNextPage ? (
+            isMapMode ? (
+              <ProposalMapListSkeleton />
+            ) : (
+              <ProposalListSkeletonGrid />
+            )
+          ) : null}
         </div>
       )}
 

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -20,7 +20,7 @@ import {
 import { useInfiniteScroll } from '@op/hooks';
 import { cn } from '@op/ui/utils';
 import { parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs';
-import { type RefObject, Suspense, useCallback, useMemo } from 'react';
+import { type RefCallback, Suspense, useCallback, useMemo } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -90,7 +90,7 @@ type ProposalsLoaderRenderProps = {
   total: number;
   isFetchingNextPage: boolean;
   shouldShowTrigger: boolean;
-  infiniteScrollRef: RefObject<HTMLDivElement | null>;
+  infiniteScrollRef: RefCallback<HTMLDivElement>;
 };
 
 const useProposalsLoaderRenderProps = (

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -26,8 +26,8 @@ import { useTranslations } from '@/lib/i18n';
 
 import { MobileViewSwitch } from './MobileViewSwitch';
 import {
+  ProposalCardSkeleton,
   ProposalListSkeletonGrid,
-  ProposalMapListSkeleton,
 } from './ProposalListSkeleton';
 import { ProposalTranslationProvider } from './ProposalTranslationContext';
 import { PROPOSAL_VIEWS, type ProposalView } from './ProposalViewToggle';
@@ -490,6 +490,17 @@ const ProposalsListContent = ({
               decisionSlug={decisionSlug}
               permissions={permissions}
               mapView={mapView}
+              listFooter={
+                shouldShowTrigger ? (
+                  <div
+                    ref={infiniteScrollRef}
+                    className="py-4"
+                    data-testid="proposals-infinite-scroll-sentinel"
+                  >
+                    {isFetchingNextPage ? <ProposalCardSkeleton /> : null}
+                  </div>
+                ) : null
+              }
             />
           ) : (
             // Local boundaries keep the pin query from suspending / erroring
@@ -521,6 +532,17 @@ const ProposalsListContent = ({
                     votedByProfileId: queryParams.votedByProfileId,
                     status: queryParams.status,
                   }}
+                  listFooter={
+                    shouldShowTrigger ? (
+                      <div
+                        ref={infiniteScrollRef}
+                        className="py-4"
+                        data-testid="proposals-infinite-scroll-sentinel"
+                      >
+                        {isFetchingNextPage ? <ProposalCardSkeleton /> : null}
+                      </div>
+                    ) : null
+                  }
                 />
               </Suspense>
             </APIErrorBoundary>
@@ -546,21 +568,13 @@ const ProposalsListContent = ({
         )}
       </ProposalTranslationProvider>
 
-      {shouldShowTrigger && (
+      {!isMapMode && shouldShowTrigger && (
         <div
           ref={infiniteScrollRef}
-          // Mobile map view is a fullscreen map with no list — hide the
-          // sentinel there so it can't add stray space or fetch unseen pages.
-          className={cn('py-4', isMapMode && 'max-sm:hidden')}
+          className="py-4"
           data-testid="proposals-infinite-scroll-sentinel"
         >
-          {isFetchingNextPage ? (
-            isMapMode ? (
-              <ProposalMapListSkeleton />
-            ) : (
-              <ProposalListSkeletonGrid />
-            )
-          ) : null}
+          {isFetchingNextPage ? <ProposalListSkeletonGrid /> : null}
         </div>
       )}
 

--- a/apps/app/src/components/decisions/ProposalsMapView.tsx
+++ b/apps/app/src/components/decisions/ProposalsMapView.tsx
@@ -42,6 +42,10 @@ interface ProposalsMapViewProps {
   /** Fallback camera — the process's default view, used only when no proposal
    * has a location to fit. */
   mapView: MapDefaultView;
+  /** Rendered after the last list item on desktop — hosts the infinite-scroll
+   * sentinel inside the list column so loading more never adds space below
+   * the sticky map. Mobile (map only, no list) never renders it. */
+  listFooter?: React.ReactNode;
 }
 
 /**
@@ -61,6 +65,7 @@ export function ProposalsMapView({
   decisionSlug,
   permissions,
   mapView,
+  listFooter,
 }: ProposalsMapViewProps) {
   const canManageProposals = permissions?.admin ?? false;
   const t = useTranslations();
@@ -193,6 +198,7 @@ export function ProposalsMapView({
             onDeactivate={() => setActiveId(null)}
           />
         ))}
+        {listFooter && <li className="list-none">{listFooter}</li>}
       </ul>
       <aside className="sticky top-20 hidden h-[calc(100dvh_-_10rem)] overflow-hidden rounded-lg border border-neutral-gray1 sm:block">
         {map}

--- a/apps/app/src/components/decisions/ProposalsMapView.tsx
+++ b/apps/app/src/components/decisions/ProposalsMapView.tsx
@@ -198,7 +198,7 @@ export function ProposalsMapView({
             onDeactivate={() => setActiveId(null)}
           />
         ))}
-        {listFooter && <li className="list-none">{listFooter}</li>}
+        {listFooter && <li>{listFooter}</li>}
       </ul>
       <aside className="sticky top-20 hidden h-[calc(100dvh_-_10rem)] overflow-hidden rounded-lg border border-neutral-gray1 sm:block">
         {map}

--- a/apps/app/src/components/screens/LandingScreen/Feed.tsx
+++ b/apps/app/src/components/screens/LandingScreen/Feed.tsx
@@ -90,7 +90,7 @@ const FeedContent = ({ limit = 10 }: { limit?: number }) => {
       ))}
 
       {allPosts.length > 0 && shouldShowTrigger && (
-        <div ref={ref as React.RefObject<HTMLDivElement>}>
+        <div ref={ref}>
           {isFetchingNextPage && <PostFeedSkeleton numPosts={1} />}
         </div>
       )}

--- a/packages/hooks/src/useIntersectionObserver.tsx
+++ b/packages/hooks/src/useIntersectionObserver.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface UseIntersectionObserverOptions {
   threshold?: number;
@@ -23,10 +23,14 @@ export const useIntersectionObserver = <T extends HTMLElement = HTMLElement>(
     initialIsIntersecting = false,
   } = options;
   const [isIntersecting, setIsIntersecting] = useState(initialIsIntersecting);
-  const ref = useRef<T>(null);
+  // The observed node is state (set via callback ref), not a ref, so the
+  // observer re-attaches when the element mounts later than this hook's
+  // effect — e.g. a sentinel inside a Suspense boundary that resolves after
+  // the first commit.
+  const [node, setNode] = useState<T | null>(null);
 
   useEffect(() => {
-    if (!enabled || !ref.current) return;
+    if (!enabled || !node) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -40,12 +44,12 @@ export const useIntersectionObserver = <T extends HTMLElement = HTMLElement>(
       },
     );
 
-    observer.observe(ref.current);
+    observer.observe(node);
 
     return () => {
       observer.disconnect();
     };
-  }, [threshold, rootMargin, enabled]);
+  }, [node, threshold, rootMargin, enabled]);
 
-  return { ref, isIntersecting };
+  return { ref: setNode, isIntersecting };
 };

--- a/packages/hooks/src/useIntersectionObserver.tsx
+++ b/packages/hooks/src/useIntersectionObserver.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { type RefCallback, useEffect, useState } from 'react';
 
 interface UseIntersectionObserverOptions {
   threshold?: number;
@@ -33,7 +33,9 @@ export const useIntersectionObserver = <T extends HTMLElement = HTMLElement>(
     if (!enabled || !node) return;
 
     const observer = new IntersectionObserver(
-      ([entry]) => {
+      (entries) => {
+        // Entries are chronological; only the newest reflects current state.
+        const entry = entries[entries.length - 1];
         if (entry) {
           setIsIntersecting(entry.isIntersecting);
         }
@@ -48,8 +50,16 @@ export const useIntersectionObserver = <T extends HTMLElement = HTMLElement>(
 
     return () => {
       observer.disconnect();
+      // Without a live observer nothing can correct a frozen `true`, and a
+      // stale intersecting state re-triggers consumers (e.g. a spurious
+      // fetchNextPage) the moment they re-enable.
+      setIsIntersecting(initialIsIntersecting);
     };
-  }, [node, threshold, rootMargin, enabled]);
+  }, [node, threshold, rootMargin, enabled, initialIsIntersecting]);
 
-  return { ref: setNode, isIntersecting };
+  // Typed as a plain callback ref so the state-setter implementation detail
+  // doesn't leak into consumers' prop types.
+  const ref: RefCallback<T> = setNode;
+
+  return { ref, isIntersecting };
 };

--- a/tests/e2e/tests/proposal-listing-infinite-scroll.spec.ts
+++ b/tests/e2e/tests/proposal-listing-infinite-scroll.spec.ts
@@ -96,4 +96,105 @@ test.describe('Proposal Listing — Infinite Scroll', () => {
       })
       .toBe(TOTAL_PROPOSALS);
   });
+
+  /**
+   * Map browse mode renders the sentinel inside the list column, and that
+   * column mounts late — behind the Suspense boundary around the map's pin
+   * query — so this guards the callback-ref observer attach in
+   * `useIntersectionObserver` (a ref-object observer set up before the
+   * sentinel mounts never fires; see the map-view infinite scroll fix).
+   */
+  test('map view list column loads remaining proposals when scrolling', async ({
+    authenticatedPage,
+    org,
+  }) => {
+    test.setTimeout(120_000);
+
+    const process = await createDecisionProcess({
+      createdByProfileId: org.organizationProfile.id,
+      name: `Infinite Scroll Map Listing ${Date.now()}`,
+    });
+
+    // A template with a location field puts the process in map browse mode
+    // (map is the default view when the template collects a location).
+    const { instance, slug, name } = await createDecisionInstance({
+      processId: process.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: process.processSchema,
+      proposalTemplate: {
+        type: 'object',
+        required: ['title'],
+        'x-field-order': ['title', 'location'],
+        properties: {
+          title: {
+            type: 'string',
+            title: 'Title',
+            'x-format': 'short-text',
+          },
+          location: {
+            type: 'object',
+            title: 'Location',
+            'x-format': 'location',
+          },
+        },
+      },
+    });
+
+    // Keep in sync with PROPOSALS_PAGE_LIMIT in ProposalsList.tsx.
+    const PAGE_LIMIT = 51;
+    const TOTAL_PROPOSALS = PAGE_LIMIT + 4;
+
+    for (let i = 1; i <= TOTAL_PROPOSALS; i++) {
+      await createProposal({
+        processInstanceId: instance.id,
+        submittedByProfileId: org.organizationProfile.id,
+        authUserId: org.adminUser.authUserId,
+        email: org.adminUser.email,
+        status: ProposalStatus.SUBMITTED,
+        proposalData: {
+          title: `Proposal ${i}`,
+          collaborationDocId: MOCK_DOC_ID,
+        },
+      });
+    }
+
+    await authenticatedPage.goto(
+      `/en/decisions/${slug}/current?filter=all&view=map`,
+      { waitUntil: 'domcontentloaded' },
+    );
+
+    await expect(
+      authenticatedPage.getByRole('heading', { name, level: 2 }),
+    ).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const proposalLink = authenticatedPage.getByRole('link', {
+      name: MOCK_PROPOSAL_TITLE,
+    });
+
+    // First page lands at PAGE_LIMIT — proving the list column is paginated,
+    // not the full set.
+    await expect(proposalLink.first()).toBeVisible({ timeout: 30_000 });
+    await expect
+      .poll(() => proposalLink.count(), {
+        timeout: 30_000,
+        message: 'first page should load PAGE_LIMIT proposals',
+      })
+      .toBe(PAGE_LIMIT);
+
+    // The map column is sticky; the list column drives page height, so pulling
+    // the last card into view brings the in-column sentinel into the viewport.
+    await proposalLink.last().scrollIntoViewIfNeeded();
+
+    await expect
+      .poll(() => proposalLink.count(), {
+        timeout: 30_000,
+        message:
+          'after scrolling the list column, all proposals across pages should render',
+      })
+      .toBe(TOTAL_PROPOSALS);
+  });
 });


### PR DESCRIPTION
The list column next to the map never loaded past its first page — the infinite-scroll sentinel was gated behind `!isMapMode`, and even when rendered there, the observer never attached because the map subtree mounts behind a Suspense boundary.

- `useIntersectionObserver` now holds the observed node in state via a callback ref, so the observer attaches whenever the element actually mounts (late-mounting sentinels included) and detaches on unmount. It also resets `isIntersecting` on disconnect — a frozen `true` previously re-fired `fetchNextPage` on re-enable — and reads the newest batched observer entry instead of the oldest.
- `ProposalsList` defines one shared scroll sentinel for both views: grid mode renders it below the grid (unchanged), map mode passes it into `ProposalsMapView`'s list column via a new `listFooter` slot, so loading more grows the list under the sticky map. Mobile map (no list) never renders it.
- The hook's ref is now typed `RefCallback<T>`, deleting the `as React.RefObject<HTMLDivElement>` casts at all six call sites.
- New e2e test covers map-mode infinite scroll end to end (location-field template, Suspense-mounted sentinel, 51 → 55 cards).

Inline comments below walk through the decisions worth reviewer attention.