### PR TITLE
feat(decision): add excludeAssignedForReview flag to listProposals

### DIFF
--- a/packages/common/src/services/decision/listProposals.ts
+++ b/packages/common/src/services/decision/listProposals.ts
@@ -34,6 +34,12 @@ export interface ListProposalsInput {
    */
   votedByProfileId?: string;
   /**
+   * Exclude proposals the current user is assigned to review in the viewed
+   * phase (reviewer's "Other proposals" tab). Resolved server-side from the
+   * caller's profile — never a client-supplied ID list.
+   */
+  excludeAssignedForReview?: boolean;
+  /**
    * Internal override: skip phase resolution and use this exact set of IDs.
    * Not exposed on the tRPC schema — public callers should use phaseId or
    * votedByProfileId.

--- a/packages/common/src/services/decision/resolveProposalListScope.ts
+++ b/packages/common/src/services/decision/resolveProposalListScope.ts
@@ -7,6 +7,7 @@ import {
   inArray,
   isNull,
   ne,
+  notExists,
   or,
   sql,
 } from '@op/db/client';
@@ -18,6 +19,7 @@ import {
   processInstances,
   profileUsers,
   proposalCategories,
+  proposalReviewAssignments,
   proposals,
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
@@ -29,6 +31,7 @@ import {
   getCurrentProfileId,
   resolveAccessUserIds,
 } from '../access';
+import { assertUserByAuthId } from '../assert';
 import { noActiveModerationFlag } from '../moderation/moderationVisibility';
 import {
   type PhaseProposalSqlScope,
@@ -131,6 +134,14 @@ const resolveExplicitScope = async ({
 const buildBaseConditions = (
   t: typeof proposals,
   input: ListProposalsInput,
+  /**
+   * The reviewer's *individual* profile id (`users.profileId`) — the identity
+   * review assignments are keyed on and the value `listReviewAssignments`
+   * filters by. NOT the acting/org `currentProfileId`, which would never match
+   * an assignment when reviewing inside an org/decision profile context.
+   */
+  reviewerProfileId: string | undefined,
+  resolvedPhaseId: string | undefined,
 ): SQL => {
   const { processInstanceId, submittedByProfileId, status, search } = input;
 
@@ -155,6 +166,38 @@ const buildBaseConditions = (
   if (search) {
     // Search in proposal data (JSONB) - convert to text for searching
     conditions.push(ilike(sql`${t.proposalData}::text`, `%${search}%`));
+  }
+
+  // "Other proposals" tab: exclude proposals the caller is assigned to review
+  // in the viewed phase. Correlated anti-join on the outer row's id; the four
+  // predicates match the `(processInstanceId, proposalId, reviewerProfileId,
+  // phaseId)` unique index exactly, so it's an index-only probe per row.
+  // Phase-scoping is deliberate — an assignment from a past review phase must
+  // not hide the proposal in the current one. Anonymous / no-profile callers
+  // (no reviewerProfileId) have no assignments, so the filter is skipped and
+  // they see the full phase set.
+  if (input.excludeAssignedForReview && reviewerProfileId && resolvedPhaseId) {
+    conditions.push(
+      notExists(
+        db
+          .select({ id: proposalReviewAssignments.id })
+          .from(proposalReviewAssignments)
+          .where(
+            and(
+              eq(
+                proposalReviewAssignments.processInstanceId,
+                processInstanceId,
+              ),
+              eq(proposalReviewAssignments.proposalId, t.id),
+              eq(
+                proposalReviewAssignments.reviewerProfileId,
+                reviewerProfileId,
+              ),
+              eq(proposalReviewAssignments.phaseId, resolvedPhaseId),
+            ),
+          ),
+      ),
+    );
   }
 
   return and(...conditions)!;
@@ -311,12 +354,38 @@ export const resolveProposalListScope = async ({
   // makes the whole scope empty, so callers should short-circuit.
   const isEmpty = phaseScope.isEmpty || categoryIsEmpty;
 
+  // The phase actually being viewed. The "Other proposals" tab doesn't pass a
+  // phaseId (it defaults to the current phase), so fall back to the instance's
+  // current state for scoping the assignment exclusion.
+  const resolvedPhaseId = input.phaseId ?? instance.currentStateId ?? undefined;
+
+  // Reviewer identity for the `excludeAssignedForReview` anti-join. Review
+  // assignments are keyed on the user's individual profile (`users.profileId`,
+  // what `listReviewAssignments` filters on), which is distinct from the
+  // acting `currentProfileId` when reviewing inside an org/decision context.
+  // Resolved only when the flag is set; anonymous / profile-less callers stay
+  // undefined and the exclusion is skipped.
+  let reviewerProfileId: string | undefined;
+  if (input.excludeAssignedForReview && user) {
+    try {
+      reviewerProfileId =
+        (await assertUserByAuthId(user.id)).profileId ?? undefined;
+    } catch {
+      reviewerProfileId = undefined;
+    }
+  }
+
   // Assemble the full WHERE clause. Parameterized on the table reference so
   // the same builder can be used for the v2 relational findMany (where Drizzle
   // passes an aliased `table`) and the plain count query (which passes the
   // schema table). See `buildBaseConditions` above for the same pattern.
   const buildWhereClause = (proposalsTable: typeof proposals): SQL => {
-    let clause: SQL = buildBaseConditions(proposalsTable, input);
+    let clause: SQL = buildBaseConditions(
+      proposalsTable,
+      input,
+      reviewerProfileId,
+      resolvedPhaseId,
+    );
 
     // Explicit scope (proposalIds or votedByProfileId): constrain the entire
     // query to that ID set so the draft branch can't independently surface

--- a/packages/common/src/services/decision/resolveProposalListScope.ts
+++ b/packages/common/src/services/decision/resolveProposalListScope.ts
@@ -126,6 +126,16 @@ const resolveExplicitScope = async ({
   return votedRows.map((row) => row.proposalId);
 };
 
+/**
+ * Reviewer identity + phase for the `excludeAssignedForReview` anti-join. Both
+ * are required together; absent means skip the exclusion.
+ */
+type ReviewAssignmentExclusion = {
+  /** The reviewer's individual profile id (`users.profileId`). */
+  reviewerProfileId: string;
+  phaseId: string;
+};
+
 // Shared function to build WHERE conditions for both count and data queries.
 // Parameterized on the table reference so callers can pass either the schema
 // table (for plain `db.select(...).from(proposals).where(...)`) or the
@@ -134,14 +144,7 @@ const resolveExplicitScope = async ({
 const buildBaseConditions = (
   t: typeof proposals,
   input: ListProposalsInput,
-  /**
-   * The reviewer's *individual* profile id (`users.profileId`) — the identity
-   * review assignments are keyed on and the value `listReviewAssignments`
-   * filters by. NOT the acting/org `currentProfileId`, which would never match
-   * an assignment when reviewing inside an org/decision profile context.
-   */
-  reviewerProfileId: string | undefined,
-  resolvedPhaseId: string | undefined,
+  reviewExclusion: ReviewAssignmentExclusion | undefined,
 ): SQL => {
   const { processInstanceId, submittedByProfileId, status, search } = input;
 
@@ -169,14 +172,10 @@ const buildBaseConditions = (
   }
 
   // "Other proposals" tab: exclude proposals the caller is assigned to review
-  // in the viewed phase. Correlated anti-join on the outer row's id; the four
-  // predicates match the `(processInstanceId, proposalId, reviewerProfileId,
-  // phaseId)` unique index exactly, so it's an index-only probe per row.
-  // Phase-scoping is deliberate — an assignment from a past review phase must
-  // not hide the proposal in the current one. Anonymous / no-profile callers
-  // (no reviewerProfileId) have no assignments, so the filter is skipped and
-  // they see the full phase set.
-  if (input.excludeAssignedForReview && reviewerProfileId && resolvedPhaseId) {
+  // in the viewed phase. Correlated anti-join matching the
+  // (processInstanceId, proposalId, reviewerProfileId, phaseId) unique index.
+  // Phase-scoped so a past-phase assignment can't hide the proposal now.
+  if (reviewExclusion) {
     conditions.push(
       notExists(
         db
@@ -191,9 +190,9 @@ const buildBaseConditions = (
               eq(proposalReviewAssignments.proposalId, t.id),
               eq(
                 proposalReviewAssignments.reviewerProfileId,
-                reviewerProfileId,
+                reviewExclusion.reviewerProfileId,
               ),
-              eq(proposalReviewAssignments.phaseId, resolvedPhaseId),
+              eq(proposalReviewAssignments.phaseId, reviewExclusion.phaseId),
             ),
           ),
       ),
@@ -354,24 +353,18 @@ export const resolveProposalListScope = async ({
   // makes the whole scope empty, so callers should short-circuit.
   const isEmpty = phaseScope.isEmpty || categoryIsEmpty;
 
-  // The phase actually being viewed. The "Other proposals" tab doesn't pass a
-  // phaseId (it defaults to the current phase), so fall back to the instance's
-  // current state for scoping the assignment exclusion.
-  const resolvedPhaseId = input.phaseId ?? instance.currentStateId ?? undefined;
+  // The phase being viewed — the "Other proposals" tab omits phaseId and
+  // defaults to the instance's current state.
+  const phaseId = input.phaseId ?? instance.currentStateId ?? undefined;
 
-  // Reviewer identity for the `excludeAssignedForReview` anti-join. Review
-  // assignments are keyed on the user's individual profile (`users.profileId`,
-  // what `listReviewAssignments` filters on), which is distinct from the
-  // acting `currentProfileId` when reviewing inside an org/decision context.
-  // Resolved only when the flag is set; anonymous / profile-less callers stay
-  // undefined and the exclusion is skipped.
-  let reviewerProfileId: string | undefined;
-  if (input.excludeAssignedForReview && user) {
-    try {
-      reviewerProfileId =
-        (await assertUserByAuthId(user.id)).profileId ?? undefined;
-    } catch {
-      reviewerProfileId = undefined;
+  // Reviewer + phase for the excludeAssignedForReview anti-join. Assignments are
+  // keyed on the user's individual profile (users.profileId), resolved only when
+  // the flag is set; profile-less callers skip the exclusion.
+  let reviewExclusion: ReviewAssignmentExclusion | undefined;
+  if (input.excludeAssignedForReview && user && phaseId) {
+    const reviewer = await assertUserByAuthId(user.id).catch(() => null);
+    if (reviewer?.profileId) {
+      reviewExclusion = { reviewerProfileId: reviewer.profileId, phaseId };
     }
   }
 
@@ -383,8 +376,7 @@ export const resolveProposalListScope = async ({
     let clause: SQL = buildBaseConditions(
       proposalsTable,
       input,
-      reviewerProfileId,
-      resolvedPhaseId,
+      reviewExclusion,
     );
 
     // Explicit scope (proposalIds or votedByProfileId): constrain the entire

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -672,6 +672,12 @@ export const proposalFilterSchema = z.object({
    * past the voting phase.
    */
   votedByProfileId: z.uuid().optional(),
+  /**
+   * When true, exclude proposals the current user is assigned to review in the
+   * viewed phase. Resolved server-side from the request's user context. Powers
+   * the reviewer's "Other proposals" tab.
+   */
+  excludeAssignedForReview: z.boolean().optional(),
   /** When set to 'results', all proposals are returned as non-editable */
   phase: z.enum(['results']).optional(),
   /** Keyset pagination cursor from the previous page's `next`. */

--- a/services/api/src/routers/decision/proposals/list.test.ts
+++ b/services/api/src/routers/decision/proposals/list.test.ts
@@ -12,6 +12,7 @@ import {
   stateTransitionHistory,
 } from '@op/db/schema';
 import { ROLES } from '@op/db/seedData/accessControl';
+import { createReviewAssignment } from '@op/test';
 import { and, eq } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
@@ -2317,4 +2318,252 @@ describeDecisionAccessTierGating('listProposals', {
       );
     },
   ),
+});
+
+/**
+ * `excludeAssignedForReview` — powers the reviewer's "Other proposals" tab by
+ * hiding proposals the caller is assigned to review in the viewed phase. The
+ * exclusion is resolved server-side from the caller's profile via a phase-
+ * scoped `NOT EXISTS` anti-join, so `total` and keyset pagination reflect it.
+ */
+describe.concurrent('listProposals: excludeAssignedForReview', () => {
+  /** Resolves the caller's current profile id (what the service excludes on). */
+  async function getProfileId(authUserId: string): Promise<string> {
+    const row = await db.query.users.findFirst({
+      where: { authUserId },
+      columns: { profileId: true },
+    });
+    if (!row?.profileId) {
+      throw new Error(`No profile for auth user ${authUserId}`);
+    }
+    return row.profileId;
+  }
+
+  /**
+   * Creates a PUBLISHED, no-pipeline instance with three SUBMITTED proposals
+   * and advances it to the `review` phase (where all three stay visible).
+   */
+  async function setupReviewPhaseWithProposals(
+    testData: TestDecisionsDataManager,
+    task: { id: string },
+  ) {
+    const setup = await testData.createDecisionSetup({
+      processSchema: schemaWithoutPipeline,
+      instanceCount: 1,
+      status: ProcessStatus.PUBLISHED,
+      grantAccess: true,
+    });
+    const instanceId = setup.instance.instance.id;
+    const { userEmail } = setup;
+
+    const [p1, p2, p3] = await Promise.all([
+      testData.createProposal({
+        userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal 1 ${task.id}` },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal 2 ${task.id}` },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail,
+        processInstanceId: instanceId,
+        proposalData: { title: `Proposal 3 ${task.id}` },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ]);
+
+    await testData.advancePhase({
+      instanceId,
+      fromPhaseId: 'submission',
+      toPhaseId: 'review',
+    });
+
+    return { setup, instanceId, userEmail, p1, p2, p3 };
+  }
+
+  it('excludes the caller-assigned proposal and reflects it in total', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instanceId, userEmail, p1 } =
+      await setupReviewPhaseWithProposals(testData, task);
+
+    const callerProfileId = await getProfileId(setup.user.id);
+
+    // Assign the caller to review p1 in the current (review) phase.
+    await createReviewAssignment({
+      processInstanceId: instanceId,
+      proposalId: p1.id,
+      reviewerProfileId: callerProfileId,
+      phaseId: 'review',
+    });
+
+    const caller = await createAuthenticatedCaller(userEmail);
+
+    // Flag off: all three proposals, including the assigned one.
+    const withAssigned = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+    });
+    expect(withAssigned.total).toBe(3);
+    expect(withAssigned.proposals.map((p) => p.id)).toContain(p1.id);
+
+    // Flag on: the assigned proposal is gone and total drops to match.
+    const withoutAssigned = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+      excludeAssignedForReview: true,
+    });
+    expect(withoutAssigned.total).toBe(2);
+    expect(withoutAssigned.proposals.map((p) => p.id)).not.toContain(p1.id);
+  });
+
+  it('keeps total and keyset pagination consistent with the exclusion', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instanceId, userEmail, p1, p2, p3 } =
+      await setupReviewPhaseWithProposals(testData, task);
+
+    const callerProfileId = await getProfileId(setup.user.id);
+    await createReviewAssignment({
+      processInstanceId: instanceId,
+      proposalId: p1.id,
+      reviewerProfileId: callerProfileId,
+      phaseId: 'review',
+    });
+
+    const caller = await createAuthenticatedCaller(userEmail);
+
+    // Page through the excluded list one row at a time.
+    const page1 = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+      excludeAssignedForReview: true,
+      limit: 1,
+    });
+    expect(page1.total).toBe(2);
+    expect(page1.hasMore).toBe(true);
+    expect(page1.next).not.toBeNull();
+
+    const page2 = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+      excludeAssignedForReview: true,
+      limit: 1,
+      cursor: page1.next,
+    });
+    expect(page2.total).toBe(2);
+    expect(page2.hasMore).toBe(false);
+
+    // The assigned proposal never surfaces on any page; the other two do.
+    const seenIds = [...page1.proposals, ...page2.proposals].map((p) => p.id);
+    expect(seenIds).not.toContain(p1.id);
+    expect(seenIds).toEqual(expect.arrayContaining([p2.id, p3.id]));
+  });
+
+  it('only excludes the current caller — a peer reviewer still sees everything', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instanceId, p1 } = await setupReviewPhaseWithProposals(
+      testData,
+      task,
+    );
+
+    // Assign p1 to a *different* reviewer.
+    const peer = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [setup.instance.profileId],
+    });
+    await createReviewAssignment({
+      processInstanceId: instanceId,
+      proposalId: p1.id,
+      reviewerProfileId: peer.profileId,
+      phaseId: 'review',
+    });
+
+    // The caller (owner, no assignments of their own) sees all three even with
+    // the flag on — the exclusion is scoped to the requester's assignments.
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+    const result = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+      excludeAssignedForReview: true,
+    });
+    expect(result.total).toBe(3);
+    expect(result.proposals.map((p) => p.id)).toContain(p1.id);
+  });
+
+  it('does not exclude assignments from a different phase', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instanceId, userEmail, p1 } =
+      await setupReviewPhaseWithProposals(testData, task);
+
+    const callerProfileId = await getProfileId(setup.user.id);
+
+    // Assignment lives in the *submission* phase, but we're viewing review.
+    await createReviewAssignment({
+      processInstanceId: instanceId,
+      proposalId: p1.id,
+      reviewerProfileId: callerProfileId,
+      phaseId: 'submission',
+    });
+
+    const caller = await createAuthenticatedCaller(userEmail);
+    const result = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+      excludeAssignedForReview: true,
+    });
+
+    // The past-phase assignment must not hide the proposal in the current one.
+    expect(result.total).toBe(3);
+    expect(result.proposals.map((p) => p.id)).toContain(p1.id);
+  });
+
+  it('composes with sort direction, excluding the assigned proposal', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instanceId, userEmail, p1, p2, p3 } =
+      await setupReviewPhaseWithProposals(testData, task);
+
+    const callerProfileId = await getProfileId(setup.user.id);
+    await createReviewAssignment({
+      processInstanceId: instanceId,
+      proposalId: p1.id,
+      reviewerProfileId: callerProfileId,
+      phaseId: 'review',
+    });
+
+    const caller = await createAuthenticatedCaller(userEmail);
+
+    // Canonical ascending order with the flag off (creation order via
+    // Promise.all isn't deterministic, so derive the expected order instead of
+    // hard-coding it).
+    const baseline = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+      dir: 'asc',
+    });
+    const excluded = await caller.decision.listProposals({
+      processInstanceId: instanceId,
+      excludeAssignedForReview: true,
+      dir: 'asc',
+    });
+
+    // The excluded list is exactly the baseline order minus the assigned p1 —
+    // sort composes with the exclusion, order is otherwise preserved.
+    const expectedIds = baseline.proposals
+      .map((p) => p.id)
+      .filter((id) => id !== p1.id);
+    expect(excluded.proposals.map((p) => p.id)).toEqual(expectedIds);
+    expect(expectedIds).toEqual(expect.arrayContaining([p2.id, p3.id]));
+  });
 });


### PR DESCRIPTION
API-only groundwork for the reviewer's "Other proposals" tab: a single self-contained query that excludes proposals the caller is assigned to review, so total and keyset pagination stay correct without a client-side waterfall.