### PR TITLE
fix(account): let existing accounts log in regardless of the invite allow-list

### DIFF
--- a/services/api/src/routers/account/login.test.ts
+++ b/services/api/src/routers/account/login.test.ts
@@ -1,9 +1,21 @@
-import { expect } from 'vitest';
+import { randomUUID } from 'crypto';
+import { describe, expect, it } from 'vitest';
 
+import { appRouter } from '..';
 import {
   accessTierGatingCell,
   describeAccessTierGating,
 } from '../../test/helpers/gating';
+import {
+  inviteEmail,
+  signUpAllowlistedUser,
+  signUpConfirmedUser,
+  signUpNonAllowlistedUser,
+} from '../../test/helpers/loginTestUtils';
+import { createTestContextWithSession } from '../../test/supabase-utils';
+import { createCallerFactory } from '../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
 
 // account.login is a PUBLIC `commonProcedure` — it has no authentication
 // middleware and ignores the caller's JWT entirely (it gates on the *input*
@@ -44,4 +56,90 @@ describeAccessTierGating('account.login', {
       await expect(caller.account.login(input)).resolves.toBe(true);
     },
   ),
+});
+
+// The invite gate decides admission along two independent axes: whether the
+// email already owns an account (`auth.users`) and whether it is invited (an
+// allow-list entry, or a network email domain — `adminEmails` is not a third
+// axis, its only entry is on a network domain already). Only the no-account +
+// not-invited cell is waitlisted: an existing account may always log back in,
+// and an invited newcomer may sign up.
+//
+//                     | allow-listed | network domain | not invited |
+//   no account        |    admit     |     admit      |  waitlist   |
+//   existing account  |    admit     |     admit      |    admit    |
+//
+// Every cell calls with `usingOAuth: true` and no session, so it asserts the
+// gate decision alone — no OTP send or account-creation side effects, and the
+// created-by-this-sign-in OAuth caveat (exercised in loginOAuthCleanup.test.ts)
+// stays out of play.
+describe.concurrent('account.login: allow-list × account-existence matrix', () => {
+  const createAnonymousCaller = async () =>
+    createCaller(await createTestContextWithSession(null));
+
+  it('admits an allow-listed email with no account (first-time signup)', async ({
+    onTestFinished,
+  }) => {
+    const email = `invited-new-${randomUUID()}@example.com`;
+    await inviteEmail(email, onTestFinished);
+
+    const caller = await createAnonymousCaller();
+    await expect(
+      caller.account.login({ email, usingOAuth: true }),
+    ).resolves.toBe(true);
+  });
+
+  it('admits a network-domain email with no account (first-time signup)', async () => {
+    const email = `member-new-${randomUUID()}@oneproject.org`;
+
+    const caller = await createAnonymousCaller();
+    await expect(
+      caller.account.login({ email, usingOAuth: true }),
+    ).resolves.toBe(true);
+  });
+
+  it('waitlists an uninvited email with no account', async () => {
+    const email = `stranger-${randomUUID()}@example.com`;
+
+    const caller = await createAnonymousCaller();
+    await expect(
+      caller.account.login({ email, usingOAuth: true }),
+    ).rejects.toThrow(/invite-only/);
+  });
+
+  it('admits an allow-listed email with an existing account', async ({
+    onTestFinished,
+  }) => {
+    const { email } = await signUpAllowlistedUser(onTestFinished);
+
+    const caller = await createAnonymousCaller();
+    await expect(
+      caller.account.login({ email, usingOAuth: true }),
+    ).resolves.toBe(true);
+  });
+
+  it('admits a network-domain email with an existing account', async ({
+    onTestFinished,
+  }) => {
+    const { email } = await signUpConfirmedUser(
+      `member-${randomUUID()}@oneproject.org`,
+      onTestFinished,
+    );
+
+    const caller = await createAnonymousCaller();
+    await expect(
+      caller.account.login({ email, usingOAuth: true }),
+    ).resolves.toBe(true);
+  });
+
+  it('admits an uninvited email with an existing account (claim-flow accounts)', async ({
+    onTestFinished,
+  }) => {
+    const { email } = await signUpNonAllowlistedUser(onTestFinished);
+
+    const caller = await createAnonymousCaller();
+    await expect(
+      caller.account.login({ email, usingOAuth: true }),
+    ).resolves.toBe(true);
+  });
 });

--- a/services/api/src/routers/account/login.ts
+++ b/services/api/src/routers/account/login.ts
@@ -47,31 +47,61 @@ const login = router({
         throw new ValidationError('Invalid email');
       }
 
-      const allowedUserEmail = await cache<ReturnType<typeof getAllowListUser>>(
-        {
+      // An existing account may always log back in: the OTP/OAuth exchange
+      // proves email ownership, and network access is gated separately by
+      // `isNetworkMember`. Claim-flow accounts (`useClaimAccount`) have no
+      // allow-list entry, so the allow-list only decides (below) whether an
+      // email without an account may create one. auth.users is the canonical
+      // record; anonymous accounts have a NULL email there.
+      const existingAuthUser = await db.query.authUsers.findFirst({
+        columns: { id: true },
+        where: { email: input.email },
+      });
+
+      let ownsExistingAccount = Boolean(existingAuthUser);
+
+      if (ownsExistingAccount && input.usingOAuth) {
+        // The OAuth code exchange creates the account before this gate runs,
+        // so discount one created by the very sign-in being gated.
+        const {
+          data: { user: authUser },
+        } = await getCachedAuthUser(ctx);
+
+        if (
+          authUser?.email?.toLowerCase() === input.email &&
+          wasCreatedByThisSignIn(authUser)
+        ) {
+          ownsExistingAccount = false;
+        }
+      }
+
+      if (!ownsExistingAccount) {
+        const allowedUserEmail = await cache<
+          ReturnType<typeof getAllowListUser>
+        >({
           type: 'allowList',
           params: [input.email],
           fetch: () => getAllowListUser({ email: input.email }),
-        },
-      );
+        });
 
-      // If the user is not invited, add them to the waitlist
-      if (
-        !allowedUserEmail?.email &&
-        !allowedEmailDomains.includes(emailDomain) &&
-        !adminEmails.includes(input.email)
-      ) {
-        if (input.usingOAuth) {
-          // The OAuth code exchange already created the account (auth.users
-          // plus the trigger-created public.users row and individual profile)
-          // before this gate ran, so remove it or the rejected visitor
-          // persists as an orphaned user.
-          await deleteRejectedOAuthSignup({ ctx, email: input.email });
+        // No account and not invited: add them to the waitlist.
+        if (
+          !allowedUserEmail?.email &&
+          !allowedEmailDomains.includes(emailDomain) &&
+          !adminEmails.includes(input.email)
+        ) {
+          if (input.usingOAuth) {
+            // The OAuth code exchange already created the account (auth.users
+            // plus the trigger-created public.users row and individual profile)
+            // before this gate ran, so remove it or the rejected visitor
+            // persists as an orphaned user.
+            await deleteRejectedOAuthSignup({ ctx, email: input.email });
+          }
+
+          throw new UnauthorizedError(
+            `${APP_NAME} is invite-only! You’re now on the waitlist. Keep an eye on your inbox for updates.`,
+          );
         }
-
-        throw new UnauthorizedError(
-          `${APP_NAME} is invite-only! You’re now on the waitlist. Keep an eye on your inbox for updates.`,
-        );
       }
 
       // If the user is not using OAuth and doesn't have a token, send them an OTP

--- a/services/api/src/routers/account/loginOAuthCleanup.test.ts
+++ b/services/api/src/routers/account/loginOAuthCleanup.test.ts
@@ -1,12 +1,16 @@
 import { db, eq } from '@op/db/client';
-import { allowList, profiles, users } from '@op/db/schema';
+import { authUsers, profiles, users } from '@op/db/schema';
 import { randomUUID } from 'crypto';
-import { type TestContext, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '..';
 import {
+  signUpAllowlistedUser,
+  signUpConfirmedUser,
+  signUpNonAllowlistedUser,
+} from '../../test/helpers/loginTestUtils';
+import {
   TEST_USER_DEFAULT_PASSWORD,
-  createIsolatedTestClient,
   createTestContextWithSession,
   supabaseTestAdminClient,
 } from '../../test/supabase-utils';
@@ -14,72 +18,6 @@ import { createCallerFactory } from '../../trpcFactory';
 import { wasCreatedByThisSignIn } from './login';
 
 const createCaller = createCallerFactory(appRouter);
-
-// Teardown is registered through the running test's own context rather than the
-// global `onTestFinished` import: under `describe.concurrent` the global helper
-// can't reliably resolve which concurrent test is current across `await`s.
-type RegisterCleanup = TestContext['onTestFinished'];
-
-/**
- * Signs up a confirmed user (the signup trigger creates the `public.users` row
- * and individual profile) and registers teardown for the auth user and profile.
- * Mimics the account Supabase creates during a Google OAuth code exchange
- * before the allow-list gate runs. Each user is created on its own isolated
- * client so concurrent tests never share auth session state.
- */
-const signUpConfirmedUser = async (
-  email: string,
-  onTestFinished: RegisterCleanup,
-) => {
-  const { data, error } = await createIsolatedTestClient().auth.signUp({
-    email,
-    password: TEST_USER_DEFAULT_PASSWORD,
-  });
-  const user = data.user;
-  const session = data.session;
-  if (error || !user || !session) {
-    throw new Error(
-      `Failed to sign up test user ${email}: ${error?.message ?? 'no session'}`,
-    );
-  }
-
-  const userRow = await db.query.users.findFirst({
-    where: { authUserId: user.id },
-  });
-  if (!userRow?.profileId) {
-    throw new Error(`Signup trigger did not create a profile for ${email}`);
-  }
-  const profileId = userRow.profileId;
-
-  onTestFinished(async () => {
-    await db.delete(profiles).where(eq(profiles.id, profileId));
-    await supabaseTestAdminClient.auth.admin
-      .deleteUser(user.id)
-      .catch(() => {});
-  });
-
-  return { email, user, session, profileId };
-};
-
-/** A confirmed user whose email clears neither the allow-list nor a network domain. */
-const signUpNonAllowlistedUser = (onTestFinished: RegisterCleanup) =>
-  signUpConfirmedUser(
-    `oauth-orphan-${randomUUID()}@example.com`,
-    onTestFinished,
-  );
-
-/** A confirmed user admitted by an explicit allow-list entry (non-network domain). */
-const signUpAllowlistedUser = async (onTestFinished: RegisterCleanup) => {
-  const result = await signUpConfirmedUser(
-    `allowlisted-${randomUUID()}@example.com`,
-    onTestFinished,
-  );
-  await db.insert(allowList).values({ email: result.email });
-  onTestFinished(async () => {
-    await db.delete(allowList).where(eq(allowList.email, result.email));
-  });
-  return result;
-};
 
 describe.concurrent('account.login: rejected OAuth sign-in cleanup', () => {
   it('deletes the just-created account when the allow-list rejects an OAuth sign-in', async ({
@@ -106,22 +44,6 @@ describe.concurrent('account.login: rejected OAuth sign-in cleanup', () => {
       where: { id: profileId },
     });
     expect(profileAfter).toBeUndefined();
-  });
-
-  it('keeps the account when a rejected login is not OAuth', async ({
-    onTestFinished,
-  }) => {
-    const { email, user, session } =
-      await signUpNonAllowlistedUser(onTestFinished);
-
-    const caller = createCaller(await createTestContextWithSession(session));
-    await expect(
-      caller.account.login({ email, usingOAuth: false }),
-    ).rejects.toThrow(/invite-only/);
-
-    const { data: authAfter } =
-      await supabaseTestAdminClient.auth.admin.getUserById(user.id);
-    expect(authAfter?.user?.id).toBe(user.id);
   });
 
   it('keeps a users row that predates this sign-in (trigger ON CONFLICT repoint)', async ({
@@ -166,6 +88,95 @@ describe.concurrent('account.login: rejected OAuth sign-in cleanup', () => {
     const { data: authAfter } =
       await supabaseTestAdminClient.auth.admin.getUserById(user.id);
     expect(authAfter?.user?.id).toBe(user.id);
+  });
+});
+
+// The anon claim flow (`useClaimAccount`) attaches an email onto an anonymous
+// user through GoTrue directly, so its accounts own an `auth.users` row with
+// the email set (anonymous rows keep email NULL) but have no allow-list
+// entry. `signUpConfirmedUser` yields that exact DB state, so these tests
+// stand in for a claimed account logging back in after its session ended.
+describe.concurrent('account.login: existing claimed accounts', () => {
+  it('lets a confirmed out-of-network account owner log back in via OTP', async ({
+    onTestFinished,
+  }) => {
+    const { email, user } = await signUpNonAllowlistedUser(onTestFinished);
+
+    // No session: the owner comes back on a fresh device/browser.
+    const caller = createCaller(await createTestContextWithSession(null));
+    await expect(
+      caller.account.login({ email, usingOAuth: false }),
+    ).resolves.toBe(true);
+
+    const { data: authAfter } =
+      await supabaseTestAdminClient.auth.admin.getUserById(user.id);
+    expect(authAfter?.user?.id).toBe(user.id);
+  });
+
+  it('lets a pre-existing out-of-network account through the OAuth gate without deleting it', async ({
+    onTestFinished,
+  }) => {
+    const { email, user, session, profileId } =
+      await signUpNonAllowlistedUser(onTestFinished);
+
+    // Age the account so `wasCreatedByThisSignIn` no longer treats it as a
+    // signup made by the OAuth exchange currently being gated.
+    await db
+      .update(authUsers)
+      .set({ createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000) })
+      .where(eq(authUsers.id, user.id));
+
+    const caller = createCaller(await createTestContextWithSession(session));
+    await expect(
+      caller.account.login({ email, usingOAuth: true }),
+    ).resolves.toBe(true);
+
+    const { data: authAfter } =
+      await supabaseTestAdminClient.auth.admin.getUserById(user.id);
+    expect(authAfter?.user?.id).toBe(user.id);
+
+    const profileAfter = await db.query.profiles.findFirst({
+      where: { id: profileId },
+    });
+    expect(profileAfter).toBeDefined();
+  });
+
+  it('lets an unconfirmed account proceed to the OTP', async ({
+    onTestFinished,
+  }) => {
+    // The gate only asks whether the email is attached to an account, not
+    // whether it was confirmed — the OTP itself is what proves email
+    // ownership before a session is issued.
+    const email = `unconfirmed-${randomUUID()}@example.com`;
+    const { data, error } = await supabaseTestAdminClient.auth.admin.createUser(
+      {
+        email,
+        password: TEST_USER_DEFAULT_PASSWORD,
+        email_confirm: false,
+      },
+    );
+    const user = data.user;
+    if (error || !user) {
+      throw new Error(
+        `Failed to create unconfirmed test user ${email}: ${error?.message}`,
+      );
+    }
+    onTestFinished(async () => {
+      const userRow = await db.query.users.findFirst({
+        where: { authUserId: user.id },
+      });
+      await supabaseTestAdminClient.auth.admin
+        .deleteUser(user.id)
+        .catch(() => {});
+      if (userRow?.profileId) {
+        await db.delete(profiles).where(eq(profiles.id, userRow.profileId));
+      }
+    });
+
+    const caller = createCaller(await createTestContextWithSession(null));
+    await expect(
+      caller.account.login({ email, usingOAuth: false }),
+    ).resolves.toBe(true);
   });
 });
 

--- a/services/api/src/test/helpers/loginTestUtils.ts
+++ b/services/api/src/test/helpers/loginTestUtils.ts
@@ -1,0 +1,86 @@
+import { db, eq } from '@op/db/client';
+import { allowList, profiles } from '@op/db/schema';
+import { randomUUID } from 'crypto';
+import type { TestContext } from 'vitest';
+
+import {
+  TEST_USER_DEFAULT_PASSWORD,
+  createIsolatedTestClient,
+  supabaseTestAdminClient,
+} from '../supabase-utils';
+
+// Teardown is registered through the running test's own context rather than the
+// global `onTestFinished` import: under `describe.concurrent` the global helper
+// can't reliably resolve which concurrent test is current across `await`s.
+export type RegisterCleanup = TestContext['onTestFinished'];
+
+/**
+ * Signs up a confirmed user (the signup trigger creates the `public.users` row
+ * and individual profile) and registers teardown for the auth user and profile.
+ * Mimics the account Supabase creates during a Google OAuth code exchange
+ * before the allow-list gate runs. Each user is created on its own isolated
+ * client so concurrent tests never share auth session state.
+ */
+export const signUpConfirmedUser = async (
+  email: string,
+  onTestFinished: RegisterCleanup,
+) => {
+  const { data, error } = await createIsolatedTestClient().auth.signUp({
+    email,
+    password: TEST_USER_DEFAULT_PASSWORD,
+  });
+  const user = data.user;
+  const session = data.session;
+  if (error || !user || !session) {
+    throw new Error(
+      `Failed to sign up test user ${email}: ${error?.message ?? 'no session'}`,
+    );
+  }
+
+  const userRow = await db.query.users.findFirst({
+    where: { authUserId: user.id },
+  });
+  if (!userRow?.profileId) {
+    throw new Error(`Signup trigger did not create a profile for ${email}`);
+  }
+  const profileId = userRow.profileId;
+
+  onTestFinished(async () => {
+    await db.delete(profiles).where(eq(profiles.id, profileId));
+    await supabaseTestAdminClient.auth.admin
+      .deleteUser(user.id)
+      .catch(() => {});
+  });
+
+  return { email, user, session, profileId };
+};
+
+/** A confirmed user whose email clears neither the allow-list nor a network domain. */
+export const signUpNonAllowlistedUser = (onTestFinished: RegisterCleanup) =>
+  signUpConfirmedUser(
+    `oauth-orphan-${randomUUID()}@example.com`,
+    onTestFinished,
+  );
+
+/** Inserts an allow-list entry for the email and registers its teardown. */
+export const inviteEmail = async (
+  email: string,
+  onTestFinished: RegisterCleanup,
+) => {
+  await db.insert(allowList).values({ email });
+  onTestFinished(async () => {
+    await db.delete(allowList).where(eq(allowList.email, email));
+  });
+};
+
+/** A confirmed user admitted by an explicit allow-list entry (non-network domain). */
+export const signUpAllowlistedUser = async (
+  onTestFinished: RegisterCleanup,
+) => {
+  const result = await signUpConfirmedUser(
+    `allowlisted-${randomUUID()}@example.com`,
+    onTestFinished,
+  );
+  await inviteEmail(result.email, onTestFinished);
+  return result;
+};


### PR DESCRIPTION
Accounts created outside the allow-list gate (anon claim flow, pre-#1507 rejected-OAuth orphans) have no allowList entry and were locked out of login entirely once their session ended. The allow-list is a network-membership concept, not an authentication one — an existing account may always log back in (the OTP/OAuth exchange proves email ownership; isNetworkMember gates walled-garden access separately), so it now only decides whether an email with no account may create one. Existence is checked against auth.users because public.users.email is drifted (broken sync_user_email trigger, tracked separately).