### PR TITLE
fix(admin): source user email from auth.users

### DIFF
--- a/packages/common/src/services/platform/listAllUsers.ts
+++ b/packages/common/src/services/platform/listAllUsers.ts
@@ -1,5 +1,5 @@
-import { and, count, db, ilike } from '@op/db/client';
-import { users } from '@op/db/schema';
+import { and, count, db, ilike, inArray } from '@op/db/client';
+import { authUsers, users } from '@op/db/schema';
 import type { SQL } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
@@ -33,13 +33,19 @@ export const listAllUsers = async ({
   // Filter shared by the paginated query and the total count: exclude the
   // sentinel users and, when searching, match the email. The cursor condition
   // is added only to the paginated query.
-  const baseConds = (table: {
-    authUserId: AnyPgColumn;
-    email: AnyPgColumn;
-  }): SQL[] => {
+  const baseConds = (table: { authUserId: AnyPgColumn }): SQL[] => {
     const conds: SQL[] = [excludeGlobalUsers(table.authUserId)];
     if (hasSearch) {
-      conds.push(ilike(table.email, `%${query}%`));
+      // Match against auth.users.email (authoritative) via the auth_user_id FK.
+      conds.push(
+        inArray(
+          table.authUserId,
+          db
+            .select({ id: authUsers.id })
+            .from(authUsers)
+            .where(ilike(authUsers.email, `%${query}%`)),
+        ),
+      );
     }
     return conds;
   };

--- a/services/api/src/routers/platform/admin/listAllUsers.test.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.test.ts
@@ -1,4 +1,6 @@
 import { GLOBAL_USER_IDS } from '@op/core';
+import { db, eq } from '@op/db/client';
+import { users } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { platformAdminRouter } from '.';
@@ -348,6 +350,35 @@ describe.concurrent('platform.admin.listAllUsers', () => {
         customDomainUserEmails.has(user.email!),
       ),
     );
+  });
+
+  it('finds and displays a user by auth.users email when public.users.email is NULL', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestOrganizationDataManager(task.id, onTestFinished);
+    const { adminUser, memberUsers } = await testData.createOrganization({
+      users: { admin: 1, member: 1 },
+    });
+    const member = memberUsers[0]!;
+
+    // Simulate the anonymous-upgrade bug: email lives on auth.users but
+    // public.users.email is NULL.
+    await db
+      .update(users)
+      .set({ email: null })
+      .where(eq(users.authUserId, member.authUserId));
+
+    const { session } = await createIsolatedSession(adminUser.email);
+    const caller = createCaller(await createTestContextWithSession(session));
+
+    const result = await caller.listAllUsers({ limit: 100, query: task.id });
+
+    const found = result.items.find(
+      (user) => user.authUserId === member.authUserId,
+    );
+    expect(found).toBeDefined();
+    expect(found?.email).toBe(member.email);
   });
 
   it('should never surface the global sentinel users', async ({

--- a/services/api/src/routers/platform/admin/listAllUsers.ts
+++ b/services/api/src/routers/platform/admin/listAllUsers.ts
@@ -40,6 +40,8 @@ export const listAllUsersRouter = router({
         items: items.map((user) =>
           adminUserEncoder.parse({
             ...user,
+            // Email is authoritative on auth.users, not public.users.
+            email: user.authUser?.email ?? null,
             isAnonymous: Boolean(user.authUser?.isAnonymous),
             lastSignInAt: user.authUser?.lastSignInAt ?? null,
           }),


### PR DESCRIPTION
public.users.email is NULL for accounts upgraded from anonymous, so those users were invisible in the admin dashboard. Read and search email from the authoritative auth.users instead.