### PR TITLE
chore(api): raise rate limits on decision-process endpoints for shared-IP events

### DIFF
--- a/services/api/src/routers/customForms/getForProfile.ts
+++ b/services/api/src/routers/customForms/getForProfile.ts
@@ -9,7 +9,7 @@ export const getForProfile = router({
   // needed inside the logged-in proposal flow, so there is no reason to
   // let anonymous callers enumerate profile UUIDs for form contents.
   getForProfile: authenticatedProcedure({
-    rateLimit: { windowSize: 10, maxRequests: 30 },
+    rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(getCustomFormForProfileInputSchema)
     .output(customFormEncoder.nullable())

--- a/services/api/src/routers/decision/instances/getDecisionBySlug.ts
+++ b/services/api/src/routers/decision/instances/getDecisionBySlug.ts
@@ -16,7 +16,7 @@ const inputSchema = z.object({
 
 export const getDecisionBySlugRouter = router({
   getDecisionBySlug: openProcedure({
-    rateLimit: { windowSize: 10, maxRequests: 20 },
+    rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(inputSchema)
     .output(decisionProfileWithSchemaEncoder)

--- a/services/api/src/routers/decision/instances/getInstance.ts
+++ b/services/api/src/routers/decision/instances/getInstance.ts
@@ -22,7 +22,7 @@ import {
 
 export const getLegacyInstanceRouter = router({
   getLegacyInstance: networkAuthenticatedProcedure({
-    rateLimit: { windowSize: 10, maxRequests: 30 },
+    rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(legacyGetInstanceInputSchema)
     .output(legacyProcessInstanceEncoder)
@@ -63,7 +63,7 @@ export const getLegacyInstanceRouter = router({
  */
 export const getInstanceRouter = router({
   getInstance: openProcedure({
-    rateLimit: { windowSize: 10, maxRequests: 30 },
+    rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(getInstanceInputSchema)
     .output(processInstanceWithSchemaEncoder)

--- a/services/api/src/routers/decision/proposals/create.ts
+++ b/services/api/src/routers/decision/proposals/create.ts
@@ -6,7 +6,9 @@ import { authenticatedProcedure, router } from '../../../trpcFactory';
 
 export const createProposalRouter = router({
   /** Creates a new proposal in draft status. Use submitProposal to transition to submitted. */
-  createProposal: authenticatedProcedure()
+  createProposal: authenticatedProcedure({
+    rateLimit: { windowSize: 10, maxRequests: 30 },
+  })
     .input(createProposalInputSchema)
     .output(proposalSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/getLatestSelection.ts
+++ b/services/api/src/routers/decision/proposals/getLatestSelection.ts
@@ -5,7 +5,9 @@ import { z } from 'zod';
 import { openProcedure, router } from '../../../trpcFactory';
 
 export const getLatestSelectionForProposalRouter = router({
-  getLatestSelectionForProposal: openProcedure()
+  getLatestSelectionForProposal: openProcedure({
+    rateLimit: { windowSize: 10, maxRequests: 100 },
+  })
     .input(
       z.object({
         proposalId: z.uuid(),

--- a/services/api/src/routers/decision/proposals/list.ts
+++ b/services/api/src/routers/decision/proposals/list.ts
@@ -10,7 +10,9 @@ import { openProcedure, router } from '../../../trpcFactory';
 
 export const listProposalsRouter = router({
   /** Lists proposals for a given process instance in the current phase. */
-  listProposals: openProcedure()
+  listProposals: openProcedure({
+    rateLimit: { windowSize: 10, maxRequests: 100 },
+  })
     .input(proposalFilterSchema)
     .output(proposalListSchema)
     .query(async ({ ctx, input }) => {
@@ -27,7 +29,9 @@ export const listProposalsRouter = router({
       return proposalListSchema.parse(result);
     }),
   /** Lists all proposals for a given process instance, no phase filter. */
-  listAllProposals: openProcedure()
+  listAllProposals: openProcedure({
+    rateLimit: { windowSize: 10, maxRequests: 100 },
+  })
     .input(allProposalsFilterSchema)
     .output(allProposalsListSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/listProposalLocations.ts
+++ b/services/api/src/routers/decision/proposals/listProposalLocations.ts
@@ -9,7 +9,9 @@ export const listProposalLocationsRouter = router({
    * Every located proposal in the instance's current scope — the map's pin
    * source, so the map isn't capped by the list's page size.
    */
-  listProposalLocations: openProcedure()
+  listProposalLocations: openProcedure({
+    rateLimit: { windowSize: 10, maxRequests: 100 },
+  })
     .input(proposalLocationsFilterSchema)
     .output(proposalLocationsSchema)
     .query(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/submit.ts
+++ b/services/api/src/routers/decision/proposals/submit.ts
@@ -13,7 +13,9 @@ const submitProposalInputSchema = z.object({
 });
 
 export const submitProposalRouter = router({
-  submitProposal: authenticatedProcedure()
+  submitProposal: authenticatedProcedure({
+    rateLimit: { windowSize: 10, maxRequests: 30 },
+  })
     .input(submitProposalInputSchema)
     .output(proposalSchema)
     .mutation(async ({ ctx, input }) => {

--- a/services/api/src/routers/decision/proposals/update.ts
+++ b/services/api/src/routers/decision/proposals/update.ts
@@ -11,7 +11,7 @@ import { authenticatedProcedure, router } from '../../../trpcFactory';
 
 export const updateProposalRouter = router({
   updateProposal: authenticatedProcedure({
-    rateLimit: { windowSize: 10, maxRequests: 20 },
+    rateLimit: { windowSize: 10, maxRequests: 100 },
   })
     .input(
       z.object({


### PR DESCRIPTION
Ups rate limits on the decision-process endpoints to cater for in-person events (e.g. a library with shared terminals), where all attendees egress through a single shared IP and currently share each endpoint's per-IP bucket.