### PR TITLE
fix(decisions): tweak the DecisionViewToggle style

### DIFF
--- a/apps/app/src/components/decisions/DecisionViewToggle.tsx
+++ b/apps/app/src/components/decisions/DecisionViewToggle.tsx
@@ -25,6 +25,7 @@ export function DecisionViewToggle({ decisionSlug }: DecisionViewToggleProps) {
 
   return (
     <Tabs value={activeView}>
+      {/* TODO: remove these overrides when we migrate to @op/sense */}
       <TabsList className="!h-9">
         <TabsTrigger
           value="overview"

--- a/apps/app/src/components/decisions/DecisionViewToggle.tsx
+++ b/apps/app/src/components/decisions/DecisionViewToggle.tsx
@@ -25,26 +25,18 @@ export function DecisionViewToggle({ decisionSlug }: DecisionViewToggleProps) {
 
   return (
     <Tabs value={activeView}>
-      <TabsList>
+      <TabsList className="!h-9">
         <TabsTrigger
           value="overview"
-          render={
-            <Link
-              className="hover:no-underline"
-              href={`/decisions/${decisionSlug}`}
-            />
-          }
+          className="font-normal hover:no-underline"
+          render={<Link href={`/decisions/${decisionSlug}`} />}
         >
           {t('Overview')}
         </TabsTrigger>
         <TabsTrigger
           value="current"
-          render={
-            <Link
-              className="hover:no-underline"
-              href={`/decisions/${decisionSlug}/current`}
-            />
-          }
+          className="font-normal hover:no-underline"
+          render={<Link href={`/decisions/${decisionSlug}/current`} />}
         >
           {t('Current Phase')}
         </TabsTrigger>


### PR DESCRIPTION
Manually overriding our default `@op/sense` styles for the tabs component until we migrate the whole app to use those styles (they look out of place with the current component set). 

We are using the sense Tabs component because it is a closer match to the Figma spec than our RAC-based component. 