### PR TITLE
chore(ui): collapse legacy @op/ui storybook stories under a Legacy/ folder

### DIFF
--- a/packages/ui/stories/Accordion.stories.tsx
+++ b/packages/ui/stories/Accordion.stories.tsx
@@ -45,7 +45,7 @@ const AccordionTitleInput = ({
 };
 
 const meta: Meta<typeof Accordion> = {
-  title: 'Accordion',
+  title: 'Legacy/Accordion',
   component: Accordion,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/AlertBanner.stories.tsx
+++ b/packages/ui/stories/AlertBanner.stories.tsx
@@ -4,7 +4,7 @@ import { LuLock, LuTriangleAlert } from 'react-icons/lu';
 import { AlertBanner } from '../src/components/AlertBanner';
 
 const meta: Meta<typeof AlertBanner> = {
-  title: 'AlertBanner',
+  title: 'Legacy/AlertBanner',
   component: AlertBanner,
   tags: ['autodocs'],
   args: {

--- a/packages/ui/stories/AllComponents.stories.tsx
+++ b/packages/ui/stories/AllComponents.stories.tsx
@@ -31,7 +31,7 @@ import * as TabsStories from './Tabs.stories';
 import * as TextFieldStories from './TextField.stories';
 
 const meta: Meta = {
-  title: 'All Components',
+  title: 'Legacy/All Components',
   parameters: {
     layout: 'centered',
   },

--- a/packages/ui/stories/AutoSizeInput.stories.tsx
+++ b/packages/ui/stories/AutoSizeInput.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { AutoSizeInput } from '../src/components/AutoSizeInput';
 
 const meta: Meta<typeof AutoSizeInput> = {
+  title: 'Legacy/AutoSizeInput',
   component: AutoSizeInput,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Avatar.stories.tsx
+++ b/packages/ui/stories/Avatar.stories.tsx
@@ -1,7 +1,7 @@
 import { Avatar, AvatarSkeleton } from '../src/components/Avatar';
 
 export default {
-  title: 'Avatar',
+  title: 'Legacy/Avatar',
   component: Avatar,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/BannerImageField.stories.tsx
+++ b/packages/ui/stories/BannerImageField.stories.tsx
@@ -6,7 +6,7 @@ const SAMPLE_IMAGE = 'https://picsum.photos/1200/400';
 
 const copy = {
   label: 'Banner image',
-  title: 'Legacy/Upload banner image',
+  title: 'Upload banner image',
   description: 'PNG, JPG, WebP or GIF · recommended 2400×800px · max 25MB',
   helperText:
     'The headline appears centered over a dark overlay. Avoid images with key subjects in the middle.',
@@ -15,7 +15,7 @@ const copy = {
 };
 
 const meta: Meta<typeof BannerImageField> = {
-  title: 'BannerImageField',
+  title: 'Legacy/BannerImageField',
   component: BannerImageField,
   tags: ['autodocs'],
   args: {

--- a/packages/ui/stories/BannerImageField.stories.tsx
+++ b/packages/ui/stories/BannerImageField.stories.tsx
@@ -6,7 +6,7 @@ const SAMPLE_IMAGE = 'https://picsum.photos/1200/400';
 
 const copy = {
   label: 'Banner image',
-  title: 'Upload banner image',
+  title: 'Legacy/Upload banner image',
   description: 'PNG, JPG, WebP or GIF · recommended 2400×800px · max 25MB',
   helperText:
     'The headline appears centered over a dark overlay. Avoid images with key subjects in the middle.',

--- a/packages/ui/stories/Breadcrumbs.stories.tsx
+++ b/packages/ui/stories/Breadcrumbs.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta } from '@storybook/react-vite';
 import { Breadcrumb, Breadcrumbs } from '../src/components/Breadcrumbs';
 
 const meta: Meta<typeof Breadcrumbs> = {
+  title: 'Legacy/Breadcrumbs',
   component: Breadcrumbs,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Button.stories.tsx
+++ b/packages/ui/stories/Button.stories.tsx
@@ -1,7 +1,7 @@
 import { Button } from '../src/components/Button';
 
 export default {
-  title: 'Button',
+  title: 'Legacy/Button',
   component: Button,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/ButtonGroup.stories.tsx
+++ b/packages/ui/stories/ButtonGroup.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from '../src/components/Button';
 import { ButtonGroup } from '../src/components/ButtonGroup';
 
 const meta: Meta = {
-  title: 'ButtonGroup',
+  title: 'Legacy/ButtonGroup',
   parameters: {
     layout: 'centered',
   },

--- a/packages/ui/stories/ButtonLink.stories.tsx
+++ b/packages/ui/stories/ButtonLink.stories.tsx
@@ -1,7 +1,7 @@
 import { ButtonLink } from '../src/components/Button';
 
 export default {
-  title: 'ButtonLink',
+  title: 'Legacy/ButtonLink',
   component: ButtonLink,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/CategoryList.stories.tsx
+++ b/packages/ui/stories/CategoryList.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { CategoryList } from '../src/components/CategoryList';
 
 const meta: Meta<typeof CategoryList> = {
+  title: 'Legacy/CategoryList',
   component: CategoryList,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Checkbox.stories.tsx
+++ b/packages/ui/stories/Checkbox.stories.tsx
@@ -1,7 +1,7 @@
 import { Checkbox } from '../src/components/Checkbox';
 
 export default {
-  title: 'Checkbox',
+  title: 'Legacy/Checkbox',
   component: Checkbox,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/CheckboxGroup.stories.tsx
+++ b/packages/ui/stories/CheckboxGroup.stories.tsx
@@ -4,7 +4,7 @@ import { Button } from '../src/components/Button';
 import { Checkbox, CheckboxGroup } from '../src/components/Checkbox';
 
 export default {
-  title: 'CheckboxGroup',
+  title: 'Legacy/CheckboxGroup',
   component: CheckboxGroup,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/CollapsibleConfigCard.stories.tsx
+++ b/packages/ui/stories/CollapsibleConfigCard.stories.tsx
@@ -13,7 +13,7 @@ import {
 import type { SortableItemControls } from '../src/components/Sortable';
 
 export default {
-  title: 'CollapsibleConfigCard',
+  title: 'Legacy/CollapsibleConfigCard',
   component: CollapsibleConfigCard,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/ComboBox.stories.tsx
+++ b/packages/ui/stories/ComboBox.stories.tsx
@@ -10,6 +10,7 @@ import {
 } from '../src/components/ComboBox';
 
 const meta: Meta<typeof ComboBox> = {
+  title: 'Legacy/ComboBox',
   component: ComboBox,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/CommentButton.stories.tsx
+++ b/packages/ui/stories/CommentButton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta } from '@storybook/react-vite';
 import { CommentButton } from '../src/components/CommentButton';
 
 const meta: Meta<typeof CommentButton> = {
-  title: 'CommentButton',
+  title: 'Legacy/CommentButton',
   component: CommentButton,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/DatePicker.stories.tsx
+++ b/packages/ui/stories/DatePicker.stories.tsx
@@ -6,6 +6,7 @@ import type { DateValue } from 'react-aria-components';
 import { DatePicker } from '../src/components/DatePicker';
 
 const meta: Meta<typeof DatePicker> = {
+  title: 'Legacy/DatePicker',
   component: DatePicker,
   tags: ['autodocs'],
   args: {

--- a/packages/ui/stories/Dialog.stories.tsx
+++ b/packages/ui/stories/Dialog.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { Modal } from '../src/components/Modal';
 
 export default {
-  title: 'Dialog',
+  title: 'Legacy/Dialog',
   component: Dialog,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/EmptyState.stories.tsx
+++ b/packages/ui/stories/EmptyState.stories.tsx
@@ -4,7 +4,7 @@ import { Button } from '../src/components/Button';
 import { EmptyState } from '../src/components/EmptyState';
 
 export default {
-  title: 'EmptyState',
+  title: 'Legacy/EmptyState',
   component: EmptyState,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/FileDropZone.stories.tsx
+++ b/packages/ui/stories/FileDropZone.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { FileDropZone } from '../src/components/FileDropZone';
 
 const meta: Meta<typeof FileDropZone> = {
+  title: 'Legacy/FileDropZone',
   component: FileDropZone,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/FooterBar.stories.tsx
+++ b/packages/ui/stories/FooterBar.stories.tsx
@@ -10,7 +10,7 @@ import { FooterBar } from '../src/components/FooterBar';
 import { StepperProgressIndicator } from '../src/components/Stepper';
 
 export default {
-  title: 'FooterBar',
+  title: 'Legacy/FooterBar',
   component: FooterBar,
   parameters: {
     layout: 'fullscreen',

--- a/packages/ui/stories/Form.stories.tsx
+++ b/packages/ui/stories/Form.stories.tsx
@@ -5,6 +5,7 @@ import { Form } from '../src/components/Form';
 import { TextField } from '../src/components/TextField';
 
 const meta: Meta<typeof Form> = {
+  title: 'Legacy/Form',
   component: Form,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/HorizontalList.stories.tsx
+++ b/packages/ui/stories/HorizontalList.stories.tsx
@@ -5,7 +5,7 @@ import {
 import { Surface } from '../src/components/Surface';
 
 export default {
-  title: 'HorizontalList',
+  title: 'Legacy/HorizontalList',
   component: HorizontalList,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/IconButton.stories.tsx
+++ b/packages/ui/stories/IconButton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { IconButton } from '../src/components/IconButton';
 
 const meta: Meta<typeof IconButton> = {
-  title: 'Components/IconButton',
+  title: 'Legacy/Components/IconButton',
   component: IconButton,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/LoadingSpinner.stories.tsx
+++ b/packages/ui/stories/LoadingSpinner.stories.tsx
@@ -1,7 +1,7 @@
 import { LoadingSpinner } from '../src/components/LoadingSpinner';
 
 export default {
-  title: 'LoadingSpinner',
+  title: 'Legacy/LoadingSpinner',
   component: LoadingSpinner,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/MediaDisplay.stories.tsx
+++ b/packages/ui/stories/MediaDisplay.stories.tsx
@@ -1,7 +1,7 @@
 import { MediaDisplay } from '../src/components/MediaDisplay';
 
 export default {
-  title: 'MediaDisplay',
+  title: 'Legacy/MediaDisplay',
   component: MediaDisplay,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Menu.stories.tsx
+++ b/packages/ui/stories/Menu.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from '../src/components/Menu';
 
 const meta: Meta<typeof Menu> = {
+  title: 'Legacy/Menu',
   component: Menu,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Modal.stories.tsx
+++ b/packages/ui/stories/Modal.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from '../src/components/Modal';
 
 export default {
-  title: 'Modal',
+  title: 'Legacy/Modal',
   component: Modal,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/MultiSelectComboBox.stories.tsx
+++ b/packages/ui/stories/MultiSelectComboBox.stories.tsx
@@ -7,6 +7,7 @@ import {
 } from '../src/components/MultiSelectComboBox';
 
 const meta: Meta<typeof MultiSelectComboBox> = {
+  title: 'Legacy/MultiSelectComboBox',
   component: MultiSelectComboBox,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/NotificationPanel.stories.tsx
+++ b/packages/ui/stories/NotificationPanel.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { ProfileItem } from '../src/components/ProfileItem';
 
 export default {
-  title: 'NotificationPanel',
+  title: 'Legacy/NotificationPanel',
   component: NotificationPanel,
   parameters: {
     layout: 'padded',

--- a/packages/ui/stories/NumberField.stories.tsx
+++ b/packages/ui/stories/NumberField.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../src/components/Button';
 import { NumberField } from '../src/components/NumberField';
 
 const meta: Meta<typeof NumberField> = {
+  title: 'Legacy/NumberField',
   component: NumberField,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Pagination.stories.tsx
+++ b/packages/ui/stories/Pagination.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Pagination } from '../src/components/Pagination';
 
 export default {
-  title: 'Pagination',
+  title: 'Legacy/Pagination',
   component: Pagination,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/PhaseCard.stories.tsx
+++ b/packages/ui/stories/PhaseCard.stories.tsx
@@ -3,7 +3,7 @@ import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import { PhaseCard } from '../src/components/PhaseCard';
 
 const meta: Meta<typeof PhaseCard> = {
-  title: 'PhaseCard',
+  title: 'Legacy/PhaseCard',
   component: PhaseCard,
   parameters: {
     layout: 'padded',

--- a/packages/ui/stories/PhaseStepper.stories.tsx
+++ b/packages/ui/stories/PhaseStepper.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PhaseStepper } from '../src/components/PhaseStepper';
 
 const meta: Meta<typeof PhaseStepper> = {
-  title: 'PhaseStepper',
+  title: 'Legacy/PhaseStepper',
   component: PhaseStepper,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Popover.stories.tsx
+++ b/packages/ui/stories/Popover.stories.tsx
@@ -7,6 +7,7 @@ import { Dialog } from '../src/components/Dialog';
 import { Popover } from '../src/components/Popover';
 
 const meta: Meta<typeof Popover> = {
+  title: 'Legacy/Popover',
   component: Popover,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/ProfileItem.stories.tsx
+++ b/packages/ui/stories/ProfileItem.stories.tsx
@@ -3,7 +3,7 @@ import { Button } from '../src/components/Button';
 import { ProfileItem } from '../src/components/ProfileItem';
 
 export default {
-  title: 'ProfileItem',
+  title: 'Legacy/ProfileItem',
   component: ProfileItem,
   parameters: {
     layout: 'padded',

--- a/packages/ui/stories/RadioGroup.stories.tsx
+++ b/packages/ui/stories/RadioGroup.stories.tsx
@@ -4,7 +4,7 @@ import { Button } from '../src/components/Button';
 import { Radio, RadioGroup } from '../src/components/RadioGroup';
 
 export default {
-  title: 'RadioGroup',
+  title: 'Legacy/RadioGroup',
   component: RadioGroup,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/ReactionsButton.stories.tsx
+++ b/packages/ui/stories/ReactionsButton.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { ReactionsButton } from '../src/components/ReactionsButton';
 
 export default {
-  title: 'ReactionsButton',
+  title: 'Legacy/ReactionsButton',
   component: ReactionsButton,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/RequiredAsterisk.stories.tsx
+++ b/packages/ui/stories/RequiredAsterisk.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { RequiredAsterisk } from '../src/components/RequiredAsterisk';
 
 const meta: Meta<typeof RequiredAsterisk> = {
-  title: 'RequiredAsterisk',
+  title: 'Legacy/RequiredAsterisk',
   component: RequiredAsterisk,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/RichTextEditor.stories.tsx
+++ b/packages/ui/stories/RichTextEditor.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from '../src/components/RichTextEditor/RichTextEditor';
 
 const meta: Meta<typeof RichTextEditor> = {
+  title: 'Legacy/RichTextEditor',
   component: RichTextEditor,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/SearchField.stories.tsx
+++ b/packages/ui/stories/SearchField.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from '../src/components/Button';
 import { SearchField } from '../src/components/SearchField';
 
 const meta: Meta<typeof SearchField> = {
+  title: 'Legacy/SearchField',
   component: SearchField,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Select.stories.tsx
+++ b/packages/ui/stories/Select.stories.tsx
@@ -5,6 +5,7 @@ import { Button } from '../src/components/Button';
 import { Select, SelectItem, SelectSection } from '../src/components/Select';
 
 const meta: Meta<typeof Select> = {
+  title: 'Legacy/Select',
   component: Select,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Sheet.stories.tsx
+++ b/packages/ui/stories/Sheet.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from '../src/components/Sheet';
 
 export default {
-  title: 'Sheet',
+  title: 'Legacy/Sheet',
   component: Sheet,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Skeleton.stories.tsx
+++ b/packages/ui/stories/Skeleton.stories.tsx
@@ -1,7 +1,7 @@
 import { Skeleton, SkeletonLine } from '../src/components/Skeleton';
 
 export default {
-  title: 'Skeleton',
+  title: 'Legacy/Skeleton',
   component: Skeleton,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Sortable.stories.tsx
+++ b/packages/ui/stories/Sortable.stories.tsx
@@ -9,7 +9,7 @@ import {
 import { cn } from '../src/lib/utils';
 
 export default {
-  title: 'Sortable',
+  title: 'Legacy/Sortable',
   component: Sortable,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/SplitPane.stories.tsx
+++ b/packages/ui/stories/SplitPane.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { SplitPane } from '../src/components/SplitPane';
 
 const meta: Meta<typeof SplitPane> = {
-  title: 'SplitPane',
+  title: 'Legacy/SplitPane',
   component: SplitPane,
   tags: ['autodocs'],
   parameters: {

--- a/packages/ui/stories/StatusDot.stories.tsx
+++ b/packages/ui/stories/StatusDot.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { StatusDot } from '../src/components/StatusDot';
 
 const meta: Meta<typeof StatusDot> = {
-  title: 'StatusDot',
+  title: 'Legacy/StatusDot',
   component: StatusDot,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Stepper.stories.tsx
+++ b/packages/ui/stories/Stepper.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from '../src/components/Stepper';
 
 const meta: Meta<any> = {
-  title: 'Components/Stepper',
+  title: 'Legacy/Components/Stepper',
   component: StepItem,
   tags: ['autodocs'],
 };

--- a/packages/ui/stories/Surface.stories.tsx
+++ b/packages/ui/stories/Surface.stories.tsx
@@ -1,7 +1,7 @@
 import { Surface } from '../src/components/Surface';
 
 export default {
-  title: 'Surface',
+  title: 'Legacy/Surface',
   component: Surface,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Table.stories.tsx
+++ b/packages/ui/stories/Table.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '../src/components/ui/table';
 
 const meta: Meta<typeof Table> = {
-  title: 'Intent UI/Table',
+  title: 'Legacy/Intent UI/Table',
   component: Table,
   parameters: {
     layout: 'padded',

--- a/packages/ui/stories/Tabs.stories.tsx
+++ b/packages/ui/stories/Tabs.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta } from '@storybook/react-vite';
 import { Tab, TabList, TabPanel, Tabs } from '../src/components/Tabs';
 
 const meta: Meta<typeof Tabs> = {
+  title: 'Legacy/Tabs',
   component: Tabs,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/TagGroup.stories.tsx
+++ b/packages/ui/stories/TagGroup.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta } from '@storybook/react-vite';
 import { Tag, TagGroup } from '../src/components/TagGroup';
 
 const meta: Meta<typeof Example> = {
+  title: 'Legacy/TagGroup',
   component: TagGroup,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/TextField.stories.tsx
+++ b/packages/ui/stories/TextField.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../src/components/Button';
 import { TextField } from '../src/components/TextField';
 
 const meta: Meta<typeof TextField> = {
+  title: 'Legacy/TextField',
   component: TextField,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Toast.stories.tsx
+++ b/packages/ui/stories/Toast.stories.tsx
@@ -2,7 +2,7 @@ import { Button } from '../src/components/Button';
 import { Toast, toast } from '../src/components/Toast';
 
 export default {
-  title: 'Toast',
+  title: 'Legacy/Toast',
   component: Toast,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/ToggleButton.stories.tsx
+++ b/packages/ui/stories/ToggleButton.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta } from '@storybook/react-vite';
 import { ToggleButton } from '../src/components/ToggleButton';
 
 const meta: Meta<typeof ToggleButton> = {
+  title: 'Legacy/ToggleButton',
   component: ToggleButton,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/Tooltip.stories.tsx
+++ b/packages/ui/stories/Tooltip.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../src/components/Button';
 import { Tooltip } from '../src/components/Tooltip';
 
 const meta: Meta<typeof Tooltip> = {
+  title: 'Legacy/Tooltip',
   component: Tooltip,
   parameters: {
     layout: 'centered',

--- a/packages/ui/stories/TranslateBanner.stories.tsx
+++ b/packages/ui/stories/TranslateBanner.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { TranslateBanner } from '../src/components/TranslateBanner';
 
 const meta: Meta<typeof TranslateBanner> = {
-  title: 'Components/TranslateBanner',
+  title: 'Legacy/Components/TranslateBanner',
   component: TranslateBanner,
   parameters: {
     layout: 'centered',


### PR DESCRIPTION
Groups the legacy @op/ui Storybook stories under a single collapsed `Legacy/` root so the sidebar isn't cluttered during the sense migration.

- prefixes every non-`Sense Comparison` meta title in `packages/ui/stories` with `Legacy/` (57 stories: 38 explicit-title + 19 previously auto-titled)
- `storySort` already lands on a Sense story, so `Legacy` renders collapsed by default
- verified against Storybook's generated index: 3 roots (Sense, Sense Comparison, Legacy), zero dangling stories
