### PR TITLE
refactor(decision): harmonize proposal count headers across lists

### DIFF
--- a/apps/app/src/components/TranslatedText/index.tsx
+++ b/apps/app/src/components/TranslatedText/index.tsx
@@ -8,7 +8,13 @@
 import { useTranslations } from '@/lib/i18n';
 import type { TranslationKey } from '@/lib/i18n';
 
-export const TranslatedText = ({ text }: { text: TranslationKey }) => {
+export const TranslatedText = ({
+  text,
+  values,
+}: {
+  text: TranslationKey;
+  values?: Record<string, unknown>;
+}) => {
   const t = useTranslations();
-  return t(text);
+  return t(text, values);
 };

--- a/apps/app/src/components/decisions/ManualSelectionToolbar.tsx
+++ b/apps/app/src/components/decisions/ManualSelectionToolbar.tsx
@@ -4,7 +4,7 @@ import { ProposalFilter } from '@op/api/encoders';
 
 import { useTranslations } from '@/lib/i18n';
 
-import { ProposalCountHeader } from './ProposalsFilterBar';
+import { ProposalCount } from './ProposalCount';
 import { ResponsiveSelect } from './ResponsiveSelect';
 import { useProposalFilterItems } from './useProposalFilters';
 
@@ -48,7 +48,7 @@ export const ManualSelectionToolbar = ({
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-4">
-      <ProposalCountHeader count={count} total={total} />
+      <ProposalCount count={count} total={total} />
       <div className="flex flex-wrap items-center gap-2">
         <ResponsiveSelect
           selectedKey={proposalFilter}

--- a/apps/app/src/components/decisions/ProposalCount.tsx
+++ b/apps/app/src/components/decisions/ProposalCount.tsx
@@ -1,0 +1,37 @@
+import { TranslatedText } from '../TranslatedText';
+
+// Canonical proposal count label. With no `total` (or nothing filtered out) it
+// reads a single-size "328 proposals"; a narrowing search sets `total` to the
+// full pool and it reads "6 of 328 proposals" with a muted remainder.
+export const ProposalCount = ({
+  count,
+  total,
+}: {
+  count: number;
+  total?: number;
+}) => {
+  const narrowed = total != null && count < total;
+  if (!narrowed) {
+    return (
+      <span className="font-serif text-title-base text-neutral-black">
+        <TranslatedText
+          text="{count, plural, one {# proposal} other {# proposals}}"
+          values={{ count: total ?? count }}
+        />
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-baseline gap-1">
+      <span className="font-serif text-title-base text-neutral-black">
+        {count}
+      </span>
+      <span className="text-base text-neutral-gray4">
+        <TranslatedText
+          text="of {total, plural, one {# proposal} other {# proposals}}"
+          values={{ total }}
+        />
+      </span>
+    </span>
+  );
+};

--- a/apps/app/src/components/decisions/ProposalsFilterBar.tsx
+++ b/apps/app/src/components/decisions/ProposalsFilterBar.tsx
@@ -6,6 +6,7 @@ import { LuArrowDownToLine } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
+import { ProposalCount } from './ProposalCount';
 import { ResponsiveSelect } from './ResponsiveSelect';
 import { useProposalFilterItems } from './useProposalFilters';
 
@@ -26,41 +27,7 @@ export const ProposalsListHeader = ({
       </span>
     );
   }
-  return <ProposalCountHeader count={count} total={total} />;
-};
-
-// `count` is the number matching the active filter; `total` the full proposal
-// pool. A narrowing filter reads "6 of 328 proposals" — the count in title
-// styling, the muted "of {total} proposals" carrying the pool size. When
-// nothing is filtered out (count === total) the redundant "of N" is dropped and
-// it reads "328 proposals". Shared with ManualSelectionToolbar so both header
-// sites stay in lockstep.
-export const ProposalCountHeader = ({
-  count,
-  total,
-}: {
-  count: number;
-  total: number;
-}) => {
-  const t = useTranslations();
-  // Both layouts share the shape "<title-styled number> <muted remainder>". When
-  // nothing is filtered out the remainder is just the word "proposals"; a
-  // narrowing filter makes it "of {total} proposals".
-  const unfiltered = count >= total;
-  return (
-    <span className="flex items-baseline gap-1">
-      <span className="font-serif text-title-base text-neutral-black">
-        {unfiltered ? total : count}
-      </span>
-      <span className="text-base text-neutral-gray4">
-        {unfiltered
-          ? t('{total, plural, one {proposal} other {proposals}}', { total })
-          : t('of {total, plural, one {# proposal} other {# proposals}}', {
-              total,
-            })}
-      </span>
-    </span>
-  );
+  return <ProposalCount count={count} total={total} />;
 };
 
 // fallow-ignore-next-line complexity

--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -11,7 +11,7 @@ import { LuLeaf } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
-import { Bullet } from '../Bullet';
+import { ProposalCount } from './ProposalCount';
 import { ProposalMasonry } from './ProposalMasonry';
 import { ResponsiveSelect } from './ResponsiveSelect';
 import { ReviewAssignmentCard } from './ReviewAssignmentCard';
@@ -69,15 +69,7 @@ export function ReviewAssignmentsList({
     <div className="flex flex-col gap-6">
       {/* Filter bar */}
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex items-center gap-2">
-          <span className="font-serif text-title-base text-neutral-black">
-            {t('Proposals to review')}
-          </span>
-          <Bullet />
-          <span className="font-serif text-title-base text-neutral-black">
-            {assignments.length}
-          </span>
-        </div>
+        <ProposalCount count={assignments.length} />
         <div className="grid max-w-fit grid-cols-2 justify-end gap-2 sm:flex sm:flex-1 sm:flex-wrap sm:items-center sm:justify-end">
           <ResponsiveSelect
             selectedKey={statusFilter ?? 'all'}

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1237,7 +1237,6 @@
   "Number of proposals each participant can vote on": "عدد المقترحات التي يمكن لكل مشارك التصويت عليها",
   "No limit": "بلا حد",
   "{count, plural, one {# vote} other {# votes}}": "{count, plural, zero {لا أصوات} one {صوت واحد} two {صوتان} few {# أصوات} many {# صوتًا} other {# صوت}}",
-  "{total, plural, one {proposal} other {proposals}}": "{total, plural, zero {مقترحات} one {مقترح} two {مقترحان} few {مقترحات} many {مقترحات} other {مقترحات}}",
   "of {total, plural, one {# proposal} other {# proposals}}": "من {total, plural, zero {مقترح} one {مقترح واحد} two {مقترحين} few {# مقترحات} many {# مقترحًا} other {# مقترح}}",
   "Open menu": "فتح القائمة",
   "Open process steps": "فتح خطوات العملية",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -702,7 +702,6 @@
   "Number of proposals each participant can vote on": "প্রতিটি অংশগ্রহণকারী যতগুলি প্রস্তাবে ভোট দিতে পারেন",
   "No limit": "কোনো সীমা নেই",
   "{count, plural, one {# vote} other {# votes}}": "{count, plural, one {# ভোট} other {# ভোট}}",
-  "{total, plural, one {proposal} other {proposals}}": "{total, plural, one {প্রস্তাব} other {প্রস্তাব}}",
   "of {total, plural, one {# proposal} other {# proposals}}": "{total, plural, one {# প্রস্তাবের} other {# প্রস্তাবের}} মধ্যে",
   "Template Editor": "টেমপ্লেট এডিটর",
   "Criteria": "মানদণ্ড",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -677,7 +677,6 @@
   "Number of proposals each participant can vote on": "Number of proposals each participant can vote on",
   "No limit": "No limit",
   "{count, plural, one {# vote} other {# votes}}": "{count, plural, one {# vote} other {# votes}}",
-  "{total, plural, one {proposal} other {proposals}}": "{total, plural, one {proposal} other {proposals}}",
   "of {total, plural, one {# proposal} other {# proposals}}": "of {total, plural, one {# proposal} other {# proposals}}",
   "Template Editor": "Template Editor",
   "Criteria": "Criteria",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -700,7 +700,6 @@
   "Number of proposals each participant can vote on": "Número de propuestas por las que puede votar cada participante",
   "No limit": "Sin límite",
   "{count, plural, one {# vote} other {# votes}}": "{count, plural, one {# voto} other {# votos}}",
-  "{total, plural, one {proposal} other {proposals}}": "{total, plural, one {propuesta} other {propuestas}}",
   "of {total, plural, one {# proposal} other {# proposals}}": "de {total, plural, one {# propuesta} other {# propuestas}}",
   "Template Editor": "Editor de plantilla",
   "Criteria": "Criterios",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -701,7 +701,6 @@
   "Number of proposals each participant can vote on": "Nombre de propositions pour lesquelles chaque participant peut voter",
   "No limit": "Sans limite",
   "{count, plural, one {# vote} other {# votes}}": "{count, plural, one {# vote} other {# votes}}",
-  "{total, plural, one {proposal} other {proposals}}": "{total, plural, one {proposition} other {propositions}}",
   "of {total, plural, one {# proposal} other {# proposals}}": "sur {total, plural, one {# proposition} other {# propositions}}",
   "Template Editor": "Éditeur de modèle",
   "Criteria": "Critères",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -701,7 +701,6 @@
   "Number of proposals each participant can vote on": "Número de propostas em que cada participante pode votar",
   "No limit": "Sem limite",
   "{count, plural, one {# vote} other {# votes}}": "{count, plural, one {# voto} other {# votos}}",
-  "{total, plural, one {proposal} other {proposals}}": "{total, plural, one {proposta} other {propostas}}",
   "of {total, plural, one {# proposal} other {# proposals}}": "de {total, plural, one {# proposta} other {# propostas}}",
   "Template Editor": "Editor de modelo",
   "Criteria": "Critérios",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1342,7 +1342,6 @@
   "Number of proposals each participant can vote on": "Tirada soo jeedimaha uu ka qaybgale kasta u codeyn karo",
   "No limit": "Xad ma leh",
   "{count, plural, one {# vote} other {# votes}}": "{count, plural, one {# cod} other {# codad}}",
-  "{total, plural, one {proposal} other {proposals}}": "{total, plural, one {soo jeedin} other {soo jeedimo}}",
   "of {total, plural, one {# proposal} other {# proposals}}": "ka mid ah {total, plural, one {# soo jeedin} other {# soo jeedimo}}",
   "You don't have access to updates for this decision.": "Ma haysatid fasax aad ku aragto cusboonaysiinta go'aankan.",
   "Open menu": "Fur menu-ga",


### PR DESCRIPTION
Unify the proposal count headers between the submission and review phases so both read a single-size "N proposals". The muted small-text form is now reserved for filtered search results, per design.