### PR TITLE
fix(maps): Allow showing menu when proposal is editable by author in map listings

### DIFF
--- a/apps/app/src/components/decisions/ProposalsMapView.tsx
+++ b/apps/app/src/components/decisions/ProposalsMapView.tsx
@@ -193,7 +193,7 @@ export function ProposalsMapView({
             proposal={proposal}
             href={hrefFor(proposal)}
             isActive={activeId === proposal.id}
-            canManage={canManageProposals}
+            canManage={canManageProposals || Boolean(proposal.isEditable)}
             onActivate={() => setActiveId(proposal.id)}
             onDeactivate={() => setActiveId(null)}
           />


### PR DESCRIPTION
Fixes the menu icon that wasn't showing unless you were an admin specifically on the map view proposal listing.
<img width="512" height="107" alt="Screenshot 2026-07-17 at 15 43 30" src="https://github.com/user-attachments/assets/e51b3703-171e-45eb-8add-a3b8dfb7728d" />

Asana task: https://app.asana.com/1/1108348036672214/project/1211387328265612/task/1216612346173394
