### PR TITLE
feat(decision): category filter support for review assignments API

### DIFF
--- a/apps/app/src/components/decisions/CategoryFilterSelect.tsx
+++ b/apps/app/src/components/decisions/CategoryFilterSelect.tsx
@@ -1,0 +1,58 @@
+import { useTranslations } from '@/lib/i18n';
+
+import { TranslatedText } from '../TranslatedText';
+import { ResponsiveSelect } from './ResponsiveSelect';
+
+export const ALL_CATEGORIES = 'all-categories';
+
+/**
+ * Category filter dropdown shared by the proposals list and the review
+ * screen, including the per-decision "districts" copy override.
+ */
+export const CategoryFilterSelect = ({
+  decisionSlug,
+  categories,
+  selectedCategory,
+  onSelectCategory,
+}: {
+  decisionSlug: string | undefined;
+  categories: { id: string; name: string }[];
+  selectedCategory: string;
+  onSelectCategory: (category: string) => void;
+}) => {
+  const t = useTranslations();
+
+  // TODO: This is a hardcoded, per-decision copy override — the Columbus
+  // decision refers to its categories as "districts", matched here on its
+  // decision slug. Replace this with a proper configurable terminology/labeling
+  // mechanism (e.g. per-process category term settings) instead of matching on
+  // a hardcoded slug so we don't accrue more of these.
+  const usesDistricts = decisionSlug === 'columbus';
+
+  return (
+    <ResponsiveSelect
+      selectedKey={selectedCategory}
+      onSelectionChange={onSelectCategory}
+      aria-label={
+        usesDistricts
+          ? t('Filter proposals by district')
+          : t('Filter proposals by category')
+      }
+      items={[
+        {
+          id: ALL_CATEGORIES,
+          label: usesDistricts ? (
+            <TranslatedText text="All districts" />
+          ) : (
+            <TranslatedText text="All categories" />
+          ),
+          textValue: usesDistricts ? t('All districts') : t('All categories'),
+        },
+        ...categories.map((category) => ({
+          id: category.id,
+          label: category.name,
+        })),
+      ]}
+    />
+  );
+};

--- a/apps/app/src/components/decisions/ProposalsFilterBar.tsx
+++ b/apps/app/src/components/decisions/ProposalsFilterBar.tsx
@@ -6,6 +6,7 @@ import { LuArrowDownToLine } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
+import { CategoryFilterSelect } from './CategoryFilterSelect';
 import { ProposalCount } from './ProposalCount';
 import { ResponsiveSelect } from './ResponsiveSelect';
 import { useProposalFilterItems } from './useProposalFilters';
@@ -69,13 +70,6 @@ export const ProposalsFilterBar = ({
   const t = useTranslations();
   const filterItems = useProposalFilterItems({ hasVoted, currentProfileId });
 
-  // TODO: This is a hardcoded, per-decision copy override — the Columbus
-  // decision refers to its categories as "districts", matched here on its
-  // decision slug. Replace this with a proper configurable terminology/labeling
-  // mechanism (e.g. per-process category term settings) instead of matching on
-  // a hardcoded slug so we don't accrue more of these.
-  const usesDistricts = decisionSlug === 'columbus';
-
   return (
     <>
       <ResponsiveSelect
@@ -89,24 +83,11 @@ export const ProposalsFilterBar = ({
         aria-label={t('Filter proposals')}
         items={filterItems}
       />
-      <ResponsiveSelect
-        selectedKey={selectedCategory}
-        onSelectionChange={onSelectCategory}
-        aria-label={
-          usesDistricts
-            ? t('Filter proposals by district')
-            : t('Filter proposals by category')
-        }
-        items={[
-          {
-            id: 'all-categories',
-            label: usesDistricts ? t('All districts') : t('All categories'),
-          },
-          ...categories.map((category) => ({
-            id: category.id,
-            label: category.name,
-          })),
-        ]}
+      <CategoryFilterSelect
+        decisionSlug={decisionSlug}
+        categories={categories}
+        selectedCategory={selectedCategory}
+        onSelectCategory={onSelectCategory}
       />
       <ResponsiveSelect
         selectedKey={sortOrder}

--- a/apps/app/src/components/decisions/ResponsiveSelect.tsx
+++ b/apps/app/src/components/decisions/ResponsiveSelect.tsx
@@ -16,7 +16,9 @@ const BOTTOM_SHEET_CLASS =
 
 interface SelectOption<T extends string> {
   id: T;
-  label: string;
+  label: ReactNode;
+  /** Plain-text value for typeahead — required when `label` isn't a plain string. */
+  textValue?: string;
   isDisabled?: boolean;
 }
 
@@ -90,6 +92,7 @@ export function ResponsiveSelect<T extends string>({
                 <MenuItem
                   key={item.id}
                   id={item.id}
+                  textValue={item.textValue}
                   isDisabled={item.isDisabled}
                   className={`bg-transparent px-6 py-4 outline-0 focus-visible:bg-primary-tealWhite focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-primary-teal ${index === 0 ? 'rounded-t-2xl rounded-b-none' : 'rounded-none'} ${index < items.length - 1 ? 'border-b border-neutral-gray1' : ''}`}
                   onAction={() => {
@@ -116,7 +119,12 @@ export function ResponsiveSelect<T extends string>({
       aria-label={ariaLabel}
     >
       {items.map((item) => (
-        <SelectItem key={item.id} id={item.id} isDisabled={item.isDisabled}>
+        <SelectItem
+          key={item.id}
+          id={item.id}
+          textValue={item.textValue}
+          isDisabled={item.isDisabled}
+        >
           {item.label}
         </SelectItem>
       ))}

--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -42,11 +42,14 @@ const UNKNOWN_STATUS_RANK = Object.keys(STATUS_SORT_RANK).length;
 export async function listReviewAssignments({
   processInstanceId,
   status,
+  categoryIds,
   sort = 'leastReviewed',
   user,
 }: {
   processInstanceId: string;
   status?: string;
+  /** Taxonomy term ids — limits results to assignments whose proposal is in any of the categories. */
+  categoryIds?: string[];
   sort?: ReviewAssignmentSort;
   user: User;
 }): Promise<ReviewAssignmentList> {
@@ -61,6 +64,29 @@ export async function listReviewAssignments({
 
   if (!instance.access.review && !instance.access.admin) {
     throw new UnauthorizedError("You don't have access to review proposals");
+  }
+
+  // Resolve the categories' proposal IDs up front (same approach as
+  // resolveProposalListScope): assignments have no category column, so the
+  // filter is an ID-set constraint on the snapshot's proposal, matching any
+  // of the requested categories. Categories matching no proposals can't
+  // match any assignment, so short-circuit.
+  let categoryProposalIds: string[] | undefined;
+  if (categoryIds && categoryIds.length > 0) {
+    const proposalIdsInCategories = await db.query.proposalCategories.findMany({
+      columns: { proposalId: true },
+      where: {
+        taxonomyTermId: { in: categoryIds },
+        // Shared taxonomy terms can tag proposals in other instances; scope
+        // here so the ID set passed to the assignment query stays tight.
+        proposal: { processInstanceId },
+      },
+    });
+
+    categoryProposalIds = proposalIdsInCategories.map((p) => p.proposalId);
+    if (categoryProposalIds.length === 0) {
+      return reviewAssignmentListSchema.parse({ assignments: [] });
+    }
   }
 
   // COMPLETED reviews for the proposal across *all* reviewers — the same
@@ -94,6 +120,9 @@ export async function listReviewAssignments({
       processInstanceId,
       reviewerProfileId: dbUser.profileId,
       ...(status && { status }),
+      ...(categoryProposalIds && {
+        proposalId: { in: categoryProposalIds },
+      }),
     },
     with: reviewAssignmentWithConfig,
     // The `id` tie-break gives a deterministic order when the primary keys are

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
@@ -4,12 +4,16 @@ import {
   ProposalReviewAssignmentStatus,
   ProposalReviewRequestState,
   ProposalReviewState,
+  proposalCategories,
+  taxonomyTerms,
 } from '@op/db/schema';
+import { db } from '@op/db/test';
 import {
   createProposalReview,
   createReviewAssignment as createReviewAssignmentRow,
   createRevisionRequest,
 } from '@op/test';
+import { inArray } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
@@ -49,6 +53,31 @@ const rubricTemplate: RubricTemplateSchema = {
 async function createAuthenticatedCaller(email: string) {
   const { session } = await createIsolatedSession(email);
   return createCaller(await createTestContextWithSession(session));
+}
+
+async function attachCategoryToProposal({
+  proposalId,
+  label,
+}: {
+  proposalId: string;
+  label: string;
+}) {
+  const [term] = await db
+    .insert(taxonomyTerms)
+    .values({
+      termUri: `${label.toLowerCase()}-${proposalId}`,
+      label,
+    })
+    .returning();
+  if (!term) {
+    throw new Error('failed to create taxonomy term');
+  }
+
+  await db
+    .insert(proposalCategories)
+    .values({ proposalId, taxonomyTermId: term.id });
+
+  return term;
 }
 
 function seedMockCollab(collaborationDocId: string) {
@@ -334,6 +363,100 @@ describe.concurrent('listReviewAssignments', () => {
     expect(result.assignments[0]?.assignment.proposal.id).toBe(
       inProgress.proposal.id,
     );
+  });
+
+  it('filters assignments by category, matching any of the requested categories', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const inDistrictOne = await testData.createReviewAssignment({
+      title: 'District 1 proposal',
+    });
+    const inDistrictTwo = await testData.createReviewAssignment({
+      context: inDistrictOne.context,
+      reviewer: inDistrictOne.reviewer,
+      title: 'District 2 proposal',
+    });
+    const uncategorized = await testData.createReviewAssignment({
+      context: inDistrictOne.context,
+      reviewer: inDistrictOne.reviewer,
+      title: 'Uncategorized proposal',
+    });
+
+    for (const created of [inDistrictOne, inDistrictTwo, uncategorized]) {
+      const { collaborationDocId } = created.proposal.proposalData as {
+        collaborationDocId: string;
+      };
+      seedMockCollab(collaborationDocId);
+    }
+
+    const [termOne, termTwo] = await Promise.all([
+      attachCategoryToProposal({
+        proposalId: inDistrictOne.proposal.id,
+        label: 'District 1',
+      }),
+      attachCategoryToProposal({
+        proposalId: inDistrictTwo.proposal.id,
+        label: 'District 2',
+      }),
+    ]);
+    // proposalCategories cascades on taxonomyTerms delete, so cleaning up the
+    // terms cleans up the join rows too.
+    onTestFinished(async () => {
+      await db
+        .delete(taxonomyTerms)
+        .where(inArray(taxonomyTerms.id, [termOne.id, termTwo.id]));
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      inDistrictOne.reviewer.email,
+    );
+
+    const single = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: inDistrictOne.context.instance.instance.id,
+      categoryIds: [termOne.id],
+    });
+
+    expect(single.assignments).toHaveLength(1);
+    expect(single.assignments[0]?.assignment.proposal.id).toBe(
+      inDistrictOne.proposal.id,
+    );
+
+    // Multiple categories OR together — the uncategorized proposal stays out.
+    const multiple = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: inDistrictOne.context.instance.instance.id,
+      categoryIds: [termOne.id, termTwo.id],
+    });
+
+    expect(
+      multiple.assignments.map((a) => a.assignment.proposal.id).sort(),
+    ).toEqual([inDistrictOne.proposal.id, inDistrictTwo.proposal.id].sort());
+  });
+
+  it('returns empty list when the category matches no proposals', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'Uncategorized proposal',
+    });
+
+    const { collaborationDocId } = created.proposal.proposalData as {
+      collaborationDocId: string;
+    };
+    seedMockCollab(collaborationDocId);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: created.context.instance.instance.id,
+      categoryIds: [crypto.randomUUID()],
+    });
+
+    expect(result.assignments).toHaveLength(0);
   });
 
   it('returns empty list when reviewer has no assignments', async ({

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.ts
@@ -15,6 +15,7 @@ export const listReviewAssignmentsRouter = router({
       z.object({
         processInstanceId: z.uuid(),
         status: z.enum(ProposalReviewAssignmentStatus).optional(),
+        categoryIds: z.array(z.string()).optional(),
         sort: z.enum(REVIEW_ASSIGNMENT_SORTS).optional(),
       }),
     )
@@ -27,6 +28,7 @@ export const listReviewAssignmentsRouter = router({
       return await listReviewAssignments({
         processInstanceId: input.processInstanceId,
         status: input.status,
+        categoryIds: input.categoryIds,
         sort: input.sort,
         user: ctx.user,
       });

--- a/services/db/relations.ts
+++ b/services/db/relations.ts
@@ -53,6 +53,19 @@ export const relations = defineRelations(schema, (r) => ({
   },
 
   /**
+   * Proposal Categories relations (junction table)
+   *
+   * proposalId is NOT NULL, so we mark the relation as optional: false.
+   */
+  proposalCategories: {
+    proposal: r.one.proposals({
+      from: r.proposalCategories.proposalId,
+      to: r.proposals.id,
+      optional: false,
+    }),
+  },
+
+  /**
    * Decision Transition Proposals relations (junction table)
    *
    * Links state transitions to the proposals that were active at that point.


### PR DESCRIPTION
Extracts the proposals category dropdown into a shared CategoryFilterSelect and adds a categoryIds filter to the review-assignments API (plural to leave room for multi-select), for the upcoming admin review-progress view. Reviewers' personal queues stay unfiltered; admins without review permission already get the filter via the proposals list.