### PR TITLE
fix(onboarding): unblock promote-flow users who did not finish onboarding

### DIFF
--- a/apps/app/src/app/[locale]/(main)/layout.tsx
+++ b/apps/app/src/app/[locale]/(main)/layout.tsx
@@ -1,8 +1,12 @@
 import { UserProvider } from '@/utils/UserProvider';
 import { getUser } from '@/utils/getUser';
-import { shouldRedirectToOnboarding } from '@/utils/onboarding';
+import {
+  buildOnboardingRedirect,
+  shouldRedirectToOnboarding,
+} from '@/utils/onboarding';
 import { assertWalledGardenAccess } from '@/utils/walledGarden';
 import { SidebarLayout, SidebarProvider } from '@op/ui/Sidebar';
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import Script from 'next/script';
 
@@ -23,7 +27,13 @@ const AppRoot = async ({ children }: { children: React.ReactNode }) => {
   await assertWalledGardenAccess(user);
 
   if (shouldRedirectToOnboarding(user)) {
-    redirect('/en/start');
+    const requestHeaders = await headers();
+    redirect(
+      buildOnboardingRedirect(
+        requestHeaders.get('x-pathname'),
+        requestHeaders.get('x-search'),
+      ),
+    );
   }
 
   return (

--- a/apps/app/src/app/[locale]/(no-header)/layout.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/layout.tsx
@@ -1,6 +1,10 @@
 import { UserProvider } from '@/utils/UserProvider';
 import { getUser } from '@/utils/getUser';
-import { shouldRedirectToOnboarding } from '@/utils/onboarding';
+import {
+  buildOnboardingRedirect,
+  shouldRedirectToOnboarding,
+} from '@/utils/onboarding';
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 import { PolicyReacceptanceModal } from '@/components/PolicyReacceptanceModal';
@@ -11,7 +15,13 @@ const Layout = async ({ children }: { children: React.ReactNode }) => {
   const user = await getUser();
 
   if (shouldRedirectToOnboarding(user)) {
-    redirect('/en/start');
+    const requestHeaders = await headers();
+    redirect(
+      buildOnboardingRedirect(
+        requestHeaders.get('x-pathname'),
+        requestHeaders.get('x-search'),
+      ),
+    );
   }
 
   return (

--- a/apps/app/src/app/[locale]/start/layout.tsx
+++ b/apps/app/src/app/[locale]/start/layout.tsx
@@ -1,6 +1,5 @@
 import { getUser } from '@/utils/getUser';
 import { assertWalledGardenAccess } from '@/utils/walledGarden';
-import { headers } from 'next/headers';
 
 import { Link } from '@/lib/i18n/routing';
 
@@ -10,13 +9,9 @@ import { TranslatedText } from '@/components/TranslatedText';
 const StartLayout = async ({ children }: { children: React.ReactNode }) => {
   const user = await getUser();
 
-  // Layouts don't get searchParams; read the query string the proxy exposes via
-  // x-search. The promote flow runs as non-members, so admit them past the gate.
-  const search = (await headers()).get('x-search') ?? '';
-  const isPromoteFlow = new URLSearchParams(search).get('promote') === '1';
-
-  // Onboarding is inside the walled garden.
-  await assertWalledGardenAccess(user, { allowNonMembers: isPromoteFlow });
+  // Admit any real account: non-members belong in onboarding, and gating them
+  // out only deadlocks returning users. Real protection is in the service layer.
+  await assertWalledGardenAccess(user, { allowNonMembers: true });
 
   return (
     <div className="relative flex h-svh w-full flex-col items-center justify-center font-sans">

--- a/apps/app/src/app/[locale]/start/page.tsx
+++ b/apps/app/src/app/[locale]/start/page.tsx
@@ -1,3 +1,4 @@
+import { getUser } from '@/utils/getUser';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
@@ -13,10 +14,13 @@ export async function generateMetadata({
   return { title: t('Get Started') };
 }
 
-export default function OnboardingPage() {
+export default async function OnboardingPage() {
+  // Resolve membership server-side so OnboardingFlow branches synchronously.
+  const user = await getUser();
+
   return (
     <div className="flex flex-1 flex-col items-center">
-      <OnboardingFlow />
+      <OnboardingFlow isNetworkMember={user?.isNetworkMember ?? false} />
     </div>
   );
 }

--- a/apps/app/src/components/Onboarding/PromoteOnboardingFlow.tsx
+++ b/apps/app/src/components/Onboarding/PromoteOnboardingFlow.tsx
@@ -3,6 +3,7 @@
 import { analyzeError, useConnectionStatus } from '@/utils/connectionErrors';
 import { trpc } from '@op/api/client';
 import { isSafeRedirectPath } from '@op/common/client';
+import { logger } from '@op/logging/client';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { StepperProgressIndicator } from '@op/ui/Stepper';
 import { toast } from '@op/ui/Toast';
@@ -55,6 +56,8 @@ export const PromoteOnboardingFlow = ({
 
   const searchParams = useSearchParams();
   const redirectParam = searchParams.get('redirect');
+  // No fallback is safe for a non-member; the `redirect` back to their public
+  // origin page is the only real return path.
   const promoteRedirect = isSafeRedirectPath(redirectParam)
     ? redirectParam
     : '/';
@@ -77,6 +80,14 @@ export const PromoteOnboardingFlow = ({
     try {
       await completeOnboarding.mutateAsync({ tos: true, privacy: true });
       await trpcUtils.account.getMyAccount.invalidate();
+      if (!isSafeRedirectPath(redirectParam)) {
+        // `/` sends a non-member into the walled garden (403) — track how often
+        // onboarding dead-ends here.
+        logger.warn(
+          'Promote onboarding finished without a safe redirect; landing may be gated',
+          { redirectParam },
+        );
+      }
       window.location.assign(promoteRedirect);
     } catch (err) {
       setIsSubmitting(false);
@@ -90,7 +101,14 @@ export const PromoteOnboardingFlow = ({
           : errorInfo.message,
       });
     }
-  }, [isOnline, completeOnboarding, trpcUtils, promoteRedirect, t]);
+  }, [
+    isOnline,
+    completeOnboarding,
+    trpcUtils,
+    promoteRedirect,
+    redirectParam,
+    t,
+  ]);
 
   const ToSStep = useMemo(() => {
     const Step = (props: StepProps) => (

--- a/apps/app/src/components/Onboarding/index.tsx
+++ b/apps/app/src/components/Onboarding/index.tsx
@@ -2,6 +2,7 @@
 
 import { analyzeError, useConnectionStatus } from '@/utils/connectionErrors';
 import { trpc } from '@op/api/client';
+import { isSafeRedirectPath } from '@op/common/client';
 import { logger } from '@op/logging/client';
 import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { StepperProgressIndicator } from '@op/ui/Stepper';
@@ -68,10 +69,22 @@ const processOrgInputs = (data: OrgCreationFormValues) => ({
   website: data.website ?? '',
 });
 
-export const OnboardingFlow = () => {
+export const OnboardingFlow = ({
+  isNetworkMember,
+}: {
+  isNetworkMember: boolean;
+}) => {
   const t = useTranslations();
   const router = useRouter();
   const isOnline = useConnectionStatus();
+  // Return to where the layout redirect sent the user from (?redirect=), falling
+  // back to the post-onboarding home. Without this the preserved destination
+  // added by the (main)/(no-header) layouts is ignored for members.
+  const searchParams = useSearchParams();
+  const redirectParam = searchParams.get('redirect');
+  const completionDestination = isSafeRedirectPath(redirectParam)
+    ? redirectParam
+    : '/?new=1';
   const [hasHydrated, setHasHydrated] = useState(false);
   const [invitesComplete, setInvitesComplete] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -89,11 +102,6 @@ export const OnboardingFlow = () => {
   const createJoinRequest = trpc.profile.createJoinRequest.useMutation();
   const completeOnboarding = trpc.account.completeOnboarding.useMutation();
   const createOrganization = trpc.organization.create.useMutation();
-
-  // Promote flow (just-upgraded anon visitor) skips org joining; that journey
-  // lives in PromoteOnboardingFlow.
-  const searchParams = useSearchParams();
-  const isPromoteFlow = searchParams.get('promote') === '1';
 
   // Handle hydration detection
   React.useEffect(() => {
@@ -178,7 +186,7 @@ export const OnboardingFlow = () => {
         await completeOnboarding.mutateAsync({ tos: true, privacy: true });
         await trpcUtils.account.getMyAccount.invalidate();
         await trpcUtils.account.getMyAccount.refetch();
-        router.push('/?new=1');
+        router.push(completionDestination);
       } catch (err) {
         setIsSubmitting(false);
         const errorInfo = analyzeError(err);
@@ -202,6 +210,7 @@ export const OnboardingFlow = () => {
       completeOnboarding,
       trpcUtils,
       router,
+      completionDestination,
       t,
     ],
   );
@@ -258,7 +267,7 @@ export const OnboardingFlow = () => {
         await completeOnboarding.mutateAsync({ tos: true, privacy: true });
         await trpcUtils.account.getMyAccount.invalidate();
         await trpcUtils.account.getMyAccount.refetch();
-        router.push('/?new=1');
+        router.push(completionDestination);
       })
       .catch((err) => {
         logger.error('Onboarding: failed to create organization', {
@@ -288,6 +297,7 @@ export const OnboardingFlow = () => {
     t,
     getOrgCreationStepValues,
     completeOnboarding,
+    completionDestination,
   ]);
 
   if (!hasHydrated) {
@@ -306,7 +316,9 @@ export const OnboardingFlow = () => {
     return <LoadingSpinner />;
   }
 
-  if (isPromoteFlow) {
+  // Non-members get the org-less journey; members get the full org flow. Keyed
+  // on membership, not `?promote=1`, which is gone once a user returns.
+  if (!isNetworkMember) {
     return <PromoteOnboardingFlow hasHydrated={hasHydrated} />;
   }
 

--- a/apps/app/src/utils/onboarding.ts
+++ b/apps/app/src/utils/onboarding.ts
@@ -1,4 +1,5 @@
 import type { CommonUser } from '@op/api/encoders';
+import { isSafeRedirectPath } from '@op/common/client';
 
 /**
  * Whether a viewer must be sent through the onboarding flow at /start.
@@ -10,3 +11,19 @@ import type { CommonUser } from '@op/api/encoders';
 export const shouldRedirectToOnboarding = (
   user: CommonUser | null | undefined,
 ): boolean => Boolean(user && !user.isAnonymous && !user.onboardedAt);
+
+/**
+ * The `/start` redirect target, preserving the full destination (the proxy's
+ * `x-pathname` + `x-search` headers) via `?redirect=` so the user returns there
+ * — query string and all — after onboarding.
+ */
+export const buildOnboardingRedirect = (
+  pathname: string | null,
+  search?: string | null,
+): string => {
+  const dest = pathname ? `${pathname}${search ?? ''}` : pathname;
+
+  return isSafeRedirectPath(dest)
+    ? `/en/start?redirect=${encodeURIComponent(dest)}`
+    : '/en/start';
+};

--- a/tests/e2e/tests/onboarding-resume.spec.ts
+++ b/tests/e2e/tests/onboarding-resume.spec.ts
@@ -1,0 +1,247 @@
+import { users } from '@op/db/schema';
+import { db, eq } from '@op/db/test';
+import { randomUUID } from 'node:crypto';
+
+import {
+  TEST_USER_DEFAULT_PASSWORD,
+  authenticateAsUser,
+  createSupabaseAdminClient,
+  createUser,
+  expect,
+  test,
+} from '../fixtures/index.js';
+
+/**
+ * Resuming an unfinished onboarding.
+ *
+ * An account whose onboarding was abandoned mid-session (`onboardedAt` never
+ * set) must be able to pick it back up on any later visit: the app routes it
+ * back into onboarding — preserving where it was headed via `?redirect=` — and
+ * never locks it out. This holds for members and non-members alike; once
+ * onboarding is complete the account is no longer pulled back in.
+ *
+ * `member` = a network email domain; `non-member` = anything else.
+ * `createUser` marks accounts onboarded, so "unfinished" nulls `onboardedAt`.
+ */
+
+const MEMBER_DOMAIN = 'oneproject.org';
+const NON_MEMBER_DOMAIN = 'example.com';
+
+test.describe('Onboarding resume', () => {
+  // Authenticate manually per test → start each from a clean, logged-out state.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  const admin = createSupabaseAdminClient();
+  const createdAuthUserIds: string[] = [];
+
+  const signInAs = async (
+    page: Parameters<typeof authenticateAsUser>[0],
+    { member, onboarded }: { member: boolean; onboarded: boolean },
+  ) => {
+    const email = `e2e-onboard-resume-${randomUUID().slice(0, 8)}@${member ? MEMBER_DOMAIN : NON_MEMBER_DOMAIN}`;
+    const authUser = await createUser({ supabaseAdmin: admin, email });
+    createdAuthUserIds.push(authUser.id);
+
+    if (!onboarded) {
+      await db
+        .update(users)
+        .set({ onboardedAt: null })
+        .where(eq(users.authUserId, authUser.id));
+    }
+
+    await authenticateAsUser(page, {
+      email,
+      password: TEST_USER_DEFAULT_PASSWORD,
+    });
+
+    return email;
+  };
+
+  test.afterAll(async () => {
+    await Promise.all(
+      createdAuthUserIds.map((id) => admin.auth.admin.deleteUser(id)),
+    );
+  });
+
+  test('non-member resumes onboarding when returning to a public page', async ({
+    page,
+  }) => {
+    await signInAs(page, { member: false, onboarded: false });
+
+    // A public (no-header) URL: the layout routes back into onboarding before it
+    // ever loads a decision, so any slug exercises the return path.
+    const target = '/en/decisions/any-decision-slug';
+    const response = await page.goto(target, { waitUntil: 'domcontentloaded' });
+
+    // Never a dead-end (this used to 403 at /start): lands on onboarding with the
+    // original destination preserved.
+    expect(response?.status()).not.toBe(403);
+    await expect(page).toHaveURL(/\/en\/start\?redirect=/, { timeout: 15000 });
+    expect(new URL(page.url()).searchParams.get('redirect')).toBe(target);
+    await expect(
+      page.getByRole('heading', { name: 'Set up your individual profile.' }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByText('You do not have permission to view this page'),
+    ).not.toBeVisible();
+  });
+
+  test('member resumes onboarding when returning to an app page', async ({
+    page,
+  }) => {
+    await signInAs(page, { member: true, onboarded: false });
+
+    // A member passes the walled-garden gate, then gets sent to onboarding with
+    // the destination carried through so they return there afterwards.
+    await page.goto('/en/decisions', { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/\/en\/start\?redirect=/, { timeout: 15000 });
+    expect(new URL(page.url()).searchParams.get('redirect')).toBe(
+      '/en/decisions',
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Set up your individual profile.' }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test('a resumed non-member continues in the org-less flow', async ({
+    page,
+  }) => {
+    const email = await signInAs(page, { member: false, onboarded: false });
+
+    await page.goto('/en/start', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', { name: 'Set up your individual profile.' }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.getByLabel('Full Name').fill('Resume NonMember');
+    await page.getByLabel('Headline').fill('Tester');
+    const emailField = page.getByLabel('Email');
+    await emailField.clear();
+    await emailField.fill(email);
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    // Non-members skip org search and go straight to ToS.
+    await expect(
+      page.getByRole('heading', { name: 'One last step' }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByRole('heading', { name: 'Find organizations you belong to' }),
+    ).not.toBeVisible();
+  });
+
+  test('a resumed member continues in the full org flow', async ({ page }) => {
+    const email = await signInAs(page, { member: true, onboarded: false });
+
+    await page.goto('/en/start', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', { name: 'Set up your individual profile.' }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.getByLabel('Full Name').fill('Resume Member');
+    await page.getByLabel('Headline').fill('Tester');
+    const emailField = page.getByLabel('Email');
+    await emailField.clear();
+    await emailField.fill(email);
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    // Members get the organization search step.
+    await expect(
+      page.getByRole('heading', { name: 'Find organizations you belong to' }),
+    ).toBeVisible({ timeout: 15000 });
+  });
+
+  test('a resumed member returns to where they were headed after finishing', async ({
+    page,
+  }) => {
+    const email = await signInAs(page, { member: true, onboarded: false });
+
+    // Arrive as if redirected from /en/decisions, then finish onboarding.
+    await page.goto('/en/start?redirect=%2Fen%2Fdecisions', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await expect(
+      page.getByRole('heading', { name: 'Set up your individual profile.' }),
+    ).toBeVisible({ timeout: 15000 });
+    await page.getByLabel('Full Name').fill('Resume Return');
+    await page.getByLabel('Headline').fill('Tester');
+    const emailField = page.getByLabel('Email');
+    await emailField.clear();
+    await emailField.fill(email);
+    await page.getByRole('button', { name: 'Continue' }).click();
+
+    await expect(
+      page.getByRole('heading', { name: 'Find organizations you belong to' }),
+    ).toBeVisible({ timeout: 15000 });
+    const removeButtons = page.getByRole('button', { name: 'Remove' });
+    while ((await removeButtons.count()) > 0) {
+      await removeButtons.first().click();
+    }
+    await page.getByRole('button', { name: 'Skip for now' }).click();
+
+    await expect(
+      page.getByRole('heading', { name: 'One last step' }),
+    ).toBeVisible({ timeout: 15000 });
+    const checkboxes = page.getByRole('checkbox');
+    await checkboxes.nth(0).click({ force: true });
+    await checkboxes.nth(1).click({ force: true });
+    await page.getByRole('button', { name: 'Join Common' }).click();
+
+    // Lands back on the preserved destination, not the default /?new=1 home.
+    await page.waitForURL(/\/en\/decisions/, { timeout: 30000 });
+    expect(page.url()).not.toContain('new=1');
+  });
+
+  test('the preserved destination keeps its query string', async ({ page }) => {
+    await signInAs(page, { member: true, onboarded: false });
+
+    await page.goto('/en/search?q=climate', { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/\/en\/start\?redirect=/, { timeout: 15000 });
+    expect(new URL(page.url()).searchParams.get('redirect')).toBe(
+      '/en/search?q=climate',
+    );
+  });
+
+  test('a completed member onboarding is not resumed', async ({ page }) => {
+    await signInAs(page, { member: true, onboarded: true });
+
+    const response = await page.goto('/en/decisions', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    expect(response?.status()).not.toBe(403);
+    await expect(page).toHaveURL(/\/en\/decisions/, { timeout: 15000 });
+    await expect(page).not.toHaveURL(/\/en\/start/);
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+
+  test('a completed non-member is not resumed, and the network boundary still holds', async ({
+    page,
+  }) => {
+    await signInAs(page, { member: false, onboarded: true });
+
+    // /start admits any real account — no 403 even once onboarding is done, so a
+    // stray visit is never a dead-end.
+    const startResponse = await page.goto('/en/start', {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(startResponse?.status()).not.toBe(403);
+    await expect(
+      page.getByRole('heading', { name: 'Set up your individual profile.' }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // The walled garden still forbids non-members in the (main) route group.
+    const appResponse = await page.goto('/en/decisions', {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(appResponse?.status()).toBe(403);
+    await expect(
+      page.getByText('You do not have permission to view this page'),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+});


### PR DESCRIPTION
Returning non-members who abandoned onboarding mid-session were permanently 403'd: every route redirected them to /start, which then rejected them once the transient ?promote=1 was gone. Onboarding now admits any real account and branches on account state, and onboarding redirects preserve where the user was headed.