### PR TITLE
chore: drop obsolete @typescript/native-preview dependency

### DIFF
--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -90,8 +90,8 @@ const config = {
   webpack: (config, { isServer }) => {
     config.resolve = config.resolve || {};
     // Next builds webpack's tsconfig `paths` aliases via the TypeScript JS API,
-    // which the TypeScript 7 native compiler (@typescript/native-preview) does
-    // not expose, so the `@/*` alias must be registered here explicitly.
+    // which the TypeScript 7 native compiler does not expose, so the `@/*`
+    // alias must be registered here explicitly.
     // Turbopack (dev) resolves it natively from tsconfig.
     config.resolve.alias = {
       ...(config.resolve.alias || {}),

--- a/package.json
+++ b/package.json
@@ -47,9 +47,7 @@
     "w:ui": "pnpm -C ./packages/ui",
     "w:workflows": "pnpm -C ./services/workflows"
   },
-  "dependencies": {},
   "devDependencies": {
-    "oxfmt": "^0.46.0",
     "@op/core": "workspace:*",
     "@op/typescript-config": "workspace:*",
     "@react-three/drei": "^10.0.4",
@@ -73,7 +71,6 @@
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",
     "@types/three": "^0.174.0",
-    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "@xyflow/react": "^12.5.2",
     "ai": "^4.2.2",
     "concurrently": "^9.1.2",
@@ -91,6 +88,7 @@
     "nanoid": "5.1.2",
     "next": "catalog:",
     "open": "^10.1.0",
+    "oxfmt": "^0.46.0",
     "postcss": "^8.5.3",
     "postgres": "^3.4.5",
     "react": "^19.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,99 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@internationalized/date':
-      specifier: ^3.12.1
-      version: 3.12.1
-    '@rjsf/utils':
-      specifier: ^5.24.12
-      version: 5.24.12
-    '@tiptap/core':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-blockquote':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-bubble-menu':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-bullet-list':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-collaboration':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-collaboration-caret':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-details':
-      specifier: 3.17.1
-      version: 3.17.1
-    '@tiptap/extension-document':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-heading':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-horizontal-rule':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-image':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-link':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-list-item':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-ordered-list':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-paragraph':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-placeholder':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-strike':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-text':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-text-align':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/extension-underline':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/html':
-      specifier: ^3.15.3
-      version: 3.19.0
-    '@tiptap/pm':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/react':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/starter-kit':
-      specifier: ^3.15.3
-      version: 3.17.1
-    '@tiptap/static-renderer':
-      specifier: 3.17.1
-      version: 3.17.1
-    '@tiptap/suggestion':
-      specifier: ^3.15.3
-      version: 3.17.1
-    access-zones:
-      specifier: 1.1.0
-      version: 1.1.0
-    drizzle-orm:
-      specifier: 1.0.0-beta.11-05230d9
-      version: 1.0.0-beta.11-05230d9
-    drizzle-zod:
-      specifier: 1.0.0-beta.11-05230d9
-      version: 1.0.0-beta.11-05230d9
     next:
       specifier: 16.2.6
       version: 16.2.6
@@ -108,12 +15,6 @@ catalogs:
     react-aria-components:
       specifier: ^1.17.0
       version: 1.17.0
-    react-stately:
-      specifier: ^3.46.0
-      version: 3.46.0
-    vitest:
-      specifier: ^4.0.17
-      version: 4.0.18
     zod:
       specifier: ^4.1.12
       version: 4.1.12
@@ -243,9 +144,6 @@ importers:
       '@types/three':
         specifier: ^0.174.0
         version: 0.174.0
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260707.2
-        version: 7.0.0-dev.20260707.2
       '@xyflow/react':
         specifier: ^12.5.2
         version: 12.5.2(@types/react@19.0.10)(immer@10.1.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
@@ -293,7 +191,7 @@ importers:
         version: 5.1.2
       next:
         specifier: 'catalog:'
-        version: 16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1)
+        version: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1)
       open:
         specifier: ^10.1.0
         version: 10.2.0
@@ -5550,53 +5448,6 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20260707.2':
-    resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -13493,7 +13344,7 @@ snapshots:
     dependencies:
       '@trpc/client': 11.6.0(@trpc/server@11.6.0(typescript@7.0.2))(typescript@7.0.2)
       '@trpc/server': 11.6.0(typescript@7.0.2)
-      next: 16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1)
+      next: 16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       typescript: 7.0.2
@@ -13778,37 +13629,6 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.13.14
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
-    optional: true
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
-    optional: true
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
-    optional: true
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
-    optional: true
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
-    optional: true
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
-    optional: true
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
-    optional: true
-
-  '@typescript/native-preview@7.0.0-dev.20260707.2':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -16437,6 +16257,34 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.85.1):
+    dependencies:
+      '@next/env': 16.2.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.0
+      caniuse-lite: 1.0.30001692
+      postcss: 8.5.3
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      styled-jsx: 5.1.6(react@19.2.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.58.2
+      babel-plugin-react-compiler: 1.0.0
+      sass: 1.85.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
@@ -17723,6 +17571,11 @@ snapshots:
       react: 19.2.1
     optionalDependencies:
       '@babel/core': 7.28.5
+
+  styled-jsx@5.1.6(react@19.2.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.1
 
   supabase@2.95.4:
     dependencies:


### PR DESCRIPTION
TypeScript 7 ships the native compiler in the canonical typescript package (pinned at 7.0.2), so the preview channel is redundant and unused.