### PR TITLE
feat(sense): input extension composites — TagGroup, DatePicker, NumberField, RequiredAsterisk

### DIFF
--- a/packages/sense/package.json
+++ b/packages/sense/package.json
@@ -50,6 +50,7 @@
     "./Popover": "./src/components/ui/popover.tsx",
     "./Progress": "./src/components/ui/progress.tsx",
     "./RadioGroup": "./src/components/ui/radio-group.tsx",
+    "./RequiredAsterisk": "./src/components/RequiredAsterisk/index.tsx",
     "./Resizable": "./src/components/ui/resizable.tsx",
     "./ScrollArea": "./src/components/ui/scroll-area.tsx",
     "./Select": "./src/components/ui/select.tsx",

--- a/packages/sense/package.json
+++ b/packages/sense/package.json
@@ -28,6 +28,7 @@
     "./Combobox": "./src/components/ui/combobox.tsx",
     "./Command": "./src/components/ui/command.tsx",
     "./ContextMenu": "./src/components/ui/context-menu.tsx",
+    "./DatePicker": "./src/components/DatePicker/index.tsx",
     "./Dialog": "./src/components/ui/dialog.tsx",
     "./Direction": "./src/components/ui/direction.tsx",
     "./Drawer": "./src/components/ui/drawer.tsx",

--- a/packages/sense/package.json
+++ b/packages/sense/package.json
@@ -45,6 +45,7 @@
     "./Menubar": "./src/components/ui/menubar.tsx",
     "./NativeSelect": "./src/components/ui/native-select.tsx",
     "./NavigationMenu": "./src/components/ui/navigation-menu.tsx",
+    "./NumberField": "./src/components/NumberField/index.tsx",
     "./Pagination": "./src/components/ui/pagination.tsx",
     "./Popover": "./src/components/ui/popover.tsx",
     "./Progress": "./src/components/ui/progress.tsx",

--- a/packages/sense/package.json
+++ b/packages/sense/package.json
@@ -60,6 +60,7 @@
     "./Spinner": "./src/components/ui/spinner.tsx",
     "./Switch": "./src/components/ui/switch.tsx",
     "./Table": "./src/components/ui/table.tsx",
+    "./TagGroup": "./src/components/TagGroup/index.tsx",
     "./Tabs": "./src/components/ui/tabs.tsx",
     "./Textarea": "./src/components/ui/textarea.tsx",
     "./Toggle": "./src/components/ui/toggle.tsx",

--- a/packages/sense/src/components/DatePicker/index.tsx
+++ b/packages/sense/src/components/DatePicker/index.tsx
@@ -52,9 +52,16 @@ function DatePicker({
   const [open, setOpen] = React.useState(false);
   const [inputValue, setInputValue] = React.useState(() => formatDate(value));
 
-  // Follow external value changes (calendar picks route through here too).
+  // Follow external value changes (calendar picks route through here too) —
+  // but leave the text alone when it already parses to the incoming value:
+  // that's our own onChange echoing back, and reformatting non-canonical
+  // typed text ("7/4/2026") mid-keystroke would yank the cursor.
   React.useEffect(() => {
-    setInputValue(formatDate(value));
+    setInputValue((current) =>
+      parseDate(current)?.getTime() === value?.getTime()
+        ? current
+        : formatDate(value),
+    );
   }, [value]);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -64,6 +71,12 @@ function DatePicker({
     if (parsed) {
       onChange?.(parsed);
     }
+  };
+
+  // Reconcile on blur: canonicalize parseable text, reset garbage back to
+  // the committed value so display and value can't diverge.
+  const handleBlur = () => {
+    setInputValue(formatDate(parseDate(inputValue) ?? value));
   };
 
   return (
@@ -83,6 +96,7 @@ function DatePicker({
             id={inputId}
             value={inputValue}
             onChange={handleInputChange}
+            onBlur={handleBlur}
             onClick={() => setOpen(true)}
             onKeyDown={(event) => {
               if (event.key === 'ArrowDown') {
@@ -109,7 +123,8 @@ function DatePicker({
             </PopoverTrigger>
           </InputGroupAddon>
         </InputGroup>
-        <PopoverContent align="start" className="w-auto p-0">
+        {/* Portaled outside the .sense scope — re-scope so sense tokens apply. */}
+        <PopoverContent align="start" className="sense w-auto p-0">
           <Calendar
             mode="single"
             selected={value}

--- a/packages/sense/src/components/DatePicker/index.tsx
+++ b/packages/sense/src/components/DatePicker/index.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { format } from 'date-fns';
 import * as React from 'react';
 import { LuCalendar } from 'react-icons/lu';
 
 import { cn } from '../../lib/utils';
 import { RequiredAsterisk } from '../RequiredAsterisk';
+import { Button } from '../ui/button';
 import { Calendar } from '../ui/calendar';
 import { FieldDescription, FieldError, FieldLabel } from '../ui/field';
 import {
@@ -30,6 +32,12 @@ interface DatePickerProps {
   required?: boolean;
   id?: string;
   className?: string;
+  /**
+   * Open the calendar when the input gains focus, without moving focus into
+   * it — typing keeps working while the calendar is visible. ArrowDown moves
+   * focus into the calendar for keyboard navigation.
+   */
+  openOnFocus?: boolean;
 }
 
 function DatePicker({
@@ -45,11 +53,26 @@ function DatePicker({
   required,
   id,
   className,
+  openOnFocus = false,
 }: DatePickerProps) {
   const reactId = React.useId();
   const inputId = id ?? reactId;
+  const popupId = React.useId();
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  // Set while we refocus the input after a day pick, so the focus handler
+  // doesn't immediately reopen the popup the pick just closed.
+  const suppressOpenOnFocusRef = React.useRef(false);
 
   const [open, setOpen] = React.useState(false);
+
+  // In openOnFocus mode the popup never takes focus, so ArrowDown hands
+  // focus to the calendar explicitly (day-picker keeps one day tabbable).
+  const focusCalendar = () => {
+    document
+      .getElementById(popupId)
+      ?.querySelector<HTMLElement>('[tabindex="0"]')
+      ?.focus();
+  };
   const [inputValue, setInputValue] = React.useState(() => formatDate(value));
 
   // Follow external value changes (calendar picks route through here too) —
@@ -93,23 +116,49 @@ function DatePicker({
       <Popover open={open} onOpenChange={setOpen}>
         <InputGroup>
           <InputGroupInput
+            ref={inputRef}
             id={inputId}
             value={inputValue}
             onChange={handleInputChange}
             onBlur={handleBlur}
-            // No onClick open — clicking the input is for typing; the popup
-            // would steal focus. Calendar opens via the icon or ArrowDown,
-            // matching the upstream shadcn date-picker input example.
+            // Default mode never opens from the input itself — clicking it is
+            // for typing, and the popup would steal focus (upstream shadcn
+            // behavior). openOnFocus opens a non-focus-stealing popup instead.
+            onFocus={
+              openOnFocus
+                ? () => {
+                    if (suppressOpenOnFocusRef.current) {
+                      suppressOpenOnFocusRef.current = false;
+                      return;
+                    }
+                    setOpen(true);
+                  }
+                : undefined
+            }
+            onClick={openOnFocus ? () => setOpen(true) : undefined}
             onKeyDown={(event) => {
               if (event.key === 'ArrowDown') {
                 event.preventDefault();
-                setOpen(true);
+                if (openOnFocus && open) {
+                  focusCalendar();
+                } else {
+                  setOpen(true);
+                }
+              }
+              if (openOnFocus && open && event.key === 'Escape') {
+                setOpen(false);
               }
             }}
             placeholder={placeholder}
             disabled={disabled}
             required={required}
             aria-invalid={errorMessage ? true : undefined}
+            // The popup opens without an announcement in openOnFocus mode, so
+            // the input carries combobox semantics to surface it to AT.
+            role={openOnFocus ? 'combobox' : undefined}
+            aria-haspopup={openOnFocus ? 'dialog' : undefined}
+            aria-expanded={openOnFocus ? open : undefined}
+            aria-controls={openOnFocus && open ? popupId : undefined}
           />
           <InputGroupAddon align="inline-end">
             <PopoverTrigger
@@ -128,11 +177,117 @@ function DatePicker({
         {/* Portaled outside the .sense scope — re-scope so sense tokens apply. */}
         {/* End-aligned to the calendar icon, per the upstream input example. */}
         <PopoverContent
+          id={popupId}
           align="end"
           alignOffset={-8}
           sideOffset={10}
           className="sense w-auto overflow-hidden p-0"
+          // openOnFocus: never move focus on open, and don't return it on
+          // close either — a mouse day-pick refocuses the input explicitly
+          // below, while an outside click must not steal focus back.
+          initialFocus={openOnFocus ? false : undefined}
+          finalFocus={openOnFocus ? false : undefined}
         >
+          <Calendar
+            mode="single"
+            selected={value}
+            defaultMonth={value}
+            disabled={dateBounds(minDate, maxDate)}
+            onSelect={(date) => {
+              onChange?.(date);
+              setOpen(false);
+              if (openOnFocus) {
+                suppressOpenOnFocusRef.current = true;
+                inputRef.current?.focus();
+                // focus() fires the focus event synchronously; if the input
+                // was already focused (Safari keeps it there), no event fires
+                // — clear the flag so it can't swallow the next real focus.
+                queueMicrotask(() => {
+                  suppressOpenOnFocusRef.current = false;
+                });
+              }
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+      {description ? <FieldDescription>{description}</FieldDescription> : null}
+      {errorMessage ? <FieldError>{errorMessage}</FieldError> : null}
+    </div>
+  );
+}
+
+interface DatePickerButtonProps {
+  value?: Date;
+  onChange?: (date: Date | undefined) => void;
+  /** Earliest selectable day (inclusive). */
+  minDate?: Date;
+  /** Latest selectable day (inclusive). */
+  maxDate?: Date;
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  errorMessage?: React.ReactNode;
+  /** Button text while no date is selected. */
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  id?: string;
+  className?: string;
+}
+
+/**
+ * Calendar-only date picker: a button trigger, no free-text entry. Matches
+ * the upstream shadcn "simple" date-picker example.
+ */
+function DatePickerButton({
+  value,
+  onChange,
+  minDate,
+  maxDate,
+  label,
+  description,
+  errorMessage,
+  placeholder = 'Pick a date',
+  disabled,
+  required,
+  id,
+  className,
+}: DatePickerButtonProps) {
+  const reactId = React.useId();
+  const buttonId = id ?? reactId;
+
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div
+      data-slot="date-picker-button"
+      className={cn('flex flex-col gap-1', className)}
+    >
+      {label ? (
+        <FieldLabel htmlFor={buttonId}>
+          {label}
+          {required ? <RequiredAsterisk /> : null}
+        </FieldLabel>
+      ) : null}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <Button
+              id={buttonId}
+              variant="outline"
+              disabled={disabled}
+              aria-invalid={errorMessage ? true : undefined}
+              className={cn(
+                'justify-start font-normal',
+                !value && 'text-muted-foreground',
+              )}
+            />
+          }
+        >
+          <LuCalendar />
+          {value ? format(value, 'PPP') : <span>{placeholder}</span>}
+        </PopoverTrigger>
+        {/* Portaled outside the .sense scope — re-scope so sense tokens apply. */}
+        <PopoverContent align="start" className="sense w-auto p-0">
           <Calendar
             mode="single"
             selected={value}
@@ -209,4 +364,4 @@ function dateBounds(minDate: Date | undefined, maxDate: Date | undefined) {
   return undefined;
 }
 
-export { DatePicker };
+export { DatePicker, DatePickerButton };

--- a/packages/sense/src/components/DatePicker/index.tsx
+++ b/packages/sense/src/components/DatePicker/index.tsx
@@ -126,7 +126,13 @@ function DatePicker({
           </InputGroupAddon>
         </InputGroup>
         {/* Portaled outside the .sense scope — re-scope so sense tokens apply. */}
-        <PopoverContent align="start" className="sense w-auto p-0">
+        {/* End-aligned to the calendar icon, per the upstream input example. */}
+        <PopoverContent
+          align="end"
+          alignOffset={-8}
+          sideOffset={10}
+          className="sense w-auto overflow-hidden p-0"
+        >
           <Calendar
             mode="single"
             selected={value}

--- a/packages/sense/src/components/DatePicker/index.tsx
+++ b/packages/sense/src/components/DatePicker/index.tsx
@@ -97,7 +97,9 @@ function DatePicker({
             value={inputValue}
             onChange={handleInputChange}
             onBlur={handleBlur}
-            onClick={() => setOpen(true)}
+            // No onClick open — clicking the input is for typing; the popup
+            // would steal focus. Calendar opens via the icon or ArrowDown,
+            // matching the upstream shadcn date-picker input example.
             onKeyDown={(event) => {
               if (event.key === 'ArrowDown') {
                 event.preventDefault();

--- a/packages/sense/src/components/DatePicker/index.tsx
+++ b/packages/sense/src/components/DatePicker/index.tsx
@@ -32,12 +32,6 @@ interface DatePickerProps {
   required?: boolean;
   id?: string;
   className?: string;
-  /**
-   * Open the calendar when the input gains focus, without moving focus into
-   * it — typing keeps working while the calendar is visible. ArrowDown moves
-   * focus into the calendar for keyboard navigation.
-   */
-  openOnFocus?: boolean;
 }
 
 function DatePicker({
@@ -53,26 +47,11 @@ function DatePicker({
   required,
   id,
   className,
-  openOnFocus = false,
 }: DatePickerProps) {
   const reactId = React.useId();
   const inputId = id ?? reactId;
-  const popupId = React.useId();
-  const inputRef = React.useRef<HTMLInputElement | null>(null);
-  // Set while we refocus the input after a day pick, so the focus handler
-  // doesn't immediately reopen the popup the pick just closed.
-  const suppressOpenOnFocusRef = React.useRef(false);
 
   const [open, setOpen] = React.useState(false);
-
-  // In openOnFocus mode the popup never takes focus, so ArrowDown hands
-  // focus to the calendar explicitly (day-picker keeps one day tabbable).
-  const focusCalendar = () => {
-    document
-      .getElementById(popupId)
-      ?.querySelector<HTMLElement>('[tabindex="0"]')
-      ?.focus();
-  };
   const [inputValue, setInputValue] = React.useState(() => formatDate(value));
 
   // Follow external value changes (calendar picks route through here too) —
@@ -116,49 +95,23 @@ function DatePicker({
       <Popover open={open} onOpenChange={setOpen}>
         <InputGroup>
           <InputGroupInput
-            ref={inputRef}
             id={inputId}
             value={inputValue}
             onChange={handleInputChange}
             onBlur={handleBlur}
-            // Default mode never opens from the input itself — clicking it is
-            // for typing, and the popup would steal focus (upstream shadcn
-            // behavior). openOnFocus opens a non-focus-stealing popup instead.
-            onFocus={
-              openOnFocus
-                ? () => {
-                    if (suppressOpenOnFocusRef.current) {
-                      suppressOpenOnFocusRef.current = false;
-                      return;
-                    }
-                    setOpen(true);
-                  }
-                : undefined
-            }
-            onClick={openOnFocus ? () => setOpen(true) : undefined}
+            // No onClick open — clicking the input is for typing; the popup
+            // would steal focus. Calendar opens via the icon or ArrowDown,
+            // matching the upstream shadcn date-picker input example.
             onKeyDown={(event) => {
               if (event.key === 'ArrowDown') {
                 event.preventDefault();
-                if (openOnFocus && open) {
-                  focusCalendar();
-                } else {
-                  setOpen(true);
-                }
-              }
-              if (openOnFocus && open && event.key === 'Escape') {
-                setOpen(false);
+                setOpen(true);
               }
             }}
             placeholder={placeholder}
             disabled={disabled}
             required={required}
             aria-invalid={errorMessage ? true : undefined}
-            // The popup opens without an announcement in openOnFocus mode, so
-            // the input carries combobox semantics to surface it to AT.
-            role={openOnFocus ? 'combobox' : undefined}
-            aria-haspopup={openOnFocus ? 'dialog' : undefined}
-            aria-expanded={openOnFocus ? open : undefined}
-            aria-controls={openOnFocus && open ? popupId : undefined}
           />
           <InputGroupAddon align="inline-end">
             <PopoverTrigger
@@ -177,16 +130,10 @@ function DatePicker({
         {/* Portaled outside the .sense scope — re-scope so sense tokens apply. */}
         {/* End-aligned to the calendar icon, per the upstream input example. */}
         <PopoverContent
-          id={popupId}
           align="end"
           alignOffset={-8}
           sideOffset={10}
           className="sense w-auto overflow-hidden p-0"
-          // openOnFocus: never move focus on open, and don't return it on
-          // close either — a mouse day-pick refocuses the input explicitly
-          // below, while an outside click must not steal focus back.
-          initialFocus={openOnFocus ? false : undefined}
-          finalFocus={openOnFocus ? false : undefined}
         >
           <Calendar
             mode="single"
@@ -196,16 +143,6 @@ function DatePicker({
             onSelect={(date) => {
               onChange?.(date);
               setOpen(false);
-              if (openOnFocus) {
-                suppressOpenOnFocusRef.current = true;
-                inputRef.current?.focus();
-                // focus() fires the focus event synchronously; if the input
-                // was already focused (Safari keeps it there), no event fires
-                // — clear the flag so it can't swallow the next real focus.
-                queueMicrotask(() => {
-                  suppressOpenOnFocusRef.current = false;
-                });
-              }
             }}
           />
         </PopoverContent>

--- a/packages/sense/src/components/DatePicker/index.tsx
+++ b/packages/sense/src/components/DatePicker/index.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import * as React from 'react';
+import { LuCalendar } from 'react-icons/lu';
+
+import { cn } from '../../lib/utils';
+import { Calendar } from '../ui/calendar';
+import { FieldDescription, FieldError, FieldLabel } from '../ui/field';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '../ui/input-group';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+
+interface DatePickerProps {
+  value?: Date;
+  onChange?: (date: Date | undefined) => void;
+  /** Earliest selectable day (inclusive). */
+  minDate?: Date;
+  /** Latest selectable day (inclusive). */
+  maxDate?: Date;
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  errorMessage?: React.ReactNode;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  id?: string;
+  className?: string;
+}
+
+function DatePicker({
+  value,
+  onChange,
+  minDate,
+  maxDate,
+  label,
+  description,
+  errorMessage,
+  placeholder = 'Select date',
+  disabled,
+  required,
+  id,
+  className,
+}: DatePickerProps) {
+  const reactId = React.useId();
+  const inputId = id ?? reactId;
+
+  const [open, setOpen] = React.useState(false);
+  const [inputValue, setInputValue] = React.useState(() => formatDate(value));
+
+  // Follow external value changes (calendar picks route through here too).
+  React.useEffect(() => {
+    setInputValue(formatDate(value));
+  }, [value]);
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const next = event.target.value;
+    setInputValue(next);
+    const parsed = parseDate(next);
+    if (parsed) {
+      onChange?.(parsed);
+    }
+  };
+
+  return (
+    <div
+      data-slot="date-picker"
+      className={cn('flex flex-col gap-1', className)}
+    >
+      {label ? (
+        <FieldLabel htmlFor={inputId}>
+          {label}
+          {required ? <span aria-hidden>*</span> : null}
+        </FieldLabel>
+      ) : null}
+      <Popover open={open} onOpenChange={setOpen}>
+        <InputGroup>
+          <InputGroupInput
+            id={inputId}
+            value={inputValue}
+            onChange={handleInputChange}
+            onClick={() => setOpen(true)}
+            onKeyDown={(event) => {
+              if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setOpen(true);
+              }
+            }}
+            placeholder={placeholder}
+            disabled={disabled}
+            required={required}
+            aria-invalid={errorMessage ? true : undefined}
+          />
+          <InputGroupAddon align="inline-end">
+            <PopoverTrigger
+              render={
+                <InputGroupButton
+                  size="icon-sm"
+                  aria-label="Open calendar"
+                  disabled={disabled}
+                />
+              }
+            >
+              <LuCalendar />
+            </PopoverTrigger>
+          </InputGroupAddon>
+        </InputGroup>
+        <PopoverContent align="start" className="w-auto p-0">
+          <Calendar
+            mode="single"
+            selected={value}
+            defaultMonth={value}
+            disabled={dateBounds(minDate, maxDate)}
+            onSelect={(date) => {
+              onChange?.(date);
+              setOpen(false);
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+      {description ? <FieldDescription>{description}</FieldDescription> : null}
+      {errorMessage ? <FieldError>{errorMessage}</FieldError> : null}
+    </div>
+  );
+}
+
+function formatDate(date: Date | undefined) {
+  if (!date || isNaN(date.getTime())) {
+    return '';
+  }
+
+  return date.toLocaleDateString('en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    year: 'numeric',
+  });
+}
+
+// Accepts MM/DD/YYYY or YYYY-MM-DD; returns undefined for anything else or
+// impossible dates (e.g. 02/31).
+function parseDate(input: string): Date | undefined {
+  const trimmed = input.trim();
+  const mmddyyyy = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(trimmed);
+  const yyyymmdd = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(trimmed);
+
+  let year: number, month: number, day: number;
+  if (mmddyyyy) {
+    [month, day, year] = [
+      Number(mmddyyyy[1]),
+      Number(mmddyyyy[2]),
+      Number(mmddyyyy[3]),
+    ];
+  } else if (yyyymmdd) {
+    [year, month, day] = [
+      Number(yyyymmdd[1]),
+      Number(yyyymmdd[2]),
+      Number(yyyymmdd[3]),
+    ];
+  } else {
+    return undefined;
+  }
+
+  const date = new Date(year, month - 1, day);
+  const roundTrips =
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day;
+
+  return roundTrips ? date : undefined;
+}
+
+function dateBounds(minDate: Date | undefined, maxDate: Date | undefined) {
+  if (minDate && maxDate) {
+    return { before: minDate, after: maxDate };
+  }
+  if (minDate) {
+    return { before: minDate };
+  }
+  if (maxDate) {
+    return { after: maxDate };
+  }
+  return undefined;
+}
+
+export { DatePicker };

--- a/packages/sense/src/components/DatePicker/index.tsx
+++ b/packages/sense/src/components/DatePicker/index.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { LuCalendar } from 'react-icons/lu';
 
 import { cn } from '../../lib/utils';
+import { RequiredAsterisk } from '../RequiredAsterisk';
 import { Calendar } from '../ui/calendar';
 import { FieldDescription, FieldError, FieldLabel } from '../ui/field';
 import {
@@ -73,7 +74,7 @@ function DatePicker({
       {label ? (
         <FieldLabel htmlFor={inputId}>
           {label}
-          {required ? <span aria-hidden>*</span> : null}
+          {required ? <RequiredAsterisk /> : null}
         </FieldLabel>
       ) : null}
       <Popover open={open} onOpenChange={setOpen}>

--- a/packages/sense/src/components/NumberField/index.tsx
+++ b/packages/sense/src/components/NumberField/index.tsx
@@ -54,23 +54,21 @@ function NumberField({
   const reactId = React.useId();
   const inputId = id ?? reactId;
 
-  const [displayValue, setDisplayValue] = React.useState(
-    () => value?.toString() ?? defaultValue?.toString() ?? '',
+  const [displayValue, setDisplayValue] = React.useState(() =>
+    formatValue(value ?? defaultValue),
   );
   const [boundsError, setBoundsError] = React.useState<string | null>(null);
 
   // Follow external value changes when controlled — but leave the display
   // alone when it already parses to the incoming value: that's our own
-  // onChange echoing back, and reformatting it via toString() would flip
-  // large numbers into scientific notation (1e21+) mid-keystroke.
+  // onChange echoing back, and reformatting it would disturb in-progress
+  // typing (e.g. a trailing decimal point).
   React.useEffect(() => {
     if (value === undefined) {
       return;
     }
     setDisplayValue((current) =>
-      parseNumericValue(current) === value
-        ? current
-        : (value?.toString() ?? ''),
+      parseNumericValue(current) === value ? current : formatValue(value),
     );
   }, [value]);
 
@@ -92,14 +90,11 @@ function NumberField({
     const numeric = parseNumericValue(displayValue);
     setBoundsError(validateBounds(numeric, minValue, maxValue));
 
-    // Canonicalize on blur ("00003" → "3", "5." → "5") — unless toString
-    // would flip to scientific notation (1e21+), where the typed digits are
-    // the better representation.
+    // Canonicalize on blur ("00003" → "3", "5." → "5"). toPlainString never
+    // emits scientific notation, so extreme magnitudes stay round-trippable
+    // through filterNumericInput (which would strip an "e").
     if (numeric !== null) {
-      const canonical = numeric.toString();
-      if (!canonical.includes('e')) {
-        setDisplayValue(canonical);
-      }
+      setDisplayValue(toPlainString(numeric));
     }
 
     onBlur?.(event);
@@ -162,6 +157,21 @@ function filterNumericInput(value: string) {
     .replace(/[^0-9.-]/g, '') // Keep only digits, minus, and decimal
     .replace(/(?!^)-/g, '') // Remove minus signs that aren't at the beginning
     .replace(/\.(?=.*\.)/g, ''); // Remove decimal points except the last one
+}
+
+// Render a number as plain digits, never scientific notation — toString()
+// flips to "1e21"/"1e-7" at the extremes, and filterNumericInput would strip
+// the "e" and corrupt the value on the next parse ("1e-7" → 17).
+// Intl caps at 20 fraction digits, so |n| < 1e-21 rounds to "0".
+function toPlainString(n: number) {
+  return n.toLocaleString('en-US', {
+    useGrouping: false,
+    maximumFractionDigits: 20,
+  });
+}
+
+function formatValue(value: number | null | undefined) {
+  return value == null ? '' : toPlainString(value);
 }
 
 function parseNumericValue(value: string) {

--- a/packages/sense/src/components/NumberField/index.tsx
+++ b/packages/sense/src/components/NumberField/index.tsx
@@ -59,11 +59,19 @@ function NumberField({
   );
   const [boundsError, setBoundsError] = React.useState<string | null>(null);
 
-  // Follow external value changes when controlled.
+  // Follow external value changes when controlled — but leave the display
+  // alone when it already parses to the incoming value: that's our own
+  // onChange echoing back, and reformatting it via toString() would flip
+  // large numbers into scientific notation (1e21+) mid-keystroke.
   React.useEffect(() => {
-    if (value !== undefined) {
-      setDisplayValue(value?.toString() ?? '');
+    if (value === undefined) {
+      return;
     }
+    setDisplayValue((current) =>
+      parseNumericValue(current) === value
+        ? current
+        : (value?.toString() ?? ''),
+    );
   }, [value]);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/sense/src/components/NumberField/index.tsx
+++ b/packages/sense/src/components/NumberField/index.tsx
@@ -89,9 +89,19 @@ function NumberField({
   };
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    setBoundsError(
-      validateBounds(parseNumericValue(displayValue), minValue, maxValue),
-    );
+    const numeric = parseNumericValue(displayValue);
+    setBoundsError(validateBounds(numeric, minValue, maxValue));
+
+    // Canonicalize on blur ("00003" → "3", "5." → "5") — unless toString
+    // would flip to scientific notation (1e21+), where the typed digits are
+    // the better representation.
+    if (numeric !== null) {
+      const canonical = numeric.toString();
+      if (!canonical.includes('e')) {
+        setDisplayValue(canonical);
+      }
+    }
+
     onBlur?.(event);
   };
 

--- a/packages/sense/src/components/NumberField/index.tsx
+++ b/packages/sense/src/components/NumberField/index.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+import { FieldDescription, FieldError, FieldLabel } from '../ui/field';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from '../ui/input-group';
+
+interface NumberFieldProps extends Omit<
+  React.ComponentProps<'input'>,
+  'type' | 'value' | 'defaultValue' | 'onChange' | 'onInput'
+> {
+  value?: number | null;
+  defaultValue?: number | null;
+  onChange?: (value: number | null) => void;
+  onInput?: (value: number | null) => void;
+  /** Minimum allowed value. Validated on blur with a built-in message. */
+  minValue?: number;
+  /** Maximum allowed value. Validated on blur with a built-in message. */
+  maxValue?: number;
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  /** External error message. Takes precedence over min/max messages. */
+  errorMessage?: React.ReactNode;
+  /** Static text rendered at the inline start of the input (e.g. "$"). */
+  prefixText?: string;
+  className?: string;
+}
+
+function NumberField({
+  value,
+  defaultValue,
+  onChange,
+  onInput,
+  minValue,
+  maxValue,
+  label,
+  description,
+  errorMessage,
+  prefixText,
+  required,
+  disabled,
+  id,
+  className,
+  onBlur,
+  ...inputProps
+}: NumberFieldProps) {
+  const reactId = React.useId();
+  const inputId = id ?? reactId;
+
+  const [displayValue, setDisplayValue] = React.useState(
+    () => value?.toString() ?? defaultValue?.toString() ?? '',
+  );
+  const [boundsError, setBoundsError] = React.useState<string | null>(null);
+
+  // Follow external value changes when controlled.
+  React.useEffect(() => {
+    if (value !== undefined) {
+      setDisplayValue(value?.toString() ?? '');
+    }
+  }, [value]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const filtered = filterNumericInput(event.target.value);
+    const numeric = parseNumericValue(filtered);
+
+    setDisplayValue(filtered);
+    onChange?.(numeric);
+    onInput?.(numeric);
+
+    // Clear the bounds error as soon as the value becomes valid.
+    if (boundsError && !validateBounds(numeric, minValue, maxValue)) {
+      setBoundsError(null);
+    }
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    setBoundsError(
+      validateBounds(parseNumericValue(displayValue), minValue, maxValue),
+    );
+    onBlur?.(event);
+  };
+
+  const resolvedError = errorMessage ?? boundsError;
+
+  return (
+    <div
+      data-slot="number-field"
+      className={cn('flex flex-col gap-1', className)}
+    >
+      {label ? (
+        <FieldLabel htmlFor={inputId}>
+          {label}
+          {required ? <span aria-hidden>*</span> : null}
+        </FieldLabel>
+      ) : null}
+      <InputGroup>
+        {prefixText ? (
+          <InputGroupAddon align="inline-start">
+            <InputGroupText>{prefixText}</InputGroupText>
+          </InputGroupAddon>
+        ) : null}
+        <InputGroupInput
+          {...inputProps}
+          id={inputId}
+          type="text"
+          inputMode="decimal"
+          // Numeric content is always rendered as ASCII (see normalizeDigits),
+          // so the input stays LTR even in RTL locales.
+          dir="ltr"
+          value={displayValue}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          required={required}
+          disabled={disabled}
+          aria-invalid={resolvedError ? true : undefined}
+        />
+      </InputGroup>
+      {description ? <FieldDescription>{description}</FieldDescription> : null}
+      {resolvedError ? <FieldError>{resolvedError}</FieldError> : null}
+    </div>
+  );
+}
+
+// Normalize non-ASCII numerals to ASCII so the field accepts Arabic input.
+// Arabic-Indic (U+0660–0669) and Extended Arabic-Indic/Persian (U+06F0–06F9)
+// digits map to ASCII; Arabic decimal/thousands separators map to `.`/``.
+function normalizeDigits(value: string) {
+  return value
+    .replace(/[٠-٩]/g, (d) => String(d.charCodeAt(0) - 0x0660))
+    .replace(/[۰-۹]/g, (d) => String(d.charCodeAt(0) - 0x06f0))
+    .replace(/٫/g, '.') // Arabic decimal separator
+    .replace(/٬/g, ''); // Arabic thousands separator
+}
+
+function filterNumericInput(value: string) {
+  return normalizeDigits(value)
+    .replace(/[^0-9.-]/g, '') // Keep only digits, minus, and decimal
+    .replace(/(?!^)-/g, '') // Remove minus signs that aren't at the beginning
+    .replace(/\.(?=.*\.)/g, ''); // Remove decimal points except the last one
+}
+
+function parseNumericValue(value: string) {
+  const filtered = filterNumericInput(value);
+  if (filtered === '' || filtered === '-') {
+    return null;
+  }
+  const parsed = parseFloat(filtered);
+  return isNaN(parsed) ? null : parsed;
+}
+
+function validateBounds(
+  numericValue: number | null,
+  minValue?: number,
+  maxValue?: number,
+): string | null {
+  if (numericValue === null) {
+    return null;
+  }
+  if (maxValue !== undefined && numericValue > maxValue) {
+    return `Must be at most ${maxValue.toLocaleString()}`;
+  }
+  if (minValue !== undefined && numericValue < minValue) {
+    return `Must be at least ${minValue.toLocaleString()}`;
+  }
+  return null;
+}
+
+export { NumberField };

--- a/packages/sense/src/components/NumberField/index.tsx
+++ b/packages/sense/src/components/NumberField/index.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { cn } from '../../lib/utils';
+import { RequiredAsterisk } from '../RequiredAsterisk';
 import { FieldDescription, FieldError, FieldLabel } from '../ui/field';
 import {
   InputGroup,
@@ -96,7 +97,7 @@ function NumberField({
       {label ? (
         <FieldLabel htmlFor={inputId}>
           {label}
-          {required ? <span aria-hidden>*</span> : null}
+          {required ? <RequiredAsterisk /> : null}
         </FieldLabel>
       ) : null}
       <InputGroup>

--- a/packages/sense/src/components/RequiredAsterisk/index.tsx
+++ b/packages/sense/src/components/RequiredAsterisk/index.tsx
@@ -1,0 +1,21 @@
+import { cn } from '../../lib/utils';
+
+interface RequiredAsteriskProps {
+  className?: string;
+}
+
+/**
+ * Decorative asterisk marking a required field. Hidden from assistive tech
+ * (`aria-hidden`) — the required semantics belong on the input itself via
+ * `required`/`aria-required`, not on this visual marker.
+ */
+function RequiredAsterisk({ className }: RequiredAsteriskProps) {
+  return (
+    <span className={cn('text-destructive', className)} aria-hidden="true">
+      {' '}
+      *
+    </span>
+  );
+}
+
+export { RequiredAsterisk };

--- a/packages/sense/src/components/TagGroup/index.tsx
+++ b/packages/sense/src/components/TagGroup/index.tsx
@@ -7,6 +7,15 @@ import { cn } from '../../lib/utils';
 import { Badge } from '../ui/badge';
 import { FieldDescription, FieldError, FieldLabel } from '../ui/field';
 
+type TagSize = 'default' | 'lg';
+
+// Badge stays upstream-pure (it has no size variant), so the size classes
+// live here in the composite.
+const tagSizeClasses: Record<TagSize, string> = {
+  default: '',
+  lg: 'h-7 rounded-md px-2.5 text-base',
+};
+
 interface TagGroupProps extends React.ComponentProps<'div'> {
   label?: React.ReactNode;
   description?: React.ReactNode;
@@ -53,6 +62,7 @@ interface TagProps extends React.ComponentProps<typeof Badge> {
   onRemove?: () => void;
   /** Accessible label for the remove button — pass a translated string. */
   removeLabel?: string;
+  size?: TagSize;
 }
 
 function Tag({
@@ -60,6 +70,7 @@ function Tag({
   onRemove,
   removeLabel = 'Remove',
   variant = 'accent',
+  size = 'default',
   className,
   ...props
 }: TagProps) {
@@ -67,7 +78,7 @@ function Tag({
     <li data-slot="tag" className="max-w-full list-none">
       <Badge
         variant={variant}
-        className={cn('max-w-full', className)}
+        className={cn('max-w-full', tagSizeClasses[size], className)}
         {...props}
       >
         <span className="truncate">{children}</span>
@@ -78,7 +89,7 @@ function Tag({
             onClick={onRemove}
             className="-me-0.5 flex shrink-0 cursor-pointer items-center justify-center rounded-full p-0.5 outline-none hover:bg-foreground/10 focus-visible:ring-2 focus-visible:ring-ring/50"
           >
-            <LuX aria-hidden className="size-3" />
+            <LuX aria-hidden className={size === 'lg' ? 'size-4' : 'size-3'} />
           </button>
         ) : null}
       </Badge>

--- a/packages/sense/src/components/TagGroup/index.tsx
+++ b/packages/sense/src/components/TagGroup/index.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import * as React from 'react';
+import { LuX } from 'react-icons/lu';
+
+import { cn } from '../../lib/utils';
+import { Badge } from '../ui/badge';
+import { FieldDescription, FieldError, FieldLabel } from '../ui/field';
+
+interface TagGroupProps extends React.ComponentProps<'div'> {
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  errorMessage?: React.ReactNode;
+}
+
+function TagGroup({
+  label,
+  description,
+  errorMessage,
+  className,
+  children,
+  ...props
+}: TagGroupProps) {
+  return (
+    <div
+      data-slot="tag-group"
+      className={cn('flex flex-col gap-1', className)}
+      {...props}
+    >
+      {label ? <FieldLabel>{label}</FieldLabel> : null}
+      <ul data-slot="tag-list" className="flex flex-wrap gap-2">
+        {children}
+      </ul>
+      {description ? <FieldDescription>{description}</FieldDescription> : null}
+      {errorMessage ? <FieldError>{errorMessage}</FieldError> : null}
+    </div>
+  );
+}
+
+interface TagProps extends React.ComponentProps<typeof Badge> {
+  /** Renders a remove affordance; called on click. */
+  onRemove?: () => void;
+  /** Accessible label for the remove button — pass a translated string. */
+  removeLabel?: string;
+}
+
+function Tag({
+  children,
+  onRemove,
+  removeLabel = 'Remove',
+  variant = 'accent',
+  className,
+  ...props
+}: TagProps) {
+  return (
+    <li data-slot="tag" className="max-w-full list-none">
+      <Badge
+        variant={variant}
+        className={cn('max-w-full', className)}
+        {...props}
+      >
+        <span className="truncate">{children}</span>
+        {onRemove ? (
+          <button
+            type="button"
+            aria-label={removeLabel}
+            onClick={onRemove}
+            className="-me-0.5 flex shrink-0 cursor-pointer items-center justify-center rounded-full p-0.5 outline-none hover:bg-foreground/10 focus-visible:ring-2 focus-visible:ring-ring/50"
+          >
+            <LuX aria-hidden className="size-3" />
+          </button>
+        ) : null}
+      </Badge>
+    </li>
+  );
+}
+
+export { TagGroup, Tag };

--- a/packages/sense/src/components/TagGroup/index.tsx
+++ b/packages/sense/src/components/TagGroup/index.tsx
@@ -21,17 +21,28 @@ function TagGroup({
   children,
   ...props
 }: TagGroupProps) {
+  // A <label> can't label a <ul>, so the group name rides aria-labelledby.
+  const labelId = React.useId();
+  const descriptionId = React.useId();
+
   return (
     <div
       data-slot="tag-group"
       className={cn('flex flex-col gap-1', className)}
       {...props}
     >
-      {label ? <FieldLabel>{label}</FieldLabel> : null}
-      <ul data-slot="tag-list" className="flex flex-wrap gap-2">
+      {label ? <FieldLabel id={labelId}>{label}</FieldLabel> : null}
+      <ul
+        data-slot="tag-list"
+        aria-labelledby={label ? labelId : undefined}
+        aria-describedby={description ? descriptionId : undefined}
+        className="flex flex-wrap gap-2"
+      >
         {children}
       </ul>
-      {description ? <FieldDescription>{description}</FieldDescription> : null}
+      {description ? (
+        <FieldDescription id={descriptionId}>{description}</FieldDescription>
+      ) : null}
       {errorMessage ? <FieldError>{errorMessage}</FieldError> : null}
     </div>
   );

--- a/packages/sense/src/components/TagGroup/index.tsx
+++ b/packages/sense/src/components/TagGroup/index.tsx
@@ -13,7 +13,7 @@ type TagSize = 'default' | 'lg';
 // live here in the composite.
 const tagSizeClasses: Record<TagSize, string> = {
   default: '',
-  lg: 'h-7 rounded-md px-2.5 text-base',
+  lg: 'h-7 rounded-md px-2.5 text-sm',
 };
 
 interface TagGroupProps extends React.ComponentProps<'div'> {

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -43,6 +43,17 @@ const config: StorybookConfig = {
       ) {
         return;
       }
+      // Companion noise (vitejs/vite#15012): reporting the directive warning
+      // trips a sourcemap lookup at the directive's position (1:0), which
+      // emits a SOURCEMAP_ERROR per module. Only that position is filtered —
+      // genuine sourcemap errors elsewhere still surface.
+      if (
+        warning.code === 'SOURCEMAP_ERROR' &&
+        warning.loc?.line === 1 &&
+        warning.loc?.column === 0
+      ) {
+        return;
+      }
       if (previousOnwarn) {
         previousOnwarn(warning, warn);
       } else {

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -28,6 +28,28 @@ const config: StorybookConfig = {
       ...config.resolve.alias,
       '@': resolve(__dirname, '../src'),
     };
+
+    // Rollup drops module-level directives when bundling and warns once per
+    // module — base-ui ships 'use client' in nearly every file. The directive
+    // is meaningless in a Storybook (client-only) bundle; silence just that
+    // warning and forward everything else.
+    config.build = config.build || {};
+    config.build.rollupOptions = config.build.rollupOptions || {};
+    const previousOnwarn = config.build.rollupOptions.onwarn;
+    config.build.rollupOptions.onwarn = (warning, warn) => {
+      if (
+        warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
+        warning.message.includes('use client')
+      ) {
+        return;
+      }
+      if (previousOnwarn) {
+        previousOnwarn(warning, warn);
+      } else {
+        warn(warning);
+      }
+    };
+
     return config;
   },
 };

--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -34,7 +34,7 @@ const preview: Preview = {
       // Sort the @op/ui ↔ @op/sense migration surface to the top so it's
       // easy to find; everything else stays in default alphabetical order.
       storySort: {
-        order: ['Sense', 'Sense Comparison', '*'],
+        order: ['Sense', ['Primitives', 'Composites'], 'Sense Comparison', '*'],
       },
     },
   },

--- a/packages/ui/stories-sense/Accordion.stories.tsx
+++ b/packages/ui/stories-sense/Accordion.stories.tsx
@@ -9,7 +9,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Accordion> = {
-  title: 'Sense/Accordion',
+  title: 'Sense/Primitives/Accordion',
   component: Accordion,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Alert.stories.tsx
+++ b/packages/ui/stories-sense/Alert.stories.tsx
@@ -16,7 +16,7 @@ import {
 import { withSense } from './sense';
 
 const meta: Meta<typeof Alert> = {
-  title: 'Sense/Alert',
+  title: 'Sense/Primitives/Alert',
   component: Alert,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/AlertDialog.stories.tsx
+++ b/packages/ui/stories-sense/AlertDialog.stories.tsx
@@ -17,7 +17,7 @@ import { LuTriangleAlert } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof AlertDialog> = {
-  title: 'Sense/AlertDialog',
+  title: 'Sense/Primitives/AlertDialog',
   component: AlertDialog,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/AspectRatio.stories.tsx
+++ b/packages/ui/stories-sense/AspectRatio.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof AspectRatio> = {
-  title: 'Sense/AspectRatio',
+  title: 'Sense/Primitives/AspectRatio',
   component: AspectRatio,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Avatar.stories.tsx
+++ b/packages/ui/stories-sense/Avatar.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Avatar> = {
-  title: 'Sense/Avatar',
+  title: 'Sense/Primitives/Avatar',
   component: Avatar,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Badge.stories.tsx
+++ b/packages/ui/stories-sense/Badge.stories.tsx
@@ -5,7 +5,7 @@ import { LuCheck, LuTriangleAlert } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Badge> = {
-  title: 'Sense/Badge',
+  title: 'Sense/Primitives/Badge',
   component: Badge,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Breadcrumb.stories.tsx
+++ b/packages/ui/stories-sense/Breadcrumb.stories.tsx
@@ -19,7 +19,7 @@ import { LuChevronDown, LuSlash } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Breadcrumb> = {
-  title: 'Sense/Breadcrumb',
+  title: 'Sense/Primitives/Breadcrumb',
   component: Breadcrumb,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Button.stories.tsx
+++ b/packages/ui/stories-sense/Button.stories.tsx
@@ -6,7 +6,7 @@ import { LuChevronRight, LuMail } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Button> = {
-  title: 'Sense/Button',
+  title: 'Sense/Primitives/Button',
   component: Button,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/ButtonGroup.stories.tsx
+++ b/packages/ui/stories-sense/ButtonGroup.stories.tsx
@@ -36,7 +36,7 @@ import {
 import { withSense } from './sense';
 
 const meta: Meta<typeof ButtonGroup> = {
-  title: 'Sense/ButtonGroup',
+  title: 'Sense/Primitives/ButtonGroup',
   component: ButtonGroup,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Calendar.stories.tsx
+++ b/packages/ui/stories-sense/Calendar.stories.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Calendar> = {
-  title: 'Sense/Calendar',
+  title: 'Sense/Primitives/Calendar',
   component: Calendar,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Card.stories.tsx
+++ b/packages/ui/stories-sense/Card.stories.tsx
@@ -15,7 +15,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Card> = {
-  title: 'Sense/Card',
+  title: 'Sense/Primitives/Card',
   component: Card,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Carousel.stories.tsx
+++ b/packages/ui/stories-sense/Carousel.stories.tsx
@@ -10,7 +10,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Carousel> = {
-  title: 'Sense/Carousel',
+  title: 'Sense/Primitives/Carousel',
   component: Carousel,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Checkbox.stories.tsx
+++ b/packages/ui/stories-sense/Checkbox.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Checkbox> = {
-  title: 'Sense/Checkbox',
+  title: 'Sense/Primitives/Checkbox',
   component: Checkbox,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Collapsible.stories.tsx
+++ b/packages/ui/stories-sense/Collapsible.stories.tsx
@@ -10,7 +10,7 @@ import { LuChevronsUpDown } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Collapsible> = {
-  title: 'Sense/Collapsible',
+  title: 'Sense/Primitives/Collapsible',
   component: Collapsible,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Combobox.stories.tsx
+++ b/packages/ui/stories-sense/Combobox.stories.tsx
@@ -19,7 +19,7 @@ import { LuGlobe } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Combobox> = {
-  title: 'Sense/Combobox',
+  title: 'Sense/Primitives/Combobox',
   component: Combobox,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Command.stories.tsx
+++ b/packages/ui/stories-sense/Command.stories.tsx
@@ -34,7 +34,7 @@ import {
 import { withSense } from './sense';
 
 const meta: Meta<typeof Command> = {
-  title: 'Sense/Command',
+  title: 'Sense/Primitives/Command',
   component: Command,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/ContextMenu.stories.tsx
+++ b/packages/ui/stories-sense/ContextMenu.stories.tsx
@@ -27,7 +27,7 @@ import {
 import { withSense } from './sense';
 
 const meta: Meta<typeof ContextMenu> = {
-  title: 'Sense/ContextMenu',
+  title: 'Sense/Primitives/ContextMenu',
   component: ContextMenu,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/DatePicker.stories.tsx
+++ b/packages/ui/stories-sense/DatePicker.stories.tsx
@@ -1,0 +1,69 @@
+import { DatePicker } from '@op/sense/DatePicker';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { withSense } from './sense';
+
+const meta: Meta<typeof DatePicker> = {
+  title: 'Sense/DatePicker',
+  component: DatePicker,
+  decorators: [withSense],
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DatePicker>;
+
+// Initial dates pinned for stable snapshots; selection is stateful so both
+// typing (MM/DD/YYYY or YYYY-MM-DD) and calendar picks work.
+const DefaultDemo = () => {
+  const [date, setDate] = useState<Date | undefined>(new Date(2026, 5, 15));
+
+  return (
+    <DatePicker
+      label="Start date"
+      description="Type a date or pick one from the calendar."
+      value={date}
+      onChange={setDate}
+      className="w-72"
+    />
+  );
+};
+
+export const Default: Story = {
+  render: () => <DefaultDemo />,
+};
+
+const BoundedDemo = () => {
+  const [date, setDate] = useState<Date | undefined>(new Date(2026, 5, 15));
+
+  return (
+    <DatePicker
+      label="End date"
+      required
+      value={date}
+      onChange={setDate}
+      minDate={new Date(2026, 5, 10)}
+      maxDate={new Date(2026, 6, 10)}
+      className="w-72"
+    />
+  );
+};
+
+export const WithBounds: Story = {
+  render: () => <BoundedDemo />,
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="flex w-72 flex-col gap-6">
+      <DatePicker label="Disabled" disabled value={new Date(2026, 5, 15)} />
+      <DatePicker
+        label="With error"
+        errorMessage="The end date must come after the start date."
+        value={new Date(2026, 5, 15)}
+      />
+    </div>
+  ),
+};

--- a/packages/ui/stories-sense/DatePicker.stories.tsx
+++ b/packages/ui/stories-sense/DatePicker.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { withSense } from './sense';
 
 const meta: Meta<typeof DatePicker> = {
-  title: 'Sense/DatePicker',
+  title: 'Sense/Composites/DatePicker',
   component: DatePicker,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/DatePicker.stories.tsx
+++ b/packages/ui/stories-sense/DatePicker.stories.tsx
@@ -1,4 +1,4 @@
-import { DatePicker } from '@op/sense/DatePicker';
+import { DatePicker, DatePickerButton } from '@op/sense/DatePicker';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
@@ -66,4 +66,44 @@ export const States: Story = {
       />
     </div>
   ),
+};
+
+// Calendar opens on focus without stealing it — typing keeps working while
+// the calendar is visible. ArrowDown moves focus into the calendar.
+const OpenOnFocusDemo = () => {
+  const [date, setDate] = useState<Date | undefined>(new Date(2026, 5, 15));
+
+  return (
+    <DatePicker
+      label="Event date"
+      description="Focus the field: the calendar appears but typing still works."
+      openOnFocus
+      value={date}
+      onChange={setDate}
+      className="w-72"
+    />
+  );
+};
+
+export const OpenOnFocus: Story = {
+  render: () => <OpenOnFocusDemo />,
+};
+
+// Calendar-only picker (no typing), matching the upstream shadcn simple
+// date-picker example.
+const ButtonDemo = () => {
+  const [date, setDate] = useState<Date | undefined>();
+
+  return (
+    <DatePickerButton
+      label="Date"
+      value={date}
+      onChange={setDate}
+      className="w-44"
+    />
+  );
+};
+
+export const ButtonVariant: Story = {
+  render: () => <ButtonDemo />,
 };

--- a/packages/ui/stories-sense/DatePicker.stories.tsx
+++ b/packages/ui/stories-sense/DatePicker.stories.tsx
@@ -68,27 +68,6 @@ export const States: Story = {
   ),
 };
 
-// Calendar opens on focus without stealing it — typing keeps working while
-// the calendar is visible. ArrowDown moves focus into the calendar.
-const OpenOnFocusDemo = () => {
-  const [date, setDate] = useState<Date | undefined>(new Date(2026, 5, 15));
-
-  return (
-    <DatePicker
-      label="Event date"
-      description="Focus the field: the calendar appears but typing still works."
-      openOnFocus
-      value={date}
-      onChange={setDate}
-      className="w-72"
-    />
-  );
-};
-
-export const OpenOnFocus: Story = {
-  render: () => <OpenOnFocusDemo />,
-};
-
 // Calendar-only picker (no typing), matching the upstream shadcn simple
 // date-picker example.
 const ButtonDemo = () => {

--- a/packages/ui/stories-sense/Dialog.stories.tsx
+++ b/packages/ui/stories-sense/Dialog.stories.tsx
@@ -16,7 +16,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Dialog> = {
-  title: 'Sense/Dialog',
+  title: 'Sense/Primitives/Dialog',
   component: Dialog,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Direction.stories.tsx
+++ b/packages/ui/stories-sense/Direction.stories.tsx
@@ -27,7 +27,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof DirectionProvider> = {
-  title: 'Sense/Direction',
+  title: 'Sense/Primitives/Direction',
   component: DirectionProvider,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Drawer.stories.tsx
+++ b/packages/ui/stories-sense/Drawer.stories.tsx
@@ -16,7 +16,7 @@ import { LuMinus, LuPlus } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Drawer> = {
-  title: 'Sense/Drawer',
+  title: 'Sense/Primitives/Drawer',
   component: Drawer,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/DropdownMenu.stories.tsx
+++ b/packages/ui/stories-sense/DropdownMenu.stories.tsx
@@ -21,7 +21,7 @@ import { LuCopy, LuEllipsis, LuPencil, LuTrash2 } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof DropdownMenu> = {
-  title: 'Sense/DropdownMenu',
+  title: 'Sense/Primitives/DropdownMenu',
   component: DropdownMenu,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Empty.stories.tsx
+++ b/packages/ui/stories-sense/Empty.stories.tsx
@@ -13,7 +13,7 @@ import { LuArrowUpRight, LuFolder } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Empty> = {
-  title: 'Sense/Empty',
+  title: 'Sense/Primitives/Empty',
   component: Empty,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Field.stories.tsx
+++ b/packages/ui/stories-sense/Field.stories.tsx
@@ -19,7 +19,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Field> = {
-  title: 'Sense/Field',
+  title: 'Sense/Primitives/Field',
   component: Field,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/HoverCard.stories.tsx
+++ b/packages/ui/stories-sense/HoverCard.stories.tsx
@@ -11,7 +11,7 @@ import { LuCalendarDays } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof HoverCard> = {
-  title: 'Sense/HoverCard',
+  title: 'Sense/Primitives/HoverCard',
   component: HoverCard,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Input.stories.tsx
+++ b/packages/ui/stories-sense/Input.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Input> = {
-  title: 'Sense/Input',
+  title: 'Sense/Primitives/Input',
   component: Input,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/InputGroup.stories.tsx
+++ b/packages/ui/stories-sense/InputGroup.stories.tsx
@@ -20,7 +20,7 @@ import { LuCheck, LuCopy, LuInfo, LuSearch, LuSend } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof InputGroup> = {
-  title: 'Sense/InputGroup',
+  title: 'Sense/Primitives/InputGroup',
   component: InputGroup,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/InputOTP.stories.tsx
+++ b/packages/ui/stories-sense/InputOTP.stories.tsx
@@ -10,7 +10,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof InputOTP> = {
-  title: 'Sense/InputOTP',
+  title: 'Sense/Primitives/InputOTP',
   component: InputOTP,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Item.stories.tsx
+++ b/packages/ui/stories-sense/Item.stories.tsx
@@ -31,7 +31,7 @@ import {
 import { withSense } from './sense';
 
 const meta: Meta<typeof Item> = {
-  title: 'Sense/Item',
+  title: 'Sense/Primitives/Item',
   component: Item,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Kbd.stories.tsx
+++ b/packages/ui/stories-sense/Kbd.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Kbd> = {
-  title: 'Sense/Kbd',
+  title: 'Sense/Primitives/Kbd',
   component: Kbd,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Label.stories.tsx
+++ b/packages/ui/stories-sense/Label.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Label> = {
-  title: 'Sense/Label',
+  title: 'Sense/Primitives/Label',
   component: Label,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Menubar.stories.tsx
+++ b/packages/ui/stories-sense/Menubar.stories.tsx
@@ -18,7 +18,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Menubar> = {
-  title: 'Sense/Menubar',
+  title: 'Sense/Primitives/Menubar',
   component: Menubar,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/NativeSelect.stories.tsx
+++ b/packages/ui/stories-sense/NativeSelect.stories.tsx
@@ -9,7 +9,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof NativeSelect> = {
-  title: 'Sense/NativeSelect',
+  title: 'Sense/Primitives/NativeSelect',
   component: NativeSelect,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/NavigationMenu.stories.tsx
+++ b/packages/ui/stories-sense/NavigationMenu.stories.tsx
@@ -13,7 +13,7 @@ import { LuCircle, LuCircleCheck, LuCircleDashed } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof NavigationMenu> = {
-  title: 'Sense/NavigationMenu',
+  title: 'Sense/Primitives/NavigationMenu',
   component: NavigationMenu,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/NumberField.stories.tsx
+++ b/packages/ui/stories-sense/NumberField.stories.tsx
@@ -1,0 +1,90 @@
+import { NumberField } from '@op/sense/NumberField';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { withSense } from './sense';
+
+const meta: Meta<typeof NumberField> = {
+  title: 'Sense/NumberField',
+  component: NumberField,
+  decorators: [withSense],
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NumberField>;
+
+const DefaultDemo = () => {
+  const [amount, setAmount] = useState<number | null>(250);
+
+  return (
+    <NumberField
+      label="Budget"
+      description="Whole numbers or decimals; non-numeric input is filtered."
+      prefixText="$"
+      value={amount}
+      onChange={setAmount}
+      className="w-72"
+    />
+  );
+};
+
+export const Default: Story = {
+  render: () => <DefaultDemo />,
+};
+
+const BoundsDemo = () => {
+  const [votes, setVotes] = useState<number | null>(5);
+
+  return (
+    <NumberField
+      label="Votes"
+      description="Between 0 and 10. Bounds are validated on blur."
+      minValue={0}
+      maxValue={10}
+      value={votes}
+      onChange={setVotes}
+      className="w-72"
+    />
+  );
+};
+
+export const WithBounds: Story = {
+  render: () => <BoundsDemo />,
+};
+
+// Type Arabic-Indic (٠١٢٣) or Persian (۰۱۲۳) digits — they normalize to
+// ASCII on input, and the field stays LTR in RTL locales.
+const ArabicDigitsDemo = () => {
+  const [amount, setAmount] = useState<number | null>(null);
+
+  return (
+    <div dir="rtl">
+      <NumberField
+        label="المبلغ"
+        description="جرّب كتابة ٤٢ أو ۴۲"
+        value={amount}
+        onChange={setAmount}
+        className="w-72"
+      />
+    </div>
+  );
+};
+
+export const ArabicDigits: Story = {
+  render: () => <ArabicDigitsDemo />,
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="flex w-72 flex-col gap-6">
+      <NumberField label="Disabled" disabled value={42} />
+      <NumberField
+        label="With error"
+        errorMessage="The budget exceeds the remaining funds."
+        value={9000}
+      />
+    </div>
+  ),
+};

--- a/packages/ui/stories-sense/NumberField.stories.tsx
+++ b/packages/ui/stories-sense/NumberField.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { withSense } from './sense';
 
 const meta: Meta<typeof NumberField> = {
-  title: 'Sense/NumberField',
+  title: 'Sense/Composites/NumberField',
   component: NumberField,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Pagination.stories.tsx
+++ b/packages/ui/stories-sense/Pagination.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Pagination> = {
-  title: 'Sense/Pagination',
+  title: 'Sense/Primitives/Pagination',
   component: Pagination,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Popover.stories.tsx
+++ b/packages/ui/stories-sense/Popover.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Popover> = {
-  title: 'Sense/Popover',
+  title: 'Sense/Primitives/Popover',
   component: Popover,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Progress.stories.tsx
+++ b/packages/ui/stories-sense/Progress.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Progress> = {
-  title: 'Sense/Progress',
+  title: 'Sense/Primitives/Progress',
   component: Progress,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/RadioGroup.stories.tsx
+++ b/packages/ui/stories-sense/RadioGroup.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof RadioGroup> = {
-  title: 'Sense/RadioGroup',
+  title: 'Sense/Primitives/RadioGroup',
   component: RadioGroup,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/RequiredAsterisk.stories.tsx
+++ b/packages/ui/stories-sense/RequiredAsterisk.stories.tsx
@@ -1,0 +1,30 @@
+import { FieldLabel } from '@op/sense/Field';
+import { Input } from '@op/sense/Input';
+import { RequiredAsterisk } from '@op/sense/RequiredAsterisk';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { withSense } from './sense';
+
+const meta: Meta<typeof RequiredAsterisk> = {
+  title: 'Sense/RequiredAsterisk',
+  component: RequiredAsterisk,
+  decorators: [withSense],
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RequiredAsterisk>;
+
+// Decorative marker only — the input itself carries `required`.
+export const Default: Story = {
+  render: () => (
+    <div className="flex w-72 flex-col gap-1">
+      <FieldLabel htmlFor="required-demo">
+        Organization name
+        <RequiredAsterisk />
+      </FieldLabel>
+      <Input id="required-demo" required placeholder="One Project" />
+    </div>
+  ),
+};

--- a/packages/ui/stories-sense/RequiredAsterisk.stories.tsx
+++ b/packages/ui/stories-sense/RequiredAsterisk.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof RequiredAsterisk> = {
-  title: 'Sense/RequiredAsterisk',
+  title: 'Sense/Composites/RequiredAsterisk',
   component: RequiredAsterisk,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Resizable.stories.tsx
+++ b/packages/ui/stories-sense/Resizable.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof ResizablePanelGroup> = {
-  title: 'Sense/Resizable',
+  title: 'Sense/Primitives/Resizable',
   component: ResizablePanelGroup,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/ScrollArea.stories.tsx
+++ b/packages/ui/stories-sense/ScrollArea.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof ScrollArea> = {
-  title: 'Sense/ScrollArea',
+  title: 'Sense/Primitives/ScrollArea',
   component: ScrollArea,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Select.stories.tsx
+++ b/packages/ui/stories-sense/Select.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Select> = {
-  title: 'Sense/Select',
+  title: 'Sense/Primitives/Select',
   component: Select,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Separator.stories.tsx
+++ b/packages/ui/stories-sense/Separator.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Separator> = {
-  title: 'Sense/Separator',
+  title: 'Sense/Primitives/Separator',
   component: Separator,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Sheet.stories.tsx
+++ b/packages/ui/stories-sense/Sheet.stories.tsx
@@ -16,7 +16,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Sheet> = {
-  title: 'Sense/Sheet',
+  title: 'Sense/Primitives/Sheet',
   component: Sheet,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Sidebar.stories.tsx
+++ b/packages/ui/stories-sense/Sidebar.stories.tsx
@@ -31,7 +31,7 @@ import {
 import { withSense } from './sense';
 
 const meta: Meta<typeof Sidebar> = {
-  title: 'Sense/Sidebar',
+  title: 'Sense/Primitives/Sidebar',
   component: Sidebar,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Skeleton.stories.tsx
+++ b/packages/ui/stories-sense/Skeleton.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Skeleton> = {
-  title: 'Sense/Skeleton',
+  title: 'Sense/Primitives/Skeleton',
   component: Skeleton,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Slider.stories.tsx
+++ b/packages/ui/stories-sense/Slider.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Slider> = {
-  title: 'Sense/Slider',
+  title: 'Sense/Primitives/Slider',
   component: Slider,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Sonner.stories.tsx
+++ b/packages/ui/stories-sense/Sonner.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Toaster> = {
-  title: 'Sense/Sonner',
+  title: 'Sense/Primitives/Sonner',
   component: Toaster,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Spinner.stories.tsx
+++ b/packages/ui/stories-sense/Spinner.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Spinner> = {
-  title: 'Sense/Spinner',
+  title: 'Sense/Primitives/Spinner',
   component: Spinner,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Switch.stories.tsx
+++ b/packages/ui/stories-sense/Switch.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Switch> = {
-  title: 'Sense/Switch',
+  title: 'Sense/Primitives/Switch',
   component: Switch,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Table.stories.tsx
+++ b/packages/ui/stories-sense/Table.stories.tsx
@@ -23,7 +23,7 @@ import { LuEllipsis } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Table> = {
-  title: 'Sense/Table',
+  title: 'Sense/Primitives/Table',
   component: Table,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Tabs.stories.tsx
+++ b/packages/ui/stories-sense/Tabs.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Tabs> = {
-  title: 'Sense/Tabs',
+  title: 'Sense/Primitives/Tabs',
   component: Tabs,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/TagGroup.stories.tsx
+++ b/packages/ui/stories-sense/TagGroup.stories.tsx
@@ -1,0 +1,90 @@
+import { Tag, TagGroup } from '@op/sense/TagGroup';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { withSense } from './sense';
+
+const meta: Meta<typeof TagGroup> = {
+  title: 'Sense/TagGroup',
+  component: TagGroup,
+  decorators: [withSense],
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TagGroup>;
+
+const focusAreas = [
+  'Climate justice',
+  'Food sovereignty',
+  'Housing',
+  'Mutual aid',
+  'Participatory budgeting',
+];
+
+export const Default: Story = {
+  render: () => (
+    <TagGroup label="Focus areas" className="max-w-md">
+      {focusAreas.map((area) => (
+        <Tag key={area}>{area}</Tag>
+      ))}
+    </TagGroup>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <TagGroup className="max-w-md">
+      {(['accent', 'default', 'secondary', 'outline'] as const).map(
+        (variant) => (
+          <Tag key={variant} variant={variant}>
+            {variant}
+          </Tag>
+        ),
+      )}
+    </TagGroup>
+  ),
+};
+
+// Removable tags are stateful so the remove buttons actually work.
+const RemovableDemo = () => {
+  const [tags, setTags] = useState(focusAreas);
+
+  return (
+    <TagGroup
+      label="Selected topics"
+      description="Remove topics that no longer apply."
+      className="max-w-md"
+    >
+      {tags.map((tag) => (
+        <Tag
+          key={tag}
+          onRemove={() =>
+            setTags((current) => current.filter((t) => t !== tag))
+          }
+          removeLabel={`Remove ${tag}`}
+        >
+          {tag}
+        </Tag>
+      ))}
+    </TagGroup>
+  );
+};
+
+export const Removable: Story = {
+  render: () => <RemovableDemo />,
+};
+
+export const WithError: Story = {
+  render: () => (
+    <TagGroup
+      label="Invitees"
+      errorMessage="One or more email addresses are invalid."
+      className="max-w-md"
+    >
+      <Tag variant="destructive">not-an-email</Tag>
+      <Tag>frida@example.com</Tag>
+    </TagGroup>
+  ),
+};

--- a/packages/ui/stories-sense/TagGroup.stories.tsx
+++ b/packages/ui/stories-sense/TagGroup.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { withSense } from './sense';
 
 const meta: Meta<typeof TagGroup> = {
-  title: 'Sense/TagGroup',
+  title: 'Sense/Composites/TagGroup',
   component: TagGroup,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/TagGroup.stories.tsx
+++ b/packages/ui/stories-sense/TagGroup.stories.tsx
@@ -47,6 +47,18 @@ export const Variants: Story = {
   ),
 };
 
+export const Large: Story = {
+  render: () => (
+    <TagGroup label="Focus areas" className="max-w-md">
+      {focusAreas.map((area) => (
+        <Tag key={area} size="lg">
+          {area}
+        </Tag>
+      ))}
+    </TagGroup>
+  ),
+};
+
 // Removable tags are stateful so the remove buttons actually work.
 const RemovableDemo = () => {
   const [tags, setTags] = useState(focusAreas);

--- a/packages/ui/stories-sense/Textarea.stories.tsx
+++ b/packages/ui/stories-sense/Textarea.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Textarea> = {
-  title: 'Sense/Textarea',
+  title: 'Sense/Primitives/Textarea',
   component: Textarea,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Toggle.stories.tsx
+++ b/packages/ui/stories-sense/Toggle.stories.tsx
@@ -5,7 +5,7 @@ import { LuBold, LuItalic } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Toggle> = {
-  title: 'Sense/Toggle',
+  title: 'Sense/Primitives/Toggle',
   component: Toggle,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/ToggleGroup.stories.tsx
+++ b/packages/ui/stories-sense/ToggleGroup.stories.tsx
@@ -12,7 +12,7 @@ import {
 import { withSense } from './sense';
 
 const meta: Meta<typeof ToggleGroup> = {
-  title: 'Sense/ToggleGroup',
+  title: 'Sense/Primitives/ToggleGroup',
   component: ToggleGroup,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories-sense/Tooltip.stories.tsx
+++ b/packages/ui/stories-sense/Tooltip.stories.tsx
@@ -11,7 +11,7 @@ import { LuPlus } from 'react-icons/lu';
 import { withSense } from './sense';
 
 const meta: Meta<typeof Tooltip> = {
-  title: 'Sense/Tooltip',
+  title: 'Sense/Primitives/Tooltip',
   component: Tooltip,
   decorators: [withSense],
   tags: ['autodocs'],

--- a/packages/ui/stories/senseComposites/DatePicker.stories.tsx
+++ b/packages/ui/stories/senseComposites/DatePicker.stories.tsx
@@ -1,0 +1,73 @@
+import { parseDate } from '@internationalized/date';
+import { DatePicker } from '@op/sense/DatePicker';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import type { DateValue } from 'react-aria-components';
+
+import { Pair, Section } from '../../src/comparison/Comparison';
+import { DatePicker as OldDatePicker } from '../../src/components/DatePicker';
+
+// Side-by-side of the @op/ui composite and its @op/sense port. The old
+// component speaks @internationalized/date DateValue; the port speaks native
+// Date (react-day-picker conventions).
+
+const meta: Meta = {
+  title: 'Sense Comparison/Composites/DatePicker',
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const NewDemo = () => {
+  const [date, setDate] = useState<Date | undefined>(new Date(2026, 5, 15));
+
+  return (
+    <DatePicker
+      label="Start date"
+      value={date}
+      onChange={setDate}
+      className="w-64"
+    />
+  );
+};
+
+const OldDemo = () => {
+  const [date, setDate] = useState<DateValue>(parseDate('2026-06-15'));
+
+  return (
+    <div className="w-64">
+      <OldDatePicker label="Start date" value={date} onChange={setDate} />
+    </div>
+  );
+};
+
+export const DatePickerComparison: Story = {
+  name: 'DatePicker',
+  render: () => (
+    <div className="p-8">
+      <Section title="DatePicker">
+        <Pair label="Basic" old={<OldDemo />} raw={<NewDemo />} />
+        <Pair
+          label="Error state"
+          old={
+            <div className="w-64">
+              <OldDatePicker
+                label="End date"
+                errorMessage="End must follow start."
+              />
+            </div>
+          }
+          raw={
+            <DatePicker
+              label="End date"
+              errorMessage="End must follow start."
+              className="w-64"
+            />
+          }
+        />
+      </Section>
+    </div>
+  ),
+};

--- a/packages/ui/stories/senseComposites/NumberField.stories.tsx
+++ b/packages/ui/stories/senseComposites/NumberField.stories.tsx
@@ -1,0 +1,75 @@
+import { NumberField } from '@op/sense/NumberField';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Pair, Section } from '../../src/comparison/Comparison';
+import { NumberField as OldNumberField } from '../../src/components/NumberField';
+
+// Side-by-side of the @op/ui composite and its @op/sense port. Same numeric
+// filtering and Arabic-digit normalization; the prefix now rides InputGroup
+// instead of a ResizeObserver.
+
+const meta: Meta = {
+  title: 'Sense Comparison/Composites/NumberField',
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const NewDemo = () => {
+  const [amount, setAmount] = useState<number | null>(250);
+
+  return (
+    <NumberField
+      label="Budget"
+      prefixText="$"
+      value={amount}
+      onChange={setAmount}
+      className="w-64"
+    />
+  );
+};
+
+const OldDemo = () => {
+  const [amount, setAmount] = useState<number | null>(250);
+
+  return (
+    <div className="w-64">
+      <OldNumberField
+        label="Budget"
+        prefixText="$"
+        value={amount}
+        onChange={setAmount}
+      />
+    </div>
+  );
+};
+
+export const NumberFieldComparison: Story = {
+  name: 'NumberField',
+  render: () => (
+    <div className="p-8">
+      <Section title="NumberField">
+        <Pair label="With prefix" old={<OldDemo />} raw={<NewDemo />} />
+        <Pair
+          label="Bounds error"
+          old={
+            <div className="w-64">
+              <OldNumberField label="Votes" minValue={0} maxValue={10} />
+            </div>
+          }
+          raw={
+            <NumberField
+              label="Votes"
+              minValue={0}
+              maxValue={10}
+              className="w-64"
+            />
+          }
+        />
+      </Section>
+    </div>
+  ),
+};

--- a/packages/ui/stories/senseComposites/RequiredAsterisk.stories.tsx
+++ b/packages/ui/stories/senseComposites/RequiredAsterisk.stories.tsx
@@ -1,0 +1,39 @@
+import { RequiredAsterisk } from '@op/sense/RequiredAsterisk';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Pair, Section } from '../../src/comparison/Comparison';
+import { RequiredAsterisk as OldRequiredAsterisk } from '../../src/components/RequiredAsterisk';
+
+const meta: Meta = {
+  title: 'Sense Comparison/Composites/RequiredAsterisk',
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const RequiredAsteriskComparison: Story = {
+  name: 'RequiredAsterisk',
+  render: () => (
+    <div className="p-8">
+      <Section title="RequiredAsterisk">
+        <Pair
+          label="In a label"
+          old={
+            <span>
+              Organization name
+              <OldRequiredAsterisk />
+            </span>
+          }
+          raw={
+            <span>
+              Organization name
+              <RequiredAsterisk />
+            </span>
+          }
+        />
+      </Section>
+    </div>
+  ),
+};

--- a/packages/ui/stories/senseComposites/TagGroup.stories.tsx
+++ b/packages/ui/stories/senseComposites/TagGroup.stories.tsx
@@ -1,0 +1,111 @@
+import { Tag, TagGroup } from '@op/sense/TagGroup';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Pair, Section } from '../../src/comparison/Comparison';
+import {
+  TagGroup as OldTagGroup,
+  Tag as OldTag,
+} from '../../src/components/TagGroup';
+
+// Side-by-side of the @op/ui composite and its @op/sense port. One file per
+// ported composite; the old column disappears with @op/ui.
+
+const meta: Meta = {
+  title: 'Sense Comparison/Composites/TagGroup',
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const focusAreas = ['Climate justice', 'Food sovereignty', 'Housing'];
+
+const RemovableNew = () => {
+  const [tags, setTags] = useState(focusAreas);
+
+  return (
+    <TagGroup label="Topics">
+      {tags.map((tag) => (
+        <Tag
+          key={tag}
+          onRemove={() =>
+            setTags((current) => current.filter((t) => t !== tag))
+          }
+          removeLabel={`Remove ${tag}`}
+        >
+          {tag}
+        </Tag>
+      ))}
+    </TagGroup>
+  );
+};
+
+const RemovableOld = () => {
+  const [tags, setTags] = useState(focusAreas);
+
+  return (
+    <OldTagGroup
+      label="Topics"
+      onRemove={(keys) =>
+        setTags((current) => current.filter((t) => !keys.has(t)))
+      }
+    >
+      {tags.map((tag) => (
+        <OldTag key={tag} id={tag}>
+          {tag}
+        </OldTag>
+      ))}
+    </OldTagGroup>
+  );
+};
+
+export const TagGroupComparison: Story = {
+  name: 'TagGroup',
+  render: () => (
+    <div className="p-8">
+      <Section title="TagGroup">
+        <Pair
+          label="Static tags"
+          old={
+            <OldTagGroup label="Focus areas">
+              {focusAreas.map((area) => (
+                <OldTag key={area}>{area}</OldTag>
+              ))}
+            </OldTagGroup>
+          }
+          raw={
+            <TagGroup label="Focus areas">
+              {focusAreas.map((area) => (
+                <Tag key={area}>{area}</Tag>
+              ))}
+            </TagGroup>
+          }
+        />
+        <Pair label="Removable" old={<RemovableOld />} raw={<RemovableNew />} />
+        <Pair
+          label="Description + error"
+          old={
+            <OldTagGroup
+              label="Invitees"
+              description="Emails to invite."
+              errorMessage="One address is invalid."
+            >
+              <OldTag>not-an-email</OldTag>
+            </OldTagGroup>
+          }
+          raw={
+            <TagGroup
+              label="Invitees"
+              description="Emails to invite."
+              errorMessage="One address is invalid."
+            >
+              <Tag variant="destructive">not-an-email</Tag>
+            </TagGroup>
+          }
+        />
+      </Section>
+    </div>
+  ),
+};


### PR DESCRIPTION
P2 input-extensions family, first entries in the @op/sense composite layer (`packages/sense/src/components/`):

- **TagGroup** + **Tag** on Badge + Field parts (static chips, per-tag remove, label/description/error; unused react-aria selection + empty color variants dropped)
- **DatePicker** on Calendar + Popover + InputGroup — native `Date` API (rdp conventions), typed-input parsing (MM/DD/YYYY + ISO) preserved, min/max via rdp `disabled` matchers
- **NumberField** on InputGroup + Field parts — Arabic-Indic/Persian digit normalization and numeric filtering preserved verbatim; prefix uses InputGroupAddon (ResizeObserver hack gone); input pinned `dir=ltr` per the RTL rules
- **RequiredAsterisk** — matching-name port so P3 is an import swap; dogfooded by the two composites above
- **Form**: deliberately no sense component — call sites move to native `form` + FieldGroup in P3

Every composite ships a first-class story (`Sense/*`) and an old-vs-new comparison story (`Sense Comparison/Composites/*`).

Asana: https://app.asana.com/1/1108348036672214/project/1216361907129487/task/1216401513246035