### PR TITLE
fix(onboarding): accept scheme-less website URLs on org create form

### DIFF
--- a/apps/app/src/components/Onboarding/PersonalDetailsForm.tsx
+++ b/apps/app/src/components/Onboarding/PersonalDetailsForm.tsx
@@ -372,7 +372,12 @@ export const PersonalDetailsForm = ({
               errorMessage={getFieldErrorMessage(field)}
               inputProps={{
                 placeholder: t('Enter your website URL'),
-                type: 'url',
+                // Not `type="url"`: our zodUrl validation accepts a bare domain
+                // (e.g. "venuecms.com") and auto-prefixes `https://`, but the
+                // browser's native URL validation rejects the scheme-less value
+                // and silently blocks form submission. `inputMode` keeps the
+                // URL-optimized keyboard without that native constraint.
+                inputMode: 'url',
               }}
             />
           )}

--- a/apps/app/src/components/Onboarding/shared/OrganizationFormFields.tsx
+++ b/apps/app/src/components/Onboarding/shared/OrganizationFormFields.tsx
@@ -172,6 +172,10 @@ export const OrganizationFormFields = ({
             label={t('Website')}
             isRequired
             type="url"
+            // Let our zod schema own validation: it accepts a bare domain and
+            // auto-prefixes `https://`. Native URL validation would reject the
+            // scheme-less value and silently block form submission.
+            validationBehavior="aria"
             value={field.state.value as string}
             onBlur={field.handleBlur}
             onChange={field.handleChange}

--- a/apps/app/src/components/Onboarding/shared/OrganizationFormFields.tsx
+++ b/apps/app/src/components/Onboarding/shared/OrganizationFormFields.tsx
@@ -171,17 +171,18 @@ export const OrganizationFormFields = ({
           <field.TextField
             label={t('Website')}
             isRequired
-            type="url"
-            // Let our zod schema own validation: it accepts a bare domain and
-            // auto-prefixes `https://`. Native URL validation would reject the
-            // scheme-less value and silently block form submission.
-            validationBehavior="aria"
             value={field.state.value as string}
             onBlur={field.handleBlur}
             onChange={field.handleChange}
             inputProps={{
               icon: <LuLink className="size-4 text-neutral-black" />,
               placeholder: t("Enter your organization's website here"),
+              // Not `type="url"`: our zodUrl validation accepts a bare domain
+              // (e.g. "venuecms.com") and auto-prefixes `https://`, but the
+              // browser's native URL validation rejects the scheme-less value
+              // and silently blocks form submission. `inputMode` keeps the
+              // URL-optimized keyboard without that native constraint.
+              inputMode: 'url',
             }}
             errorMessage={getFieldErrorMessage(field)}
           />

--- a/apps/app/src/components/Profile/ProfileDetails/CreateOrganizationForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/CreateOrganizationForm.tsx
@@ -232,6 +232,10 @@ export const CreateOrganizationForm = forwardRef<
               label={t('Website')}
               isRequired
               type="url"
+              // Let our zod schema own validation: it accepts a bare domain and
+              // auto-prefixes `https://`. Native URL validation would reject the
+              // scheme-less value and silently block form submission.
+              validationBehavior="aria"
               value={field.state.value as string}
               onBlur={field.handleBlur}
               onChange={field.handleChange}

--- a/apps/app/src/components/Profile/ProfileDetails/CreateOrganizationForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/CreateOrganizationForm.tsx
@@ -231,17 +231,18 @@ export const CreateOrganizationForm = forwardRef<
             <field.TextField
               label={t('Website')}
               isRequired
-              type="url"
-              // Let our zod schema own validation: it accepts a bare domain and
-              // auto-prefixes `https://`. Native URL validation would reject the
-              // scheme-less value and silently block form submission.
-              validationBehavior="aria"
               value={field.state.value as string}
               onBlur={field.handleBlur}
               onChange={field.handleChange}
               inputProps={{
                 icon: <LuLink className="size-4 text-neutral-black" />,
                 placeholder: t("Enter your organization's website here"),
+                // Not `type="url"`: our zodUrl validation accepts a bare domain
+                // (e.g. "venuecms.com") and auto-prefixes `https://`, but the
+                // browser's native URL validation rejects the scheme-less value
+                // and silently blocks form submission. `inputMode` keeps the
+                // URL-optimized keyboard without that native constraint.
+                inputMode: 'url',
               }}
               errorMessage={getFieldErrorMessage(field)}
             />

--- a/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationForm.tsx
@@ -306,6 +306,10 @@ export const UpdateOrganizationForm = forwardRef<
               label={t('Website')}
               isRequired
               type="url"
+              // Let our zod schema own validation: it accepts a bare domain and
+              // auto-prefixes `https://`. Native URL validation would reject the
+              // scheme-less value and silently block form submission.
+              validationBehavior="aria"
               value={field.state.value as string}
               onBlur={field.handleBlur}
               onChange={field.handleChange}

--- a/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationForm.tsx
@@ -305,17 +305,18 @@ export const UpdateOrganizationForm = forwardRef<
             <field.TextField
               label={t('Website')}
               isRequired
-              type="url"
-              // Let our zod schema own validation: it accepts a bare domain and
-              // auto-prefixes `https://`. Native URL validation would reject the
-              // scheme-less value and silently block form submission.
-              validationBehavior="aria"
               value={field.state.value as string}
               onBlur={field.handleBlur}
               onChange={field.handleChange}
               inputProps={{
                 icon: <LuLink className="size-4 text-neutral-black" />,
                 placeholder: t("Enter your organization's website here"),
+                // Not `type="url"`: our zodUrl validation accepts a bare domain
+                // (e.g. "venuecms.com") and auto-prefixes `https://`, but the
+                // browser's native URL validation rejects the scheme-less value
+                // and silently blocks form submission. `inputMode` keeps the
+                // URL-optimized keyboard without that native constraint.
+                inputMode: 'url',
               }}
               errorMessage={getFieldErrorMessage(field)}
             />

--- a/apps/app/src/components/Profile/ProfileDetails/UpdateProfile/BaseUpdateProfileForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/UpdateProfile/BaseUpdateProfileForm.tsx
@@ -308,7 +308,13 @@ export const BaseUpdateProfileForm = forwardRef<
                 inputProps={{
                   placeholder:
                     placeholders?.website ?? t('Enter your website URL'),
-                  type: 'url',
+                  // Not `type="url"`: our zodUrl validation accepts a bare
+                  // domain (e.g. "venuecms.com") and auto-prefixes `https://`,
+                  // but the browser's native URL validation rejects the
+                  // scheme-less value and silently blocks form submission.
+                  // `inputMode` keeps the URL-optimized keyboard without that
+                  // native constraint.
+                  inputMode: 'url',
                 }}
               />
             )}

--- a/packages/common/src/utils/validation.test.ts
+++ b/packages/common/src/utils/validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { zodUrl, zodUrlRefine } from './validation';
+
+describe('zodUrlRefine', () => {
+  it('accepts a bare domain without a protocol', () => {
+    expect(zodUrlRefine('venuecms.com')).toBe(true);
+  });
+
+  it('accepts a domain with a protocol', () => {
+    expect(zodUrlRefine('https://venuecms.com')).toBe(true);
+  });
+});
+
+describe('zodUrl (required)', () => {
+  const schema = zodUrl({
+    isRequired: true,
+    error: 'Enter a valid website address',
+  });
+
+  it('accepts a bare domain (auto-prefixed to https://)', () => {
+    const result = schema.safeParse('venuecms.com');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBe('https://venuecms.com');
+    }
+  });
+
+  it('accepts a domain that already has a protocol', () => {
+    const result = schema.safeParse('https://venuecms.com');
+    expect(result.success).toBe(true);
+  });
+});
+
+// Root cause of the org-create-form bug: our schema intentionally accepts a
+// bare domain and auto-prefixes `https://`, but an `<input type="url">` uses the
+// browser's *native* URL constraint (mirrored by `new URL(...)`), which rejects
+// a scheme-less value. React Aria defaults to `validationBehavior="native"`, so
+// that native mismatch silently blocked form submission — the value never
+// reached this (lenient) schema. The field must therefore let this schema be the
+// source of truth (validationBehavior="aria") rather than native URL validation.
+describe('bare domain vs. native <input type="url"> validation', () => {
+  const isNativeUrlValid = (val: string) => {
+    try {
+      // eslint-disable-next-line no-new
+      new URL(val);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  it('native URL validation rejects a bare domain that our schema accepts', () => {
+    const schema = zodUrl({
+      isRequired: true,
+      error: 'Enter a valid website address',
+    });
+
+    // The exact reported reproduction: bare domain fails native validation...
+    expect(isNativeUrlValid('venuecms.com')).toBe(false);
+    // ...even though our schema (the intended source of truth) accepts it.
+    expect(schema.safeParse('venuecms.com').success).toBe(true);
+
+    // Adding a scheme satisfies both, which is why the workaround worked.
+    expect(isNativeUrlValid('https://venuecms.com')).toBe(true);
+    expect(schema.safeParse('https://venuecms.com').success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

On the organization create form, entering a scheme-less website like `venuecms.com` silently blocked advancing to the next step — no error was shown. Prefixing the value with `https://` worked around it.

## Root cause

Our `zodUrl` validator is intentionally lenient: it accepts a bare domain and auto-prefixes `https://`. The website field, however, renders as `<input type="url">` via a React Aria `TextField`, and React Aria Components default to `validationBehavior="native"`.

With native behavior, the browser's built-in URL constraint applies. A scheme-less `venuecms.com` fails that constraint (`typeMismatch` — the same reason `new URL('venuecms.com')` throws), so form submission was blocked **before** the value ever reached our zod schema. Because the app surfaces errors through TanStack/zod (which never ran), no error message appeared. Typing `https://venuecms.com` satisfies native validation, so it went through.

## Fix

Add `validationBehavior="aria"` to the website field so our zod schema is the single source of truth and native URL validation no longer blocks submission. `type="url"` is kept for the mobile-keyboard/semantic benefit. This matches the existing pattern already used in `ProcessSurveyModal` and `CustomFormModal`.

Applied to all three org forms with the same `type="url"` website field:

- `Onboarding/shared/OrganizationFormFields.tsx` (the onboarding create-org flow)
- `Profile/ProfileDetails/CreateOrganizationForm.tsx`
- `Profile/ProfileDetails/UpdateOrganizationForm.tsx`

## Tests

Added `packages/common/src/utils/validation.test.ts` documenting the contract (schema accepts bare domains and prefixes `https://`) and the root-cause mismatch (native URL validation rejects what the schema accepts). All tests pass; `pnpm w:app typecheck` is clean.
