### PR TITLE
feat(decision): backfill review assignments when a reviewer is added mid-phase

### DIFF
--- a/packages/common/src/services/decision/acceptProposalInvite.ts
+++ b/packages/common/src/services/decision/acceptProposalInvite.ts
@@ -4,10 +4,7 @@ import {
   profileUserToAccessRoles,
   profileUsers,
 } from '@op/db/schema';
-import { Events, event } from '@op/events';
-import { logger } from '@op/logging';
 import type { User } from '@op/supabase/lib';
-import { waitUntil } from '@vercel/functions';
 
 import {
   CommonError,
@@ -16,6 +13,7 @@ import {
   UnauthorizedError,
 } from '../../utils/error';
 import { assertGlobalRole } from '../assert';
+import { emitDecisionMemberRolesChanged } from './events/emitDecisionMemberRolesChanged';
 
 /**
  * Accept a proposal invite and ensure the user is also added as a Member
@@ -96,6 +94,9 @@ export const acceptProposalInvite = async ({
 
   // Write all data
 
+  const decisionRoleIdToGrant =
+    pendingDecisionInvite?.accessRoleId ?? memberRole.id;
+
   const profileUser = await db.transaction(async (tx) => {
     const now = new Date().toISOString();
     const userValues = {
@@ -145,7 +146,7 @@ export const acceptProposalInvite = async ({
       followUpWrites.push(
         tx.insert(profileUserToAccessRoles).values({
           profileUserId: decisionProfileUser.id,
-          accessRoleId: pendingDecisionInvite?.accessRoleId ?? memberRole.id,
+          accessRoleId: decisionRoleIdToGrant,
         }),
       );
 
@@ -166,26 +167,12 @@ export const acceptProposalInvite = async ({
 
   // Only the decision-profile grant is relevant to decision-side consumers.
   if (decisionProfileIdToAdd) {
-    const eventData = {
+    emitDecisionMemberRolesChanged({
       decisionProfileId: decisionProfileIdToAdd,
       authUserId: user.id,
-      addedRoleIds: [pendingDecisionInvite?.accessRoleId ?? memberRole.id],
+      addedRoleIds: [decisionRoleIdToGrant],
       removedRoleIds: [],
-    };
-    waitUntil(
-      event
-        .send({
-          name: Events.decisionMemberRolesChanged.name,
-          data: eventData,
-        })
-        .catch((error) => {
-          // Log the full payload so a dropped event can be replayed by hand.
-          logger.error('Failed to send decision member roles changed event', {
-            eventData,
-            error,
-          });
-        }),
-    );
+    });
   }
 
   return { profileUser };

--- a/packages/common/src/services/decision/acceptProposalInvite.ts
+++ b/packages/common/src/services/decision/acceptProposalInvite.ts
@@ -4,7 +4,10 @@ import {
   profileUserToAccessRoles,
   profileUsers,
 } from '@op/db/schema';
+import { Events, event } from '@op/events';
+import { logger } from '@op/logging';
 import type { User } from '@op/supabase/lib';
+import { waitUntil } from '@vercel/functions';
 
 import {
   CommonError,
@@ -160,6 +163,30 @@ export const acceptProposalInvite = async ({
 
     return proposalProfileUser;
   });
+
+  // Only the decision-profile grant is relevant to decision-side consumers.
+  if (decisionProfileIdToAdd) {
+    const eventData = {
+      decisionProfileId: decisionProfileIdToAdd,
+      authUserId: user.id,
+      addedRoleIds: [pendingDecisionInvite?.accessRoleId ?? memberRole.id],
+      removedRoleIds: [],
+    };
+    waitUntil(
+      event
+        .send({
+          name: Events.decisionMemberRolesChanged.name,
+          data: eventData,
+        })
+        .catch((error) => {
+          // Log the full payload so a dropped event can be replayed by hand.
+          logger.error('Failed to send decision member roles changed event', {
+            eventData,
+            error,
+          });
+        }),
+    );
+  }
 
   return { profileUser };
 };

--- a/packages/common/src/services/decision/backfillReviewAssignments.ts
+++ b/packages/common/src/services/decision/backfillReviewAssignments.ts
@@ -1,0 +1,127 @@
+import { db } from '@op/db/client';
+import { ProcessStatus, ProposalStatus } from '@op/db/schema';
+import { logger } from '@op/logging';
+
+import { getEligibleReviewerProfileIds } from './getEligibleReviewerProfileIds';
+import { insertReviewAssignments } from './insertReviewAssignments';
+import type { DecisionInstanceData } from './schemas/instanceData';
+import { assertInstancePhase } from './utils/instance';
+
+export interface BackfillReviewAssignmentsInput {
+  instanceId: string;
+  /** Narrowing hint; eligibility is still re-checked against current roles. */
+  reviewerProfileIds?: string[];
+}
+
+export type BackfillReviewAssignmentsResult =
+  | { skipped: string }
+  | { inserted: number; reviewerCount: number; proposalCount: number };
+
+/**
+ * Idempotent, add-only backfill of review assignments for the instance's
+ * current phase — used when a member gains the reviewer capability mid-phase.
+ *
+ * The proposal set is the phase's inbound transition attachment set, NOT live
+ * phase membership: mid-phase submissions were never assigned to existing
+ * reviewers, and the new reviewer must match them exactly. Never prunes —
+ * deleting non-pending assignments would cascade-delete submitted reviews.
+ * Guards no-op with a log so event-driven callers can invoke it blindly.
+ */
+export async function backfillReviewAssignments({
+  instanceId,
+  reviewerProfileIds,
+}: BackfillReviewAssignmentsInput): Promise<BackfillReviewAssignmentsResult> {
+  const skip = (reason: string): BackfillReviewAssignmentsResult => {
+    logger.info('backfillReviewAssignments: skipped', { instanceId, reason });
+    return { skipped: reason };
+  };
+
+  const instance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+
+  if (!instance) {
+    return skip('instance not found');
+  }
+  if (instance.status !== ProcessStatus.PUBLISHED) {
+    return skip(`instance is not published (status: ${instance.status})`);
+  }
+  if (!instance.profileId) {
+    return skip('instance has no profileId');
+  }
+  const currentPhaseId = instance.currentStateId;
+  if (!currentPhaseId) {
+    return skip('instance has no current phase');
+  }
+
+  const instanceData = instance.instanceData as DecisionInstanceData;
+
+  const reviewsPolicy = instanceData.config?.reviewsPolicy;
+  if (reviewsPolicy && reviewsPolicy !== 'full_coverage') {
+    return skip(`reviews policy '${reviewsPolicy}' is not backfillable`);
+  }
+
+  const currentPhase = assertInstancePhase({
+    instance: { instanceData },
+    phaseId: currentPhaseId,
+  });
+  if (!currentPhase.rules?.proposals?.review) {
+    return skip('current phase is not review-capable');
+  }
+
+  // Most recent transition INTO the current phase — the one whose attachment
+  // set fed generateReviewAssignments.
+  const inboundTransition = await db.query.stateTransitionHistory.findFirst({
+    where: {
+      processInstanceId: instanceId,
+      toStateId: currentPhaseId,
+    },
+    orderBy: { transitionedAt: 'desc' },
+    columns: { id: true },
+  });
+
+  if (!inboundTransition) {
+    // Initial phase: generation never ran, nothing to reach parity with.
+    return skip('current phase has no inbound transition');
+  }
+
+  const [attachedProposals, eligibleReviewerProfileIds] = await Promise.all([
+    db.query.decisionTransitionProposals.findMany({
+      where: {
+        transitionHistoryId: inboundTransition.id,
+        proposal: {
+          status: { ne: ProposalStatus.DRAFT },
+          deletedAt: { isNull: true },
+          moderationDetachedAt: { isNull: true },
+        },
+      },
+      columns: { proposalId: true, proposalHistoryId: true },
+      with: { proposal: { columns: { submittedByProfileId: true } } },
+    }),
+
+    getEligibleReviewerProfileIds({
+      decisionProfileId: instance.profileId,
+    }),
+  ]);
+
+  const targetReviewerIds = reviewerProfileIds
+    ? eligibleReviewerProfileIds.filter((id) => reviewerProfileIds.includes(id))
+    : eligibleReviewerProfileIds;
+
+  const inserted = await insertReviewAssignments({
+    instanceId,
+    phaseId: currentPhaseId,
+    reviewerProfileIds: targetReviewerIds,
+    assignableProposals: attachedProposals.map((row) => ({
+      proposalId: row.proposalId,
+      submittedByProfileId: row.proposal.submittedByProfileId,
+      assignedProposalHistoryId: row.proposalHistoryId,
+    })),
+  });
+
+  return {
+    inserted,
+    reviewerCount: targetReviewerIds.length,
+    proposalCount: attachedProposals.length,
+  };
+}

--- a/packages/common/src/services/decision/backfillReviewAssignments.ts
+++ b/packages/common/src/services/decision/backfillReviewAssignments.ts
@@ -25,7 +25,10 @@ export type BackfillReviewAssignmentsResult =
  * phase membership: mid-phase submissions were never assigned to existing
  * reviewers, and the new reviewer must match them exactly. Never prunes —
  * deleting non-pending assignments would cascade-delete submitted reviews.
- * Guards no-op with a log so event-driven callers can invoke it blindly.
+ * Expected no-op states (wrong phase, no reviewers, nothing to assign) are
+ * logged skips, not errors — but corrupt instance data still throws, which
+ * event-driven callers should surface (e.g. as a retried job) rather than
+ * swallow.
  */
 export async function backfillReviewAssignments({
   instanceId,

--- a/packages/common/src/services/decision/events/emitDecisionMemberRolesChanged.ts
+++ b/packages/common/src/services/decision/events/emitDecisionMemberRolesChanged.ts
@@ -1,0 +1,40 @@
+import { Events, event } from '@op/events';
+import { logger } from '@op/logging';
+import { waitUntil } from '@vercel/functions';
+import type { z } from 'zod';
+
+type DecisionMemberRolesChangedData = z.infer<
+  typeof Events.decisionMemberRolesChanged.schema
+>;
+
+/**
+ * Fire-and-forget emission of the decision/member-roles-changed event.
+ * Never throws — a committed role change must not surface as a failure
+ * to the caller because event scheduling failed.
+ */
+export const emitDecisionMemberRolesChanged = (
+  eventData: DecisionMemberRolesChangedData,
+): void => {
+  try {
+    waitUntil(
+      event
+        .send({
+          name: Events.decisionMemberRolesChanged.name,
+          data: eventData,
+        })
+        .catch((error) => {
+          // Log the full payload so a dropped event can be replayed by hand.
+          logger.error('Failed to send decision member roles changed event', {
+            eventData,
+            error,
+          });
+        }),
+    );
+  } catch (error) {
+    // waitUntil can throw synchronously off-Vercel (no request context).
+    logger.error('Failed to schedule decision member roles changed event', {
+      eventData,
+      error,
+    });
+  }
+};

--- a/packages/common/src/services/decision/generateReviewAssignments.ts
+++ b/packages/common/src/services/decision/generateReviewAssignments.ts
@@ -1,20 +1,9 @@
-import { and, db, eq, inArray } from '@op/db/client';
-import {
-  decisionTransitionProposals,
-  profileUserToAccessRoles,
-  profileUsers,
-  proposalReviewAssignments,
-  proposals,
-  users,
-} from '@op/db/schema';
+import { db } from '@op/db/client';
 import { logger } from '@op/logging';
 
 import { CommonError } from '../../utils';
-import {
-  pickEffectivePermissionRows,
-  zonePermissionsWhere,
-} from '../access/utils';
-import { decisionPermission } from './permissions';
+import { getEligibleReviewerProfileIds } from './getEligibleReviewerProfileIds';
+import { insertReviewAssignments } from './insertReviewAssignments';
 import type { DecisionInstanceData } from './schemas/instanceData';
 
 export interface GenerateReviewAssignmentsInput {
@@ -43,10 +32,9 @@ export async function generateReviewAssignments({
     return;
   }
 
-  const [instance, decisionsZone] = await Promise.all([
-    db.query.processInstances.findFirst({ where: { id: instanceId } }),
-    db.query.accessZones.findFirst({ where: { name: 'decisions' } }),
-  ]);
+  const instance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
 
   if (!instance) {
     throw new CommonError(
@@ -72,121 +60,37 @@ export async function generateReviewAssignments({
     return;
   }
 
-  if (!decisionsZone) {
-    logger.error('generateReviewAssignments: decisions access zone not found');
-    return;
-  }
-
-  // Resolve which roles grant REVIEW on the decisions zone for this decision
-  // profile. Permission rows are profile-scoped: global rows (profileId IS
-  // NULL) are the baseline, and a row scoped to the decision profile OVERRIDES
-  // the global one. Candidate roles are the profile's own roles plus global
-  // roles — the only ones grantable to its members.
-  const zonePermissionRows =
-    await db.query.accessRolePermissionsOnAccessZones.findMany({
-      where: {
-        accessZoneId: decisionsZone.id,
-        ...zonePermissionsWhere(decisionProfileId),
-        accessRole: {
-          OR: [
-            { profileId: { isNull: true } },
-            { profileId: decisionProfileId },
-          ],
-        },
-      },
-      columns: { accessRoleId: true, permission: true, profileId: true },
-    });
-
-  const reviewRoleIds = pickEffectivePermissionRows(
-    zonePermissionRows,
-    (row) => row.accessRoleId,
-    decisionProfileId,
-  )
-    .filter((row) => (row.permission & decisionPermission.REVIEW) !== 0)
-    .map((row) => row.accessRoleId);
-
   const [selectedProposals, reviewerProfileIds, transitionProposalRows] =
     await Promise.all([
-      db
-        .select({
-          id: proposals.id,
-          submittedByProfileId: proposals.submittedByProfileId,
-        })
-        .from(proposals)
-        .where(inArray(proposals.id, selectedProposalIds)),
+      db.query.proposals.findMany({
+        where: { id: { in: selectedProposalIds } },
+        columns: { id: true, submittedByProfileId: true },
+      }),
 
-      // profileUsers (decision membership)
-      //   → profileUserToAccessRoles (role assignments)
-      //   → users (personal profileId)
-      // Filtered to members holding a role with the REVIEW capability.
-      reviewRoleIds.length === 0
-        ? Promise.resolve<string[]>([])
-        : db
-            .selectDistinct({ profileId: users.profileId })
-            .from(profileUsers)
-            .innerJoin(users, eq(profileUsers.authUserId, users.authUserId))
-            .innerJoin(
-              profileUserToAccessRoles,
-              eq(profileUsers.id, profileUserToAccessRoles.profileUserId),
-            )
-            .where(
-              and(
-                eq(profileUsers.profileId, decisionProfileId),
-                inArray(profileUserToAccessRoles.accessRoleId, reviewRoleIds),
-              ),
-            )
-            .then((rows) =>
-              rows
-                .map((r) => r.profileId)
-                .filter((id): id is string => id != null),
-            ),
+      getEligibleReviewerProfileIds({ decisionProfileId }),
 
-      // Look up the proposal history snapshots captured during the phase transition.
-      db
-        .select({
-          proposalId: decisionTransitionProposals.proposalId,
-          proposalHistoryId: decisionTransitionProposals.proposalHistoryId,
-        })
-        .from(decisionTransitionProposals)
-        .where(
-          and(
-            eq(
-              decisionTransitionProposals.transitionHistoryId,
-              transitionHistoryId,
-            ),
-            inArray(
-              decisionTransitionProposals.proposalId,
-              selectedProposalIds,
-            ),
-          ),
-        ),
+      // The proposal history snapshots captured during the phase transition.
+      db.query.decisionTransitionProposals.findMany({
+        where: {
+          transitionHistoryId,
+          proposalId: { in: selectedProposalIds },
+        },
+        columns: { proposalId: true, proposalHistoryId: true },
+      }),
     ]);
-
-  if (reviewerProfileIds.length === 0 || selectedProposals.length === 0) {
-    return;
-  }
 
   const historyByProposalId = new Map(
     transitionProposalRows.map((r) => [r.proposalId, r.proposalHistoryId]),
   );
 
-  const assignmentValues = selectedProposals.flatMap((proposal) =>
-    reviewerProfileIds
-      // NOTE: we should revisit this logic when we have multiple authors per proposal
-      .filter((profileId) => profileId !== proposal.submittedByProfileId)
-      .map((profileId) => ({
-        processInstanceId: instanceId,
-        proposalId: proposal.id,
-        reviewerProfileId: profileId,
-        phaseId,
-        assignedProposalHistoryId: historyByProposalId.get(proposal.id) ?? null,
-      })),
-  );
-
-  if (assignmentValues.length > 0) {
-    await db
-      .insert(proposalReviewAssignments)
-      .values(assignmentValues)
-      .onConflictDoNothing();
-  }
+  await insertReviewAssignments({
+    instanceId,
+    phaseId,
+    reviewerProfileIds,
+    assignableProposals: selectedProposals.map((proposal) => ({
+      proposalId: proposal.id,
+      submittedByProfileId: proposal.submittedByProfileId,
+      assignedProposalHistoryId: historyByProposalId.get(proposal.id) ?? null,
+    })),
+  });
 }

--- a/packages/common/src/services/decision/getEligibleReviewerProfileIds.ts
+++ b/packages/common/src/services/decision/getEligibleReviewerProfileIds.ts
@@ -1,0 +1,82 @@
+import { and, db, eq, inArray } from '@op/db/client';
+import { profileUserToAccessRoles, profileUsers, users } from '@op/db/schema';
+import { logger } from '@op/logging';
+
+import {
+  pickEffectivePermissionRows,
+  zonePermissionsWhere,
+} from '../access/utils';
+import { decisionPermission } from './permissions';
+
+/**
+ * Personal profile ids of every member currently holding the REVIEW
+ * capability on the given decision profile. Shared by generation and backfill
+ * so both resolve eligibility identically.
+ *
+ * Permission rows are profile-scoped: global rows (profileId IS NULL) are the
+ * baseline, and a row scoped to the decision profile overrides them.
+ */
+export async function getEligibleReviewerProfileIds({
+  decisionProfileId,
+}: {
+  decisionProfileId: string;
+}): Promise<string[]> {
+  const decisionsZone = await db.query.accessZones.findFirst({
+    where: { name: 'decisions' },
+  });
+
+  if (!decisionsZone) {
+    logger.error(
+      'getEligibleReviewerProfileIds: decisions access zone not found',
+    );
+    return [];
+  }
+
+  const zonePermissionRows =
+    await db.query.accessRolePermissionsOnAccessZones.findMany({
+      where: {
+        accessZoneId: decisionsZone.id,
+        ...zonePermissionsWhere(decisionProfileId),
+        accessRole: {
+          OR: [
+            { profileId: { isNull: true } },
+            { profileId: decisionProfileId },
+          ],
+        },
+      },
+      columns: { accessRoleId: true, permission: true, profileId: true },
+    });
+
+  const reviewRoleIds = pickEffectivePermissionRows(
+    zonePermissionRows,
+    (row) => row.accessRoleId,
+    decisionProfileId,
+  )
+    .filter((row) => (row.permission & decisionPermission.REVIEW) !== 0)
+    .map((row) => row.accessRoleId);
+
+  if (reviewRoleIds.length === 0) {
+    return [];
+  }
+
+  // profileUsers (decision membership)
+  //   → profileUserToAccessRoles (role assignments)
+  //   → users (personal profileId)
+  // Filtered to members holding a role with the REVIEW capability.
+  const rows = await db
+    .selectDistinct({ profileId: users.profileId })
+    .from(profileUsers)
+    .innerJoin(users, eq(profileUsers.authUserId, users.authUserId))
+    .innerJoin(
+      profileUserToAccessRoles,
+      eq(profileUsers.id, profileUserToAccessRoles.profileUserId),
+    )
+    .where(
+      and(
+        eq(profileUsers.profileId, decisionProfileId),
+        inArray(profileUserToAccessRoles.accessRoleId, reviewRoleIds),
+      ),
+    );
+
+  return rows.map((r) => r.profileId).filter((id): id is string => id != null);
+}

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -48,6 +48,7 @@ export * from './selectionPipeline';
 
 // Proposal invites
 export * from './acceptProposalInvite';
+export * from './events/emitDecisionMemberRolesChanged';
 
 // Proposal management
 export * from './proposalDataSchema';

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -67,6 +67,8 @@ export * from './listProposalLocations';
 export * from './listAllProposals';
 export * from './generateReviewAssignments';
 export * from './runGenerateReviewAssignments';
+export * from './backfillReviewAssignments';
+export * from './getEligibleReviewerProfileIds';
 export * from './listProposalSubmitters';
 export * from './getReviewAssignment';
 export * from './listReviewAssignments';

--- a/packages/common/src/services/decision/insertReviewAssignments.ts
+++ b/packages/common/src/services/decision/insertReviewAssignments.ts
@@ -1,0 +1,51 @@
+import { db } from '@op/db/client';
+import { proposalReviewAssignments } from '@op/db/schema';
+
+export interface AssignableProposal {
+  proposalId: string;
+  submittedByProfileId: string | null;
+  assignedProposalHistoryId: string | null;
+}
+
+/**
+ * Fans proposals × reviewers into assignment rows — excluding self-review —
+ * and inserts them. `onConflictDoNothing` on the (instance, proposal,
+ * reviewer, phase) unique constraint makes re-runs safe. Returns the number
+ * of rows actually inserted. Shared by generation and backfill.
+ */
+export async function insertReviewAssignments({
+  instanceId,
+  phaseId,
+  reviewerProfileIds,
+  assignableProposals,
+}: {
+  instanceId: string;
+  phaseId: string;
+  reviewerProfileIds: string[];
+  assignableProposals: AssignableProposal[];
+}): Promise<number> {
+  const values = assignableProposals.flatMap((proposal) =>
+    reviewerProfileIds
+      // NOTE: we should revisit this logic when we have multiple authors per proposal
+      .filter((profileId) => profileId !== proposal.submittedByProfileId)
+      .map((profileId) => ({
+        processInstanceId: instanceId,
+        proposalId: proposal.proposalId,
+        reviewerProfileId: profileId,
+        phaseId,
+        assignedProposalHistoryId: proposal.assignedProposalHistoryId,
+      })),
+  );
+
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const insertedRows = await db
+    .insert(proposalReviewAssignments)
+    .values(values)
+    .onConflictDoNothing()
+    .returning({ id: proposalReviewAssignments.id });
+
+  return insertedRows.length;
+}

--- a/packages/common/src/services/profile/acceptProfileInvite.ts
+++ b/packages/common/src/services/profile/acceptProfileInvite.ts
@@ -1,10 +1,14 @@
 import { db, eq } from '@op/db/client';
 import {
+  EntityType,
   profileInvites,
   profileUserToAccessRoles,
   profileUsers,
 } from '@op/db/schema';
+import { Events, event } from '@op/events';
+import { logger } from '@op/logging';
 import { User } from '@op/supabase/lib';
+import { waitUntil } from '@vercel/functions';
 
 import {
   CommonError,
@@ -27,6 +31,10 @@ export const acceptProfileInvite = async ({
   const invite = await db.query.profileInvites.findFirst({
     where: {
       id: inviteId,
+    },
+    with: {
+      // Gates the decision-scoped role-change event below.
+      profile: { columns: { type: true } },
     },
   });
 
@@ -85,6 +93,29 @@ export const acceptProfileInvite = async ({
 
     return profileUser;
   });
+
+  if (invite.profile.type === EntityType.DECISION) {
+    const eventData = {
+      decisionProfileId: invite.profileId,
+      authUserId: user.id,
+      addedRoleIds: [invite.accessRoleId],
+      removedRoleIds: [],
+    };
+    waitUntil(
+      event
+        .send({
+          name: Events.decisionMemberRolesChanged.name,
+          data: eventData,
+        })
+        .catch((error) => {
+          // Log the full payload so a dropped event can be replayed by hand.
+          logger.error('Failed to send decision member roles changed event', {
+            eventData,
+            error,
+          });
+        }),
+    );
+  }
 
   return { profileUser: result };
 };

--- a/packages/common/src/services/profile/acceptProfileInvite.ts
+++ b/packages/common/src/services/profile/acceptProfileInvite.ts
@@ -5,10 +5,7 @@ import {
   profileUserToAccessRoles,
   profileUsers,
 } from '@op/db/schema';
-import { Events, event } from '@op/events';
-import { logger } from '@op/logging';
 import { User } from '@op/supabase/lib';
-import { waitUntil } from '@vercel/functions';
 
 import {
   CommonError,
@@ -16,6 +13,7 @@ import {
   NotFoundError,
   UnauthorizedError,
 } from '../../utils/error';
+import { emitDecisionMemberRolesChanged } from '../decision/events/emitDecisionMemberRolesChanged';
 
 /**
  * Accept a profile invite, creating a profileUser with the specified role.
@@ -95,26 +93,12 @@ export const acceptProfileInvite = async ({
   });
 
   if (invite.profile.type === EntityType.DECISION) {
-    const eventData = {
+    emitDecisionMemberRolesChanged({
       decisionProfileId: invite.profileId,
       authUserId: user.id,
       addedRoleIds: [invite.accessRoleId],
       removedRoleIds: [],
-    };
-    waitUntil(
-      event
-        .send({
-          name: Events.decisionMemberRolesChanged.name,
-          data: eventData,
-        })
-        .catch((error) => {
-          // Log the full payload so a dropped event can be replayed by hand.
-          logger.error('Failed to send decision member roles changed event', {
-            eventData,
-            error,
-          });
-        }),
-    );
+    });
   }
 
   return { profileUser: result };

--- a/packages/common/src/services/profile/updateProfileUserRole.ts
+++ b/packages/common/src/services/profile/updateProfileUserRole.ts
@@ -1,7 +1,10 @@
 import { invalidate } from '@op/cache';
 import { and, db, eq, inArray } from '@op/db/client';
-import { profileUserToAccessRoles } from '@op/db/schema';
+import { EntityType, profileUserToAccessRoles } from '@op/db/schema';
+import { Events, event } from '@op/events';
+import { logger } from '@op/logging';
 import type { User } from '@op/supabase/lib';
+import { waitUntil } from '@vercel/functions';
 import { checkPermission, permission } from 'access-zones';
 
 import { CommonError, NotFoundError, ValidationError } from '../../utils/error';
@@ -39,6 +42,8 @@ export const updateProfileUserRoles = async ({
       where: { id: profileUserId },
       with: {
         roles: true,
+        // Gates the decision-scoped role-change event below.
+        profile: { columns: { type: true } },
       },
     }),
     // Non-assignable system global roles resolve as nonexistent and fail the
@@ -126,6 +131,29 @@ export const updateProfileUserRoles = async ({
         );
       }
     });
+
+    if (targetProfileUser.profile.type === EntityType.DECISION) {
+      const eventData = {
+        decisionProfileId: targetProfileId,
+        authUserId: targetProfileUser.authUserId,
+        addedRoleIds: rolesToAdd,
+        removedRoleIds: rolesToRemove,
+      };
+      waitUntil(
+        event
+          .send({
+            name: Events.decisionMemberRolesChanged.name,
+            data: eventData,
+          })
+          .catch((error) => {
+            // Log the full payload so a dropped event can be replayed by hand.
+            logger.error('Failed to send decision member roles changed event', {
+              eventData,
+              error,
+            });
+          }),
+      );
+    }
   }
 
   await Promise.all([

--- a/packages/common/src/services/profile/updateProfileUserRole.ts
+++ b/packages/common/src/services/profile/updateProfileUserRole.ts
@@ -1,10 +1,7 @@
 import { invalidate } from '@op/cache';
 import { and, db, eq, inArray } from '@op/db/client';
 import { EntityType, profileUserToAccessRoles } from '@op/db/schema';
-import { Events, event } from '@op/events';
-import { logger } from '@op/logging';
 import type { User } from '@op/supabase/lib';
-import { waitUntil } from '@vercel/functions';
 import { checkPermission, permission } from 'access-zones';
 
 import { CommonError, NotFoundError, ValidationError } from '../../utils/error';
@@ -16,6 +13,7 @@ import {
   profileUserCacheKey,
 } from '../access';
 import { assertProfileAdmin } from '../assert';
+import { emitDecisionMemberRolesChanged } from '../decision/events/emitDecisionMemberRolesChanged';
 import { getProfileUserWithRelations } from './getProfileUserWithRelations';
 
 /**
@@ -133,26 +131,12 @@ export const updateProfileUserRoles = async ({
     });
 
     if (targetProfileUser.profile.type === EntityType.DECISION) {
-      const eventData = {
+      emitDecisionMemberRolesChanged({
         decisionProfileId: targetProfileId,
         authUserId: targetProfileUser.authUserId,
         addedRoleIds: rolesToAdd,
         removedRoleIds: rolesToRemove,
-      };
-      waitUntil(
-        event
-          .send({
-            name: Events.decisionMemberRolesChanged.name,
-            data: eventData,
-          })
-          .catch((error) => {
-            // Log the full payload so a dropped event can be replayed by hand.
-            logger.error('Failed to send decision member roles changed event', {
-              eventData,
-              error,
-            });
-          }),
-      );
+      });
     }
   }
 

--- a/services/api/src/routers/decision/instances/backfillReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/backfillReviewAssignments.test.ts
@@ -1,0 +1,539 @@
+import {
+  type DecisionInstanceData,
+  type DecisionSchemaDefinition,
+  type ReviewsPolicy,
+  advancePhase,
+  backfillReviewAssignments,
+  createDecisionRole,
+  generateReviewAssignments,
+  updateProfileUserRoles,
+} from '@op/common';
+import { db, eq } from '@op/db/client';
+import {
+  ProcessStatus,
+  ProposalStatus,
+  proposalReviewAssignments,
+} from '@op/db/schema';
+import { ROLES } from '@op/db/seedData/accessControl';
+import { event } from '@op/events';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import { TestProfileUserDataManager } from '../../../test/helpers/TestProfileUserDataManager';
+import { createIsolatedSession } from '../../../test/supabase-utils';
+
+vi.mock('@op/events', async () => {
+  const actual = await vi.importActual('@op/events');
+  return {
+    ...actual,
+    event: {
+      send: vi.fn().mockResolvedValue({ ids: ['mock-event-id'] }),
+    },
+  };
+});
+
+/**
+ * Schema with a review-capable middle phase that also accepts submissions,
+ * so tests can create mid-phase proposals (the ones backfill must NOT assign).
+ * submission → review (proposals.review + submit) → results
+ */
+const decisionSchemaWithReview = {
+  id: 'backfill-test-schema',
+  version: '1.0.0',
+  name: 'Backfill Test Schema',
+  description: 'Schema with a review phase for backfill testing',
+  config: {
+    reviewsPolicy: 'full_coverage' as const,
+  },
+  phases: [
+    {
+      id: 'submission',
+      name: 'Submission',
+      description: 'Submit proposals',
+      rules: {
+        proposals: { submit: true },
+        advancement: { method: 'manual' as const },
+      },
+      // Pass-all: every submitted proposal advances into review.
+      selectionPipeline: { version: '1.0.0', blocks: [] },
+    },
+    {
+      id: 'review',
+      name: 'Review',
+      description: 'Review proposals',
+      rules: {
+        proposals: { review: true, submit: true },
+        advancement: { method: 'manual' as const },
+      },
+    },
+    {
+      id: 'results',
+      name: 'Results',
+      description: 'Final results',
+      rules: {
+        proposals: { submit: false },
+        advancement: { method: 'manual' as const },
+      },
+    },
+  ],
+} satisfies DecisionSchemaDefinition;
+
+/** Schema whose FIRST phase is review-capable — no inbound transition exists. */
+const decisionSchemaReviewFirst = {
+  ...decisionSchemaWithReview,
+  id: 'backfill-review-first-schema',
+  name: 'Backfill Review-First Schema',
+  phases: [
+    decisionSchemaWithReview.phases[1],
+    decisionSchemaWithReview.phases[2],
+  ],
+} satisfies DecisionSchemaDefinition;
+
+/** The schema shape createDecisionSetup accepts (encoder-inferred, not exported). */
+type TestProcessSchema = NonNullable<
+  NonNullable<
+    Parameters<TestDecisionsDataManager['createDecisionSetup']>[0]
+  >['processSchema']
+>;
+
+async function createReviewInstance(
+  testData: TestDecisionsDataManager,
+  {
+    reviewsPolicy = 'full_coverage',
+    processSchema = decisionSchemaWithReview,
+  }: {
+    reviewsPolicy?: ReviewsPolicy;
+    processSchema?: TestProcessSchema;
+  } = {},
+) {
+  const setup = await testData.createDecisionSetup({
+    instanceCount: 1,
+    processSchema: {
+      ...processSchema,
+      config: { ...processSchema.config, reviewsPolicy },
+    },
+    status: ProcessStatus.PUBLISHED,
+  });
+
+  return { setup, instance: setup.instance };
+}
+
+/** Creates a "Reviewer" role on the given decision profile with the REVIEW bit set. */
+async function createReviewerRole(instanceProfileId: string) {
+  return createDecisionRole({
+    name: 'Reviewer',
+    profileId: instanceProfileId,
+    permissions: {
+      decisions: {
+        type: 'decision',
+        value: {
+          create: false,
+          read: true,
+          update: false,
+          delete: false,
+          admin: false,
+          inviteMembers: false,
+          review: true,
+          submitProposals: false,
+          vote: false,
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Advances the instance submission → review and runs the original assignment
+ * generation, mirroring what onPhaseAdvanced does at a real phase transition.
+ */
+async function advanceToReviewAndGenerate(instanceId: string) {
+  const dbInstance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+
+  if (!dbInstance) {
+    throw new Error('Instance not found');
+  }
+
+  const result = await db.transaction(async (tx) =>
+    advancePhase({
+      db: tx,
+      instance: {
+        id: dbInstance.id,
+        instanceData: dbInstance.instanceData as DecisionInstanceData,
+      },
+      fromPhaseId: 'submission',
+      toPhaseId: 'review',
+      triggeredByProfileId: null,
+    }),
+  );
+
+  if (result.conflict) {
+    throw new Error('Unexpected conflict during advance');
+  }
+
+  await generateReviewAssignments({
+    instanceId,
+    phaseId: 'review',
+    selectedProposalIds: result.selectedProposalIds,
+    transitionHistoryId: result.transitionHistoryId,
+  });
+
+  return result;
+}
+
+async function getAssignments(instanceId: string) {
+  return db
+    .select()
+    .from(proposalReviewAssignments)
+    .where(eq(proposalReviewAssignments.processInstanceId, instanceId));
+}
+
+describe.concurrent('backfillReviewAssignments', () => {
+  it('backfills a mid-phase reviewer to parity with the original generation', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(testData);
+    const reviewerRole = await createReviewerRole(instance.profileId);
+
+    // reviewerA reviews from the start; lateReviewer joins mid-phase.
+    const [reviewerA, lateReviewer] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+    ]);
+
+    const [proposalByA, proposalByLate] = await Promise.all([
+      testData.createProposal({
+        userEmail: reviewerA.email,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Proposal by Reviewer A' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: lateReviewer.email,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Proposal by Late Reviewer' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ]);
+
+    await advanceToReviewAndGenerate(instance.instance.id);
+    const assignmentsAfterGeneration = await getAssignments(
+      instance.instance.id,
+    );
+
+    // Submitted DURING the review phase: existing reviewers were never
+    // assigned it, so the backfilled reviewer must not be either.
+    const midPhaseProposal = await testData.createProposal({
+      userEmail: reviewerA.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Mid-phase proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    // The mid-phase role grant this feature exists for.
+    await testData.assignRole(
+      lateReviewer.authUserId,
+      instance.profileId,
+      reviewerRole.id,
+    );
+
+    const result = await backfillReviewAssignments({
+      instanceId: instance.instance.id,
+      reviewerProfileIds: [lateReviewer.profileId],
+    });
+
+    // Only proposalByA: own proposal excluded, mid-phase proposal excluded.
+    expect(result).toEqual({
+      inserted: 1,
+      reviewerCount: 1,
+      proposalCount: 2,
+    });
+
+    const assignments = await getAssignments(instance.instance.id);
+    const lateAssignments = assignments.filter(
+      (a) => a.reviewerProfileId === lateReviewer.profileId,
+    );
+    expect(lateAssignments).toHaveLength(1);
+    expect(lateAssignments[0]?.proposalId).toBe(proposalByA.id);
+    expect(lateAssignments[0]?.phaseId).toBe('review');
+
+    // Self-review exclusion: their own proposal was in the attachment set but
+    // must not have been assigned to them.
+    expect(
+      assignments.filter(
+        (a) =>
+          a.proposalId === proposalByLate.id &&
+          a.reviewerProfileId === lateReviewer.profileId,
+      ),
+    ).toHaveLength(0);
+
+    // Snapshot parity: the backfilled row pins the same proposal history
+    // captured at the transition as existing reviewers' rows.
+    const existingRowForSameProposal = assignmentsAfterGeneration.find(
+      (a) =>
+        a.proposalId === proposalByA.id &&
+        a.reviewerProfileId !== lateReviewer.profileId,
+    );
+    expect(
+      existingRowForSameProposal?.assignedProposalHistoryId,
+    ).not.toBeNull();
+    expect(lateAssignments[0]?.assignedProposalHistoryId).toBe(
+      existingRowForSameProposal?.assignedProposalHistoryId,
+    );
+
+    // Nobody was assigned the mid-phase proposal, and pre-existing rows are
+    // untouched (add-only).
+    expect(
+      assignments.filter((a) => a.proposalId === midPhaseProposal.id),
+    ).toHaveLength(0);
+    expect(assignments).toHaveLength(assignmentsAfterGeneration.length + 1);
+  });
+
+  it('re-checks eligibility and converges across re-runs', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(testData);
+    const reviewerRole = await createReviewerRole(instance.profileId);
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+
+    await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Creator proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    await advanceToReviewAndGenerate(instance.instance.id);
+    const assignmentsAfterGeneration = await getAssignments(
+      instance.instance.id,
+    );
+
+    // Not a reviewer yet: the narrowing hint must not bypass eligibility.
+    const beforeGrant = await backfillReviewAssignments({
+      instanceId: instance.instance.id,
+      reviewerProfileIds: [member.profileId],
+    });
+    expect(beforeGrant).toEqual({
+      inserted: 0,
+      reviewerCount: 0,
+      proposalCount: 1,
+    });
+
+    await testData.assignRole(
+      member.authUserId,
+      instance.profileId,
+      reviewerRole.id,
+    );
+
+    const afterGrant = await backfillReviewAssignments({
+      instanceId: instance.instance.id,
+      reviewerProfileIds: [member.profileId],
+    });
+    expect(afterGrant).toEqual({
+      inserted: 1,
+      reviewerCount: 1,
+      proposalCount: 1,
+    });
+
+    // Idempotent re-run (narrowed) and a full un-narrowed pass both converge
+    // without inserting anything new.
+    const rerun = await backfillReviewAssignments({
+      instanceId: instance.instance.id,
+      reviewerProfileIds: [member.profileId],
+    });
+    const unNarrowed = await backfillReviewAssignments({
+      instanceId: instance.instance.id,
+    });
+    expect(rerun).toMatchObject({ inserted: 0 });
+    expect(unNarrowed).toMatchObject({ inserted: 0 });
+
+    // Exactly one row was added across all four runs, and it's the member's.
+    const assignments = await getAssignments(instance.instance.id);
+    expect(assignments).toHaveLength(assignmentsAfterGeneration.length + 1);
+    expect(
+      assignments.filter((a) => a.reviewerProfileId === member.profileId),
+    ).toHaveLength(1);
+  });
+
+  it('no-ops (never throws) for missing, unpublished, or non-review-phase instances', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(testData);
+
+    // Published, but still in the submission phase.
+    await expect(
+      backfillReviewAssignments({ instanceId: instance.instance.id }),
+    ).resolves.toEqual({
+      skipped: 'current phase is not review-capable',
+    });
+
+    // Draft sibling instance on the same process.
+    const draftInstance = await testData.createInstanceForProcess({
+      processId: setup.process.id,
+      user: setup.user,
+      name: 'Draft instance',
+    });
+    await expect(
+      backfillReviewAssignments({ instanceId: draftInstance.instance.id }),
+    ).resolves.toEqual({
+      skipped: expect.stringContaining('not published'),
+    });
+
+    await expect(
+      backfillReviewAssignments({ instanceId: randomUUID() }),
+    ).resolves.toEqual({ skipped: 'instance not found' });
+
+    expect(await getAssignments(instance.instance.id)).toHaveLength(0);
+  });
+
+  it('no-ops for non-backfillable review policies instead of throwing', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instance } = await createReviewInstance(testData, {
+      reviewsPolicy: 'self_selection',
+    });
+
+    await expect(
+      backfillReviewAssignments({ instanceId: instance.instance.id }),
+    ).resolves.toEqual({
+      skipped: expect.stringContaining('self_selection'),
+    });
+  });
+
+  it('no-ops when the review phase is the initial phase (no inbound transition)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instance } = await createReviewInstance(testData, {
+      processSchema: decisionSchemaReviewFirst,
+    });
+
+    // Generation never ran for this phase either — nothing to reach parity
+    // with, so the backfill must decline rather than invent assignments.
+    await expect(
+      backfillReviewAssignments({ instanceId: instance.instance.id }),
+    ).resolves.toEqual({
+      skipped: 'current phase has no inbound transition',
+    });
+  });
+});
+
+describe.concurrent('decision/member-roles-changed emission', () => {
+  it('emits for decision-profile role changes only, and only when roles actually change', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(testData);
+    const reviewerRole = await createReviewerRole(instance.profileId);
+
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+
+    const decisionProfileUser = await db.query.profileUsers.findFirst({
+      where: {
+        profileId: instance.profileId,
+        authUserId: member.authUserId,
+      },
+      with: { roles: true },
+    });
+    if (!decisionProfileUser) {
+      throw new Error('Expected decision profileUser for member');
+    }
+    const existingRoleIds = decisionProfileUser.roles.map(
+      (r) => r.accessRoleId,
+    );
+
+    // Role change on a decision profile → emits with the exact delta.
+    await updateProfileUserRoles({
+      profileUserId: decisionProfileUser.id,
+      roleIds: [...existingRoleIds, reviewerRole.id],
+      user: setup.user,
+    });
+
+    expect(event.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'decision/member-roles-changed',
+        data: {
+          decisionProfileId: instance.profileId,
+          authUserId: member.authUserId,
+          addedRoleIds: [reviewerRole.id],
+          removedRoleIds: [],
+        },
+      }),
+    );
+
+    // Same roles again → no change → no event (an empty-delta emission
+    // would show up as added/removed both []).
+    await updateProfileUserRoles({
+      profileUserId: decisionProfileUser.id,
+      roleIds: [...existingRoleIds, reviewerRole.id],
+      user: setup.user,
+    });
+
+    expect(event.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'decision/member-roles-changed',
+        data: expect.objectContaining({
+          decisionProfileId: instance.profileId,
+          addedRoleIds: [],
+          removedRoleIds: [],
+        }),
+      }),
+    );
+
+    // Role change on an ORG-type profile → not a decision profile → no event.
+    const orgTestData = new TestProfileUserDataManager(task.id, onTestFinished);
+    const {
+      profile: orgProfile,
+      adminUser,
+      memberUsers,
+    } = await orgTestData.createProfile({
+      users: { admin: 1, member: 1 },
+    });
+    const orgMember = memberUsers[0];
+    if (!orgMember) {
+      throw new Error('Expected org member to be defined');
+    }
+    const { session } = await createIsolatedSession(adminUser.email);
+
+    await updateProfileUserRoles({
+      profileUserId: orgMember.profileUserId,
+      roleIds: [ROLES.MEMBER.id, ROLES.ADMIN.id],
+      user: session.user,
+    });
+
+    expect(event.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'decision/member-roles-changed',
+        data: expect.objectContaining({
+          decisionProfileId: orgProfile.id,
+        }),
+      }),
+    );
+  });
+});

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -72,6 +72,17 @@ export const Events = {
       proposalId: z.string().uuid(),
     }),
   },
+  // Emitted only for decision profiles. Role-id arrays are a narrowing hint —
+  // consumers must re-derive state from the DB.
+  decisionMemberRolesChanged: {
+    name: 'decision/member-roles-changed' as const,
+    schema: z.object({
+      decisionProfileId: z.string().uuid(),
+      authUserId: z.string().uuid(),
+      addedRoleIds: z.array(z.string().uuid()),
+      removedRoleIds: z.array(z.string().uuid()),
+    }),
+  },
   phaseTransitioned: {
     name: 'decision/phase-transitioned' as const,
     schema: z.object({

--- a/services/workflows/src/functions/decisions/backfillReviewAssignmentsOnRoleChange.ts
+++ b/services/workflows/src/functions/decisions/backfillReviewAssignmentsOnRoleChange.ts
@@ -1,0 +1,59 @@
+import { backfillReviewAssignments } from '@op/common';
+import { db } from '@op/db/client';
+import { Events, inngest } from '@op/events';
+
+const { decisionMemberRolesChanged } = Events;
+
+/**
+ * Backfills the review assignments a member would have received at the phase
+ * transition when they gain roles on a decision mid-phase. The concurrency
+ * key serializes rapid edits per decision; the service re-derives eligibility
+ * from the DB, so the last run converges.
+ */
+export const backfillReviewAssignmentsOnRoleChange = inngest.createFunction(
+  {
+    id: 'backfillReviewAssignmentsOnRoleChange',
+    concurrency: { key: 'event.data.decisionProfileId', limit: 1 },
+  },
+  { event: decisionMemberRolesChanged.name },
+  async ({ event, step }) => {
+    const { decisionProfileId, authUserId, addedRoleIds } =
+      decisionMemberRolesChanged.schema.parse(event.data);
+
+    // Additive-only: a pure removal can never create assignments.
+    if (addedRoleIds.length === 0) {
+      return { skipped: 'no roles added' };
+    }
+
+    const instance = await step.run('resolve-instance', () =>
+      db.query.processInstances.findFirst({
+        where: { profileId: decisionProfileId },
+        columns: { id: true },
+      }),
+    );
+
+    if (!instance) {
+      return { skipped: 'profile is not a decision instance' };
+    }
+
+    // Assignments key on the member's personal profile id, not authUserId.
+    const member = await step.run('resolve-member-profile', () =>
+      db.query.users.findFirst({
+        where: { authUserId },
+        columns: { profileId: true },
+      }),
+    );
+
+    const memberProfileId = member?.profileId;
+    if (!memberProfileId) {
+      return { skipped: 'member has no personal profile' };
+    }
+
+    return step.run('backfill-review-assignments', () =>
+      backfillReviewAssignments({
+        instanceId: instance.id,
+        reviewerProfileIds: [memberProfileId],
+      }),
+    );
+  },
+);

--- a/services/workflows/src/functions/decisions/index.ts
+++ b/services/workflows/src/functions/decisions/index.ts
@@ -1,0 +1,1 @@
+export * from './backfillReviewAssignmentsOnRoleChange';

--- a/services/workflows/src/functions/index.ts
+++ b/services/workflows/src/functions/index.ts
@@ -1,3 +1,4 @@
+export * from './decisions';
 export * from './notifications';
 export * from './exports';
 export * from './modules';


### PR DESCRIPTION
Adding a reviewer after the review phase has started previously did nothing — assignments were only generated at the phase transition. Role grants on decision profiles now emit a decision/member-roles-changed event whose consumer backfills the new reviewer to parity with the original generation (same proposal set, same history snapshots, self-review excluded), additively and idempotently. Role removals are intentionally out of scope for now: pruning assignments could cascade-delete submitted reviews, so removal semantics stay with the future assignment-management work.