### PR TITLE
fix(app): restore menu content in mobile bottom sheets

### DIFF
--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -30,7 +30,6 @@ import {
   LuCircleHelp,
   LuLogOut,
   LuSearch,
-  LuX,
 } from 'react-icons/lu';
 
 import { Link, useRouter, useTranslations } from '@/lib/i18n';
@@ -343,7 +342,6 @@ const AvatarMenuContent = ({
 };
 
 export const UserAvatarMenu = ({ className }: { className?: string }) => {
-  const t = useTranslations();
   const { user } = useRequiredUser();
   const isMobile = useMediaQuery(`(max-width: ${screens.sm})`);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -415,17 +413,7 @@ export const UserAvatarMenu = ({ className }: { className?: string }) => {
           className="m-0 h-auto max-h-[85svh] w-screen max-w-none animate-in rounded-t rounded-b-none border-0 outline-0 duration-300 ease-out slide-in-from-bottom-full"
         >
           <ModalBody className="pb-safe p-0">
-            <div className="flex justify-end px-4 pt-3">
-              <button
-                type="button"
-                aria-label={t('Close')}
-                onClick={() => setIsDrawerOpen(false)}
-                className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg outline-none hover:bg-neutral-gray1 focus-visible:ring-2 focus-visible:ring-primary-teal focus-visible:ring-offset-2"
-              >
-                <LuX className="size-4" />
-              </button>
-            </div>
-            <MenuList className="flex min-w-full flex-col border-t-0 p-4 pt-0 pb-8">
+            <MenuList className="flex min-w-full flex-col border-t-0 p-4 pb-8">
               <AvatarMenuContent
                 setIsProfileOpen={setIsProfileOpen}
                 setIsOrgDeletionOpen={setIsOrgDeletionOpen}

--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -30,6 +30,7 @@ import {
   LuCircleHelp,
   LuLogOut,
   LuSearch,
+  LuX,
 } from 'react-icons/lu';
 
 import { Link, useRouter, useTranslations } from '@/lib/i18n';
@@ -342,6 +343,7 @@ const AvatarMenuContent = ({
 };
 
 export const UserAvatarMenu = ({ className }: { className?: string }) => {
+  const t = useTranslations();
   const { user } = useRequiredUser();
   const isMobile = useMediaQuery(`(max-width: ${screens.sm})`);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -413,7 +415,17 @@ export const UserAvatarMenu = ({ className }: { className?: string }) => {
           className="m-0 h-auto w-screen max-w-none animate-in rounded-t rounded-b-none border-0 outline-0 duration-300 ease-out slide-in-from-bottom-full"
         >
           <ModalBody className="pb-safe p-0">
-            <MenuList className="flex min-w-full flex-col border-t-0 p-4 pb-8">
+            <div className="flex justify-end px-4 pt-3">
+              <button
+                type="button"
+                aria-label={t('Close')}
+                onClick={() => setIsDrawerOpen(false)}
+                className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg outline-none hover:bg-neutral-gray1 focus-visible:ring-2 focus-visible:ring-primary-teal focus-visible:ring-offset-2"
+              >
+                <LuX className="size-4" />
+              </button>
+            </div>
+            <MenuList className="flex min-w-full flex-col border-t-0 p-4 pt-0 pb-8">
               <AvatarMenuContent
                 setIsProfileOpen={setIsProfileOpen}
                 setIsOrgDeletionOpen={setIsOrgDeletionOpen}

--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -15,6 +15,7 @@ import {
   Menu,
   MenuItem,
   MenuItemSimple,
+  MenuList,
   MenuSeparator,
   MenuTrigger,
 } from '@op/ui/Menu';
@@ -412,14 +413,14 @@ export const UserAvatarMenu = ({ className }: { className?: string }) => {
           className="m-0 h-auto w-screen max-w-none animate-in rounded-t rounded-b-none border-0 outline-0 duration-300 ease-out slide-in-from-bottom-full"
         >
           <ModalBody className="pb-safe p-0">
-            <Menu className="flex min-w-full flex-col border-t-0 p-4 pb-8">
+            <MenuList className="flex min-w-full flex-col border-t-0 p-4 pb-8">
               <AvatarMenuContent
                 setIsProfileOpen={setIsProfileOpen}
                 setIsOrgDeletionOpen={setIsOrgDeletionOpen}
                 onClose={() => setIsDrawerOpen(false)}
                 onProfileSwitch={handleProfileSwitch}
               />
-            </Menu>
+            </MenuList>
           </ModalBody>
         </Modal>
         <UpdateProfileModal

--- a/apps/app/src/components/SiteHeader/index.tsx
+++ b/apps/app/src/components/SiteHeader/index.tsx
@@ -412,7 +412,7 @@ export const UserAvatarMenu = ({ className }: { className?: string }) => {
           isDismissable={true}
           isKeyboardDismissDisabled={false}
           overlayClassName="animate-in items-end justify-center p-0 duration-300 fade-in-0"
-          className="m-0 h-auto w-screen max-w-none animate-in rounded-t rounded-b-none border-0 outline-0 duration-300 ease-out slide-in-from-bottom-full"
+          className="m-0 h-auto max-h-[85svh] w-screen max-w-none animate-in rounded-t rounded-b-none border-0 outline-0 duration-300 ease-out slide-in-from-bottom-full"
         >
           <ModalBody className="pb-safe p-0">
             <div className="flex justify-end px-4 pt-3">

--- a/apps/app/src/components/decisions/AdminOverviewBar.tsx
+++ b/apps/app/src/components/decisions/AdminOverviewBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@op/ui/Button';
-import { Menu, MenuItem } from '@op/ui/Menu';
+import { MenuItem, MenuList } from '@op/ui/Menu';
 import { Sheet, SheetBody } from '@op/ui/Sheet';
 import { useLocale } from 'next-intl';
 import { useState } from 'react';
@@ -81,7 +81,7 @@ export function AdminOverviewBar({
         className="md:hidden"
       >
         <SheetBody>
-          <Menu
+          <MenuList
             aria-label={t('Admin options')}
             className="flex min-w-full flex-col border-0 p-0 shadow-none"
           >
@@ -102,7 +102,7 @@ export function AdminOverviewBar({
             >
               {t('Process settings')}
             </MenuItem>
-          </Menu>
+          </MenuList>
         </SheetBody>
       </Sheet>
 

--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardMenu.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardMenu.tsx
@@ -9,7 +9,7 @@ import { screens } from '@op/styles/constants';
 import { Button } from '@op/ui/Button';
 import { DialogTrigger } from '@op/ui/Dialog';
 import { IconButton } from '@op/ui/IconButton';
-import { Menu, MenuItem, MenuTrigger } from '@op/ui/Menu';
+import { Menu, MenuItem, MenuList, MenuTrigger } from '@op/ui/Menu';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
 import { toast } from '@op/ui/Toast';
 import { useState } from 'react';
@@ -304,9 +304,9 @@ export function ProposalCardMenu({
             className="m-0 h-auto w-screen max-w-none animate-in rounded-t-2xl rounded-b-none border-0 outline-0 duration-300 ease-out slide-in-from-bottom-full"
           >
             <ModalBody className="pb-safe p-0">
-              <Menu className="flex min-w-full flex-col border-0 p-0 shadow-none">
+              <MenuList className="flex min-w-full flex-col border-0 p-0 shadow-none">
                 {renderMenuItems(true)}
-              </Menu>
+              </MenuList>
             </ModalBody>
           </Modal>
         </>


### PR DESCRIPTION
- The Menu refactor (#1156) changed `Menu` into a `Popover + MenuList` combo, but three mobile sheets still rendered `Menu` inside a `Modal`/`Sheet` without a `MenuTrigger`, leaving an orphan popover — the sheet opened with no usable menu content. Swapped all three to `MenuList`: the user avatar drawer (`SiteHeader`), the proposal card menu (`ProposalCardMenu`), and the decision admin options sheet (`AdminOverviewBar`).
- Capped the avatar drawer at `max-h-[85svh]` (matching `Sheet`'s bottom variant) so a long profile list can't stretch it full-screen — the overlay stays visible and tap-outside-to-dismiss works.