### PR TITLE
refactor(decision): resolve review settings per phase with config fallback

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/ProposalViewClient.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/ProposalViewClient.tsx
@@ -3,7 +3,7 @@
 import { ResourceErrorBoundary } from '@/utils/ResourceErrorBoundary';
 import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
-import { isLastPhase } from '@op/common/client';
+import { isLastPhase, isReviewPhase } from '@op/common/client';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
@@ -33,7 +33,7 @@ function ProposalViewPageContent({
   const currentPhase = phases.find(
     (phase) => phase.phaseId === instance.currentStateId,
   );
-  const isInReviewPhase = currentPhase?.rules?.proposals?.review === true;
+  const isInReviewPhase = !!currentPhase && isReviewPhase(currentPhase);
   const isAuthor =
     !!user?.currentProfile?.id &&
     proposal.submittedBy?.id === user.currentProfile.id;

--- a/apps/app/src/components/decisions/DecisionStateRouter.tsx
+++ b/apps/app/src/components/decisions/DecisionStateRouter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { isLastPhase } from '@op/common/client';
+import { isLastPhase, isReviewPhase, isVotingPhase } from '@op/common/client';
 import { notFound } from 'next/navigation';
 
 import { FinalPhaseManualSelectionPage } from './pages/FinalPhaseManualSelectionPage';
@@ -45,8 +45,8 @@ function DecisionStateRouterNew({
   const { currentStateId } = instance;
   const phases = instance.instanceData?.phases ?? [];
   const currentPhase = phases.find((p) => p.phaseId === currentStateId);
-  const isVotingEnabled = currentPhase?.rules?.voting?.submit === true;
-  const isReviewEnabled = currentPhase?.rules?.proposals?.review === true;
+  const isVotingEnabled = !!currentPhase && isVotingPhase(currentPhase);
+  const isReviewEnabled = !!currentPhase && isReviewPhase(currentPhase);
   const isAdmin = Boolean(instance.access?.admin);
 
   if (!instance.selectionsAreConfirmed) {
@@ -56,7 +56,7 @@ function DecisionStateRouterNew({
     // Everyone else falls back to the generic manual-selection prompt.
     const currentIdx = phases.findIndex((p) => p.phaseId === currentStateId);
     const previousPhase = currentIdx > 0 ? phases[currentIdx - 1] : null;
-    const previousWasReview = previousPhase?.rules?.proposals?.review === true;
+    const previousWasReview = !!previousPhase && isReviewPhase(previousPhase);
 
     if (previousWasReview && previousPhase && isAdmin) {
       return (

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -3,6 +3,7 @@
 import { parseAbsoluteToLocal, toCalendarDate } from '@internationalized/date';
 import { trpc } from '@op/api/client';
 import type { PhaseDefinition, PhaseRules } from '@op/api/encoders';
+import { isReviewPhase, isVotingPhase } from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { DatePicker } from '@op/ui/DatePicker';
 import { Header2 } from '@op/ui/Header';
@@ -391,10 +392,10 @@ function PhaseDetailForm({
           )}
         >
           <ToggleButton
-            isSelected={phase.rules?.proposals?.review ?? false}
+            isSelected={isReviewPhase(phase)}
             onChange={(val) =>
               updateRules({
-                proposals: { ...phase.rules?.proposals, review: val },
+                reviews: { ...phase.rules?.reviews, submit: val },
               })
             }
             size="small"
@@ -407,7 +408,7 @@ function PhaseDetailForm({
           )}
         >
           <ToggleButton
-            isSelected={phase.rules?.voting?.submit ?? false}
+            isSelected={isVotingPhase(phase)}
             onChange={(val) => {
               const nextVoting: PhaseRules['voting'] = {
                 ...phase.rules?.voting,
@@ -423,7 +424,7 @@ function PhaseDetailForm({
             size="small"
           />
         </ToggleRow>
-        {phase.rules?.voting?.submit && (
+        {isVotingPhase(phase) && (
           <ToggleRow
             label={t('Voting limit')}
             description={t('Number of proposals each participant can vote on')}

--- a/apps/app/src/components/decisions/ProcessBuilder/useNavigationConfig.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/useNavigationConfig.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { trpc } from '@op/api/client';
+import { isReviewPhase } from '@op/common/client';
 import { useMemo } from 'react';
 
 import {
@@ -33,9 +34,7 @@ export function useNavigationConfig(
     true;
 
   const phases = storePhases ?? instance?.instanceData?.phases ?? [];
-  const hasReviewPhase = phases.some(
-    (p) => p.rules?.proposals?.review === true,
-  );
+  const hasReviewPhase = phases.some(isReviewPhase);
 
   return useMemo(
     () => ({

--- a/apps/app/src/components/decisions/ProcessBuilder/validation/processBuilderValidation.ts
+++ b/apps/app/src/components/decisions/ProcessBuilder/validation/processBuilderValidation.ts
@@ -1,4 +1,4 @@
-import { SYSTEM_FIELD_KEYS } from '@op/common/client';
+import { SYSTEM_FIELD_KEYS, isReviewPhase } from '@op/common/client';
 import { z } from 'zod';
 
 import type { TranslationKey } from '@/lib/i18n';
@@ -52,7 +52,7 @@ const LOCKED_PROPOSAL_FIELD_KEYS = new Set(
 
 /** Returns true when at least one phase has review enabled. */
 function hasReviewPhase(data: ProcessBuilderInstanceData | undefined): boolean {
-  return (data?.phases ?? []).some((p) => p.rules?.proposals?.review === true);
+  return (data?.phases ?? []).some(isReviewPhase);
 }
 
 /** Returns true when the rubric template contains at least one criterion. */

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -15,6 +15,8 @@ import {
   type Proposal,
   ProposalReviewRequestState,
   getLocationFieldMapView,
+  isReviewPhase,
+  isVotingPhase,
   templateCollectsLocation,
 } from '@op/common/client';
 import { useInfiniteScroll } from '@op/hooks';
@@ -373,8 +375,8 @@ const ProposalsListContent = ({
   sortOrder,
   setSortOrder,
 }: ProposalsListContentProps) => {
-  const isReviewPhase = currentPhase?.rules?.proposals?.review === true;
-  const isVotingPhase = currentPhase?.rules?.voting?.submit === true;
+  const isInReviewPhase = !!currentPhase && isReviewPhase(currentPhase);
+  const isInVotingPhase = !!currentPhase && isVotingPhase(currentPhase);
   const t = useTranslations();
   const { user } = useUser();
 
@@ -441,7 +443,7 @@ const ProposalsListContent = ({
   const { data: revisionRequestsData } =
     trpc.decision.listProposalsRevisionRequests.useQuery(
       { states: [ProposalReviewRequestState.REQUESTED] },
-      { enabled: !!isReviewPhase },
+      { enabled: isInReviewPhase },
     );
 
   const revisionRequestIdByProposalId = useMemo(
@@ -619,7 +621,7 @@ const ProposalsListContent = ({
             permissions={permissions}
             votedProposalIds={selectedProposalIds}
             hasFilter={hasActiveFilter}
-            isVotingPhase={isVotingPhase}
+            isVotingPhase={isInVotingPhase}
             proposalsHidden={proposalsHidden}
             excludeAssignedForReview={excludeAssignedForReview}
             revisionRequestIdByProposalId={revisionRequestIdByProposalId}

--- a/apps/app/src/components/decisions/Review/ReviewLayout.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayout.tsx
@@ -5,6 +5,7 @@ import {
 } from '@op/api/server';
 import { createClient } from '@op/api/serverClient';
 import { CommonError } from '@op/common';
+import { getPhaseReviewSettings } from '@op/common/client';
 import { SplitPane } from '@op/ui/SplitPane';
 import { forbidden, notFound } from 'next/navigation';
 
@@ -29,14 +30,27 @@ export async function ReviewLayout({
     createServerUtils(),
   ]);
 
-  let decisionProfile;
+  let allowRevisions: boolean;
   try {
-    [decisionProfile] = await Promise.all([
+    const [decisionProfile, reviewAssignment] = await Promise.all([
       client.decision.getDecisionBySlug({ slug: decisionSlug }),
       utils.decision.getReviewAssignment.fetch({ assignmentId }),
     ]);
+
+    // Throws NotFoundError when the assignment's phase is no longer in the
+    // instance's phase list (stale assignment) — mapped to notFound() below.
+    ({ allowRevisions } = getPhaseReviewSettings(
+      decisionProfile.processInstance.instanceData,
+      reviewAssignment.assignment.phaseId,
+    ));
   } catch (error) {
-    const cause = error instanceof Error ? error.cause : null;
+    // tRPC errors carry the CommonError in `cause`; local throws are the error itself.
+    const cause =
+      error instanceof CommonError
+        ? error
+        : error instanceof Error
+          ? error.cause
+          : null;
     if (cause instanceof CommonError && cause.statusCode === 403) {
       forbidden();
     }
@@ -45,10 +59,6 @@ export async function ReviewLayout({
     }
     throw error;
   }
-
-  const allowRevisions =
-    decisionProfile.processInstance.instanceData.config
-      ?.reviewsAllowRevisions ?? true;
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
@@ -5,6 +5,7 @@ import {
 } from '@op/api/server';
 import { createClient } from '@op/api/serverClient';
 import { CommonError } from '@op/common';
+import { isReviewPhase } from '@op/common/client';
 import { forbidden, notFound } from 'next/navigation';
 
 import { ReviewSummaryView } from './ReviewSummaryView';
@@ -118,7 +119,7 @@ function resolveReviewPhaseId(instance: {
   const startIdx = currentIdx === -1 ? phases.length - 1 : currentIdx;
   for (let i = startIdx; i >= 0; i--) {
     const phase = phases[i];
-    if (phase?.rules?.proposals?.review === true) {
+    if (phase && isReviewPhase(phase)) {
       return phase.phaseId;
     }
   }

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -4,6 +4,14 @@
 export * from './money';
 export * from './services/decision/proposalDataSchema';
 export * from './services/decision/schemas/reviews';
+// Re-exported from the decision utils so client components can resolve
+// phase-level settings without pulling in the server-only utils barrel.
+export {
+  getPhaseReviewSettings,
+  isReviewPhase,
+  isVotingPhase,
+  type ReviewSettings,
+} from './services/decision/utils/phaseSettings';
 export {
   attachmentSchema,
   documentContentSchema,
@@ -111,7 +119,11 @@ export {
   type RecommendationValue,
   isOverallRecommendationField,
 } from './services/decision/getRubricScoringInfo';
-export { REVIEWS_POLICIES } from './services/decision/schemas/types';
+export {
+  REVIEWS_POLICIES,
+  phaseReviewSettingsSchema,
+  type PhaseReviewSettings,
+} from './services/decision/schemas/types';
 export { isLastPhase } from './services/decision/schemas/instanceData';
 export {
   VOTING_INELIGIBLE_STATUSES,

--- a/packages/common/src/services/decision/backfillReviewAssignments.ts
+++ b/packages/common/src/services/decision/backfillReviewAssignments.ts
@@ -6,6 +6,7 @@ import { getEligibleReviewerProfileIds } from './getEligibleReviewerProfileIds';
 import { insertReviewAssignments } from './insertReviewAssignments';
 import type { DecisionInstanceData } from './schemas/instanceData';
 import { assertInstancePhase } from './utils/instance';
+import { isReviewPhase } from './utils/phaseSettings';
 
 export interface BackfillReviewAssignmentsInput {
   instanceId: string;
@@ -63,7 +64,7 @@ export async function backfillReviewAssignments({
     instance: { instanceData },
     phaseId: currentPhaseId,
   });
-  if (!currentPhase.rules?.proposals?.review) {
+  if (!isReviewPhase(currentPhase)) {
     return skip('current phase is not review-capable');
   }
 

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -122,6 +122,9 @@ export * from './decisionRoles';
 // Instance utilities
 export * from './utils/instance';
 
+// Phase-level settings resolution
+export * from './utils/phaseSettings';
+
 // Voting management
 export * from './voting';
 
@@ -145,8 +148,13 @@ export { createInstanceDataFromTemplate } from './schemas/instanceData';
 export type {
   DecisionSchemaDefinition,
   PhaseDefinition,
+  PhaseReviewSettings,
   PhaseRules,
   ProcessConfig,
   ReviewsPolicy,
 } from './schemas/types';
-export { REVIEWS_POLICIES } from './schemas/types';
+export {
+  DEFAULT_REVIEWS_POLICY,
+  REVIEWS_POLICIES,
+  phaseReviewSettingsSchema,
+} from './schemas/types';

--- a/packages/common/src/services/decision/onPhaseAdvanced.ts
+++ b/packages/common/src/services/decision/onPhaseAdvanced.ts
@@ -5,6 +5,7 @@ import type { AdvancePhaseResult } from './advancePhase';
 import { processResults } from './processResults';
 import { runGenerateReviewAssignments } from './runGenerateReviewAssignments';
 import { type PhaseInstanceData, isLastPhase } from './schemas/instanceData';
+import { isReviewPhase } from './utils/phaseSettings';
 
 export interface OnPhaseAdvancedInput {
   instanceId: string;
@@ -39,7 +40,7 @@ export async function onPhaseAdvanced(
       });
     });
 
-  if (targetPhase?.rules?.proposals?.review) {
+  if (targetPhase && isReviewPhase(targetPhase)) {
     await runGenerateReviewAssignments(input);
   }
 

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -4,6 +4,7 @@
  */
 import type { UiSchema } from '@rjsf/utils';
 import type { JSONSchema7 } from 'json-schema';
+import { z } from 'zod';
 
 import type { SelectionPipeline } from '../selectionPipeline/types';
 import type { ProposalTemplateSchema, RubricTemplateSchema } from '../types';
@@ -15,6 +16,7 @@ export interface PhaseRules {
   proposals?: {
     submit?: boolean;
     edit?: boolean;
+    /** @deprecated Superseded by `reviews.submit`; kept only as its read fallback. */
     review?: boolean;
     defaults?: {
       hidden?: boolean;
@@ -30,6 +32,8 @@ export interface PhaseRules {
     method: 'date' | 'manual';
     endDate?: string;
   };
+  /** Review enablement + settings; read via `isReviewPhase` / `getPhaseReviewSettings`. */
+  reviews?: PhaseReviewSettings;
 }
 
 /**
@@ -65,6 +69,23 @@ export interface ProposalCategory {
 export const REVIEWS_POLICIES = ['full_coverage'] as const;
 
 export type ReviewsPolicy = (typeof REVIEWS_POLICIES)[number];
+
+/** Coverage policy applied when neither phase rules nor legacy config set one. */
+export const DEFAULT_REVIEWS_POLICY: ReviewsPolicy = 'full_coverage';
+
+/**
+ * `PhaseRules.reviews` shape — single source for the interface, the API
+ * encoder, and the resolved `ReviewSettings`.
+ */
+export const phaseReviewSettingsSchema = z.object({
+  /** Enablement, like `voting.submit`. */
+  submit: z.boolean().optional(),
+  policy: z.enum(REVIEWS_POLICIES).optional(),
+  allowRevisions: z.boolean().optional(),
+  anonymousFeedback: z.boolean().optional(),
+});
+
+export type PhaseReviewSettings = z.infer<typeof phaseReviewSettingsSchema>;
 
 export interface ProcessConfig {
   hideBudget?: boolean;

--- a/packages/common/src/services/decision/submitManualSelection.ts
+++ b/packages/common/src/services/decision/submitManualSelection.ts
@@ -28,6 +28,7 @@ import type {
   ManualSelectionAudit,
   TransitionData,
 } from './schemas/transitionData';
+import { isReviewPhase } from './utils/phaseSettings';
 
 export interface SubmitManualSelectionInput {
   processInstanceId: string;
@@ -264,7 +265,7 @@ export async function submitManualSelection({
     // rows and writes assignments on the pooled `db` connection, which can't see
     // this transaction's uncommitted writes (mirrors onPhaseAdvanced's ordering).
     const currentPhase = lockedPhases?.[lockedPhaseIndex];
-    if (lockedPhases && currentPhase?.rules?.proposals?.review) {
+    if (lockedPhases && currentPhase && isReviewPhase(currentPhase)) {
       reviewAssignmentInput = {
         instanceId: processInstanceId,
         fromPhaseId: lockedPreviousPhaseId,

--- a/packages/common/src/services/decision/utils/instance.ts
+++ b/packages/common/src/services/decision/utils/instance.ts
@@ -1,24 +1,22 @@
-import { NotFoundError } from '../../../utils';
-import type {
-  DecisionInstanceData,
-  PhaseInstanceData,
-} from '../schemas/instanceData';
+// Direct module import (not the barrel) to stay client-safe.
+import { NotFoundError } from '../../../utils/error';
 
 /**
  * Throws NotFoundError when `phaseId` is not configured on the instance's
- * `instanceData.phases`. Use this in routes/services that accept a phaseId
- * from the caller, so an unknown phase fails loudly instead of silently
- * resolving to empty results. Returns the matched phase so callers can
- * read its config without a second `find`.
+ * `instanceData.phases`, so an unknown phase fails loudly instead of silently
+ * resolving to empty results. Returns the matched phase. Generic/structural so
+ * it accepts both domain and API-encoder instance data.
  */
-export function assertInstancePhase({
+export function assertInstancePhase<Phase extends { phaseId: string }>({
   instance,
   phaseId,
 }: {
-  instance: { instanceData: DecisionInstanceData };
+  instance: { instanceData: { phases?: readonly Phase[] } };
   phaseId: string;
-}): PhaseInstanceData {
-  const phase = instance.instanceData.phases.find((p) => p.phaseId === phaseId);
+}): Phase {
+  const phase = instance.instanceData.phases?.find(
+    (p) => p.phaseId === phaseId,
+  );
   if (!phase) {
     throw new NotFoundError('Phase', phaseId);
   }

--- a/packages/common/src/services/decision/utils/phaseSettings.test.ts
+++ b/packages/common/src/services/decision/utils/phaseSettings.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getPhaseReviewSettings,
+  isReviewPhase,
+  isVotingPhase,
+} from './phaseSettings';
+
+describe('isReviewPhase', () => {
+  it('reads reviews.submit as the source of truth', () => {
+    expect(isReviewPhase({ rules: { reviews: { submit: true } } })).toBe(true);
+    expect(
+      isReviewPhase({
+        rules: { reviews: { submit: false }, proposals: { review: true } },
+      }),
+    ).toBe(false);
+  });
+
+  it('falls back to the legacy proposals.review flag', () => {
+    expect(isReviewPhase({ rules: { proposals: { review: true } } })).toBe(
+      true,
+    );
+    expect(isReviewPhase({ rules: { proposals: { review: false } } })).toBe(
+      false,
+    );
+  });
+
+  it('defaults to false when neither flag is set', () => {
+    expect(isReviewPhase({ rules: {} })).toBe(false);
+    expect(isReviewPhase({})).toBe(false);
+  });
+});
+
+describe('isVotingPhase', () => {
+  it('reads voting.submit, defaulting to false', () => {
+    expect(isVotingPhase({ rules: { voting: { submit: true } } })).toBe(true);
+    expect(isVotingPhase({ rules: { voting: { submit: false } } })).toBe(false);
+    expect(isVotingPhase({})).toBe(false);
+  });
+});
+
+describe('getPhaseReviewSettings', () => {
+  it('returns defaults when neither phase rules nor config set anything', () => {
+    const result = getPhaseReviewSettings(
+      { phases: [{ phaseId: 'review' }] },
+      'review',
+    );
+
+    expect(result).toEqual({
+      submit: false,
+      policy: 'full_coverage',
+      allowRevisions: true,
+      anonymousFeedback: undefined,
+    });
+  });
+
+  it('resolves submit from reviews.submit or the legacy proposals.review flag', () => {
+    const phases = [
+      { phaseId: 'a', rules: { reviews: { submit: true } } },
+      { phaseId: 'b', rules: { proposals: { review: true } } },
+    ];
+
+    expect(getPhaseReviewSettings({ phases }, 'a').submit).toBe(true);
+    expect(getPhaseReviewSettings({ phases }, 'b').submit).toBe(true);
+  });
+
+  it('falls back to legacy config values when the phase has no reviews block', () => {
+    const result = getPhaseReviewSettings(
+      {
+        config: {
+          reviewsPolicy: 'full_coverage',
+          reviewsAllowRevisions: false,
+          reviewsAnonymousFeedback: true,
+        },
+        phases: [{ phaseId: 'review' }],
+      },
+      'review',
+    );
+
+    expect(result).toEqual({
+      submit: false,
+      policy: 'full_coverage',
+      allowRevisions: false,
+      anonymousFeedback: true,
+    });
+  });
+
+  it('prefers the phase rules value over config and defaults', () => {
+    const result = getPhaseReviewSettings(
+      {
+        config: {
+          reviewsAllowRevisions: true,
+          reviewsAnonymousFeedback: false,
+        },
+        phases: [
+          {
+            phaseId: 'review',
+            rules: {
+              reviews: {
+                allowRevisions: false,
+                anonymousFeedback: true,
+              },
+            },
+          },
+        ],
+      },
+      'review',
+    );
+
+    expect(result).toEqual({
+      submit: false,
+      policy: 'full_coverage',
+      allowRevisions: false,
+      anonymousFeedback: true,
+    });
+  });
+
+  it('resolves each field independently — phase wins per field, config fills the rest', () => {
+    const result = getPhaseReviewSettings(
+      {
+        config: {
+          reviewsAllowRevisions: false,
+          reviewsAnonymousFeedback: true,
+        },
+        phases: [
+          {
+            phaseId: 'review',
+            // Phase only overrides allowRevisions; anonymousFeedback falls back
+            // to config, policy falls all the way through to the default.
+            rules: { reviews: { allowRevisions: true } },
+          },
+        ],
+      },
+      'review',
+    );
+
+    expect(result).toEqual({
+      submit: false,
+      policy: 'full_coverage',
+      allowRevisions: true,
+      anonymousFeedback: true,
+    });
+  });
+
+  it('does not let a phase `false` fall through to a truthy config value', () => {
+    const result = getPhaseReviewSettings(
+      {
+        config: { reviewsAllowRevisions: true },
+        phases: [
+          { phaseId: 'review', rules: { reviews: { allowRevisions: false } } },
+        ],
+      },
+      'review',
+    );
+
+    expect(result.allowRevisions).toBe(false);
+  });
+
+  it('reads the matching phase, not the first one', () => {
+    const result = getPhaseReviewSettings(
+      {
+        phases: [
+          {
+            phaseId: 'submission',
+            rules: { reviews: { allowRevisions: false } },
+          },
+          {
+            phaseId: 'review',
+            rules: { reviews: { allowRevisions: true } },
+          },
+        ],
+      },
+      'review',
+    );
+
+    expect(result.allowRevisions).toBe(true);
+  });
+
+  it('throws when the phase is not configured on the instance', () => {
+    expect(() =>
+      getPhaseReviewSettings(
+        {
+          config: { reviewsAllowRevisions: false },
+          phases: [{ phaseId: 'submission' }],
+        },
+        'review',
+      ),
+    ).toThrow();
+  });
+});

--- a/packages/common/src/services/decision/utils/phaseSettings.ts
+++ b/packages/common/src/services/decision/utils/phaseSettings.ts
@@ -1,0 +1,60 @@
+import { DEFAULT_REVIEWS_POLICY } from '../schemas/types';
+import type { PhaseReviewSettings, ReviewsPolicy } from '../schemas/types';
+import { assertInstancePhase } from './instance';
+
+/**
+ * Phase-level settings resolution: `rules.<domain>` → legacy `config.*` →
+ * defaults. Consumers go through these helpers; nothing reads either location
+ * directly. Typed structurally so domain types and the API-encoder
+ * `InstanceData` both pass.
+ */
+
+interface ReviewPhaseRules {
+  reviews?: PhaseReviewSettings;
+  proposals?: { review?: boolean };
+}
+
+/** Reviewing happens in this phase (`reviews.submit`, legacy `proposals.review`). */
+export function isReviewPhase(phase: { rules?: ReviewPhaseRules }): boolean {
+  return (
+    phase.rules?.reviews?.submit ?? phase.rules?.proposals?.review ?? false
+  );
+}
+
+/** Voting happens in this phase. */
+export function isVotingPhase(phase: {
+  rules?: { voting?: { submit?: boolean } };
+}): boolean {
+  return phase.rules?.voting?.submit ?? false;
+}
+
+/** `PhaseReviewSettings` with defaults applied (`anonymousFeedback` has none). */
+export type ReviewSettings = Required<
+  Pick<PhaseReviewSettings, 'submit' | 'policy' | 'allowRevisions'>
+> & { anonymousFeedback: PhaseReviewSettings['anonymousFeedback'] };
+
+/** Resolves review settings for `phaseId`; throws if the phase doesn't exist. */
+export function getPhaseReviewSettings(
+  instanceData: {
+    config?: {
+      reviewsPolicy?: ReviewsPolicy;
+      reviewsAllowRevisions?: boolean;
+      reviewsAnonymousFeedback?: boolean;
+    };
+    phases?: ReadonlyArray<{ phaseId: string; rules?: ReviewPhaseRules }>;
+  },
+  phaseId: string,
+): ReviewSettings {
+  const phase = assertInstancePhase({ instance: { instanceData }, phaseId });
+  const reviews = phase.rules?.reviews;
+  const config = instanceData.config;
+
+  return {
+    submit: isReviewPhase(phase),
+    policy: reviews?.policy ?? config?.reviewsPolicy ?? DEFAULT_REVIEWS_POLICY,
+    allowRevisions:
+      reviews?.allowRevisions ?? config?.reviewsAllowRevisions ?? true,
+    anonymousFeedback:
+      reviews?.anonymousFeedback ?? config?.reviewsAnonymousFeedback,
+  };
+}

--- a/packages/common/src/services/decision/voting.ts
+++ b/packages/common/src/services/decision/voting.ts
@@ -24,6 +24,7 @@ import { decisionPermission } from './permissions';
 import { processDecisionProcessSchema } from './schemaRegistry';
 import { validateVoteSelection } from './schemaValidators';
 import type { DecisionInstanceData } from './schemas/instanceData';
+import { isVotingPhase } from './utils/phaseSettings';
 import { isVotingEligible } from './votingEligibility';
 
 interface PhaseConfig {
@@ -57,7 +58,7 @@ function getCurrentPhaseConfig(processInstance: {
 
   return {
     allowProposals: currentPhase.rules?.proposals?.submit ?? false,
-    allowDecisions: currentPhase.rules?.voting?.submit ?? false,
+    allowDecisions: isVotingPhase(currentPhase),
     maxVotesPerMember: currentPhase.rules?.voting?.maxVotesPerMember,
   };
 }

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -1,6 +1,7 @@
 import {
   REVIEWS_POLICIES,
   checkpointVersionSchema,
+  phaseReviewSettingsSchema,
   proposalSchema,
   rubricTemplateSchema,
 } from '@op/common/client';
@@ -80,6 +81,7 @@ const phaseRulesEncoder = z.object({
       endDate: z.string().optional(),
     })
     .optional(),
+  reviews: phaseReviewSettingsSchema.optional(),
 }) satisfies z.ZodType<CommonPhaseRules>;
 
 /** Selection pipeline block encoder */


### PR DESCRIPTION
Move review-settings reads to phase level (rules.reviews) behind a per-field fallback to the legacy instance config, so per-phase overrides become possible without changing any current behavior. Groundwork for reviews-by-category.