### PR TITLE
fix(profile): make listProfileUsers keyset pagination robust to NULL name/email

### DIFF
--- a/apps/app/src/components/decisions/ProfileUsersAccess.tsx
+++ b/apps/app/src/components/decisions/ProfileUsersAccess.tsx
@@ -95,7 +95,17 @@ export const ProfileUsersAccess = ({
     { retry: false },
   );
 
-  const profileUsers = data?.pages.flatMap((page) => page.items) ?? [];
+  // Dedupe by id: duplicate row keys send the react-aria Table collection
+  // into an infinite loop (RangeError: Invalid array length), so a single
+  // overlapping page must never reach it.
+  const profileUsers = Array.from(
+    new Map(
+      (data?.pages.flatMap((page) => page.items) ?? []).map((profileUser) => [
+        profileUser.id,
+        profileUser,
+      ]),
+    ).values(),
+  );
   const roles = rolesData?.items ?? [];
 
   return (

--- a/packages/common/src/services/profile/listProfileUsers.ts
+++ b/packages/common/src/services/profile/listProfileUsers.ts
@@ -85,8 +85,14 @@ export const listProfileUsers = async ({
       : undefined;
 
   // Build cursor condition for pagination
-  // The cursor must match the ORDER BY columns for correct pagination
-  type ProfileUserCursor = { value: string; tiebreaker?: string };
+  // The cursor must match the ORDER BY columns for correct pagination.
+  // name and email are nullable, so every comparison COALESCEs them to ''
+  // (matching the `?? ''` cursor encoding below and the ORDER BY expressions),
+  // and id is the final tiebreaker so the keyset is strictly monotonic.
+  // Without this, a NULL at a page boundary encodes a '' cursor that
+  // re-matches the whole previous page (duplicates) while NULL rows never
+  // satisfy the comparison at all (dropped rows).
+  type ProfileUserCursor = { value: string; tiebreaker?: string; id?: string };
   const decodedCursor = cursor
     ? decodeCursor<ProfileUserCursor>(cursor)
     : undefined;
@@ -98,29 +104,59 @@ export const listProfileUsers = async ({
       return undefined;
     }
 
-    if (orderBy === 'email') {
-      // Email is unique, no tiebreaker needed
-      return compareFn(profileUsers.email, decodedCursor.value);
-    }
+    const compareOp = dir === 'asc' ? sql`>` : sql`<`;
+    const coalescedName = sql`COALESCE(${profileUsers.name}, '')`;
+    const coalescedEmail = sql`COALESCE(${profileUsers.email}, '')`;
+    // Cursors issued before the id tiebreaker existed omit id; guard so we
+    // never compare the uuid column against ''.
+    const idTiebreaker = decodedCursor.id
+      ? compareFn(profileUsers.id, decodedCursor.id)
+      : undefined;
 
-    if (orderBy === 'name') {
-      // ORDER BY name, email - compound condition
+    if (orderBy === 'email') {
+      // ORDER BY email, id - compound condition
       return or(
-        compareFn(profileUsers.name, decodedCursor.value),
-        and(
-          eq(profileUsers.name, decodedCursor.value),
-          compareFn(profileUsers.email, decodedCursor.tiebreaker ?? ''),
-        ),
+        sql`${coalescedEmail} ${compareOp} ${decodedCursor.value}`,
+        idTiebreaker
+          ? and(sql`${coalescedEmail} = ${decodedCursor.value}`, idTiebreaker)
+          : undefined,
       );
     }
 
-    // orderBy === 'role' - uses shared subquery helper
+    if (orderBy === 'name') {
+      // ORDER BY name, email, id - compound condition
+      return or(
+        sql`${coalescedName} ${compareOp} ${decodedCursor.value}`,
+        and(
+          sql`${coalescedName} = ${decodedCursor.value}`,
+          sql`${coalescedEmail} ${compareOp} ${decodedCursor.tiebreaker ?? ''}`,
+        ),
+        idTiebreaker
+          ? and(
+              sql`${coalescedName} = ${decodedCursor.value}`,
+              sql`${coalescedEmail} = ${decodedCursor.tiebreaker ?? ''}`,
+              idTiebreaker,
+            )
+          : undefined,
+      );
+    }
+
+    // orderBy === 'role' - uses shared subquery helper (already COALESCEd)
     const roleSubquery = buildRoleNameSubquery(profileUsers.id);
-    const compareOp = dir === 'asc' ? sql`>` : sql`<`;
-    return sql`(
-      ${roleSubquery} ${compareOp} ${decodedCursor.value}
-      OR (${roleSubquery} = ${decodedCursor.value} AND ${profileUsers.email} ${compareOp} ${decodedCursor.tiebreaker ?? ''})
-    )`;
+    return or(
+      sql`${roleSubquery} ${compareOp} ${decodedCursor.value}`,
+      and(
+        sql`${roleSubquery} = ${decodedCursor.value}`,
+        sql`${coalescedEmail} ${compareOp} ${decodedCursor.tiebreaker ?? ''}`,
+      ),
+      idTiebreaker
+        ? and(
+            sql`${roleSubquery} = ${decodedCursor.value}`,
+            sql`${coalescedEmail} = ${decodedCursor.tiebreaker ?? ''}`,
+            idTiebreaker,
+          )
+        : undefined,
+    );
   };
 
   const cursorCondition = buildCursorCondition();
@@ -158,20 +194,27 @@ export const listProfileUsers = async ({
     },
     orderBy: (table, { asc, desc }) => {
       const orderFn = dir === 'desc' ? desc : asc;
+      // COALESCE nullable columns so ordering matches the cursor comparisons,
+      // and always end on id so the sort is total.
+      const nameExpr = sql`COALESCE(${table.name}, '')`;
+      const emailExpr = sql`COALESCE(${table.email}, '')`;
 
       if (orderBy === 'role') {
         // Use shared subquery helper for consistency with cursor condition
         const roleNameSubquery = buildRoleNameSubquery(table.id);
-        // Add email as secondary sort for consistent cursor pagination
-        return [orderFn(roleNameSubquery), orderFn(table.email)];
+        return [
+          orderFn(roleNameSubquery),
+          orderFn(emailExpr),
+          orderFn(table.id),
+        ];
       }
 
       if (orderBy === 'email') {
-        return [orderFn(table.email)];
+        return [orderFn(emailExpr), orderFn(table.id)];
       }
 
-      // Default to name, with email as secondary for consistent ordering
-      return [orderFn(table.name), orderFn(table.email)];
+      // Default to name, with email + id as secondary for consistent ordering
+      return [orderFn(nameExpr), orderFn(emailExpr), orderFn(table.id)];
     },
     limit: limit + 1,
   });
@@ -204,6 +247,7 @@ export const listProfileUsers = async ({
     if (orderBy === 'email') {
       return encodeCursor<ProfileUserCursor>({
         value: lastResult.email ?? '',
+        id: lastResult.id,
       });
     }
 
@@ -211,6 +255,7 @@ export const listProfileUsers = async ({
       return encodeCursor<ProfileUserCursor>({
         value: lastResult.name ?? '',
         tiebreaker: lastResult.email ?? '',
+        id: lastResult.id,
       });
     }
 
@@ -231,6 +276,7 @@ export const listProfileUsers = async ({
     return encodeCursor<ProfileUserCursor>({
       value: firstRoleName,
       tiebreaker: lastResult.email ?? '',
+      id: lastResult.id,
     });
   };
 

--- a/services/api/src/routers/profile/users/listUsers.test.ts
+++ b/services/api/src/routers/profile/users/listUsers.test.ts
@@ -1,5 +1,5 @@
 import { GLOBAL_USER_PUBLIC } from '@op/core';
-import { db, eq } from '@op/db/client';
+import { db, eq, inArray } from '@op/db/client';
 import { profileUsers } from '@op/db/schema';
 import { ROLES } from '@op/db/seedData/accessControl';
 import { describe, expect, it, vi } from 'vitest';
@@ -688,6 +688,153 @@ describe.concurrent('profile.users.listUsers', () => {
 
       // Admin should be first (A < M alphabetically)
       expect(allEmails[0]).toBe(adminUser.email);
+    });
+
+    // Regression tests: a NULL name/email at a page boundary used to encode a
+    // '' cursor that re-matched the whole previous page (duplicate rows, which
+    // crash the react-aria Table with duplicate keys) while the NULL rows
+    // themselves never satisfied the cursor comparison (dropped rows).
+    describe('NULL name/email columns', () => {
+      const paginateAllIds = async (
+        caller: ReturnType<typeof createCaller>,
+        profileId: string,
+        orderBy: 'name' | 'email' | 'role',
+      ) => {
+        const allIds: string[] = [];
+        let cursor: string | null | undefined;
+        let pageCount = 0;
+
+        do {
+          const page = await caller.listUsers({
+            profileId,
+            limit: 2,
+            cursor: cursor ?? undefined,
+            orderBy,
+            dir: 'asc',
+          });
+
+          allIds.push(...page.items.map((u) => u.id));
+          cursor = page.next;
+          pageCount++;
+
+          if (pageCount > 10) {
+            throw new Error('Too many pages - possible infinite loop');
+          }
+        } while (cursor);
+
+        return allIds;
+      };
+
+      it('should paginate by name without duplicating or dropping NULL-name rows', async ({
+        task,
+        onTestFinished,
+      }) => {
+        const testData = new TestProfileUserDataManager(
+          task.id,
+          onTestFinished,
+        );
+        const { profile, adminUser, allUsers } = await testData.createProfile({
+          users: { admin: 1, member: 4 },
+        });
+
+        // Two members with NULL name land at a page boundary with limit 2
+        const nullNameIds = allUsers
+          .filter((u) => u.role === 'Member')
+          .slice(0, 2)
+          .map((u) => u.profileUserId);
+        await db
+          .update(profileUsers)
+          .set({ name: null })
+          .where(inArray(profileUsers.id, nullNameIds));
+
+        const { session } = await createIsolatedSession(adminUser.email);
+        const caller = createCaller(
+          await createTestContextWithSession(session),
+        );
+
+        const allIds = await paginateAllIds(caller, profile.id, 'name');
+
+        expect(allIds).toHaveLength(5);
+        expect(new Set(allIds).size).toBe(5);
+        nullNameIds.forEach((id) => {
+          expect(allIds).toContain(id);
+        });
+      });
+
+      it('should paginate by email without duplicating or dropping NULL-email rows', async ({
+        task,
+        onTestFinished,
+      }) => {
+        const testData = new TestProfileUserDataManager(
+          task.id,
+          onTestFinished,
+        );
+        const { profile, adminUser, allUsers } = await testData.createProfile({
+          users: { admin: 1, member: 4 },
+        });
+
+        // Two members with NULL email: identical '' cursor values, so only
+        // the id tiebreaker can distinguish them
+        const nullEmailIds = allUsers
+          .filter((u) => u.role === 'Member')
+          .slice(0, 2)
+          .map((u) => u.profileUserId);
+        await db
+          .update(profileUsers)
+          .set({ email: null })
+          .where(inArray(profileUsers.id, nullEmailIds));
+
+        const { session } = await createIsolatedSession(adminUser.email);
+        const caller = createCaller(
+          await createTestContextWithSession(session),
+        );
+
+        const allIds = await paginateAllIds(caller, profile.id, 'email');
+
+        expect(allIds).toHaveLength(5);
+        expect(new Set(allIds).size).toBe(5);
+        nullEmailIds.forEach((id) => {
+          expect(allIds).toContain(id);
+        });
+      });
+
+      it('should paginate by role when same-role members have NULL emails', async ({
+        task,
+        onTestFinished,
+      }) => {
+        const testData = new TestProfileUserDataManager(
+          task.id,
+          onTestFinished,
+        );
+        const { profile, adminUser, allUsers } = await testData.createProfile({
+          users: { admin: 1, member: 4 },
+        });
+
+        // All four members share the Member role, and two of them also share
+        // a NULL email — both the role value and email tiebreaker are equal,
+        // leaving only the id tiebreaker
+        const nullEmailIds = allUsers
+          .filter((u) => u.role === 'Member')
+          .slice(0, 2)
+          .map((u) => u.profileUserId);
+        await db
+          .update(profileUsers)
+          .set({ email: null })
+          .where(inArray(profileUsers.id, nullEmailIds));
+
+        const { session } = await createIsolatedSession(adminUser.email);
+        const caller = createCaller(
+          await createTestContextWithSession(session),
+        );
+
+        const allIds = await paginateAllIds(caller, profile.id, 'role');
+
+        expect(allIds).toHaveLength(5);
+        expect(new Set(allIds).size).toBe(5);
+        nullEmailIds.forEach((id) => {
+          expect(allIds).toContain(id);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
A NULL name or email at a page boundary broke keyset pagination for a profile's participant list: pages overlapped and returned duplicate rows, which crashed the table, while the NULL rows themselves were silently dropped.