### PR TITLE
style(admin): decisions table wrapping and leading

### DIFF
--- a/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
@@ -58,7 +58,9 @@ export const DecisionsRowCells = ({
         )}
       </TableCell>
       <TableCell className="text-neutral-charcoal">
-        {decision.stewardName ?? '—'}
+        <span className="block max-w-44 truncate">
+          {decision.stewardName ?? '—'}
+        </span>
       </TableCell>
       <TableCell className="text-neutral-charcoal">
         {decision.totalProposalCount > decision.proposalCount ? (
@@ -88,7 +90,7 @@ export const DecisionsRowCells = ({
           ? (STATUS_DISPLAY[decision.status] ?? decision.status)
           : '—'}
       </TableCell>
-      <TableCell className="text-neutral-charcoal">
+      <TableCell className="whitespace-nowrap text-neutral-charcoal">
         {createdAt ? (
           <TooltipTrigger>
             <Button className="underline decoration-dotted underline-offset-2 outline-hidden">

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionsRow.tsx
@@ -58,9 +58,7 @@ export const DecisionsRowCells = ({
         )}
       </TableCell>
       <TableCell className="text-neutral-charcoal">
-        <span className="block max-w-44 truncate">
-          {decision.stewardName ?? '—'}
-        </span>
+        {decision.stewardName ?? '—'}
       </TableCell>
       <TableCell className="text-neutral-charcoal">
         {decision.totalProposalCount > decision.proposalCount ? (

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionsTable.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionsTable.tsx
@@ -85,6 +85,7 @@ const DecisionsTableContent = ({ searchQuery }: { searchQuery: string }) => {
       <Table
         aria-label={t('All Decisions')}
         key={decisions.map((d) => d.id).join(',')}
+        className="whitespace-normal"
       >
         <TableHeader>
           <TableColumn isRowHeader>{t('Name')}</TableColumn>

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionsTable.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionsTable.tsx
@@ -82,29 +82,32 @@ const DecisionsTableContent = ({ searchQuery }: { searchQuery: string }) => {
 
   return (
     <>
-      <Table
-        aria-label={t('All Decisions')}
-        key={decisions.map((d) => d.id).join(',')}
-        className="whitespace-normal"
-      >
-        <TableHeader>
-          <TableColumn isRowHeader>{t('Name')}</TableColumn>
-          <TableColumn>{t('Current Phase')}</TableColumn>
-          <TableColumn>{t('Steward')}</TableColumn>
-          <TableColumn>{t('Proposals')}</TableColumn>
-          <TableColumn>{t('Participants')}</TableColumn>
-          <TableColumn>{t('Status')}</TableColumn>
-          <TableColumn>{t('Created')}</TableColumn>
-          <TableColumn className="text-end">{t('Actions')}</TableColumn>
-        </TableHeader>
-        <TableBody>
-          {decisions.map((decision) => (
-            <TableRow key={decision.id} id={decision.id}>
-              <DecisionsRowCells decision={decision} />
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+      {/* Reserved height so Previous/Next don't shift as row heights vary between pages. */}
+      <div className="min-h-[26rem]">
+        <Table
+          aria-label={t('All Decisions')}
+          key={decisions.map((d) => d.id).join(',')}
+          className="leading-normal whitespace-normal"
+        >
+          <TableHeader>
+            <TableColumn isRowHeader>{t('Name')}</TableColumn>
+            <TableColumn>{t('Current Phase')}</TableColumn>
+            <TableColumn>{t('Steward')}</TableColumn>
+            <TableColumn>{t('Proposals')}</TableColumn>
+            <TableColumn>{t('Participants')}</TableColumn>
+            <TableColumn>{t('Status')}</TableColumn>
+            <TableColumn>{t('Created')}</TableColumn>
+            <TableColumn className="text-end">{t('Actions')}</TableColumn>
+          </TableHeader>
+          <TableBody>
+            {decisions.map((decision) => (
+              <TableRow key={decision.id} id={decision.id}>
+                <DecisionsRowCells decision={decision} />
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
       <div className="mt-4">
         <Pagination
           range={{

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionsTable.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionsTable.tsx
@@ -82,32 +82,31 @@ const DecisionsTableContent = ({ searchQuery }: { searchQuery: string }) => {
 
   return (
     <>
-      {/* Reserved height so Previous/Next don't shift as row heights vary between pages. */}
-      <div className="min-h-[26rem]">
-        <Table
-          aria-label={t('All Decisions')}
-          key={decisions.map((d) => d.id).join(',')}
-          className="leading-normal whitespace-normal"
-        >
-          <TableHeader>
-            <TableColumn isRowHeader>{t('Name')}</TableColumn>
-            <TableColumn>{t('Current Phase')}</TableColumn>
-            <TableColumn>{t('Steward')}</TableColumn>
-            <TableColumn>{t('Proposals')}</TableColumn>
-            <TableColumn>{t('Participants')}</TableColumn>
-            <TableColumn>{t('Status')}</TableColumn>
-            <TableColumn>{t('Created')}</TableColumn>
-            <TableColumn className="text-end">{t('Actions')}</TableColumn>
-          </TableHeader>
-          <TableBody>
-            {decisions.map((decision) => (
-              <TableRow key={decision.id} id={decision.id}>
-                <DecisionsRowCells decision={decision} />
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
+      {/* The shared table Root hardcodes text-sm/6 (24px leading); the descendant
+          override is the only hook that reaches it. */}
+      <Table
+        aria-label={t('All Decisions')}
+        key={decisions.map((d) => d.id).join(',')}
+        className="whitespace-normal [&_table]:leading-tight"
+      >
+        <TableHeader>
+          <TableColumn isRowHeader>{t('Name')}</TableColumn>
+          <TableColumn>{t('Current Phase')}</TableColumn>
+          <TableColumn>{t('Steward')}</TableColumn>
+          <TableColumn>{t('Proposals')}</TableColumn>
+          <TableColumn>{t('Participants')}</TableColumn>
+          <TableColumn>{t('Status')}</TableColumn>
+          <TableColumn>{t('Created')}</TableColumn>
+          <TableColumn className="text-end">{t('Actions')}</TableColumn>
+        </TableHeader>
+        <TableBody>
+          {decisions.map((decision) => (
+            <TableRow key={decision.id} id={decision.id}>
+              <DecisionsRowCells decision={decision} />
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
       <div className="mt-4">
         <Pagination
           range={{


### PR DESCRIPTION
- Stops the All Decisions admin table scrolling horizontally: allow wrapping (the shared table Root forces `whitespace-nowrap`), keep Created dates on one line.
- Tightens cell line-height to 1.25 — the shared Root hardcodes `text-sm/6` (24px), overridden via a descendant selector.

Split out of #1635.