### PR TITLE
feat(sense): process & stepper composites — Sortable, Stepper, PhaseStepper, PhaseCard, CollapsibleConfigCard

### DIFF
--- a/packages/sense/package.json
+++ b/packages/sense/package.json
@@ -65,6 +65,7 @@
     "./Skeleton": "./src/components/ui/skeleton.tsx",
     "./Slider": "./src/components/ui/slider.tsx",
     "./Sonner": "./src/components/ui/sonner.tsx",
+    "./Sortable": "./src/components/Sortable/index.ts",
     "./SplitPane": "./src/components/SplitPane/index.tsx",
     "./Spinner": "./src/components/ui/spinner.tsx",
     "./Switch": "./src/components/ui/switch.tsx",
@@ -83,6 +84,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@op/styles": "workspace:*",
     "@tiptap/core": "catalog:",
     "@tiptap/extension-details": "catalog:",

--- a/packages/sense/package.json
+++ b/packages/sense/package.json
@@ -25,6 +25,7 @@
     "./Chart": "./src/components/ui/chart.tsx",
     "./Checkbox": "./src/components/ui/checkbox.tsx",
     "./Collapsible": "./src/components/ui/collapsible.tsx",
+    "./CollapsibleConfigCard": "./src/components/CollapsibleConfigCard/index.tsx",
     "./Combobox": "./src/components/ui/combobox.tsx",
     "./Command": "./src/components/ui/command.tsx",
     "./ContextMenu": "./src/components/ui/context-menu.tsx",

--- a/packages/sense/package.json
+++ b/packages/sense/package.json
@@ -68,6 +68,7 @@
     "./Sortable": "./src/components/Sortable/index.ts",
     "./SplitPane": "./src/components/SplitPane/index.tsx",
     "./Spinner": "./src/components/ui/spinner.tsx",
+    "./Stepper": "./src/components/Stepper/index.ts",
     "./Switch": "./src/components/ui/switch.tsx",
     "./Table": "./src/components/ui/table.tsx",
     "./TagGroup": "./src/components/TagGroup/index.tsx",
@@ -114,7 +115,8 @@
     "sonner": "^1.7.4",
     "tailwind-merge": "3.4.0",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@op/typescript-config": "workspace:*",

--- a/packages/sense/package.json
+++ b/packages/sense/package.json
@@ -50,6 +50,8 @@
     "./NavigationMenu": "./src/components/ui/navigation-menu.tsx",
     "./NumberField": "./src/components/NumberField/index.tsx",
     "./Pagination": "./src/components/ui/pagination.tsx",
+    "./PhaseCard": "./src/components/PhaseCard/index.tsx",
+    "./PhaseStepper": "./src/components/PhaseStepper/index.tsx",
     "./Popover": "./src/components/ui/popover.tsx",
     "./Progress": "./src/components/ui/progress.tsx",
     "./RadioGroup": "./src/components/ui/radio-group.tsx",

--- a/packages/sense/src/components/CollapsibleConfigCard/index.tsx
+++ b/packages/sense/src/components/CollapsibleConfigCard/index.tsx
@@ -130,9 +130,13 @@ function CollapsibleConfigCard({
       onOpenChange={onExpandedChange}
       className={cardClasses}
     >
-      <div className="flex w-full items-center gap-3 p-4">
-        {leadingElement}
-        <CollapsibleTrigger className="group/config-card flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-start outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+      {/* Padding lives on the trigger so the whole header row (minus the
+          drag-handle strip) toggles the panel. */}
+      <div className="flex w-full items-center">
+        <div className="flex items-center self-stretch ps-4">
+          {leadingElement}
+        </div>
+        <CollapsibleTrigger className="group/config-card flex min-w-0 flex-1 cursor-pointer items-center gap-3 p-4 ps-3 text-start outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
           {headerContent}
         </CollapsibleTrigger>
       </div>

--- a/packages/sense/src/components/CollapsibleConfigCard/index.tsx
+++ b/packages/sense/src/components/CollapsibleConfigCard/index.tsx
@@ -136,8 +136,10 @@ function CollapsibleConfigCard({
           {headerContent}
         </CollapsibleTrigger>
       </div>
-      {/* ps-11 aligns the body under the trigger text (16 pad + 16 grip + 12 gap). */}
-      <CollapsibleContent>
+      {/* ps-11 aligns the body under the trigger text (16 pad + 16 grip +
+          12 gap). Height animation rides base-ui's measured panel height,
+          mirroring the accordion primitive. */}
+      <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-200 ease-out data-ending-style:h-0 data-starting-style:h-0">
         <div className="flex flex-col gap-4 ps-11 pe-10 pb-6">{children}</div>
       </CollapsibleContent>
     </Collapsible>

--- a/packages/sense/src/components/CollapsibleConfigCard/index.tsx
+++ b/packages/sense/src/components/CollapsibleConfigCard/index.tsx
@@ -103,8 +103,11 @@ function CollapsibleConfigCard({
   );
 
   // Padding lives in the header and content rows, not the card shell.
+  // Hover and open both wash the card gray-50 per the Template Card spec
+  // (the exact ramp step, not --muted, which sits darker since #1615).
   const cardClasses = cn(
-    'rounded-lg border bg-background',
+    'rounded-lg border bg-background transition-colors',
+    isCollapsible && !locked && 'hover:bg-gray-50 data-open:bg-gray-50',
     locked && 'bg-muted',
     isDragging && 'opacity-50',
     className,

--- a/packages/sense/src/components/CollapsibleConfigCard/index.tsx
+++ b/packages/sense/src/components/CollapsibleConfigCard/index.tsx
@@ -30,17 +30,18 @@ interface CollapsibleConfigCardProps {
   defaultExpanded?: boolean;
   /** Callback when expansion changes */
   onExpandedChange?: (expanded: boolean) => void;
-  /** Sortable controls for drag-and-drop */
-  controls?: SortableItemControls;
   /** Accessible label for the drag handle */
   dragHandleAriaLabel?: string;
   /** Content to render in the body (below header) */
   children?: React.ReactNode;
   /** Additional class name for the card container */
   className?: string;
-  /** Whether the card is locked (non-editable, no drag handle) */
-  locked?: boolean;
 }
+
+// Cards are always sortable — a card without drag controls is locked.
+type SortableOrLocked =
+  | { locked: true; controls?: never }
+  | { locked?: false; controls: SortableItemControls };
 
 function CollapsibleConfigCard({
   icon: Icon,
@@ -56,7 +57,7 @@ function CollapsibleConfigCard({
   children,
   className,
   locked = false,
-}: CollapsibleConfigCardProps) {
+}: CollapsibleConfigCardProps & SortableOrLocked) {
   const isDragging = controls?.isDragging ?? false;
 
   // The leading element: drag handle for editable cards, lock icon for locked cards.

--- a/packages/sense/src/components/CollapsibleConfigCard/index.tsx
+++ b/packages/sense/src/components/CollapsibleConfigCard/index.tsx
@@ -14,9 +14,9 @@ import {
 } from '../ui/collapsible';
 
 interface CollapsibleConfigCardProps {
-  /** Icon component to display in the header. When omitted, label renders as plain text (no pill). */
+  /** Optional icon rendered after the label (the Template Card spec has none). */
   icon?: React.ComponentType<{ className?: string }>;
-  /** Label text shown in the header pill (or plain text when no icon) */
+  /** Trigger label (text-base font-strong per the Template Card spec) */
   label: string;
   /** Badge text shown as a chip (e.g. "Required" / "Optional") */
   badgeLabel?: string;
@@ -73,27 +73,21 @@ function CollapsibleConfigCard({
     )
   );
 
-  // The header content that acts as the collapse trigger target:
-  // [Icon + Label pill] ... [Badge chip] [Chevron]
+  // Header per the Template Card spec: [grip|lock] Trigger Text … [Badge] [Chevron].
+  // The label reads text-base font-strong and underlines on trigger hover.
   const headerContent = (
     <>
-      {locked ? (
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          {Icon && <Icon className="size-4 shrink-0 text-muted-foreground" />}
-          <span className="truncate text-muted-foreground">{label}</span>
-        </div>
-      ) : Icon ? (
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <div className="flex min-w-0 items-center gap-2 rounded-sm bg-muted px-2 py-1">
-            <Icon className="size-4 shrink-0 text-foreground" />
-            <span className="truncate text-foreground">{label}</span>
-          </div>
-        </div>
-      ) : (
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="truncate text-foreground">{label}</span>
-        </div>
-      )}
+      <span
+        className={cn(
+          'truncate text-base font-strong',
+          locked ? 'text-muted-foreground' : 'text-foreground',
+          !locked && isCollapsible && 'group-hover/config-card:underline',
+        )}
+      >
+        {label}
+      </span>
+      {Icon ? <Icon className="size-4 shrink-0 text-muted-foreground" /> : null}
+      <span className="min-w-0 flex-1" />
 
       {badgeLabel && (
         <Badge variant="secondary" className={cn('shrink-0', badgeClassName)}>
@@ -102,13 +96,14 @@ function CollapsibleConfigCard({
       )}
 
       {isCollapsible && (
-        <LuChevronDown className="size-4 shrink-0 text-foreground transition-transform duration-200 group-data-panel-open/config-card:rotate-180" />
+        <LuChevronDown className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-panel-open/config-card:rotate-180" />
       )}
     </>
   );
 
+  // Padding lives in the header and content rows, not the card shell.
   const cardClasses = cn(
-    'rounded-lg border bg-background px-3 py-4',
+    'rounded-lg border bg-background',
     locked && 'bg-muted',
     isDragging && 'opacity-50',
     className,
@@ -118,7 +113,7 @@ function CollapsibleConfigCard({
   if (!isCollapsible) {
     return (
       <div className={cardClasses}>
-        <div className="flex w-full items-center gap-2">
+        <div className="flex w-full items-center gap-3 p-4">
           {leadingElement}
           {headerContent}
         </div>
@@ -134,21 +129,22 @@ function CollapsibleConfigCard({
       onOpenChange={onExpandedChange}
       className={cardClasses}
     >
-      <div className="flex w-full items-center gap-2">
+      <div className="flex w-full items-center gap-3 p-4">
         {leadingElement}
-        <CollapsibleTrigger className="group/config-card flex min-w-0 flex-1 cursor-pointer items-center gap-2 pe-2 text-start outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+        <CollapsibleTrigger className="group/config-card flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-start outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
           {headerContent}
         </CollapsibleTrigger>
       </div>
+      {/* ps-11 aligns the body under the trigger text (16 pad + 16 grip + 12 gap). */}
       <CollapsibleContent>
-        <div className="pt-4">{children}</div>
+        <div className="flex flex-col gap-4 ps-11 pe-10 pb-6">{children}</div>
       </CollapsibleContent>
     </Collapsible>
   );
 }
 
 interface CollapsibleConfigCardDragPreviewProps {
-  /** Icon component to display next to the label. When omitted, label renders as plain text. */
+  /** Optional icon rendered after the label. */
   icon?: React.ComponentType<{ className?: string }>;
   /** The label text */
   label: string;
@@ -188,16 +184,13 @@ function CollapsibleConfigCardDragPreview({
         <div className="me-1 flex items-center justify-center text-muted-foreground">
           <LuGripVertical className="size-4" />
         </div>
+        <span className="truncate text-base font-strong text-foreground">
+          {label}
+        </span>
         {Icon ? (
-          <div className="w-full grow">
-            <div className="flex w-fit shrink items-center gap-2 rounded-sm bg-muted px-2 py-1">
-              <Icon className="size-4 text-muted-foreground" />
-              <span className="truncate text-foreground">{label}</span>
-            </div>
-          </div>
-        ) : (
-          <span className="w-full grow truncate text-foreground">{label}</span>
-        )}
+          <Icon className="size-4 shrink-0 text-muted-foreground" />
+        ) : null}
+        <span className="min-w-0 grow" />
         {badgeLabel && (
           <Badge variant="secondary" className="shrink-0">
             {badgeLabel}

--- a/packages/sense/src/components/CollapsibleConfigCard/index.tsx
+++ b/packages/sense/src/components/CollapsibleConfigCard/index.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { LuChevronDown, LuGripVertical, LuLock } from 'react-icons/lu';
+
+import { cn } from '../../lib/utils';
+import type { SortableItemControls } from '../Sortable';
+import { DragHandle } from '../Sortable';
+import { Badge } from '../ui/badge';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../ui/collapsible';
+
+interface CollapsibleConfigCardProps {
+  /** Icon component to display in the header. When omitted, label renders as plain text (no pill). */
+  icon?: React.ComponentType<{ className?: string }>;
+  /** Label text shown in the header pill (or plain text when no icon) */
+  label: string;
+  /** Badge text shown as a chip (e.g. "Required" / "Optional") */
+  badgeLabel?: string;
+  /** Additional class name for the badge chip */
+  badgeClassName?: string;
+  /** Whether this card is collapsible. Default: false */
+  isCollapsible?: boolean;
+  /** Controlled expansion state */
+  isExpanded?: boolean;
+  /** Default expansion state (uncontrolled) */
+  defaultExpanded?: boolean;
+  /** Callback when expansion changes */
+  onExpandedChange?: (expanded: boolean) => void;
+  /** Sortable controls for drag-and-drop */
+  controls?: SortableItemControls;
+  /** Accessible label for the drag handle */
+  dragHandleAriaLabel?: string;
+  /** Content to render in the body (below header) */
+  children?: React.ReactNode;
+  /** Additional class name for the card container */
+  className?: string;
+  /** Whether the card is locked (non-editable, no drag handle) */
+  locked?: boolean;
+}
+
+function CollapsibleConfigCard({
+  icon: Icon,
+  label,
+  badgeLabel,
+  badgeClassName,
+  isCollapsible = false,
+  isExpanded,
+  defaultExpanded,
+  onExpandedChange,
+  controls,
+  dragHandleAriaLabel = 'Drag to reorder',
+  children,
+  className,
+  locked = false,
+}: CollapsibleConfigCardProps) {
+  const isDragging = controls?.isDragging ?? false;
+
+  // The leading element: drag handle for editable cards, lock icon for locked cards.
+  const leadingElement = locked ? (
+    <div className="flex size-6 items-center justify-center text-muted-foreground">
+      <LuLock className="size-4" />
+    </div>
+  ) : (
+    controls && (
+      <DragHandle
+        {...controls.dragHandleProps}
+        aria-label={dragHandleAriaLabel}
+      />
+    )
+  );
+
+  // The header content that acts as the collapse trigger target:
+  // [Icon + Label pill] ... [Badge chip] [Chevron]
+  const headerContent = (
+    <>
+      {locked ? (
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          {Icon && <Icon className="size-4 shrink-0 text-muted-foreground" />}
+          <span className="truncate text-muted-foreground">{label}</span>
+        </div>
+      ) : Icon ? (
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2 rounded-sm bg-muted px-2 py-1">
+            <Icon className="size-4 shrink-0 text-foreground" />
+            <span className="truncate text-foreground">{label}</span>
+          </div>
+        </div>
+      ) : (
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="truncate text-foreground">{label}</span>
+        </div>
+      )}
+
+      {badgeLabel && (
+        <Badge variant="secondary" className={cn('shrink-0', badgeClassName)}>
+          {badgeLabel}
+        </Badge>
+      )}
+
+      {isCollapsible && (
+        <LuChevronDown className="size-4 shrink-0 text-foreground transition-transform duration-200 group-data-panel-open/config-card:rotate-180" />
+      )}
+    </>
+  );
+
+  const cardClasses = cn(
+    'rounded-lg border bg-background px-3 py-4',
+    locked && 'bg-muted',
+    isDragging && 'opacity-50',
+    className,
+  );
+
+  // Non-collapsible: simple card
+  if (!isCollapsible) {
+    return (
+      <div className={cardClasses}>
+        <div className="flex w-full items-center gap-2">
+          {leadingElement}
+          {headerContent}
+        </div>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <Collapsible
+      open={isExpanded}
+      defaultOpen={defaultExpanded}
+      onOpenChange={onExpandedChange}
+      className={cardClasses}
+    >
+      <div className="flex w-full items-center gap-2">
+        {leadingElement}
+        <CollapsibleTrigger className="group/config-card flex min-w-0 flex-1 cursor-pointer items-center gap-2 pe-2 text-start outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+          {headerContent}
+        </CollapsibleTrigger>
+      </div>
+      <CollapsibleContent>
+        <div className="pt-4">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+interface CollapsibleConfigCardDragPreviewProps {
+  /** Icon component to display next to the label. When omitted, label renders as plain text. */
+  icon?: React.ComponentType<{ className?: string }>;
+  /** The label text */
+  label: string;
+  /** Badge text shown as a chip (e.g. "Required" / "Optional") */
+  badgeLabel?: string;
+  /** Optional custom content to override the default preview */
+  children?: ReactNode;
+  /** Additional class name for the preview container */
+  className?: string;
+}
+
+function CollapsibleConfigCardDragPreview({
+  icon: Icon,
+  label,
+  badgeLabel,
+  children,
+  className,
+}: CollapsibleConfigCardDragPreviewProps) {
+  if (children) {
+    return (
+      <div
+        className={cn(
+          'rounded-lg border bg-background p-4 shadow-lg',
+          className,
+        )}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn('rounded-lg border bg-background p-4 shadow-lg', className)}
+    >
+      <div className="flex items-center gap-2 pe-1">
+        <div className="me-1 flex items-center justify-center text-muted-foreground">
+          <LuGripVertical className="size-4" />
+        </div>
+        {Icon ? (
+          <div className="w-full grow">
+            <div className="flex w-fit shrink items-center gap-2 rounded-sm bg-muted px-2 py-1">
+              <Icon className="size-4 text-muted-foreground" />
+              <span className="truncate text-foreground">{label}</span>
+            </div>
+          </div>
+        ) : (
+          <span className="w-full grow truncate text-foreground">{label}</span>
+        )}
+        {badgeLabel && (
+          <Badge variant="secondary" className="shrink-0">
+            {badgeLabel}
+          </Badge>
+        )}
+        <LuChevronDown className="size-4 shrink-0 text-muted-foreground" />
+      </div>
+    </div>
+  );
+}
+
+export { CollapsibleConfigCard, CollapsibleConfigCardDragPreview };

--- a/packages/sense/src/components/CollapsibleConfigCard/index.tsx
+++ b/packages/sense/src/components/CollapsibleConfigCard/index.tsx
@@ -113,12 +113,21 @@ function CollapsibleConfigCard({
     className,
   );
 
+  // The drag handle floats above a full-width trigger, so the whole header
+  // (and its focus ring) spans the card; the handle intercepts its own
+  // clicks. ps-11 clears the handle (12 inset + 24 handle + 8 gap).
+  const leadingOverlay = leadingElement ? (
+    <div className="absolute start-3 top-1/2 z-10 -translate-y-1/2">
+      {leadingElement}
+    </div>
+  ) : null;
+
   // Non-collapsible: simple card
   if (!isCollapsible) {
     return (
-      <div className={cardClasses}>
-        <div className="flex w-full items-center gap-3 p-4">
-          {leadingElement}
+      <div className={cn(cardClasses, 'relative')}>
+        {leadingOverlay}
+        <div className="flex w-full items-center gap-3 p-4 ps-11">
           {headerContent}
         </div>
         {children}
@@ -131,18 +140,12 @@ function CollapsibleConfigCard({
       open={isExpanded}
       defaultOpen={defaultExpanded}
       onOpenChange={onExpandedChange}
-      className={cardClasses}
+      className={cn(cardClasses, 'relative')}
     >
-      {/* Padding lives on the trigger so the whole header row (minus the
-          drag-handle strip) toggles the panel. */}
-      <div className="flex w-full items-center">
-        <div className="flex items-center self-stretch ps-4">
-          {leadingElement}
-        </div>
-        <CollapsibleTrigger className="group/config-card flex min-w-0 flex-1 cursor-pointer items-center gap-3 p-4 ps-3 text-start outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
-          {headerContent}
-        </CollapsibleTrigger>
-      </div>
+      {leadingOverlay}
+      <CollapsibleTrigger className="group/config-card flex w-full min-w-0 cursor-pointer items-center gap-3 rounded-lg p-4 ps-11 text-start outline-none focus-visible:ring-2 focus-visible:ring-ring/50">
+        {headerContent}
+      </CollapsibleTrigger>
       {/* ps-11 aligns the body under the trigger text (16 pad + 16 grip +
           12 gap). Height animation rides base-ui's measured panel height,
           mirroring the accordion primitive. */}

--- a/packages/sense/src/components/CollapsibleConfigCard/index.tsx
+++ b/packages/sense/src/components/CollapsibleConfigCard/index.tsx
@@ -116,10 +116,10 @@ function CollapsibleConfigCard({
   // The drag handle floats above a full-width trigger, so the whole header
   // (and its focus ring) spans the card; the handle intercepts its own
   // clicks. ps-11 clears the handle (12 inset + 24 handle + 8 gap).
+  // top-4 pins the handle to the header row (its 24px box matches the
+  // header's content line), so it stays put when the card expands.
   const leadingOverlay = leadingElement ? (
-    <div className="absolute start-3 top-1/2 z-10 -translate-y-1/2">
-      {leadingElement}
-    </div>
+    <div className="absolute start-3 top-4 z-10">{leadingElement}</div>
   ) : null;
 
   // Non-collapsible: simple card

--- a/packages/sense/src/components/PhaseCard/index.tsx
+++ b/packages/sense/src/components/PhaseCard/index.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { LuArrowRight, LuCheck, LuPlay } from 'react-icons/lu';
+
+import { cn } from '../../lib/utils';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+
+type PhaseCardState = 'completed' | 'current' | 'upcoming';
+
+interface PhaseCardProps {
+  name: string;
+  startDate?: string;
+  endDate?: string;
+  locale?: string;
+  state: PhaseCardState;
+  className?: string;
+  /** Show the "Now open!" tag (current card accepting proposals). */
+  isNowOpen?: boolean;
+  nowOpenLabel?: string;
+  /** Render the Advance button (upcoming card the viewer can advance into). */
+  isAdvanceable?: boolean;
+  advanceLabel?: string;
+  onAdvance?: () => void;
+  /** Destination for the current card — the whole row links here. */
+  href?: string;
+}
+
+/**
+ * A single phase row (`<li>`) in the decision Overview timeline. Dispatches to
+ * one of four self-contained treatments; the consumer owns the `<ol>`, the
+ * completed/current/upcoming derivation, and which phase is now open or
+ * advanceable.
+ */
+function PhaseCard(props: PhaseCardProps) {
+  switch (props.state) {
+    case 'completed':
+      return <CompletedPhaseCard {...props} />;
+    case 'current':
+      return <CurrentPhaseCard {...props} />;
+    case 'upcoming':
+      return props.isAdvanceable ? (
+        <AdvanceablePhaseCard {...props} />
+      ) : (
+        <UpcomingPhaseCard {...props} />
+      );
+  }
+}
+
+/** Fields shared by every treatment. */
+type PhaseContentProps = Pick<
+  PhaseCardProps,
+  'name' | 'startDate' | 'endDate' | 'locale' | 'className'
+>;
+
+/** Completed: compact, green rail + check + dates + name. */
+function CompletedPhaseCard({
+  name,
+  startDate,
+  endDate,
+  locale,
+  className,
+}: PhaseContentProps) {
+  return (
+    <li
+      className={cn(
+        'flex flex-col gap-2 border-s border-success/30 px-4 py-2',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span className="flex size-4 items-center justify-center rounded-full bg-success-muted text-success">
+          <LuCheck className="size-3" aria-hidden />
+        </span>
+        <PhaseDates
+          startDate={startDate}
+          endDate={endDate}
+          locale={locale}
+          className="text-muted-foreground"
+        />
+      </div>
+      <PhaseName name={name} />
+    </li>
+  );
+}
+
+/** Current: filled teal card linking to `href`, optional "Now open!" tag + arrow. */
+function CurrentPhaseCard({
+  name,
+  startDate,
+  endDate,
+  locale,
+  className,
+  isNowOpen,
+  nowOpenLabel = 'Now open!',
+  href,
+}: PhaseContentProps &
+  Pick<PhaseCardProps, 'isNowOpen' | 'nowOpenLabel' | 'href'>) {
+  return (
+    <li className={className}>
+      <a
+        href={href}
+        className="flex items-center justify-between gap-4 rounded-xl bg-teal-100 p-4 text-teal-900 transition hover:bg-teal-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+      >
+        <div className="flex min-w-0 flex-col gap-4">
+          <div className="flex items-center gap-4">
+            <PhaseDates
+              startDate={startDate}
+              endDate={endDate}
+              locale={locale}
+            />
+            {isNowOpen ? (
+              <Badge className="bg-teal-900 text-background">
+                {nowOpenLabel}
+              </Badge>
+            ) : null}
+          </div>
+          <PhaseName name={name} />
+        </div>
+        <LuArrowRight className="size-4 shrink-0 rtl:rotate-180" aria-hidden />
+      </a>
+    </li>
+  );
+}
+
+/** Upcoming + advanceable: muted card with an Advance button. */
+function AdvanceablePhaseCard({
+  name,
+  startDate,
+  endDate,
+  locale,
+  className,
+  advanceLabel = 'Advance',
+  onAdvance,
+}: PhaseContentProps & Pick<PhaseCardProps, 'advanceLabel' | 'onAdvance'>) {
+  return (
+    <li
+      className={cn(
+        'flex items-center justify-between gap-4 rounded-xl bg-muted p-4',
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-col gap-2">
+        <PhaseDates
+          startDate={startDate}
+          endDate={endDate}
+          locale={locale}
+          className="text-muted-foreground"
+        />
+        <PhaseName name={name} />
+      </div>
+      <Button
+        variant="secondary"
+        onClick={() => onAdvance?.()}
+        className="shrink-0"
+      >
+        <LuPlay className="size-4" aria-hidden />
+        {advanceLabel}
+      </Button>
+    </li>
+  );
+}
+
+/** Upcoming: compact, gray rail + dates + name. */
+function UpcomingPhaseCard({
+  name,
+  startDate,
+  endDate,
+  locale,
+  className,
+}: PhaseContentProps) {
+  return (
+    <li className={cn('flex flex-col gap-2 border-s px-4 py-2', className)}>
+      <PhaseDates
+        startDate={startDate}
+        endDate={endDate}
+        locale={locale}
+        className="text-muted-foreground"
+      />
+      <PhaseName name={name} />
+    </li>
+  );
+}
+
+function PhaseDates({
+  startDate,
+  endDate,
+  locale,
+  className,
+}: {
+  startDate?: string;
+  endDate?: string;
+  locale?: string;
+  className?: string;
+}) {
+  if (!startDate && !endDate) {
+    return null;
+  }
+
+  return (
+    <span className={cn('text-base', className)}>
+      {formatDateRange(startDate, endDate, locale)}
+    </span>
+  );
+}
+
+function PhaseName({ name }: { name: string }) {
+  return (
+    <p className="font-serif text-title">
+      <bdi>{name}</bdi>
+    </p>
+  );
+}
+
+function formatDate(dateString: string, locale: string = 'en-US'): string {
+  return new Date(dateString).toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatDateRange(
+  startDate?: string,
+  endDate?: string,
+  locale?: string,
+): string {
+  if (startDate && endDate) {
+    return `${formatDate(startDate, locale)} - ${formatDate(endDate, locale)}`;
+  }
+  if (startDate) {
+    return formatDate(startDate, locale);
+  }
+  if (endDate) {
+    return formatDate(endDate, locale);
+  }
+  return '';
+}
+
+export { PhaseCard, type PhaseCardProps, type PhaseCardState };

--- a/packages/sense/src/components/PhaseCard/index.tsx
+++ b/packages/sense/src/components/PhaseCard/index.tsx
@@ -123,7 +123,7 @@ function CurrentPhaseCard({
         </div>
         <span
           aria-hidden
-          className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+          className="flex size-8 shrink-0 items-center justify-center rounded-md opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
         >
           <LuArrowRight className="size-4 rtl:rotate-180" />
         </span>

--- a/packages/sense/src/components/PhaseCard/index.tsx
+++ b/packages/sense/src/components/PhaseCard/index.tsx
@@ -19,7 +19,7 @@ interface PhaseCardProps {
   /** Show the "Now open!" tag (current card accepting proposals). */
   isNowOpen?: boolean;
   nowOpenLabel?: string;
-  /** Render the Advance button (upcoming card the viewer can advance into). */
+  /** Render the Start button (upcoming card the viewer can advance into). */
   isAdvanceable?: boolean;
   advanceLabel?: string;
   onAdvance?: () => void;
@@ -54,7 +54,7 @@ type PhaseContentProps = Pick<
   'name' | 'startDate' | 'endDate' | 'locale' | 'className'
 >;
 
-/** Completed: compact, green rail + check + dates + name. */
+/** Completed: gray rail + name with a green check, dates below. */
 function CompletedPhaseCard({
   name,
   startDate,
@@ -65,27 +65,30 @@ function CompletedPhaseCard({
   return (
     <li
       className={cn(
-        'flex flex-col gap-2 border-s border-success/30 px-4 py-2',
+        'flex flex-col gap-1 border-s border-success/30 p-4',
         className,
       )}
     >
       <div className="flex items-center gap-2">
-        <span className="flex size-4 items-center justify-center rounded-full bg-success-muted text-success">
-          <LuCheck className="size-3" aria-hidden />
+        <PhaseName name={name} />
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-success-muted text-success">
+          <LuCheck className="size-3.5" aria-hidden />
         </span>
-        <PhaseDates
-          startDate={startDate}
-          endDate={endDate}
-          locale={locale}
-          className="text-muted-foreground"
-        />
       </div>
-      <PhaseName name={name} />
+      <PhaseDates
+        startDate={startDate}
+        endDate={endDate}
+        locale={locale}
+        className="text-muted-foreground"
+      />
     </li>
   );
 }
 
-/** Current: filled teal card linking to `href`, optional "Now open!" tag + arrow. */
+/**
+ * Current: filled teal card linking to `href`. Badge over the name, dates
+ * below; the navigation arrow reveals on hover/focus (per the Figma master).
+ */
 function CurrentPhaseCard({
   name,
   startDate,
@@ -101,57 +104,62 @@ function CurrentPhaseCard({
     <li className={className}>
       <a
         href={href}
-        className="flex items-center justify-between gap-4 rounded-xl bg-teal-100 p-4 text-teal-900 transition hover:bg-teal-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+        className="group flex items-center justify-between gap-4 rounded-lg bg-teal-50 p-4 text-teal-600 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
       >
-        <div className="flex min-w-0 flex-col gap-4">
-          <div className="flex items-center gap-4">
+        <div className="flex min-w-0 flex-col gap-2">
+          {isNowOpen ? (
+            <Badge className="w-fit bg-teal-500 text-background">
+              {nowOpenLabel}
+            </Badge>
+          ) : null}
+          <div className="flex min-w-0 flex-col">
+            <PhaseName name={name} />
             <PhaseDates
               startDate={startDate}
               endDate={endDate}
               locale={locale}
             />
-            {isNowOpen ? (
-              <Badge className="bg-teal-900 text-background">
-                {nowOpenLabel}
-              </Badge>
-            ) : null}
           </div>
-          <PhaseName name={name} />
         </div>
-        <LuArrowRight className="size-4 shrink-0 rtl:rotate-180" aria-hidden />
+        <span
+          aria-hidden
+          className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+        >
+          <LuArrowRight className="size-4 rtl:rotate-180" />
+        </span>
       </a>
     </li>
   );
 }
 
-/** Upcoming + advanceable: muted card with an Advance button. */
+/** Upcoming + advanceable: light card, name over dates, with a Start button. */
 function AdvanceablePhaseCard({
   name,
   startDate,
   endDate,
   locale,
   className,
-  advanceLabel = 'Advance',
+  advanceLabel = 'Start',
   onAdvance,
 }: PhaseContentProps & Pick<PhaseCardProps, 'advanceLabel' | 'onAdvance'>) {
   return (
     <li
       className={cn(
-        'flex items-center justify-between gap-4 rounded-xl bg-muted p-4',
+        'flex items-center justify-between gap-4 rounded-lg bg-gray-50 p-4',
         className,
       )}
     >
-      <div className="flex min-w-0 flex-col gap-2">
+      <div className="flex min-w-0 flex-col gap-1">
+        <PhaseName name={name} />
         <PhaseDates
           startDate={startDate}
           endDate={endDate}
           locale={locale}
           className="text-muted-foreground"
         />
-        <PhaseName name={name} />
       </div>
       <Button
-        variant="secondary"
+        variant="outline"
         onClick={() => onAdvance?.()}
         className="shrink-0"
       >
@@ -162,7 +170,7 @@ function AdvanceablePhaseCard({
   );
 }
 
-/** Upcoming: compact, gray rail + dates + name. */
+/** Upcoming: gray rail, name over dates. */
 function UpcomingPhaseCard({
   name,
   startDate,
@@ -171,14 +179,14 @@ function UpcomingPhaseCard({
   className,
 }: PhaseContentProps) {
   return (
-    <li className={cn('flex flex-col gap-2 border-s px-4 py-2', className)}>
+    <li className={cn('flex flex-col gap-1 border-s p-4', className)}>
+      <PhaseName name={name} />
       <PhaseDates
         startDate={startDate}
         endDate={endDate}
         locale={locale}
         className="text-muted-foreground"
       />
-      <PhaseName name={name} />
     </li>
   );
 }
@@ -199,7 +207,7 @@ function PhaseDates({
   }
 
   return (
-    <span className={cn('text-base', className)}>
+    <span className={cn('text-sm', className)}>
       {formatDateRange(startDate, endDate, locale)}
     </span>
   );

--- a/packages/sense/src/components/PhaseCard/index.tsx
+++ b/packages/sense/src/components/PhaseCard/index.tsx
@@ -2,6 +2,7 @@
 
 import { LuArrowRight, LuCheck, LuPlay } from 'react-icons/lu';
 
+import { formatDateRange } from '../../lib/formatting';
 import { cn } from '../../lib/utils';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -210,30 +211,6 @@ function PhaseName({ name }: { name: string }) {
       <bdi>{name}</bdi>
     </p>
   );
-}
-
-function formatDate(dateString: string, locale: string = 'en-US'): string {
-  return new Date(dateString).toLocaleDateString(locale, {
-    month: 'short',
-    day: 'numeric',
-  });
-}
-
-function formatDateRange(
-  startDate?: string,
-  endDate?: string,
-  locale?: string,
-): string {
-  if (startDate && endDate) {
-    return `${formatDate(startDate, locale)} - ${formatDate(endDate, locale)}`;
-  }
-  if (startDate) {
-    return formatDate(startDate, locale);
-  }
-  if (endDate) {
-    return formatDate(endDate, locale);
-  }
-  return '';
 }
 
 export { PhaseCard, type PhaseCardProps, type PhaseCardState };

--- a/packages/sense/src/components/PhaseStepper/index.tsx
+++ b/packages/sense/src/components/PhaseStepper/index.tsx
@@ -178,12 +178,6 @@ function PhaseStepper({
 
   return (
     <div className={cn('w-full', className)}>
-      <style>{`
-        @keyframes phase-ripple {
-          0% { transform: scale(1); opacity: 0.4; }
-          100% { transform: scale(1.6); opacity: 0; }
-        }
-      `}</style>
       <div className="flex justify-center gap-2">
         {phases.map((phase, index) => {
           const stepState = getStepState(index);

--- a/packages/sense/src/components/PhaseStepper/index.tsx
+++ b/packages/sense/src/components/PhaseStepper/index.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { useState } from 'react';
+import { LuCheck, LuPlay } from 'react-icons/lu';
+
+import { cn } from '../../lib/utils';
+import { Button } from '../ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+
+interface Phase {
+  id: string;
+  name: string;
+  description?: string;
+  startDate?: string;
+  endDate?: string;
+  interactive?: boolean;
+  ariaLabel?: string;
+  /** When true, the play button only appears on hover. When false, it's always visible. */
+  showOnHoverOnly?: boolean;
+}
+
+type StepState = 'completed' | 'current' | 'upcoming';
+
+interface PhaseStepperProps {
+  phases: Phase[];
+  currentPhaseId: string;
+  className?: string;
+  locale?: string;
+  onTransition?: (phaseId: string) => void;
+}
+
+const RIPPLE_COUNT = 3;
+const RIPPLE_DURATION_S = 1.5;
+
+function RippleRings({ visible }: { visible: boolean }) {
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 flex items-center justify-center"
+      style={{ opacity: visible ? 1 : 0, transition: 'opacity 0.15s' }}
+    >
+      {Array.from({ length: RIPPLE_COUNT }, (_, i) => (
+        <div
+          key={i}
+          className="absolute size-6 rounded-full border border-primary"
+          style={{
+            animation: `phase-ripple ${RIPPLE_DURATION_S}s ease-out ${i * (RIPPLE_DURATION_S / RIPPLE_COUNT)}s infinite`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function StepIndicator({
+  stepState,
+  index,
+  phase,
+  onTransition,
+}: {
+  stepState: StepState;
+  index: number;
+  phase: Phase;
+  onTransition?: (phaseId: string) => void;
+}) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const baseStyles = cn(
+    'flex size-6 items-center justify-center rounded-full font-serif transition-all',
+    stepState === 'completed' && 'bg-success-muted text-success',
+    stepState === 'current' && 'bg-foreground text-background',
+    stepState === 'upcoming' &&
+      'border border-foreground bg-transparent text-foreground',
+  );
+
+  const content =
+    stepState === 'completed' ? <LuCheck className="size-4" /> : index + 1;
+
+  if (!phase.interactive) {
+    return <div className={baseStyles}>{content}</div>;
+  }
+
+  const label = phase.ariaLabel ?? `Start ${phase.name}`;
+  const showPlayButton = phase.showOnHoverOnly ? isHovered : true;
+
+  // Wrapper matches the non-interactive step's size-6 so the icon's centerline
+  // lines up exactly with sibling steps. The hover ripple is absolutely-
+  // positioned and uses transform scaling to expand visually past this box,
+  // so a smaller wrapper doesn't clip the animation.
+  return (
+    <div
+      className="relative flex size-6 items-center justify-center"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <RippleRings visible={isHovered} />
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              aria-label={label}
+              onClick={() => onTransition?.(phase.id)}
+              size="icon-xs"
+              variant="ghost"
+              className={cn(
+                baseStyles,
+                showPlayButton &&
+                  'relative cursor-pointer border-0 bg-primary text-primary-foreground hover:bg-primary active:bg-primary',
+              )}
+            />
+          }
+        >
+          {showPlayButton ? (
+            stepState === 'completed' ? (
+              <LuCheck className="size-4" />
+            ) : (
+              <LuPlay className="size-3 fill-current" />
+            )
+          ) : (
+            content
+          )}
+        </TooltipTrigger>
+        <TooltipContent className="sense">{label}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+function Step({
+  stepState,
+  index,
+  phase,
+  locale,
+  onTransition,
+}: {
+  stepState: StepState;
+  index: number;
+  phase: Phase;
+  locale?: string;
+  onTransition?: (phaseId: string) => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <StepIndicator
+        stepState={stepState}
+        index={index}
+        phase={phase}
+        onTransition={onTransition}
+      />
+      <div className="flex max-w-6 flex-col items-center justify-center text-sm text-nowrap text-foreground">
+        <div>{phase.name}</div>
+        {(phase.startDate || phase.endDate) && (
+          <div className="text-xs text-muted-foreground">
+            {formatDateRange(phase.startDate, phase.endDate, locale)}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PhaseStepper({
+  phases,
+  currentPhaseId,
+  className = '',
+  locale,
+  onTransition,
+}: PhaseStepperProps) {
+  const currentPhaseIndex = phases.findIndex(
+    (phase) => phase.id === currentPhaseId,
+  );
+
+  const getStepState = (index: number): StepState => {
+    if (index < currentPhaseIndex) return 'completed';
+    if (index === currentPhaseIndex) return 'current';
+    return 'upcoming';
+  };
+
+  return (
+    <div className={cn('w-full', className)}>
+      <style>{`
+        @keyframes phase-ripple {
+          0% { transform: scale(1); opacity: 0.4; }
+          100% { transform: scale(1.6); opacity: 0; }
+        }
+      `}</style>
+      <div className="flex justify-center gap-2">
+        {phases.map((phase, index) => {
+          const stepState = getStepState(index);
+
+          return (
+            <div key={phase.id} className="flex items-start gap-2">
+              <Step
+                stepState={stepState}
+                index={index}
+                phase={phase}
+                locale={locale}
+                onTransition={onTransition}
+              />
+              {index < phases.length - 1 && (
+                <div className="flex h-6 items-center">
+                  <div className="h-px w-28 bg-border" />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatDate(
+  dateString: string,
+  options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' },
+  locale: string = 'en-US',
+): string {
+  return new Date(dateString).toLocaleDateString(locale, options);
+}
+
+function formatDateRange(
+  startDate?: string,
+  endDate?: string,
+  locale?: string,
+): string {
+  if (startDate && endDate) {
+    return `${formatDate(startDate, undefined, locale)} - ${formatDate(endDate, undefined, locale)}`;
+  }
+  if (startDate) {
+    return formatDate(startDate, undefined, locale);
+  }
+  if (endDate) {
+    return formatDate(endDate, undefined, locale);
+  }
+  return '';
+}
+
+export { PhaseStepper, type Phase };

--- a/packages/sense/src/components/PhaseStepper/index.tsx
+++ b/packages/sense/src/components/PhaseStepper/index.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { LuCheck, LuPlay } from 'react-icons/lu';
 
+import { formatDateRange } from '../../lib/formatting';
 import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
@@ -207,31 +208,6 @@ function PhaseStepper({
       </div>
     </div>
   );
-}
-
-function formatDate(
-  dateString: string,
-  options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' },
-  locale: string = 'en-US',
-): string {
-  return new Date(dateString).toLocaleDateString(locale, options);
-}
-
-function formatDateRange(
-  startDate?: string,
-  endDate?: string,
-  locale?: string,
-): string {
-  if (startDate && endDate) {
-    return `${formatDate(startDate, undefined, locale)} - ${formatDate(endDate, undefined, locale)}`;
-  }
-  if (startDate) {
-    return formatDate(startDate, undefined, locale);
-  }
-  if (endDate) {
-    return formatDate(endDate, undefined, locale);
-  }
-  return '';
 }
 
 export { PhaseStepper, type Phase };

--- a/packages/sense/src/components/Sortable/DragHandle.tsx
+++ b/packages/sense/src/components/Sortable/DragHandle.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { forwardRef } from 'react';
+import { LuGripVertical } from 'react-icons/lu';
+
+import { cn } from '../../lib/utils';
+import type { DragHandleProps } from './types';
+
+const dragHandleClasses =
+  'flex cursor-grab touch-none items-center justify-center rounded-sm p-1 text-muted-foreground transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 active:cursor-grabbing';
+
+export const DragHandle = forwardRef<
+  HTMLButtonElement,
+  DragHandleProps &
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'>
+>(function DragHandle(
+  {
+    size = 16,
+    className,
+    'aria-label': ariaLabel = 'Drag to reorder',
+    ...props
+  },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-label={ariaLabel}
+      className={cn(dragHandleClasses, className)}
+      {...props}
+    >
+      <LuGripVertical size={size} />
+    </button>
+  );
+});

--- a/packages/sense/src/components/Sortable/DragHandle.tsx
+++ b/packages/sense/src/components/Sortable/DragHandle.tsx
@@ -6,8 +6,10 @@ import { LuGripVertical } from 'react-icons/lu';
 import { cn } from '../../lib/utils';
 import type { DragHandleProps } from './types';
 
+// Mirrors the ghost icon-button family (text-foreground, rounded-md, muted
+// hover) plus the drag-only affordances base-ui Button can't carry.
 const dragHandleClasses =
-  'flex cursor-grab touch-none items-center justify-center rounded-sm p-1 text-muted-foreground transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 active:cursor-grabbing';
+  'flex cursor-grab touch-none items-center justify-center rounded-md p-1 text-foreground transition-colors outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/50 active:cursor-grabbing';
 
 export const DragHandle = forwardRef<
   HTMLButtonElement,

--- a/packages/sense/src/components/Sortable/DropIndicators.tsx
+++ b/packages/sense/src/components/Sortable/DropIndicators.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import type { DropIndicatorProps, SortableItem } from './types';
+
+/**
+ * A thin line indicator showing where the item will be dropped.
+ * Best for lists with variable height items.
+ */
+export function DropIndicatorLine<T extends SortableItem>(
+  _props: DropIndicatorProps<T>,
+) {
+  return <div className="my-1 h-0.5 rounded-full bg-primary" />;
+}
+
+/**
+ * A placeholder that matches the size of the dragged item.
+ * Shows a dashed border where the item will be dropped.
+ */
+export function DropIndicatorPlaceholder<T extends SortableItem>({
+  children,
+}: DropIndicatorProps<T>) {
+  return (
+    <div className="rounded-lg border-1 border-dashed border-primary/40 bg-primary/20">
+      <div style={{ visibility: 'hidden' }}>{children}</div>
+    </div>
+  );
+}

--- a/packages/sense/src/components/Sortable/Sortable.tsx
+++ b/packages/sense/src/components/Sortable/Sortable.tsx
@@ -178,8 +178,14 @@ export function Sortable<T extends SortableItem>({
     const { active, over } = event;
 
     if (over && active.id !== over.id) {
-      const oldIndex = items.findIndex((item) => String(item.id) === active.id);
-      const newIndex = items.findIndex((item) => String(item.id) === over.id);
+      // active.id/over.id are UniqueIdentifier (string | number); items
+      // register as String(item.id), so normalize both sides before compare.
+      const oldIndex = items.findIndex(
+        (item) => String(item.id) === String(active.id),
+      );
+      const newIndex = items.findIndex(
+        (item) => String(item.id) === String(over.id),
+      );
       const newItems = arrayMove(items, oldIndex, newIndex);
       onChange(newItems);
     }

--- a/packages/sense/src/components/Sortable/Sortable.tsx
+++ b/packages/sense/src/components/Sortable/Sortable.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import {
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  type UniqueIdentifier,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { cn } from '../../lib/utils';
+import type {
+  DropIndicatorProps,
+  SortableItem,
+  SortableItemControls,
+  SortableProps,
+} from './types';
+
+const containerClasses = 'flex flex-col outline-none';
+
+const itemClasses = (hasDragHandle: boolean) =>
+  cn('relative outline-none', !hasDragHandle && 'cursor-grab touch-none');
+
+interface SortableItemWrapperProps<T extends SortableItem> {
+  item: T;
+  index: number;
+  dragTrigger: 'handle' | 'item';
+  children: (item: T, controls: SortableItemControls) => React.ReactNode;
+  itemClassName?: string;
+  getItemLabel?: (item: T) => string;
+  renderDropIndicator?: (props: DropIndicatorProps<T>) => React.ReactNode;
+}
+
+function SortableItemWrapper<T extends SortableItem>({
+  item,
+  index,
+  dragTrigger,
+  children,
+  itemClassName,
+  getItemLabel,
+  renderDropIndicator,
+}: SortableItemWrapperProps<T>) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isOver,
+  } = useSortable({
+    id: String(item.id),
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const dragHandleProps =
+    dragTrigger === 'handle'
+      ? {
+          ref: setActivatorNodeRef,
+          ...attributes,
+          ...listeners,
+        }
+      : {
+          ref: () => {},
+          ...attributes,
+        };
+
+  const itemProps =
+    dragTrigger === 'item'
+      ? {
+          ...attributes,
+          ...listeners,
+          'aria-label': getItemLabel?.(item) ?? String(item.id),
+        }
+      : {};
+
+  const controls: SortableItemControls = {
+    dragHandleProps,
+    isDragging,
+    isDropTarget: isOver,
+    index,
+  };
+
+  // When item is being dragged, show drop indicator or default behavior
+  if (isDragging) {
+    const itemContent = children(item, controls);
+
+    if (renderDropIndicator) {
+      return (
+        <div ref={setNodeRef} style={style}>
+          {renderDropIndicator({ item, children: itemContent })}
+        </div>
+      );
+    }
+
+    // Default: keep the space but hide the content
+    return (
+      <div ref={setNodeRef} style={style}>
+        <div style={{ visibility: 'hidden' }}>{itemContent}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(itemClasses(dragTrigger === 'handle'), itemClassName)}
+      {...itemProps}
+    >
+      {children(item, controls)}
+    </div>
+  );
+}
+
+export function Sortable<T extends SortableItem>({
+  items,
+  onChange,
+  dragTrigger = 'handle',
+  children,
+  renderDragPreview,
+  className,
+  itemClassName,
+  getItemLabel,
+  'aria-label': ariaLabel = 'Sortable list',
+  renderDropIndicator,
+}: SortableProps<T>) {
+  const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+
+  // Without activation constraints the pointer sensors swallow the initial
+  // mousedown/touchstart, which blocks clicks on interactive children (e.g.
+  // an <a> inside a dragTrigger="item" card). A small distance threshold
+  // lets a stationary click pass through; touch waits briefly so taps and
+  // scrolls aren't hijacked.
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 5 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = items.findIndex((item) => String(item.id) === active.id);
+      const newIndex = items.findIndex((item) => String(item.id) === over.id);
+      const newItems = arrayMove(items, oldIndex, newIndex);
+      onChange(newItems);
+    }
+
+    setActiveId(null);
+  };
+
+  const handleDragCancel = () => {
+    setActiveId(null);
+  };
+
+  const activeItem = activeId
+    ? items.find((item) => String(item.id) === activeId)
+    : null;
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <SortableContext
+        items={items.map((item) => String(item.id))}
+        strategy={verticalListSortingStrategy}
+      >
+        <div
+          role="listbox"
+          aria-label={ariaLabel}
+          className={cn(containerClasses, className)}
+        >
+          {items.map((item, index) => (
+            <SortableItemWrapper
+              key={String(item.id)}
+              item={item}
+              index={index}
+              dragTrigger={dragTrigger}
+              itemClassName={itemClassName}
+              getItemLabel={getItemLabel}
+              renderDropIndicator={renderDropIndicator}
+            >
+              {children}
+            </SortableItemWrapper>
+          ))}
+        </div>
+      </SortableContext>
+
+      {typeof document !== 'undefined' &&
+        createPortal(
+          <DragOverlay>
+            {activeItem ? (
+              renderDragPreview ? (
+                renderDragPreview([activeItem])
+              ) : (
+                <div style={{ cursor: 'grabbing' }}>
+                  {children(activeItem, {
+                    dragHandleProps: {
+                      ref: () => {},
+                      tabIndex: -1,
+                      role: 'button',
+                      'aria-roledescription': 'sortable',
+                      'aria-describedby': '',
+                      'aria-disabled': true,
+                      'aria-pressed': undefined,
+                    },
+                    isDragging: true,
+                    isDropTarget: false,
+                    index: items.findIndex((i) => i.id === activeItem.id),
+                  })}
+                </div>
+              )
+            ) : null}
+          </DragOverlay>,
+          document.body,
+        )}
+    </DndContext>
+  );
+}

--- a/packages/sense/src/components/Sortable/Sortable.tsx
+++ b/packages/sense/src/components/Sortable/Sortable.tsx
@@ -223,7 +223,9 @@ export function Sortable<T extends SortableItem>({
 
       {typeof document !== 'undefined' &&
         createPortal(
-          <DragOverlay>
+          // Portals to document.body, outside any `.sense` wrapper — the
+          // overlay re-scopes itself so the preview matches the in-list item.
+          <DragOverlay className="sense">
             {activeItem ? (
               renderDragPreview ? (
                 renderDragPreview([activeItem])

--- a/packages/sense/src/components/Sortable/Sortable.tsx
+++ b/packages/sense/src/components/Sortable/Sortable.tsx
@@ -108,7 +108,7 @@ function SortableItemWrapper<T extends SortableItem>({
 
     if (renderDropIndicator) {
       return (
-        <div ref={setNodeRef} style={style}>
+        <div ref={setNodeRef} style={style} role="listitem">
           {renderDropIndicator({ item, children: itemContent })}
         </div>
       );
@@ -116,7 +116,7 @@ function SortableItemWrapper<T extends SortableItem>({
 
     // Default: keep the space but hide the content
     return (
-      <div ref={setNodeRef} style={style}>
+      <div ref={setNodeRef} style={style} role="listitem">
         <div style={{ visibility: 'hidden' }}>{itemContent}</div>
       </div>
     );
@@ -128,6 +128,9 @@ function SortableItemWrapper<T extends SortableItem>({
       style={style}
       className={cn(itemClasses(dragTrigger === 'handle'), itemClassName)}
       {...itemProps}
+      // After the spread: dnd-kit's attributes carry role="button" in item
+      // mode, but the wrapper must stay a listitem for a valid list tree.
+      role="listitem"
     >
       {children(item, controls)}
     </div>
@@ -147,6 +150,10 @@ export function Sortable<T extends SortableItem>({
   renderDropIndicator,
 }: SortableProps<T>) {
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+
+  // dnd-kit's default context id is a module-level counter, which produces
+  // mismatched aria ids across SSR/hydration in Next — useId is stable.
+  const dndContextId = React.useId();
 
   // Without activation constraints the pointer sensors swallow the initial
   // mousedown/touchstart, which blocks clicks on interactive children (e.g.
@@ -190,6 +197,7 @@ export function Sortable<T extends SortableItem>({
 
   return (
     <DndContext
+      id={dndContextId}
       sensors={sensors}
       collisionDetection={closestCenter}
       onDragStart={handleDragStart}
@@ -201,7 +209,7 @@ export function Sortable<T extends SortableItem>({
         strategy={verticalListSortingStrategy}
       >
         <div
-          role="listbox"
+          role="list"
           aria-label={ariaLabel}
           className={cn(containerClasses, className)}
         >

--- a/packages/sense/src/components/Sortable/index.ts
+++ b/packages/sense/src/components/Sortable/index.ts
@@ -1,0 +1,10 @@
+export { Sortable } from './Sortable';
+export { DragHandle } from './DragHandle';
+export { DropIndicatorLine, DropIndicatorPlaceholder } from './DropIndicators';
+export type {
+  SortableProps,
+  SortableItem,
+  SortableItemControls,
+  DragHandleProps,
+  DropIndicatorProps,
+} from './types';

--- a/packages/sense/src/components/Sortable/types.ts
+++ b/packages/sense/src/components/Sortable/types.ts
@@ -1,0 +1,68 @@
+import type { ReactNode } from 'react';
+
+export interface SortableItem {
+  id: string | number;
+}
+
+export interface SortableItemControls {
+  /** Props to spread on a drag handle element (use with DragHandle component) */
+  dragHandleProps: {
+    ref: (node: HTMLElement | null) => void;
+    tabIndex: number;
+    role: string;
+    'aria-roledescription': string;
+    'aria-describedby': string;
+    'aria-disabled': boolean;
+    'aria-pressed': boolean | undefined;
+  } & Record<string, unknown>;
+  /** Whether this item is currently being dragged */
+  isDragging: boolean;
+  /** Whether this item is a drop target */
+  isDropTarget: boolean;
+  /** Index of this item in the list */
+  index: number;
+}
+
+export interface DropIndicatorProps<T extends SortableItem> {
+  /** The item being dragged */
+  item: T;
+  /** Render the item content (useful for size-matching placeholders) */
+  children: ReactNode;
+}
+
+export interface SortableProps<T extends SortableItem> {
+  /** Array of items to render and reorder */
+  items: T[];
+  /** Callback when items are reordered */
+  onChange: (items: T[]) => void;
+  /** How drag is triggered: 'handle' requires a drag handle, 'item' makes entire item draggable */
+  dragTrigger?: 'handle' | 'item';
+  /** Render function for each item */
+  children: (item: T, controls: SortableItemControls) => ReactNode;
+  /** Optional custom drag preview */
+  renderDragPreview?: (items: T[]) => ReactNode;
+  /** Class name for the container */
+  className?: string;
+  /** Class name for each item wrapper */
+  itemClassName?: string;
+  /** Function to get accessible label for an item */
+  getItemLabel?: (item: T) => string;
+  /** Accessible label for the list */
+  'aria-label'?: string;
+  /**
+   * Component to render as the drop indicator while dragging.
+   * Receives the item being dragged and a children prop containing the item content
+   * (useful for size-matching placeholders).
+   * If not provided, the item's space is preserved but content is hidden.
+   */
+  renderDropIndicator?: (props: DropIndicatorProps<T>) => ReactNode;
+}
+
+export interface DragHandleProps {
+  /** Size of the grip icon */
+  size?: number;
+  /** Additional class name */
+  className?: string;
+  /** Accessible label for the drag handle (defaults to "Drag to reorder") */
+  'aria-label'?: string;
+}

--- a/packages/sense/src/components/Stepper/Stepper.tsx
+++ b/packages/sense/src/components/Stepper/Stepper.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '../../lib/utils';
+
+export const StepItem = ({
+  currentStep,
+  itemIndex,
+  children,
+}: {
+  currentStep: number;
+  itemIndex: number;
+  children: ReactNode;
+}) => (
+  <div className={cn(currentStep !== itemIndex && 'hidden')}>{children}</div>
+);
+
+export const StepperProgressIndicator = ({
+  numItems,
+  currentStep = 0,
+}: {
+  numItems: number;
+  currentStep?: number;
+}) => {
+  const segmentSize = 100 / numItems;
+  const progress = numItems > 1 ? (currentStep + 1) * segmentSize : 0;
+
+  return (
+    <div className="relative z-40 flex h-1 w-full gap-0 bg-gradient">
+      <div className="absolute inset-0 bg-background/65" />
+      <div
+        className="absolute start-0 top-0 h-full bg-gradient transition-[width] duration-500"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+};

--- a/packages/sense/src/components/Stepper/hooks.ts
+++ b/packages/sense/src/components/Stepper/hooks.ts
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import type { StepperItem } from './types';
+
+export const useStepper = ({
+  items,
+  initialStep = 0,
+}: {
+  items: Array<StepperItem>;
+  initialStep?: number;
+}) => {
+  const [currentStep, setCurrentStep] = useState(initialStep);
+  const totalSteps = items.length;
+
+  const goToStep = (step: number) => {
+    setCurrentStep(step);
+  };
+
+  const nextStep = (values: Record<string, unknown> = {}) => {
+    const success = () =>
+      setCurrentStep((prev) => Math.min(prev + 1, totalSteps - 1));
+
+    // run the validations if they exist
+    const schema = items[currentStep]?.validator;
+
+    if (!schema) {
+      success();
+
+      return;
+    }
+
+    const currentValues = Object.keys(schema.shape).reduce(
+      (acc: Record<string, unknown>, key: string) => {
+        acc[key] = values[key];
+
+        return acc;
+      },
+      {},
+    );
+
+    const result = schema.safeParse(currentValues);
+
+    if (result.success) {
+      success();
+    } else {
+      return result.error.flatten().fieldErrors;
+    }
+  };
+
+  const prevStep = () => {
+    setCurrentStep((prev) => Math.max(prev - 1, 0));
+  };
+
+  return { currentStep, goToStep, nextStep, prevStep };
+};

--- a/packages/sense/src/components/Stepper/hooks.ts
+++ b/packages/sense/src/components/Stepper/hooks.ts
@@ -17,6 +17,12 @@ export const useStepper = ({
     setCurrentStep(step);
   };
 
+  /**
+   * Validate the current step against its zod schema and advance on success.
+   * Returns `undefined` when it advanced, or a `fieldErrors` map when
+   * validation failed — callers MUST check the return value to surface errors
+   * (a bare `onClick={() => nextStep(values)}` silently swallows them).
+   */
   const nextStep = (values: Record<string, unknown> = {}) => {
     const success = () =>
       setCurrentStep((prev) => Math.min(prev + 1, totalSteps - 1));

--- a/packages/sense/src/components/Stepper/hooks.ts
+++ b/packages/sense/src/components/Stepper/hooks.ts
@@ -3,6 +3,15 @@ import { z } from 'zod';
 
 import type { StepperItem } from './types';
 
+/** Field-name → validation messages, as produced by zod's flattenError. */
+type StepFieldErrors = Record<string, string[] | undefined>;
+
+/**
+ * Result of attempting to advance: a tagged union so callers can't silently
+ * drop validation failures (the reason a bare error-return was avoided).
+ */
+type NextStepResult = { ok: true } | { ok: false; errors: StepFieldErrors };
+
 export const useStepper = ({
   items,
   initialStep = 0,
@@ -19,11 +28,10 @@ export const useStepper = ({
 
   /**
    * Validate the current step against its zod schema and advance on success.
-   * Returns `undefined` when it advanced, or a `fieldErrors` map when
-   * validation failed — callers MUST check the return value to surface errors
-   * (a bare `onClick={() => nextStep(values)}` silently swallows them).
+   * Returns `{ ok: true }` when it advanced, or `{ ok: false, errors }` with a
+   * field-error map when validation failed — branch on `ok` to render errors.
    */
-  const nextStep = (values: Record<string, unknown> = {}) => {
+  const nextStep = (values: Record<string, unknown> = {}): NextStepResult => {
     const success = () =>
       setCurrentStep((prev) => Math.min(prev + 1, totalSteps - 1));
 
@@ -33,7 +41,7 @@ export const useStepper = ({
     if (!schema) {
       success();
 
-      return;
+      return { ok: true };
     }
 
     const currentValues = Object.keys(schema.shape).reduce(
@@ -49,9 +57,11 @@ export const useStepper = ({
 
     if (result.success) {
       success();
-    } else {
-      return z.flattenError(result.error).fieldErrors;
+
+      return { ok: true };
     }
+
+    return { ok: false, errors: z.flattenError(result.error).fieldErrors };
   };
 
   const prevStep = () => {

--- a/packages/sense/src/components/Stepper/hooks.ts
+++ b/packages/sense/src/components/Stepper/hooks.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { z } from 'zod';
 
 import type { StepperItem } from './types';
 
@@ -43,7 +44,7 @@ export const useStepper = ({
     if (result.success) {
       success();
     } else {
-      return result.error.flatten().fieldErrors;
+      return z.flattenError(result.error).fieldErrors;
     }
   };
 

--- a/packages/sense/src/components/Stepper/index.ts
+++ b/packages/sense/src/components/Stepper/index.ts
@@ -1,0 +1,3 @@
+export * from './hooks';
+export * from './Stepper';
+export * from './types';

--- a/packages/sense/src/components/Stepper/types.ts
+++ b/packages/sense/src/components/Stepper/types.ts
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+import type { z } from 'zod';
+
+export interface StepperItem {
+  key: number;
+  label: string;
+  validator?: z.ZodObject<Record<string, z.ZodTypeAny>>;
+  component: ReactNode;
+}

--- a/packages/sense/src/lib/formatting.ts
+++ b/packages/sense/src/lib/formatting.ts
@@ -1,0 +1,28 @@
+// Date-only strings ("2026-06-01") parse as UTC midnight, so they must also
+// render in UTC — otherwise viewers west of UTC see the previous day.
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+export function formatDate(dateString: string, locale: string = 'en-US') {
+  return new Date(dateString).toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: DATE_ONLY.test(dateString) ? 'UTC' : undefined,
+  });
+}
+
+export function formatDateRange(
+  startDate?: string,
+  endDate?: string,
+  locale?: string,
+) {
+  if (startDate && endDate) {
+    return `${formatDate(startDate, locale)} - ${formatDate(endDate, locale)}`;
+  }
+  if (startDate) {
+    return formatDate(startDate, locale);
+  }
+  if (endDate) {
+    return formatDate(endDate, locale);
+  }
+  return '';
+}

--- a/packages/styles/sense-theme.css
+++ b/packages/styles/sense-theme.css
@@ -350,6 +350,18 @@
   }
 }
 
+/* PhaseStepper active-step ripple (was injected inline per-instance). */
+@keyframes phase-ripple {
+  0% {
+    transform: scale(1);
+    opacity: 0.4;
+  }
+  100% {
+    transform: scale(1.6);
+    opacity: 0;
+  }
+}
+
 /* Semantic theme — values from the Common Sense Figma "Mode/Light" theme
  * collection, expressed against the Colors Scale ramps above. Dark mode is
  * unsupported (the Figma dark mode is unpopulated), so no dark block. */

--- a/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
+++ b/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
@@ -1,0 +1,96 @@
+import {
+  CollapsibleConfigCard,
+  CollapsibleConfigCardDragPreview,
+} from '@op/sense/CollapsibleConfigCard';
+import { Sortable } from '@op/sense/Sortable';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { LuListChecks, LuText, LuVote } from 'react-icons/lu';
+
+import { withSense } from './sense';
+
+const meta: Meta<typeof CollapsibleConfigCard> = {
+  title: 'Sense/Composites/CollapsibleConfigCard',
+  component: CollapsibleConfigCard,
+  decorators: [withSense],
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CollapsibleConfigCard>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex w-96 flex-col gap-2">
+      <CollapsibleConfigCard
+        icon={LuText}
+        label="Description"
+        badgeLabel="Required"
+        isCollapsible
+        defaultExpanded
+      >
+        <p className="text-sm text-muted-foreground">
+          Field configuration goes here.
+        </p>
+      </CollapsibleConfigCard>
+      <CollapsibleConfigCard
+        icon={LuListChecks}
+        label="Categories"
+        badgeLabel="Optional"
+        isCollapsible
+      >
+        <p className="text-sm text-muted-foreground">Category options.</p>
+      </CollapsibleConfigCard>
+      <CollapsibleConfigCard icon={LuVote} label="Votes" locked />
+    </div>
+  ),
+};
+
+// The ProcessBuilder shape: sortable list of collapsible config cards with
+// drag handles, a locked card, and a custom drag preview.
+const SortableDemo = () => {
+  const [fields, setFields] = useState([
+    { id: 'title', label: 'Title', badge: 'Required' },
+    { id: 'description', label: 'Description', badge: 'Required' },
+    { id: 'budget', label: 'Budget', badge: 'Optional' },
+  ]);
+
+  return (
+    <Sortable
+      items={fields}
+      onChange={setFields}
+      dragTrigger="handle"
+      aria-label="Form fields"
+      className="w-96 gap-2"
+      getItemLabel={(field) => field.label}
+      renderDragPreview={([field]) =>
+        field ? (
+          <CollapsibleConfigCardDragPreview
+            icon={LuText}
+            label={field.label}
+            badgeLabel={field.badge}
+          />
+        ) : null
+      }
+    >
+      {(field, controls) => (
+        <CollapsibleConfigCard
+          icon={LuText}
+          label={field.label}
+          badgeLabel={field.badge}
+          isCollapsible
+          controls={controls}
+        >
+          <p className="text-sm text-muted-foreground">
+            Configuration for {field.label}.
+          </p>
+        </CollapsibleConfigCard>
+      )}
+    </Sortable>
+  );
+};
+
+export const SortableCards: Story = {
+  render: () => <SortableDemo />,
+};

--- a/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
+++ b/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
@@ -24,9 +24,20 @@ export default meta;
 
 type Story = StoryObj<typeof CollapsibleConfigCard>;
 
+const requiredBadge = (required: boolean) =>
+  required ? 'Required' : 'Optional';
+
 // Mirrors the Template Card master: body content, separator, then a footer
-// row with a Required switch and a small destructive Delete.
-const CardBody = () => {
+// row with a Required switch and a small destructive Delete. The switch
+// drives the header badge (the consumer owns that wiring — the card is
+// presentational).
+const CardBody = ({
+  required,
+  onRequiredChange,
+}: {
+  required: boolean;
+  onRequiredChange: (required: boolean) => void;
+}) => {
   const toggleId = useId();
 
   return (
@@ -36,7 +47,11 @@ const CardBody = () => {
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <Label htmlFor={toggleId}>Required?</Label>
-          <Switch id={toggleId} />
+          <Switch
+            id={toggleId}
+            checked={required}
+            onCheckedChange={onRequiredChange}
+          />
         </div>
         <Button variant="destructive" size="sm">
           <LuTrash2 data-icon="inline-start" />
@@ -52,10 +67,15 @@ const CardBody = () => {
 // handles, a custom drag preview, and a locked card alongside.
 const SortableDemo = () => {
   const [fields, setFields] = useState([
-    { id: 'title', label: 'Title', badge: 'Required' },
-    { id: 'description', label: 'Description', badge: 'Required' },
-    { id: 'budget', label: 'Budget', badge: 'Optional' },
+    { id: 'title', label: 'Title', required: true },
+    { id: 'description', label: 'Description', required: true },
+    { id: 'budget', label: 'Budget', required: false },
   ]);
+
+  const setRequired = (id: string, required: boolean) =>
+    setFields((prev) =>
+      prev.map((field) => (field.id === id ? { ...field, required } : field)),
+    );
 
   return (
     <Sortable
@@ -69,7 +89,7 @@ const SortableDemo = () => {
         field ? (
           <CollapsibleConfigCardDragPreview
             label={field.label}
-            badgeLabel={field.badge}
+            badgeLabel={requiredBadge(field.required)}
           />
         ) : null
       }
@@ -77,11 +97,14 @@ const SortableDemo = () => {
       {(field, controls) => (
         <CollapsibleConfigCard
           label={field.label}
-          badgeLabel={field.badge}
+          badgeLabel={requiredBadge(field.required)}
           isCollapsible
           controls={controls}
         >
-          <CardBody />
+          <CardBody
+            required={field.required}
+            onRequiredChange={(required) => setRequired(field.id, required)}
+          />
         </CollapsibleConfigCard>
       )}
     </Sortable>

--- a/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
+++ b/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
@@ -1,11 +1,15 @@
+import { Button } from '@op/sense/Button';
 import {
   CollapsibleConfigCard,
   CollapsibleConfigCardDragPreview,
 } from '@op/sense/CollapsibleConfigCard';
+import { Label } from '@op/sense/Label';
+import { Separator } from '@op/sense/Separator';
 import { Sortable } from '@op/sense/Sortable';
+import { Switch } from '@op/sense/Switch';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { LuListChecks, LuText, LuVote } from 'react-icons/lu';
+import { LuTrash2, LuVote } from 'react-icons/lu';
 
 import { withSense } from './sense';
 
@@ -20,27 +24,37 @@ export default meta;
 
 type Story = StoryObj<typeof CollapsibleConfigCard>;
 
+// Mirrors the Template Card master: body content, separator, then a footer
+// row with a Required switch and a small destructive Delete.
+const CardBody = () => (
+  <>
+    <p className="text-base">This is an accordion content.</p>
+    <Separator />
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center gap-3">
+        <Label htmlFor="required-toggle">Required?</Label>
+        <Switch id="required-toggle" />
+      </div>
+      <Button variant="destructive" size="sm">
+        <LuTrash2 data-icon="inline-start" />
+        Delete
+      </Button>
+    </div>
+  </>
+);
+
 export const Default: Story = {
   render: () => (
-    <div className="flex w-96 flex-col gap-2">
-      <CollapsibleConfigCard
-        icon={LuText}
-        label="Description"
-        badgeLabel="Required"
-        isCollapsible
-        defaultExpanded
-      >
-        <p className="text-sm text-muted-foreground">
-          Field configuration goes here.
-        </p>
+    <div className="flex w-[36rem] flex-col gap-2">
+      <CollapsibleConfigCard label="Description" isCollapsible defaultExpanded>
+        <CardBody />
       </CollapsibleConfigCard>
       <CollapsibleConfigCard
-        icon={LuListChecks}
         label="Categories"
         badgeLabel="Optional"
         isCollapsible
       >
-        <p className="text-sm text-muted-foreground">Category options.</p>
+        <CardBody />
       </CollapsibleConfigCard>
       <CollapsibleConfigCard icon={LuVote} label="Votes" locked />
     </div>
@@ -67,7 +81,6 @@ const SortableDemo = () => {
       renderDragPreview={([field]) =>
         field ? (
           <CollapsibleConfigCardDragPreview
-            icon={LuText}
             label={field.label}
             badgeLabel={field.badge}
           />
@@ -76,15 +89,12 @@ const SortableDemo = () => {
     >
       {(field, controls) => (
         <CollapsibleConfigCard
-          icon={LuText}
           label={field.label}
           badgeLabel={field.badge}
           isCollapsible
           controls={controls}
         >
-          <p className="text-sm text-muted-foreground">
-            Configuration for {field.label}.
-          </p>
+          <CardBody />
         </CollapsibleConfigCard>
       )}
     </Sortable>

--- a/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
+++ b/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
@@ -8,7 +8,7 @@ import { Separator } from '@op/sense/Separator';
 import { Sortable } from '@op/sense/Sortable';
 import { Switch } from '@op/sense/Switch';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { LuTrash2, LuVote } from 'react-icons/lu';
 
 import { withSense } from './sense';
@@ -26,22 +26,26 @@ type Story = StoryObj<typeof CollapsibleConfigCard>;
 
 // Mirrors the Template Card master: body content, separator, then a footer
 // row with a Required switch and a small destructive Delete.
-const CardBody = () => (
-  <>
-    <p className="text-base">This is an accordion content.</p>
-    <Separator />
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex items-center gap-3">
-        <Label htmlFor="required-toggle">Required?</Label>
-        <Switch id="required-toggle" />
+const CardBody = () => {
+  const toggleId = useId();
+
+  return (
+    <>
+      <p className="text-base">This is an accordion content.</p>
+      <Separator />
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Label htmlFor={toggleId}>Required?</Label>
+          <Switch id={toggleId} />
+        </div>
+        <Button variant="destructive" size="sm">
+          <LuTrash2 data-icon="inline-start" />
+          Delete
+        </Button>
       </div>
-      <Button variant="destructive" size="sm">
-        <LuTrash2 data-icon="inline-start" />
-        Delete
-      </Button>
-    </div>
-  </>
-);
+    </>
+  );
+};
 
 // Cards are always sortable (locked cards are the only exception), so the
 // default story is the ProcessBuilder shape: a sortable list with drag

--- a/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
+++ b/packages/ui/stories-sense/CollapsibleConfigCard.stories.tsx
@@ -43,26 +43,9 @@ const CardBody = () => (
   </>
 );
 
-export const Default: Story = {
-  render: () => (
-    <div className="flex w-[36rem] flex-col gap-2">
-      <CollapsibleConfigCard label="Description" isCollapsible defaultExpanded>
-        <CardBody />
-      </CollapsibleConfigCard>
-      <CollapsibleConfigCard
-        label="Categories"
-        badgeLabel="Optional"
-        isCollapsible
-      >
-        <CardBody />
-      </CollapsibleConfigCard>
-      <CollapsibleConfigCard icon={LuVote} label="Votes" locked />
-    </div>
-  ),
-};
-
-// The ProcessBuilder shape: sortable list of collapsible config cards with
-// drag handles, a locked card, and a custom drag preview.
+// Cards are always sortable (locked cards are the only exception), so the
+// default story is the ProcessBuilder shape: a sortable list with drag
+// handles, a custom drag preview, and a locked card alongside.
 const SortableDemo = () => {
   const [fields, setFields] = useState([
     { id: 'title', label: 'Title', badge: 'Required' },
@@ -76,7 +59,7 @@ const SortableDemo = () => {
       onChange={setFields}
       dragTrigger="handle"
       aria-label="Form fields"
-      className="w-96 gap-2"
+      className="w-[36rem] gap-2"
       getItemLabel={(field) => field.label}
       renderDragPreview={([field]) =>
         field ? (
@@ -101,6 +84,14 @@ const SortableDemo = () => {
   );
 };
 
-export const SortableCards: Story = {
+export const Default: Story = {
   render: () => <SortableDemo />,
+};
+
+export const Locked: Story = {
+  render: () => (
+    <div className="w-[36rem]">
+      <CollapsibleConfigCard icon={LuVote} label="Votes" locked />
+    </div>
+  ),
 };

--- a/packages/ui/stories-sense/PhaseCard.stories.tsx
+++ b/packages/ui/stories-sense/PhaseCard.stories.tsx
@@ -21,6 +21,37 @@ const Row = ({ children }: { children: ReactNode }) => (
   <ol className="w-96">{children}</ol>
 );
 
+// The states composed into the decision Overview timeline — the default view.
+export const Timeline: Story = {
+  render: () => (
+    <ol className="flex w-96 flex-col gap-2">
+      <PhaseCard
+        state="completed"
+        name="Submissions"
+        startDate="2026-06-01"
+        endDate="2026-06-14"
+      />
+      <PhaseCard
+        state="current"
+        name="Review"
+        startDate="2026-06-15"
+        endDate="2026-06-28"
+        isNowOpen
+        href="#"
+      />
+      <PhaseCard
+        state="upcoming"
+        name="Voting"
+        startDate="2026-07-01"
+        endDate="2026-07-14"
+        isAdvanceable
+        onAdvance={() => {}}
+      />
+      <PhaseCard state="upcoming" name="Results" />
+    </ol>
+  ),
+};
+
 // Completed: gray rail, name with a green check, dates below.
 export const Completed: Story = {
   render: () => (
@@ -77,34 +108,5 @@ export const Advanceable: Story = {
         onAdvance={() => {}}
       />
     </Row>
-  ),
-};
-
-// The states composed into the decision Overview timeline.
-export const Timeline: Story = {
-  render: () => (
-    <ol className="flex w-96 flex-col gap-2">
-      <PhaseCard
-        state="completed"
-        name="Submissions"
-        startDate="2026-06-01"
-        endDate="2026-06-14"
-      />
-      <PhaseCard
-        state="current"
-        name="Review"
-        startDate="2026-06-15"
-        endDate="2026-06-28"
-        isNowOpen
-        href="#"
-      />
-      <PhaseCard
-        state="upcoming"
-        name="Voting"
-        startDate="2026-07-01"
-        endDate="2026-07-14"
-      />
-      <PhaseCard state="upcoming" name="Results" />
-    </ol>
   ),
 };

--- a/packages/ui/stories-sense/PhaseCard.stories.tsx
+++ b/packages/ui/stories-sense/PhaseCard.stories.tsx
@@ -1,0 +1,60 @@
+import { PhaseCard } from '@op/sense/PhaseCard';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { withSense } from './sense';
+
+const meta: Meta<typeof PhaseCard> = {
+  title: 'Sense/Composites/PhaseCard',
+  component: PhaseCard,
+  decorators: [withSense],
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PhaseCard>;
+
+// The consumer owns the <ol>; each card is an <li> with a state-driven
+// treatment — the shape of the decision Overview timeline.
+export const Timeline: Story = {
+  render: () => (
+    <ol className="flex w-96 flex-col gap-2">
+      <PhaseCard
+        state="completed"
+        name="Submissions"
+        startDate="2026-06-01"
+        endDate="2026-06-14"
+      />
+      <PhaseCard
+        state="current"
+        name="Review"
+        startDate="2026-06-15"
+        endDate="2026-06-28"
+        isNowOpen
+        href="#"
+      />
+      <PhaseCard
+        state="upcoming"
+        name="Voting"
+        startDate="2026-07-01"
+        endDate="2026-07-14"
+      />
+      <PhaseCard state="upcoming" name="Results" />
+    </ol>
+  ),
+};
+
+export const Advanceable: Story = {
+  render: () => (
+    <ol className="flex w-96 flex-col gap-2">
+      <PhaseCard
+        state="upcoming"
+        name="Voting"
+        startDate="2026-07-01"
+        isAdvanceable
+        advanceLabel="Advance"
+        onAdvance={() => {}}
+      />
+    </ol>
+  ),
+};

--- a/packages/ui/stories-sense/PhaseCard.stories.tsx
+++ b/packages/ui/stories-sense/PhaseCard.stories.tsx
@@ -1,5 +1,6 @@
 import { PhaseCard } from '@op/sense/PhaseCard';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
 
 import { withSense } from './sense';
 
@@ -14,8 +15,72 @@ export default meta;
 
 type Story = StoryObj<typeof PhaseCard>;
 
-// The consumer owns the <ol>; each card is an <li> with a state-driven
-// treatment — the shape of the decision Overview timeline.
+// Each card is an <li>; the consumer owns the <ol>. Single-state stories
+// wrap one card so each treatment can be reviewed on its own.
+const Row = ({ children }: { children: ReactNode }) => (
+  <ol className="w-96">{children}</ol>
+);
+
+// Completed: gray rail, name with a green check, dates below.
+export const Completed: Story = {
+  render: () => (
+    <Row>
+      <PhaseCard
+        state="completed"
+        name="Submissions"
+        startDate="2026-06-01"
+        endDate="2026-06-14"
+      />
+    </Row>
+  ),
+};
+
+// Current: filled teal card linking out; the arrow reveals on hover/focus.
+export const Current: Story = {
+  render: () => (
+    <Row>
+      <PhaseCard
+        state="current"
+        name="Review"
+        startDate="2026-06-15"
+        endDate="2026-06-28"
+        isNowOpen
+        href="#"
+      />
+    </Row>
+  ),
+};
+
+// Upcoming: gray rail, name over dates.
+export const Upcoming: Story = {
+  render: () => (
+    <Row>
+      <PhaseCard
+        state="upcoming"
+        name="Voting"
+        startDate="2026-07-01"
+        endDate="2026-07-14"
+      />
+    </Row>
+  ),
+};
+
+// Advanceable: light card with a Start button.
+export const Advanceable: Story = {
+  render: () => (
+    <Row>
+      <PhaseCard
+        state="upcoming"
+        name="Voting"
+        startDate="2026-07-01"
+        isAdvanceable
+        onAdvance={() => {}}
+      />
+    </Row>
+  ),
+};
+
+// The states composed into the decision Overview timeline.
 export const Timeline: Story = {
   render: () => (
     <ol className="flex w-96 flex-col gap-2">
@@ -40,21 +105,6 @@ export const Timeline: Story = {
         endDate="2026-07-14"
       />
       <PhaseCard state="upcoming" name="Results" />
-    </ol>
-  ),
-};
-
-export const Advanceable: Story = {
-  render: () => (
-    <ol className="flex w-96 flex-col gap-2">
-      <PhaseCard
-        state="upcoming"
-        name="Voting"
-        startDate="2026-07-01"
-        isAdvanceable
-        advanceLabel="Advance"
-        onAdvance={() => {}}
-      />
     </ol>
   ),
 };

--- a/packages/ui/stories-sense/PhaseStepper.stories.tsx
+++ b/packages/ui/stories-sense/PhaseStepper.stories.tsx
@@ -1,0 +1,57 @@
+import { PhaseStepper } from '@op/sense/PhaseStepper';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { withSense } from './sense';
+
+const meta: Meta<typeof PhaseStepper> = {
+  title: 'Sense/Composites/PhaseStepper',
+  component: PhaseStepper,
+  decorators: [withSense],
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PhaseStepper>;
+
+const phases = [
+  {
+    id: 'submissions',
+    name: 'Submissions',
+    startDate: '2026-06-01',
+    endDate: '2026-06-14',
+  },
+  {
+    id: 'review',
+    name: 'Review',
+    startDate: '2026-06-15',
+    endDate: '2026-06-28',
+  },
+  { id: 'voting', name: 'Voting', startDate: '2026-07-01' },
+  { id: 'results', name: 'Results' },
+];
+
+export const Default: Story = {
+  render: () => <PhaseStepper phases={phases} currentPhaseId="review" />,
+};
+
+// The upcoming phase is interactive: hover shows the ripple + play button
+// (portal tooltip re-scopes with .sense).
+export const WithTransition: Story = {
+  render: () => (
+    <PhaseStepper
+      phases={[
+        ...phases.slice(0, 2),
+        {
+          ...phases[2]!,
+          interactive: true,
+          showOnHoverOnly: true,
+          ariaLabel: 'Start Voting',
+        },
+        phases[3]!,
+      ]}
+      currentPhaseId="review"
+      onTransition={() => {}}
+    />
+  ),
+};

--- a/packages/ui/stories-sense/Sortable.stories.tsx
+++ b/packages/ui/stories-sense/Sortable.stories.tsx
@@ -1,0 +1,77 @@
+import { DragHandle, Sortable } from '@op/sense/Sortable';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { withSense } from './sense';
+
+const meta: Meta<typeof Sortable> = {
+  title: 'Sense/Composites/Sortable',
+  component: Sortable,
+  decorators: [withSense],
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Sortable>;
+
+const initialPhases = [
+  { id: 'submissions', name: 'Submissions' },
+  { id: 'review', name: 'Review' },
+  { id: 'voting', name: 'Voting' },
+  { id: 'results', name: 'Results' },
+];
+
+// Drag the handle to reorder. Keyboard: tab to a handle, space to lift,
+// arrows to move, space to drop.
+const WithHandleDemo = () => {
+  const [phases, setPhases] = useState(initialPhases);
+
+  return (
+    <Sortable
+      items={phases}
+      onChange={setPhases}
+      dragTrigger="handle"
+      aria-label="Process phases"
+      className="w-80 gap-2"
+      getItemLabel={(phase) => phase.name}
+    >
+      {(phase, controls) => (
+        <div className="flex items-center gap-2 rounded-lg border bg-background p-3">
+          <DragHandle {...controls.dragHandleProps} />
+          <span className="text-base">{phase.name}</span>
+        </div>
+      )}
+    </Sortable>
+  );
+};
+
+export const WithHandle: Story = {
+  render: () => <WithHandleDemo />,
+};
+
+// The whole row is draggable when dragTrigger="item".
+const WholeItemDemo = () => {
+  const [phases, setPhases] = useState(initialPhases);
+
+  return (
+    <Sortable
+      items={phases}
+      onChange={setPhases}
+      dragTrigger="item"
+      aria-label="Process phases"
+      className="w-80 gap-2"
+      getItemLabel={(phase) => phase.name}
+    >
+      {(phase) => (
+        <div className="rounded-lg border bg-background p-3 text-base">
+          {phase.name}
+        </div>
+      )}
+    </Sortable>
+  );
+};
+
+export const WholeItemDrag: Story = {
+  render: () => <WholeItemDemo />,
+};

--- a/packages/ui/stories-sense/Stepper.stories.tsx
+++ b/packages/ui/stories-sense/Stepper.stories.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@op/sense/Button';
+import {
+  StepItem,
+  StepperProgressIndicator,
+  useStepper,
+} from '@op/sense/Stepper';
+import type { StepperItem } from '@op/sense/Stepper';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { withSense } from './sense';
+
+const meta: Meta<typeof StepperProgressIndicator> = {
+  title: 'Sense/Composites/Stepper',
+  component: StepperProgressIndicator,
+  decorators: [withSense],
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StepperProgressIndicator>;
+
+const steps: StepperItem[] = [
+  { key: 0, label: 'Basics', component: <p>Name your decision process.</p> },
+  { key: 1, label: 'Phases', component: <p>Define the phases.</p> },
+  { key: 2, label: 'Members', component: <p>Invite participants.</p> },
+];
+
+// useStepper drives the flow; the gradient progress bar fills per step with
+// a CSS width transition.
+const StepperDemo = () => {
+  const { currentStep, nextStep, prevStep } = useStepper({ items: steps });
+
+  return (
+    <div className="flex w-96 flex-col gap-4 overflow-hidden rounded-lg border">
+      <StepperProgressIndicator
+        numItems={steps.length}
+        currentStep={currentStep}
+      />
+      <div className="flex flex-col gap-4 px-4 pb-4">
+        <p className="text-sm text-muted-foreground">
+          Step {currentStep + 1} of {steps.length}: {steps[currentStep]?.label}
+        </p>
+        {steps.map((step, index) => (
+          <StepItem key={step.key} currentStep={currentStep} itemIndex={index}>
+            {step.component}
+          </StepItem>
+        ))}
+        <div className="flex justify-between">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={currentStep === 0}
+            onClick={prevStep}
+          >
+            Back
+          </Button>
+          <Button
+            size="sm"
+            disabled={currentStep === steps.length - 1}
+            onClick={() => nextStep()}
+          >
+            Continue
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <StepperDemo />,
+};

--- a/packages/ui/stories/senseComposites/CollapsibleConfigCard.stories.tsx
+++ b/packages/ui/stories/senseComposites/CollapsibleConfigCard.stories.tsx
@@ -1,5 +1,7 @@
 import { CollapsibleConfigCard } from '@op/sense/CollapsibleConfigCard';
+import { Sortable } from '@op/sense/Sortable';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 import { LuText } from 'react-icons/lu';
 
 import { Pair, Section } from '../../src/comparison/Comparison';
@@ -16,6 +18,34 @@ const meta: Meta = {
 export default meta;
 
 type Story = StoryObj;
+
+// New cards are always sortable, so the new column wraps a one-item Sortable.
+const NewCollapsibleDemo = () => {
+  const [items, setItems] = useState([{ id: 'description' }]);
+
+  return (
+    <Sortable
+      items={items}
+      onChange={setItems}
+      dragTrigger="handle"
+      aria-label="Fields"
+      className="w-80"
+      getItemLabel={() => 'Description'}
+    >
+      {(_item, controls) => (
+        <CollapsibleConfigCard
+          label="Description"
+          badgeLabel="Required"
+          isCollapsible
+          defaultExpanded
+          controls={controls}
+        >
+          <p className="text-sm">Field configuration.</p>
+        </CollapsibleConfigCard>
+      )}
+    </Sortable>
+  );
+};
 
 export const CollapsibleConfigCardComparison: Story = {
   name: 'CollapsibleConfigCard',
@@ -37,19 +67,7 @@ export const CollapsibleConfigCardComparison: Story = {
               </OldCollapsibleConfigCard>
             </div>
           }
-          raw={
-            <div className="w-80">
-              <CollapsibleConfigCard
-                icon={LuText}
-                label="Description"
-                badgeLabel="Required"
-                isCollapsible
-                defaultExpanded
-              >
-                <p className="text-sm">Field configuration.</p>
-              </CollapsibleConfigCard>
-            </div>
-          }
+          raw={<NewCollapsibleDemo />}
         />
         <Pair
           label="Locked"

--- a/packages/ui/stories/senseComposites/CollapsibleConfigCard.stories.tsx
+++ b/packages/ui/stories/senseComposites/CollapsibleConfigCard.stories.tsx
@@ -1,0 +1,70 @@
+import { CollapsibleConfigCard } from '@op/sense/CollapsibleConfigCard';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LuText } from 'react-icons/lu';
+
+import { Pair, Section } from '../../src/comparison/Comparison';
+import { CollapsibleConfigCard as OldCollapsibleConfigCard } from '../../src/components/CollapsibleConfigCard';
+
+// Port swaps the unstyled-AccordionItem hack for the Collapsible primitive;
+// same header anatomy (leading element, label pill, badge, chevron).
+
+const meta: Meta = {
+  title: 'Sense Comparison/Composites/CollapsibleConfigCard',
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const CollapsibleConfigCardComparison: Story = {
+  name: 'CollapsibleConfigCard',
+  render: () => (
+    <div className="p-8">
+      <Section title="CollapsibleConfigCard">
+        <Pair
+          label="Collapsible"
+          old={
+            <div className="w-80">
+              <OldCollapsibleConfigCard
+                icon={LuText}
+                label="Description"
+                badgeLabel="Required"
+                isCollapsible
+                defaultExpanded
+              >
+                <p className="text-sm">Field configuration.</p>
+              </OldCollapsibleConfigCard>
+            </div>
+          }
+          raw={
+            <div className="w-80">
+              <CollapsibleConfigCard
+                icon={LuText}
+                label="Description"
+                badgeLabel="Required"
+                isCollapsible
+                defaultExpanded
+              >
+                <p className="text-sm">Field configuration.</p>
+              </CollapsibleConfigCard>
+            </div>
+          }
+        />
+        <Pair
+          label="Locked"
+          old={
+            <div className="w-80">
+              <OldCollapsibleConfigCard icon={LuText} label="Votes" locked />
+            </div>
+          }
+          raw={
+            <div className="w-80">
+              <CollapsibleConfigCard icon={LuText} label="Votes" locked />
+            </div>
+          }
+        />
+      </Section>
+    </div>
+  ),
+};

--- a/packages/ui/stories/senseComposites/PhaseComponents.stories.tsx
+++ b/packages/ui/stories/senseComposites/PhaseComponents.stories.tsx
@@ -1,0 +1,71 @@
+import { PhaseCard } from '@op/sense/PhaseCard';
+import { PhaseStepper } from '@op/sense/PhaseStepper';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Pair, Section } from '../../src/comparison/Comparison';
+import { PhaseCard as OldPhaseCard } from '../../src/components/PhaseCard';
+import { PhaseStepper as OldPhaseStepper } from '../../src/components/PhaseStepper';
+
+const meta: Meta = {
+  title: 'Sense Comparison/Composites/Phase components',
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const phases = [
+  {
+    id: 'a',
+    name: 'Submissions',
+    startDate: '2026-06-01',
+    endDate: '2026-06-14',
+  },
+  { id: 'b', name: 'Review', startDate: '2026-06-15' },
+  { id: 'c', name: 'Voting' },
+];
+
+export const PhaseComparison: Story = {
+  name: 'Phase components',
+  render: () => (
+    <div className="p-8">
+      <Section title="PhaseStepper">
+        <Pair
+          label="Timeline"
+          old={<OldPhaseStepper phases={phases} currentPhaseId="b" />}
+          raw={<PhaseStepper phases={phases} currentPhaseId="b" />}
+        />
+      </Section>
+      <Section title="PhaseCard">
+        <Pair
+          label="States"
+          old={
+            <ol className="flex w-80 flex-col gap-2">
+              <OldPhaseCard
+                state="completed"
+                name="Submissions"
+                startDate="2026-06-01"
+                endDate="2026-06-14"
+              />
+              <OldPhaseCard state="current" name="Review" isNowOpen href="#" />
+              <OldPhaseCard state="upcoming" name="Voting" />
+            </ol>
+          }
+          raw={
+            <ol className="flex w-80 flex-col gap-2">
+              <PhaseCard
+                state="completed"
+                name="Submissions"
+                startDate="2026-06-01"
+                endDate="2026-06-14"
+              />
+              <PhaseCard state="current" name="Review" isNowOpen href="#" />
+              <PhaseCard state="upcoming" name="Voting" />
+            </ol>
+          }
+        />
+      </Section>
+    </div>
+  ),
+};

--- a/packages/ui/stories/senseComposites/Sortable.stories.tsx
+++ b/packages/ui/stories/senseComposites/Sortable.stories.tsx
@@ -1,0 +1,79 @@
+import { DragHandle, Sortable } from '@op/sense/Sortable';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { Pair, Section } from '../../src/comparison/Comparison';
+import {
+  DragHandle as OldDragHandle,
+  Sortable as OldSortable,
+} from '../../src/components/Sortable';
+
+const meta: Meta = {
+  title: 'Sense Comparison/Composites/Sortable',
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const initialItems = [
+  { id: 'a', name: 'Submissions' },
+  { id: 'b', name: 'Review' },
+  { id: 'c', name: 'Voting' },
+];
+
+const NewDemo = () => {
+  const [items, setItems] = useState(initialItems);
+
+  return (
+    <Sortable
+      items={items}
+      onChange={setItems}
+      dragTrigger="handle"
+      aria-label="Phases"
+      className="w-64 gap-2"
+      getItemLabel={(item) => item.name}
+    >
+      {(item, controls) => (
+        <div className="flex items-center gap-2 rounded-lg border bg-background p-2">
+          <DragHandle {...controls.dragHandleProps} />
+          <span className="text-sm">{item.name}</span>
+        </div>
+      )}
+    </Sortable>
+  );
+};
+
+const OldDemo = () => {
+  const [items, setItems] = useState(initialItems);
+
+  return (
+    <OldSortable
+      items={items}
+      onChange={setItems}
+      dragTrigger="handle"
+      aria-label="Phases"
+      className="w-64 gap-2"
+      getItemLabel={(item) => item.name}
+    >
+      {(item, controls) => (
+        <div className="flex items-center gap-2 rounded-lg border border-neutral-gray1 bg-white p-2">
+          <OldDragHandle {...controls.dragHandleProps} />
+          <span className="text-sm">{item.name}</span>
+        </div>
+      )}
+    </OldSortable>
+  );
+};
+
+export const SortableComparison: Story = {
+  name: 'Sortable',
+  render: () => (
+    <div className="p-8">
+      <Section title="Sortable">
+        <Pair label="Handle drag" old={<OldDemo />} raw={<NewDemo />} />
+      </Section>
+    </div>
+  ),
+};

--- a/packages/ui/stories/senseComposites/Stepper.stories.tsx
+++ b/packages/ui/stories/senseComposites/Stepper.stories.tsx
@@ -1,0 +1,39 @@
+import { StepperProgressIndicator } from '@op/sense/Stepper';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Pair, Section } from '../../src/comparison/Comparison';
+import { StepperProgressIndicator as OldStepperProgressIndicator } from '../../src/components/Stepper';
+
+// Port swaps framer-motion for a CSS width transition; visuals identical.
+
+const meta: Meta = {
+  title: 'Sense Comparison/Composites/Stepper',
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const StepperComparison: Story = {
+  name: 'Stepper',
+  render: () => (
+    <div className="p-8">
+      <Section title="Stepper">
+        <Pair
+          label="Progress (step 2 of 3)"
+          old={
+            <div className="w-64">
+              <OldStepperProgressIndicator numItems={3} currentStep={1} />
+            </div>
+          }
+          raw={
+            <div className="w-64">
+              <StepperProgressIndicator numItems={3} currentStep={1} />
+            </div>
+          }
+        />
+      </Section>
+    </div>
+  ),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -990,6 +990,15 @@ importers:
       '@base-ui/react':
         specifier: ^1.5.0
         version: 1.5.0(@date-fns/tz@1.5.0)(@types/react@19.0.10)(date-fns@4.3.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.1)
       '@op/styles':
         specifier: workspace:*
         version: link:../styles

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1083,6 +1083,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      zod:
+        specifier: 'catalog:'
+        version: 4.1.12
     devDependencies:
       '@op/typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
P2 process & stepper family:

- **Sortable** (+ DragHandle, DropIndicators) — dnd-kit copy; tv→cn (tailwind-variants not a sense dep), tokens swapped, and the DragOverlay portal now re-scopes with `.sense` so drag previews match in-list items
- **Stepper** (useStepper + StepItem + progress bar) — framer-motion dropped: the only usage was a width tween, now a CSS `transition-[width]`; zod dep added for the step validator type
- **PhaseStepper** — success/foreground tokens, sense Tooltip (re-scoped content), Button icon-xs replaces IconButton, ripple on `border-primary`
- **PhaseCard** — four state treatments on teal ramp + semantic tokens; Badge for "Now open!"; plain `<a>` + native `switch` replace react-aria Link + @op/core match; arrow flips in RTL
- **CollapsibleConfigCard** (+ DragPreview) — rebuilt on the Collapsible primitive instead of the old unstyled-AccordionItem hack; chevron rotates via base-ui's `data-panel-open` (verified in node_modules); Badge replaces Chip

@op/sense gains @dnd-kit/{core,sortable,utilities} and zod. Every composite ships first-class + comparison stories; the SortableCards story reproduces the ProcessBuilder shape end to end.

Asana: https://app.asana.com/1/1108348036672214/project/1216361907129487/task/1216401526374191
