### PR TITLE
fix(decisions): simplify phase short name helper text

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -258,7 +258,7 @@ function PhaseDetailForm({
           onBlur={() => markTouched('name')}
           errorMessage={getErrorMessage('name')}
           description={t(
-            'A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.',
+            'A short name to easily recognize the purpose of the phase.',
           )}
           maxLength={50}
         />

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1095,7 +1095,7 @@
   "Manage Participants": "إدارة المشاركين",
   "Failed to translate content": "فشل ترجمة المحتوى",
   "Translated with DeepL": "تمت الترجمة باستخدام DeepL",
-  "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.": "اسم قصير لك للتعرف بسهولة على الغرض من المرحلة. هذا غير مرئي للمشاركين.",
+  "A short name to easily recognize the purpose of the phase.": "اسم قصير للتعرف بسهولة على الغرض من المرحلة.",
   "Field name": "اسم الحقل",
   "Optional": "اختياري",
   "Type": "النوع",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1180,7 +1180,7 @@
   "Manage Participants": "অংশগ্রহণকারীদের পরিচালনা করুন",
   "Failed to translate content": "বিষয়বস্তু অনুবাদ করতে ব্যর্থ হয়েছে",
   "Translated with DeepL": "DeepL দিয়ে অনুবাদ করা হয়েছে",
-  "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.": "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.",
+  "A short name to easily recognize the purpose of the phase.": "A short name to easily recognize the purpose of the phase.",
   "Field name": "ক্ষেত্রের নাম",
   "Optional": "ঐচ্ছিক",
   "Type": "ধরন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1192,7 +1192,7 @@
   "Manage Participants": "Manage Participants",
   "Failed to translate content": "Failed to translate content",
   "Translated with DeepL": "Translated with DeepL",
-  "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.": "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.",
+  "A short name to easily recognize the purpose of the phase.": "A short name to easily recognize the purpose of the phase.",
   "Field name": "Field name",
   "Optional": "Optional",
   "Type": "Type",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1179,7 +1179,7 @@
   "Manage Participants": "Gestionar Participantes",
   "Failed to translate content": "Error al traducir el contenido",
   "Translated with DeepL": "Traducido con DeepL",
-  "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.": "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.",
+  "A short name to easily recognize the purpose of the phase.": "A short name to easily recognize the purpose of the phase.",
   "Field name": "Nombre del campo",
   "Optional": "Opcional",
   "Type": "Tipo",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1179,7 +1179,7 @@
   "Manage Participants": "Gérer les Participants",
   "Failed to translate content": "Échec de la traduction du contenu",
   "Translated with DeepL": "Traduit avec DeepL",
-  "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.": "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.",
+  "A short name to easily recognize the purpose of the phase.": "A short name to easily recognize the purpose of the phase.",
   "Field name": "Nom du champ",
   "Optional": "Facultatif",
   "Type": "Type",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1179,7 +1179,7 @@
   "Manage Participants": "Gerenciar Participantes",
   "Failed to translate content": "Falha ao traduzir o conteúdo",
   "Translated with DeepL": "Traduzido com DeepL",
-  "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.": "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.",
+  "A short name to easily recognize the purpose of the phase.": "A short name to easily recognize the purpose of the phase.",
   "Field name": "Nome do campo",
   "Optional": "Opcional",
   "Type": "Tipo",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1114,7 +1114,7 @@
   "Manage Participants": "Maamul Ka qaybgalayaasha",
   "Failed to translate content": "Ku guuldareystay tarjumaadda",
   "Translated with DeepL": "Waxaa lagu tarjumay DeepL",
-  "A short name for you to easily recognize the purpose of the phase. This is not viewable to participants.": "Magac gaaban oo aad si fudud ugu garan karto ujeedada marxaladda. Kan ma u muuqdo ka qaybgalayaasha.",
+  "A short name to easily recognize the purpose of the phase.": "Magac gaaban oo si fudud loogu garan karo ujeedada marxaladda.",
   "Field name": "Magaca goobta",
   "Optional": "Aan qasab aheyn",
   "Type": "Nooc",


### PR DESCRIPTION
## Summary

Simplifies the helper text for the **Short name** field in the phase setup (Process Builder).

**Before:** _"A short name for you to easily recognize the purpose of the phase. This is not viewable to participants."_

**After:** _"A short name to easily recognize the purpose of the phase."_

The **overview page now uses the short name to display the phase name on the left-side timeline**, so the short name *is* in fact visible to participants. The old copy claiming it "is not viewable to participants" is no longer accurate, so that sentence has been removed.

## Changes

- Updated the source string / translation key in `PhaseDetailPage.tsx`
- Updated all i18n dictionaries (`en`, `es`, `pt`, `fr`, `bn` mirror the English; `ar` and `so` had real translations, trimmed to match the new copy)

<img width="614" height="105" alt="Screenshot 2026-07-23 at 6 18 08 PM" src="https://github.com/user-attachments/assets/9f862851-aef3-4dbc-8ec4-24643f11c82b" />

