### PR TITLE
fix(sense): post-stack polish — combobox text, destructive hover, muted token

### DIFF
--- a/packages/sense/src/components/ui/button.tsx
+++ b/packages/sense/src/components/ui/button.tsx
@@ -40,7 +40,7 @@ const buttonVariants = cva(
         variant: 'destructive',
         size: ['sm', 'xs', 'icon-sm', 'icon-xs'],
         class:
-          'bg-destructive-muted text-destructive hover:bg-[color-mix(in_oklch,var(--destructive-muted),var(--foreground)_10%)] active:bg-[color-mix(in_oklch,var(--destructive-muted),var(--foreground)_15%)] focus-visible:ring-destructive/20',
+          'bg-destructive-muted text-destructive hover:bg-red-100 active:bg-red-200 focus-visible:ring-destructive/20',
       },
     ],
     defaultVariants: {

--- a/packages/sense/src/components/ui/combobox.tsx
+++ b/packages/sense/src/components/ui/combobox.tsx
@@ -147,7 +147,7 @@ function ComboboxItem({
     <ComboboxPrimitive.Item
       data-slot="combobox-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-2 rounded-md py-2 ps-3 pe-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-muted data-highlighted:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex w-full cursor-default items-center gap-2 rounded-md py-2 ps-3 pe-8 text-base outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-highlighted:bg-muted data-highlighted:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/packages/styles/sense-theme.css
+++ b/packages/styles/sense-theme.css
@@ -371,7 +371,7 @@
   /* Muted */
   /* Nudged darker than gray-50 so muted surfaces read against white
    * (design-approved deviation from the ramp). */
-  --muted: #f5f7f7;
+  --muted: #f6f8f8;
   --muted-foreground: var(--color-gray-600);
 
   /* Accent */

--- a/packages/styles/sense-theme.css
+++ b/packages/styles/sense-theme.css
@@ -369,7 +369,9 @@
   --secondary-foreground: var(--color-gray-900);
 
   /* Muted */
-  --muted: var(--color-gray-50);
+  /* Nudged darker than gray-50 so muted surfaces read against white
+   * (design-approved deviation from the ramp). */
+  --muted: #f4f6f6;
   --muted-foreground: var(--color-gray-600);
 
   /* Accent */

--- a/packages/styles/sense-theme.css
+++ b/packages/styles/sense-theme.css
@@ -371,7 +371,7 @@
   /* Muted */
   /* Nudged darker than gray-50 so muted surfaces read against white
    * (design-approved deviation from the ramp). */
-  --muted: #f4f6f6;
+  --muted: #f5f7f7;
   --muted-foreground: var(--color-gray-600);
 
   /* Accent */


### PR DESCRIPTION
Small cleanups following the sense restyle stack (#1559–#1577):

- Combobox options render at `text-base`, matching Select items
- Small destructive buttons hover along the red ramp (`red-100`/`red-200`) instead of a gray `color-mix` that muddied the fill
- `--muted` darkened to `#F4F6F6` so muted surfaces read against white (deliberate ramp deviation, commented in sense-theme.css)