### PR TITLE
fix(landing): update text on Columbus banner and allow it to wrap

### DIFF
--- a/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
+++ b/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
@@ -7,6 +7,7 @@ import { cn } from '@op/ui/utils';
 import type { Variants } from 'motion/react';
 import * as motion from 'motion/react-client';
 import Image from 'next/image';
+import { ReactNode } from 'react';
 import { LuArrowRight } from 'react-icons/lu';
 
 import { Link, useTranslations } from '@/lib/i18n';
@@ -31,21 +32,26 @@ export const ComingSoonScreen = () => {
         >
           <div className="pointer-events-none absolute inset-x-0 top-full h-30 bg-gradient-to-b from-[white] from-10% via-[rgba(255,255,255,0.35)] via-45%" />
           <p>
-            {t(
-              "Columbus' first-ever Participatory Budgeting process is officially underway!",
+            {t.rich(
+              "Columbus' participatory budgeting is now open. <participate>Participate</participate>",
+              {
+                participate: (chunks: ReactNode) => (
+                  // Plain anchor, not the i18n Link: the vanity slug only
+                  // resolves via the afterFiles rewrite on a full-page
+                  // request. SPA/RSC navigation matches the (main)/[...rest]
+                  // catch-all instead and bounces anonymous visitors to
+                  // /login.
+                  <a
+                    href="/columbus"
+                    className="inline-flex items-center gap-1 align-bottom whitespace-nowrap text-primary-teal underline hover:no-underline"
+                  >
+                    {chunks}
+                    <LuArrowRight className="size-4" />
+                  </a>
+                ),
+              },
             )}
           </p>
-          {/* Plain anchor, not the i18n Link: the vanity slug only resolves
-              via the afterFiles rewrite on a full-page request. SPA/RSC
-              navigation matches the (main)/[...rest] catch-all instead and
-              bounces anonymous visitors to /login. */}
-          <a
-            href="/columbus"
-            className="flex items-center gap-1 whitespace-nowrap text-primary-teal underline hover:no-underline"
-          >
-            {t('Access Our Voice, Our Choice')}
-            <LuArrowRight className="size-4" />
-          </a>
         </motion.div>
         <motion.header
           transition={{ duration: 1 }}

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1394,6 +1394,5 @@
   "You're already signed in. Reload the page to continue.": "لقد سجّلت الدخول بالفعل. أعد تحميل الصفحة للمتابعة.",
   "An account with this email already exists. Try logging in instead.": "يوجد حساب بهذا البريد الإلكتروني بالفعل. حاول تسجيل الدخول بدلاً من ذلك.",
   "Join Common to comment on this proposal.": "انضم إلى Common للتعليق على هذا المقترح.",
-  "Columbus' first-ever Participatory Budgeting process is officially underway!": "انطلقت رسميًا أول عملية موازنة تشاركية في كولومبوس!",
-  "Access Our Voice, Our Choice": "الوصول إلى Our Voice, Our Choice"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "الموازنة التشاركية في كولومبوس مفتوحة الآن. <participate>شارك الآن</participate>"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1397,6 +1397,5 @@
   "You're already signed in. Reload the page to continue.": "আপনি ইতিমধ্যে সাইন ইন করেছেন। চালিয়ে যেতে পৃষ্ঠাটি পুনরায় লোড করুন।",
   "An account with this email already exists. Try logging in instead.": "এই ইমেল দিয়ে ইতিমধ্যে একটি অ্যাকাউন্ট রয়েছে। পরিবর্তে লগ ইন করার চেষ্টা করুন।",
   "Join Common to comment on this proposal.": "এই প্রস্তাবে মন্তব্য করতে Common-এ যোগ দিন।",
-  "Columbus' first-ever Participatory Budgeting process is officially underway!": "কলম্বাসের প্রথম অংশগ্রহণমূলক বাজেট প্রক্রিয়া আনুষ্ঠানিকভাবে শুরু হয়েছে!",
-  "Access Our Voice, Our Choice": "Our Voice, Our Choice দেখুন"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "কলম্বাসের অংশগ্রহণমূলক বাজেট এখন উন্মুক্ত। <participate>অংশ নিন</participate>"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1403,6 +1403,5 @@
   "You're already signed in. Reload the page to continue.": "You're already signed in. Reload the page to continue.",
   "An account with this email already exists. Try logging in instead.": "An account with this email already exists. Try logging in instead.",
   "Join Common to comment on this proposal.": "Join Common to comment on this proposal.",
-  "Columbus' first-ever Participatory Budgeting process is officially underway!": "Columbus' first-ever Participatory Budgeting process is officially underway!",
-  "Access Our Voice, Our Choice": "Access Our Voice, Our Choice"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "Columbus' participatory budgeting is now open. <participate>Participate</participate>"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1394,6 +1394,5 @@
   "You're already signed in. Reload the page to continue.": "Ya has iniciado sesión. Recarga la página para continuar.",
   "An account with this email already exists. Try logging in instead.": "Ya existe una cuenta con este correo electrónico. Intenta iniciar sesión.",
   "Join Common to comment on this proposal.": "Únete a Common para comentar esta propuesta.",
-  "Columbus' first-ever Participatory Budgeting process is officially underway!": "¡El primer proceso de Presupuesto Participativo de Columbus está oficialmente en marcha!",
-  "Access Our Voice, Our Choice": "Accede a Our Voice, Our Choice"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "El presupuesto participativo de Columbus ya está abierto. <participate>Participa</participate>"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1394,6 +1394,5 @@
   "You're already signed in. Reload the page to continue.": "Vous êtes déjà connecté. Rechargez la page pour continuer.",
   "An account with this email already exists. Try logging in instead.": "Un compte avec cet e-mail existe déjà. Essayez plutôt de vous connecter.",
   "Join Common to comment on this proposal.": "Rejoignez Common pour commenter cette proposition.",
-  "Columbus' first-ever Participatory Budgeting process is officially underway!": "Le tout premier processus de budget participatif de Columbus est officiellement lancé !",
-  "Access Our Voice, Our Choice": "Accéder à Our Voice, Our Choice"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "Le budget participatif de Columbus est maintenant ouvert. <participate>Participez</participate>"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1394,6 +1394,5 @@
   "You're already signed in. Reload the page to continue.": "Você já está com a sessão iniciada. Recarregue a página para continuar.",
   "An account with this email already exists. Try logging in instead.": "Já existe uma conta com este e-mail. Tente fazer login.",
   "Join Common to comment on this proposal.": "Junte-se ao Common para comentar esta proposta.",
-  "Columbus' first-ever Participatory Budgeting process is officially underway!": "O primeiro processo de Orçamento Participativo de Columbus está oficialmente em andamento!",
-  "Access Our Voice, Our Choice": "Acesse o Our Voice, Our Choice"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "O orçamento participativo de Columbus já está aberto. <participate>Participe</participate>"
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1396,6 +1396,5 @@
   "You're already signed in. Reload the page to continue.": "Horeyba waad u soo gashay. Dib u shub bogga si aad u sii wadato.",
   "An account with this email already exists. Try logging in instead.": "Akoon leh emailkan ayaa horey u jiray. Isku day inaad gasho.",
   "Join Common to comment on this proposal.": "Ku biir Common si aad faallo uga bixiso soo-jeedintan.",
-  "Columbus' first-ever Participatory Budgeting process is officially underway!": "Hannaankii ugu horreeyay ee Miisaaniyadda Wadajirka ah ee Columbus ayaa si rasmi ah u bilaabmay!",
-  "Access Our Voice, Our Choice": "Gal Our Voice, Our Choice"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "Miisaaniyadda wadajirka ah ee Columbus hadda waa furan tahay. <participate>Ka qaybqaado</participate>"
 }


### PR DESCRIPTION
Changes the text on the logged out banner pointing folks to the Columbus process. Also makes the link an `inline-flex` element so it flows and wraps with the text instead of taking its own line on smaller screens. 