### PR TITLE
feat(decision): add reviewer "Other proposals" tab

### DIFF
--- a/apps/app/src/components/decisions/ProposalsGrid.tsx
+++ b/apps/app/src/components/decisions/ProposalsGrid.tsx
@@ -53,6 +53,12 @@ export interface ProposalsProps {
   isVotingPhase?: boolean;
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
+  /**
+   * When true, this list is the reviewer's "Other proposals" tab (proposals
+   * outside their review queue). Tailors the empty state — the generic
+   * "submit the first proposal" copy is wrong here.
+   */
+  excludeAssignedForReview?: boolean;
 }
 
 export const ProposalsGrid = ({
@@ -85,8 +91,29 @@ export const ProposalsGrid = ({
   );
 };
 
-const NoProposalsFound = ({ hasFilter }: { hasFilter: boolean }) => {
+const NoProposalsFound = ({
+  hasFilter,
+  excludeAssignedForReview,
+}: {
+  hasFilter: boolean;
+  excludeAssignedForReview?: boolean;
+}) => {
   const t = useTranslations();
+
+  // The reviewer's "Other proposals" tab is empty because every proposal is in
+  // their review queue (or none exist yet) — not because nobody has submitted.
+  if (excludeAssignedForReview && !hasFilter) {
+    return (
+      <EmptyState icon={<LuLeaf className="size-6" />}>
+        <Header3 className="font-serif !text-title-base font-light text-neutral-black">
+          {t('No other proposals')}
+        </Header3>
+        <p className="text-base text-neutral-charcoal">
+          {t('There are no proposals outside your review queue.')}
+        </p>
+      </EmptyState>
+    );
+  }
 
   return (
     <EmptyState icon={<LuLeaf className="size-6" />}>
@@ -465,6 +492,7 @@ const ViewProposalsList = ({
   permissions,
   hasFilter,
   proposalsHidden,
+  excludeAssignedForReview,
   revisionRequestIdByProposalId,
 }: ProposalsProps & {
   revisionRequestIdByProposalId?: Map<string, string>;
@@ -474,7 +502,12 @@ const ViewProposalsList = ({
     if (proposalsHidden && !hasFilter) {
       return <HiddenProposalsEmptyState />;
     }
-    return <NoProposalsFound hasFilter={hasFilter} />;
+    return (
+      <NoProposalsFound
+        hasFilter={hasFilter}
+        excludeAssignedForReview={excludeAssignedForReview}
+      />
+    );
   }
 
   return (

--- a/apps/app/src/components/decisions/ProposalsGrid.tsx
+++ b/apps/app/src/components/decisions/ProposalsGrid.tsx
@@ -152,6 +152,7 @@ const VotingProposalsList = ({
   votedProposalIds = [],
   hasFilter,
   proposalsHidden,
+  excludeAssignedForReview,
 }: ProposalsProps) => {
   const canVote = permissions?.vote ?? false;
   const canManageProposals = permissions?.admin ?? false;
@@ -271,7 +272,12 @@ const VotingProposalsList = ({
     if (proposalsHidden && !hasFilter) {
       return <HiddenProposalsEmptyState />;
     }
-    return <NoProposalsFound hasFilter={hasFilter} />;
+    return (
+      <NoProposalsFound
+        hasFilter={hasFilter}
+        excludeAssignedForReview={excludeAssignedForReview}
+      />
+    );
   }
 
   return (

--- a/apps/app/src/components/decisions/ProposalsGrid.tsx
+++ b/apps/app/src/components/decisions/ProposalsGrid.tsx
@@ -53,11 +53,7 @@ export interface ProposalsProps {
   isVotingPhase?: boolean;
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
-  /**
-   * When true, this list is the reviewer's "Other proposals" tab (proposals
-   * outside their review queue). Tailors the empty state — the generic
-   * "submit the first proposal" copy is wrong here.
-   */
+  /** Reviewer's "Other proposals" tab — tailors the empty state. */
   excludeAssignedForReview?: boolean;
 }
 
@@ -100,8 +96,6 @@ const NoProposalsFound = ({
 }) => {
   const t = useTranslations();
 
-  // The reviewer's "Other proposals" tab is empty because every proposal is in
-  // their review queue (or none exist yet) — not because nobody has submitted.
   if (excludeAssignedForReview && !hasFilter) {
     return (
       <EmptyState icon={<LuLeaf className="size-6" />}>

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -364,6 +364,7 @@ const ProposalsListContent = ({
   permissions,
   currentPhase,
   proposalsHidden,
+  excludeAssignedForReview,
   pinOffset,
   phase,
   queryParams,
@@ -623,6 +624,7 @@ const ProposalsListContent = ({
             hasFilter={hasActiveFilter}
             isVotingPhase={isVotingPhase}
             proposalsHidden={proposalsHidden}
+            excludeAssignedForReview={excludeAssignedForReview}
             revisionRequestIdByProposalId={revisionRequestIdByProposalId}
           />
         )}

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -607,6 +607,8 @@ const ProposalsListContent = ({
                     submittedByProfileId: queryParams.submittedByProfileId,
                     votedByProfileId: queryParams.votedByProfileId,
                     status: queryParams.status,
+                    excludeAssignedForReview:
+                      queryParams.excludeAssignedForReview,
                   }}
                   listFooter={renderScrollSentinel(<ProposalCardSkeleton />)}
                 />

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -62,6 +62,13 @@ export interface ProposalsListProps {
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
   /**
+   * When true, exclude proposals the current user is assigned to review in the
+   * viewed phase. Powers the reviewer's "Other proposals" tab; the reviewer
+   * profile is resolved server-side. Applied to both the list and the count so
+   * the header reflects the non-assigned pool.
+   */
+  excludeAssignedForReview?: boolean;
+  /**
    * Px offset where the sticky filter bar pins. Decision-view passes a larger
    * value to clear the Overview/Current toggle; other routes use the default.
    */
@@ -84,6 +91,7 @@ type ProposalQueryParams = {
   dir: 'asc' | 'desc';
   limit: number;
   phase?: 'results';
+  excludeAssignedForReview?: boolean;
 };
 
 type ProposalsLoaderRenderProps = {
@@ -160,6 +168,10 @@ const CurrentPhaseProposalsLoader = ({
       dir: queryParams.dir,
       limit: 1,
       phase: queryParams.phase,
+      // Scope the "of N" denominator to the same non-assigned pool as the list
+      // so the header reads "N proposals" (not "N of M") on the reviewer's
+      // "Other proposals" tab.
+      excludeAssignedForReview: queryParams.excludeAssignedForReview,
     },
     { staleTime: 30 * 1000 },
   );
@@ -230,7 +242,7 @@ const ResultsPhaseProposalsLoader = ({
 };
 
 export const ProposalsList = (props: ProposalsListProps) => {
-  const { instanceId, phase, initialFilter } = props;
+  const { instanceId, phase, initialFilter, excludeAssignedForReview } = props;
 
   const { user } = useUser();
   const currentProfileId = user?.currentProfile?.id;
@@ -272,6 +284,7 @@ export const ProposalsList = (props: ProposalsListProps) => {
       dir: sortOrder === 'newest' ? 'desc' : 'asc',
       limit: PROPOSALS_PAGE_LIMIT,
       phase,
+      excludeAssignedForReview,
     };
 
     if (selectedCategory !== 'all-categories') {
@@ -298,6 +311,7 @@ export const ProposalsList = (props: ProposalsListProps) => {
     phase,
     proposalFilter,
     currentProfileId,
+    excludeAssignedForReview,
   ]);
 
   const renderContent = (data: ProposalsLoaderRenderProps) => (

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -518,6 +518,11 @@ const ProposalsListContent = ({
   // hosts the view toggle).
   const showFilterBar = isMapMode || allProposals.length > 0 || hasActiveFilter;
 
+  // A location-enabled decision defaults to map mode, but an empty, unfiltered
+  // result has nothing to plot. Fall through to the grid so the tailored empty
+  // state renders instead of a blank map; the filter bar keeps the view toggle.
+  const isEmptyUnfiltered = allProposals.length === 0 && !hasActiveFilter;
+
   return (
     <div
       className={cn(
@@ -564,7 +569,7 @@ const ProposalsListContent = ({
       <ProposalTranslationProvider
         translations={translation.translationState?.translations ?? {}}
       >
-        {isMapMode ? (
+        {isMapMode && !isEmptyUnfiltered ? (
           phase === 'results' ? (
             // Results uses the phase-agnostic `listAllProposals` set; source
             // pins from that same loaded data so pins match the results list.

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -61,12 +61,7 @@ export interface ProposalsListProps {
   currentPhase?: InstancePhaseData;
   /** When true, new proposals are hidden by default in the current phase. */
   proposalsHidden?: boolean;
-  /**
-   * When true, exclude proposals the current user is assigned to review in the
-   * viewed phase. Powers the reviewer's "Other proposals" tab; the reviewer
-   * profile is resolved server-side. Applied to both the list and the count so
-   * the header reflects the non-assigned pool.
-   */
+  /** Exclude proposals the current user is assigned to review (Other proposals tab). */
   excludeAssignedForReview?: boolean;
   /**
    * Px offset where the sticky filter bar pins. Decision-view passes a larger
@@ -168,9 +163,6 @@ const CurrentPhaseProposalsLoader = ({
       dir: queryParams.dir,
       limit: 1,
       phase: queryParams.phase,
-      // Scope the "of N" denominator to the same non-assigned pool as the list
-      // so the header reads "N proposals" (not "N of M") on the reviewer's
-      // "Other proposals" tab.
       excludeAssignedForReview: queryParams.excludeAssignedForReview,
     },
     { staleTime: 30 * 1000 },
@@ -518,9 +510,7 @@ const ProposalsListContent = ({
   // hosts the view toggle).
   const showFilterBar = isMapMode || allProposals.length > 0 || hasActiveFilter;
 
-  // A location-enabled decision defaults to map mode, but an empty, unfiltered
-  // result has nothing to plot. Fall through to the grid so the tailored empty
-  // state renders instead of a blank map; the filter bar keeps the view toggle.
+  // Empty + unfiltered falls through to the grid's empty state instead of a blank map.
   const isEmptyUnfiltered = allProposals.length === 0 && !hasActiveFilter;
 
   return (

--- a/apps/app/src/components/decisions/ProposalsMapView.tsx
+++ b/apps/app/src/components/decisions/ProposalsMapView.tsx
@@ -23,6 +23,7 @@ interface ProposalLocationFilter {
   submittedByProfileId?: string;
   votedByProfileId?: string;
   status?: ProposalStatus;
+  excludeAssignedForReview?: boolean;
   phase?: 'results';
 }
 

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -65,8 +65,6 @@ export function ReviewPage({
   const heroImagePath = instance.instanceData?.overview?.heroImage;
   const hasHeroImage = Boolean(heroImagePath);
 
-  // Shared across the review tabs so each panel gets its own boundary while the
-  // tab bar stays mounted.
   const proposalsLoadErrorFallback = {
     default: () => (
       <EmptyState icon={<LuLeaf className="size-6" />}>

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -5,6 +5,7 @@ import type { RouterOutput } from '@op/api';
 import { type InstancePhaseData } from '@op/api/encoders';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header3 } from '@op/ui/Header';
+import { Tab, TabList, TabPanel, Tabs } from '@op/ui/Tabs';
 import { Suspense } from 'react';
 import { LuLeaf } from 'react-icons/lu';
 
@@ -64,6 +65,21 @@ export function ReviewPage({
   const heroImagePath = instance.instanceData?.overview?.heroImage;
   const hasHeroImage = Boolean(heroImagePath);
 
+  // Shared across the review tabs so each panel gets its own boundary while the
+  // tab bar stays mounted.
+  const proposalsLoadErrorFallback = {
+    default: () => (
+      <EmptyState icon={<LuLeaf className="size-6" />}>
+        <Header3 className="font-serif !text-title-base font-light text-neutral-black">
+          <TranslatedText text="We couldn't load proposals" />
+        </Header3>
+        <p className="text-base text-neutral-charcoal">
+          <TranslatedText text="Please refresh the page to try again." />
+        </p>
+      </EmptyState>
+    ),
+  };
+
   return (
     <div className="min-h-full">
       <DecisionHeroBanner heroImagePath={heroImagePath}>
@@ -107,28 +123,45 @@ export function ReviewPage({
 
       <div className="flex w-full justify-center bg-white">
         <div className="w-full p-4 sm:max-w-6xl sm:p-8">
-          <APIErrorBoundary
-            fallbacks={{
-              default: () => (
-                <EmptyState icon={<LuLeaf className="size-6" />}>
-                  <Header3 className="font-serif !text-title-base font-light text-neutral-black">
-                    <TranslatedText text="We couldn't load proposals" />
-                  </Header3>
-                  <p className="text-base text-neutral-charcoal">
-                    <TranslatedText text="Please refresh the page to try again." />
-                  </p>
-                </EmptyState>
-              ),
-            }}
-          >
-            <Suspense fallback={<ProposalListSkeleton />}>
-              {canReview ? (
-                <ReviewAssignmentsList
-                  processInstanceId={instance.id}
-                  decisionSlug={decisionSlug}
-                  canViewReviewers={isAdmin}
-                />
-              ) : (
+          {canReview ? (
+            <Tabs className="gap-6" defaultSelectedKey="to-review">
+              <TabList className="flex gap-6">
+                <Tab id="to-review">{t('Proposals to review')}</Tab>
+                <Tab id="other-proposals">{t('Other proposals')}</Tab>
+              </TabList>
+
+              <TabPanel id="to-review" className="grow sm:p-0">
+                <APIErrorBoundary fallbacks={proposalsLoadErrorFallback}>
+                  <Suspense fallback={<ProposalListSkeleton />}>
+                    <ReviewAssignmentsList
+                      processInstanceId={instance.id}
+                      decisionSlug={decisionSlug}
+                      canViewReviewers={isAdmin}
+                    />
+                  </Suspense>
+                </APIErrorBoundary>
+              </TabPanel>
+
+              <TabPanel id="other-proposals" className="grow sm:p-0">
+                <APIErrorBoundary fallbacks={proposalsLoadErrorFallback}>
+                  <Suspense fallback={<ProposalListSkeleton />}>
+                    <ProposalsList
+                      slug={slug}
+                      instanceId={instance.id}
+                      decisionSlug={decisionSlug}
+                      decisionProfileId={decisionProfileId}
+                      permissions={instance.access}
+                      currentPhase={currentPhase}
+                      pinOffset={pinOffset}
+                      excludeAssignedForReview
+                    />
+                  </Suspense>
+                </APIErrorBoundary>
+              </TabPanel>
+            </Tabs>
+          ) : (
+            <APIErrorBoundary fallbacks={proposalsLoadErrorFallback}>
+              <Suspense fallback={<ProposalListSkeleton />}>
                 <ProposalsList
                   slug={slug}
                   instanceId={instance.id}
@@ -138,9 +171,9 @@ export function ReviewPage({
                   currentPhase={currentPhase}
                   pinOffset={pinOffset}
                 />
-              )}
-            </Suspense>
-          </APIErrorBoundary>
+              </Suspense>
+            </APIErrorBoundary>
+          )}
         </div>
       </div>
     </div>

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -267,6 +267,7 @@
   "Discover new ways to collectively decide together.": "اكتشف طرقًا جديدة للقرار الجماعي معًا.",
   "Your active processes": "عملياتك النشطة",
   "Other processes": "عمليات أخرى",
+  "Other proposals": "مقترحات أخرى",
   "No processes found": "لم يتم العثور على عمليات",
   "Could not load decisions": "تعذر تحميل القرارات",
   "Individual": "فرد",

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -129,6 +129,8 @@
   "{count, plural, one {# proposal} other {# proposals}}": "{count, plural, zero {لا مقترحات} one {مقترح واحد} two {مقترحان} few {# مقترحات} many {# مقترحًا} other {# مقترح}}",
   "{count, plural, one {# participant} other {# participants}}": "{count, plural, zero {لا مشاركين} one {مشارك واحد} two {مشاركان} few {# مشاركين} many {# مشاركًا} other {# مشارك}}",
   "No proposals yet": "لا توجد مقترحات بعد.",
+  "No other proposals": "لا توجد مقترحات أخرى",
+  "There are no proposals outside your review queue.": "لا توجد مقترحات خارج قائمة المراجعة الخاصة بك.",
   "You could be the first one to submit a proposal": "يمكن أن تكون أول من يقدم مقترحًا! 😉",
   "Current Phase": "المرحلة الحالية",
   "Proposal Submissions": "تقديمات المقترحات",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -316,6 +316,7 @@
   "Discover new ways to collectively decide together.": "সম্মিলিতভাবে সিদ্ধান্ত নেওয়ার নতুন উপায় আবিষ্কার করুন।",
   "Your active processes": "আপনার সক্রিয় প্রক্রিয়াসমূহ",
   "Other processes": "অন্যান্য প্রক্রিয়া",
+  "Other proposals": "অন্যান্য প্রস্তাবনা",
   "No processes found": "কোনো প্রক্রিয়া পাওয়া যায়নি",
   "Could not load decisions": "সিদ্ধান্তগুলো লোড করা যায়নি",
   "Individual": "ব্যক্তি",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -172,6 +172,8 @@
   "{count, plural, one {# proposal} other {# proposals}}": "{count, plural, one {#টি প্রস্তাব} other {#টি প্রস্তাব}}",
   "{count, plural, one {# participant} other {# participants}}": "{count, plural, one {# জন অংশগ্রহণকারী} other {# জন অংশগ্রহণকারী}}",
   "No proposals yet": "এখনও কোন প্রস্তাব নেই।",
+  "No other proposals": "অন্য কোনো প্রস্তাবনা নেই",
+  "There are no proposals outside your review queue.": "আপনার পর্যালোচনা তালিকার বাইরে কোনো প্রস্তাবনা নেই।",
   "You could be the first one to submit a proposal": "আপনি একটি প্রস্তাব জমা দেওয়ার ক্ষেত্রে প্রথম হতে পারেন! 😉",
   "You'll see your proposal here once you submit.": "আপনি জমা দেওয়ার পর এখানে আপনার প্রস্তাব দেখতে পাবেন।",
   "Proposals are private during this phase.": "এই পর্যায়ে প্রস্তাবগুলো ব্যক্তিগত।",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -276,6 +276,7 @@
   "Discover new ways to collectively decide together.": "Discover new ways to collectively decide together.",
   "Your active processes": "Your active processes",
   "Other processes": "Other processes",
+  "Other proposals": "Other proposals",
   "No processes found": "No processes found",
   "Could not load decisions": "Could not load decisions",
   "Individual": "Individual",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -133,6 +133,8 @@
   "{count, plural, one {# proposal} other {# proposals}}": "{count, plural, one {# proposal} other {# proposals}}",
   "{count, plural, one {# participant} other {# participants}}": "{count, plural, one {# participant} other {# participants}}",
   "No proposals yet": "No proposals yet.",
+  "No other proposals": "No other proposals",
+  "There are no proposals outside your review queue.": "There are no proposals outside your review queue.",
   "You could be the first one to submit a proposal": "You could be the first one to submit a proposal! 😉",
   "You'll see your proposal here once you submit.": "You'll see your proposal here once you submit.",
   "Proposals are private during this phase.": "Proposals are private during this phase.",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -171,6 +171,8 @@
   "{count, plural, one {# proposal} other {# proposals}}": "{count, plural, one {# propuesta} other {# propuestas}}",
   "{count, plural, one {# participant} other {# participants}}": "{count, plural, one {# participante} other {# participantes}}",
   "No proposals yet": "Aún no hay propuestas.",
+  "No other proposals": "No hay otras propuestas",
+  "There are no proposals outside your review queue.": "No hay propuestas fuera de tu cola de revisión.",
   "You could be the first one to submit a proposal": "¡Podrías ser el primero en enviar una propuesta! 😉",
   "You'll see your proposal here once you submit.": "Verás tu propuesta aquí una vez que la envíes.",
   "Proposals are private during this phase.": "Las propuestas son privadas durante esta fase.",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -315,6 +315,7 @@
   "Discover new ways to collectively decide together.": "Descubre nuevas formas de decidir colectivamente.",
   "Your active processes": "Tus procesos activos",
   "Other processes": "Otros procesos",
+  "Other proposals": "Otras propuestas",
   "No processes found": "No se encontraron procesos",
   "Could not load decisions": "No se pudieron cargar las decisiones",
   "Individual": "Individual",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -172,6 +172,8 @@
   "{count, plural, one {# proposal} other {# proposals}}": "{count, plural, one {# proposition} other {# propositions}}",
   "{count, plural, one {# participant} other {# participants}}": "{count, plural, one {# participant} other {# participants}}",
   "No proposals yet": "Aucune proposition pour le moment.",
+  "No other proposals": "Aucune autre proposition",
+  "There are no proposals outside your review queue.": "Il n'y a aucune proposition en dehors de votre file d'attente d'examen.",
   "You could be the first one to submit a proposal": "Vous pourriez être le premier à soumettre une proposition ! 😉",
   "You'll see your proposal here once you submit.": "Vous verrez votre proposition ici une fois soumise.",
   "Proposals are private during this phase.": "Les propositions sont privées durant cette phase.",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -316,6 +316,7 @@
   "Discover new ways to collectively decide together.": "Découvrez de nouvelles façons de décider collectivement.",
   "Your active processes": "Vos processus actifs",
   "Other processes": "Autres processus",
+  "Other proposals": "Autres propositions",
   "No processes found": "Aucun processus trouvé",
   "Could not load decisions": "Impossible de charger les décisions",
   "Individual": "Individu",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -316,6 +316,7 @@
   "Discover new ways to collectively decide together.": "Descubra novas formas de decidir coletivamente.",
   "Your active processes": "Seus processos ativos",
   "Other processes": "Outros processos",
+  "Other proposals": "Outras propostas",
   "No processes found": "Nenhum processo encontrado",
   "Could not load decisions": "Não foi possível carregar as decisões",
   "Individual": "Individual",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -172,6 +172,8 @@
   "{count, plural, one {# proposal} other {# proposals}}": "{count, plural, one {# proposta} other {# propostas}}",
   "{count, plural, one {# participant} other {# participants}}": "{count, plural, one {# participante} other {# participantes}}",
   "No proposals yet": "Ainda não há propostas.",
+  "No other proposals": "Nenhuma outra proposta",
+  "There are no proposals outside your review queue.": "Não há propostas fora da sua fila de revisão.",
   "You could be the first one to submit a proposal": "Você poderia ser o primeiro a enviar uma proposta! 😉",
   "You'll see your proposal here once you submit.": "Você verá sua proposta aqui assim que enviá-la.",
   "Proposals are private during this phase.": "As propostas são privadas durante esta fase.",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -269,6 +269,7 @@
   "Discover new ways to collectively decide together.": "Baro siyaabo cusub oo si wadajir ah wax loogu go'aanshado.",
   "Your active processes": "Hababkaaga firfircoon",
   "Other processes": "Habab kale",
+  "Other proposals": "Soo jeedimo kale",
   "No processes found": "Lama helin habab",
   "Could not load decisions": "Lama soo dejin karin go'aamada",
   "Individual": "Shakhsi",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -129,6 +129,8 @@
   "{count, plural, one {# proposal} other {# proposals}}": "{count, plural, one {# soo jeedin} other {# soo jeedimo}}",
   "{count, plural, one {# participant} other {# participants}}": "{count, plural, one {# ka qaybgale} other {# ka qaybgalayaal}}",
   "No proposals yet": "Wali ma jiraan soo jeedimo.",
+  "No other proposals": "Ma jiraan soo jeedimo kale",
+  "There are no proposals outside your review queue.": "Ma jiraan soo jeedimo ka baxsan safka dib-u-eegistaada.",
   "You could be the first one to submit a proposal": "Waxaad noqon kartaa kii ugu horreeyay ee soo jeedinaya! 😉",
   "Current Phase": "Marxaladda Hadda",
   "Proposal Submissions": "Soo Jeedimaha La Gudbiyay",

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -697,11 +697,6 @@ export const proposalLocationsFilterSchema = z.object({
   categoryId: z.string().optional(),
   phaseId: z.string().optional(),
   votedByProfileId: z.uuid().optional(),
-  /**
-   * When true, exclude proposals the current user is assigned to review, so map
-   * pins match the reviewer's "Other proposals" list. Applied server-side via
-   * the same scope resolver as the list.
-   */
   excludeAssignedForReview: z.boolean().optional(),
   phase: z.enum(['results']).optional(),
 });

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -697,6 +697,12 @@ export const proposalLocationsFilterSchema = z.object({
   categoryId: z.string().optional(),
   phaseId: z.string().optional(),
   votedByProfileId: z.uuid().optional(),
+  /**
+   * When true, exclude proposals the current user is assigned to review, so map
+   * pins match the reviewer's "Other proposals" list. Applied server-side via
+   * the same scope resolver as the list.
+   */
+  excludeAssignedForReview: z.boolean().optional(),
   phase: z.enum(['results']).optional(),
 });
 

--- a/tests/e2e/tests/other-proposals-tab.spec.ts
+++ b/tests/e2e/tests/other-proposals-tab.spec.ts
@@ -10,11 +10,7 @@ import {
 
 import { expect, test } from '../fixtures/index.js';
 
-/**
- * Schema with a review phase (`proposals.review: true`) so the
- * DecisionStateRouter renders the ReviewPage — which, for a reviewer, hosts the
- * "Proposals to review" and "Other proposals" tabs.
- */
+// Review phase (`proposals.review: true`) so the reviewer sees the tabs.
 const REVIEW_SCHEMA = {
   id: 'other-proposals-e2e',
   version: '1.0.0',
@@ -56,8 +52,7 @@ const REVIEW_SCHEMA = {
   ],
 } satisfies DecisionSchemaDefinition;
 
-// Titles rendered on proposal cards come from the collab-doc title fragment,
-// which the e2e mock (@op/collab) pre-seeds for these well-known doc IDs.
+// Card titles come from the collab-doc fragment the e2e mock pre-seeds for these doc IDs.
 const ASSIGNED_TITLE = 'Community Garden Project'; // test-proposal-listing-doc
 const OTHER_TITLE = 'Youth Mentorship Program'; // test-proposal-listing-doc-alt
 
@@ -66,7 +61,6 @@ test.describe('Other proposals tab', () => {
     authenticatedPage: page,
     org,
   }) => {
-    // -- Setup: a decision in the review phase with two proposals ------------
     const template = await getSeededTemplate();
 
     const instance = await createDecisionInstance({
@@ -88,8 +82,7 @@ test.describe('Other proposals tab', () => {
       email: org.adminUser.email,
     };
 
-    // Proposal assigned to the current user for review — belongs on the
-    // "Proposals to review" tab, and must be excluded from "Other proposals".
+    // Assigned to the reviewer → must be excluded from "Other proposals".
     await createReviewScenario({
       instance: { id: instance.instance.id },
       author,
@@ -100,8 +93,7 @@ test.describe('Other proposals tab', () => {
       },
     });
 
-    // A submitted proposal the user is NOT assigned to review — the only one
-    // that should surface on the "Other proposals" tab.
+    // Not assigned → the only proposal that should appear on "Other proposals".
     await createProposal({
       processInstanceId: instance.instance.id,
       submittedByProfileId: author.profileId,
@@ -114,25 +106,21 @@ test.describe('Other proposals tab', () => {
       },
     });
 
-    // History trigger settles before the page reads the list.
     await new Promise((resolve) => setTimeout(resolve, 600));
 
     await page.goto(`/en/decisions/${instance.slug}/current`, {
       waitUntil: 'domcontentloaded',
     });
 
-    // -- Both tabs render for the reviewer -----------------------------------
     const reviewTab = page.getByRole('tab', { name: 'Proposals to review' });
     const otherTab = page.getByRole('tab', { name: 'Other proposals' });
     await expect(reviewTab).toBeVisible({ timeout: 36_000 });
     await expect(otherTab).toBeVisible();
 
-    // Default tab lists the assigned proposal.
     await expect(page.getByText(ASSIGNED_TITLE).first()).toBeVisible({
       timeout: 36_000,
     });
 
-    // -- Other proposals: assigned one gone, unassigned one present ----------
     await otherTab.click();
     await expect(otherTab).toHaveAttribute('aria-selected', 'true');
 

--- a/tests/e2e/tests/other-proposals-tab.spec.ts
+++ b/tests/e2e/tests/other-proposals-tab.spec.ts
@@ -106,8 +106,6 @@ test.describe('Other proposals tab', () => {
       },
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 600));
-
     await page.goto(`/en/decisions/${instance.slug}/current`, {
       waitUntil: 'domcontentloaded',
     });

--- a/tests/e2e/tests/other-proposals-tab.spec.ts
+++ b/tests/e2e/tests/other-proposals-tab.spec.ts
@@ -1,0 +1,144 @@
+import type { DecisionSchemaDefinition } from '@op/common';
+import { ProposalStatus, processInstances } from '@op/db/schema';
+import { db, eq } from '@op/db/test';
+import {
+  createDecisionInstance,
+  createProposal,
+  createReviewScenario,
+  getSeededTemplate,
+} from '@op/test';
+
+import { expect, test } from '../fixtures/index.js';
+
+/**
+ * Schema with a review phase (`proposals.review: true`) so the
+ * DecisionStateRouter renders the ReviewPage — which, for a reviewer, hosts the
+ * "Proposals to review" and "Other proposals" tabs.
+ */
+const REVIEW_SCHEMA = {
+  id: 'other-proposals-e2e',
+  version: '1.0.0',
+  name: 'Other Proposals E2E',
+  description: 'Schema for the Other proposals tab e2e test.',
+  proposalTemplate: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        title: 'Proposal title',
+        'x-format': 'short-text',
+      },
+    },
+    'x-field-order': ['title'],
+    required: ['title'],
+  },
+  phases: [
+    {
+      id: 'submission',
+      name: 'Proposal Submission',
+      description: 'Members submit proposals.',
+      rules: {
+        proposals: { submit: true },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'review',
+      name: 'Review',
+      description: 'Reviewers evaluate proposals.',
+      rules: {
+        proposals: { submit: false, review: true },
+        voting: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+  ],
+} satisfies DecisionSchemaDefinition;
+
+// Titles rendered on proposal cards come from the collab-doc title fragment,
+// which the e2e mock (@op/collab) pre-seeds for these well-known doc IDs.
+const ASSIGNED_TITLE = 'Community Garden Project'; // test-proposal-listing-doc
+const OTHER_TITLE = 'Youth Mentorship Program'; // test-proposal-listing-doc-alt
+
+test.describe('Other proposals tab', () => {
+  test("excludes the reviewer's assigned proposals and shows the rest", async ({
+    authenticatedPage: page,
+    org,
+  }) => {
+    // -- Setup: a decision in the review phase with two proposals ------------
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: REVIEW_SCHEMA,
+    });
+
+    await db
+      .update(processInstances)
+      .set({ currentStateId: 'review' })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    const author = {
+      profileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+    };
+
+    // Proposal assigned to the current user for review — belongs on the
+    // "Proposals to review" tab, and must be excluded from "Other proposals".
+    await createReviewScenario({
+      instance: { id: instance.instance.id },
+      author,
+      reviewer: { profileId: org.adminUser.profileId },
+      proposalData: {
+        title: ASSIGNED_TITLE,
+        collaborationDocId: 'test-proposal-listing-doc',
+      },
+    });
+
+    // A submitted proposal the user is NOT assigned to review — the only one
+    // that should surface on the "Other proposals" tab.
+    await createProposal({
+      processInstanceId: instance.instance.id,
+      submittedByProfileId: author.profileId,
+      authUserId: author.authUserId,
+      email: author.email,
+      status: ProposalStatus.SUBMITTED,
+      proposalData: {
+        title: OTHER_TITLE,
+        collaborationDocId: 'test-proposal-listing-doc-alt',
+      },
+    });
+
+    // History trigger settles before the page reads the list.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    await page.goto(`/en/decisions/${instance.slug}/current`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // -- Both tabs render for the reviewer -----------------------------------
+    const reviewTab = page.getByRole('tab', { name: 'Proposals to review' });
+    const otherTab = page.getByRole('tab', { name: 'Other proposals' });
+    await expect(reviewTab).toBeVisible({ timeout: 36_000 });
+    await expect(otherTab).toBeVisible();
+
+    // Default tab lists the assigned proposal.
+    await expect(page.getByText(ASSIGNED_TITLE).first()).toBeVisible({
+      timeout: 36_000,
+    });
+
+    // -- Other proposals: assigned one gone, unassigned one present ----------
+    await otherTab.click();
+    await expect(otherTab).toHaveAttribute('aria-selected', 'true');
+
+    await expect(page.getByText(OTHER_TITLE).first()).toBeVisible({
+      timeout: 36_000,
+    });
+    await expect(page.getByText(ASSIGNED_TITLE)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Give reviewers visibility into all proposals beyond their assigned review queue so they can see the full picture and like/follow proposals outside their scope. Stacked on #1633.