### PR TITLE
feat(sense): migrate landing page to @op/sense

### DIFF
--- a/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
+++ b/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
@@ -19,8 +19,9 @@ import { ProfileItem } from '@op/sense/ProfileItem';
 import { Suspense, useState } from 'react';
 import { LuPenLine } from 'react-icons/lu';
 
-import { Link, useTranslations } from '@/lib/i18n';
+import { useTranslations } from '@/lib/i18n';
 
+import { ButtonLink } from '../ButtonLink';
 import { DecisionAvatar } from '../DecisionAvatar';
 import ErrorBoundary from '../ErrorBoundary';
 
@@ -71,15 +72,15 @@ const ActiveDecisionsNotificationsSuspense = () => {
                 }
               />
               <NotificationPanelActions>
-                <Button
-                  render={<Link href={`/decisions/${decision.slug}`} />}
+                <ButtonLink
+                  href={`/decisions/${decision.slug}`}
                   size="sm"
                   className="w-full sm:w-auto"
                   onClick={() => setNavigatingId(decision.id)}
                   loading={isNavigating}
                 >
                   {t('Participate')}
-                </Button>
+                </ButtonLink>
               </NotificationPanelActions>
             </NotificationPanelItem>
           );
@@ -141,15 +142,15 @@ const RevisionRequestRow = ({
         >
           {t('Ignore')}
         </Button>
-        <Button
-          render={<Link href={editHref} />}
+        <ButtonLink
+          href={editHref}
           size="sm"
           className="w-full sm:w-auto"
           onClick={() => setNavigating(true)}
           loading={navigating}
         >
           {t('Revise proposal')}
-        </Button>
+        </ButtonLink>
       </NotificationPanelActions>
     </NotificationPanelItem>
   );

--- a/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
+++ b/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
@@ -74,7 +74,6 @@ const ActiveDecisionsNotificationsSuspense = () => {
               <NotificationPanelActions>
                 <ButtonLink
                   href={`/decisions/${decision.slug}`}
-                  size="sm"
                   className="w-full sm:w-auto"
                   onClick={() => setNavigatingId(decision.id)}
                   loading={isNavigating}
@@ -135,7 +134,6 @@ const RevisionRequestRow = ({
       />
       <NotificationPanelActions>
         <Button
-          size="sm"
           variant="outline"
           className="w-full sm:w-auto"
           onClick={() => setDismissed(true)}
@@ -144,7 +142,6 @@ const RevisionRequestRow = ({
         </Button>
         <ButtonLink
           href={editHref}
-          size="sm"
           className="w-full sm:w-auto"
           onClick={() => setNavigating(true)}
           loading={navigating}

--- a/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
+++ b/apps/app/src/components/ActiveDecisionsNotifications/index.tsx
@@ -7,19 +7,19 @@ import {
   type ProposalRevisionRequestItem,
 } from '@op/common/client';
 import { getTextPreview } from '@op/core';
-import { Button, ButtonLink } from '@op/ui/Button';
+import { Button } from '@op/sense/Button';
 import {
   NotificationPanel,
   NotificationPanelActions,
   NotificationPanelHeader,
   NotificationPanelItem,
   NotificationPanelList,
-} from '@op/ui/NotificationPanel';
-import { ProfileItem } from '@op/ui/ProfileItem';
+} from '@op/sense/NotificationPanel';
+import { ProfileItem } from '@op/sense/ProfileItem';
 import { Suspense, useState } from 'react';
 import { LuPenLine } from 'react-icons/lu';
 
-import { useTranslations } from '@/lib/i18n';
+import { Link, useTranslations } from '@/lib/i18n';
 
 import { DecisionAvatar } from '../DecisionAvatar';
 import ErrorBoundary from '../ErrorBoundary';
@@ -71,15 +71,15 @@ const ActiveDecisionsNotificationsSuspense = () => {
                 }
               />
               <NotificationPanelActions>
-                <ButtonLink
-                  size="small"
+                <Button
+                  render={<Link href={`/decisions/${decision.slug}`} />}
+                  size="sm"
                   className="w-full sm:w-auto"
-                  href={`/decisions/${decision.slug}`}
-                  onPress={() => setNavigatingId(decision.id)}
-                  isLoading={isNavigating}
+                  onClick={() => setNavigatingId(decision.id)}
+                  loading={isNavigating}
                 >
                   {t('Participate')}
-                </ButtonLink>
+                </Button>
               </NotificationPanelActions>
             </NotificationPanelItem>
           );
@@ -134,22 +134,22 @@ const RevisionRequestRow = ({
       />
       <NotificationPanelActions>
         <Button
-          size="small"
-          color="secondary"
+          size="sm"
+          variant="outline"
           className="w-full sm:w-auto"
-          onPress={() => setDismissed(true)}
+          onClick={() => setDismissed(true)}
         >
           {t('Ignore')}
         </Button>
-        <ButtonLink
-          size="small"
+        <Button
+          render={<Link href={editHref} />}
+          size="sm"
           className="w-full sm:w-auto"
-          href={editHref}
-          onPress={() => setNavigating(true)}
-          isLoading={navigating}
+          onClick={() => setNavigating(true)}
+          loading={navigating}
         >
           {t('Revise proposal')}
-        </ButtonLink>
+        </Button>
       </NotificationPanelActions>
     </NotificationPanelItem>
   );

--- a/apps/app/src/components/ButtonLink/index.tsx
+++ b/apps/app/src/components/ButtonLink/index.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@op/sense/Button';
+import type { ComponentProps } from 'react';
+
+import { Link } from '@/lib/i18n';
+
+type ButtonLinkProps = Omit<ComponentProps<typeof Button>, 'render'> & {
+  href: ComponentProps<typeof Link>['href'];
+};
+
+/**
+ * A sense `Button` that renders as a locale-aware `Link` — the button-styled
+ * anchor (replaces `@op/ui`'s `ButtonLink`). Inherits every `Button` prop
+ * (`variant`, `size`, `loading`, …); `href` is forwarded to the i18n `Link`.
+ */
+export const ButtonLink = ({ href, ...props }: ButtonLinkProps) => {
+  return <Button render={<Link href={href} />} {...props} />;
+};

--- a/apps/app/src/components/DecisionAvatar/index.tsx
+++ b/apps/app/src/components/DecisionAvatar/index.tsx
@@ -1,7 +1,8 @@
 import { getPublicUrl } from '@/utils';
 import { Profile } from '@op/api/encoders';
-import { Avatar, AvatarSkeleton } from '@op/ui/Avatar';
-import { cn } from '@op/ui/utils';
+import { ProfileAvatar } from '@op/sense/ProfileAvatar';
+import { Skeleton } from '@op/sense/Skeleton';
+import { cn } from '@op/sense/lib/utils';
 import Image from 'next/image';
 
 import { Link } from '@/lib/i18n';
@@ -20,24 +21,24 @@ export const DecisionAvatar = ({
   }
 
   const name = profile?.name ?? '';
-  const avatarImage = profile?.avatarImage;
+  const avatarUrl = profile?.avatarImage?.name
+    ? (getPublicUrl(profile.avatarImage.name) ?? undefined)
+    : undefined;
   const slug = profile?.slug;
 
   const avatar = (
-    <Avatar
-      className={cn(withLink && slug && 'hover:opacity-80', className)}
+    <ProfileAvatar
+      name={name}
+      src={avatarUrl}
+      alt={name}
       size="lg"
-      placeholder={name ?? ''}
-    >
-      {avatarImage?.name ? (
-        <Image
-          src={getPublicUrl(avatarImage?.name) ?? ''}
-          alt={name ?? ''}
-          fill
-          className="object-cover"
-        />
-      ) : null}
-    </Avatar>
+      className={cn(withLink && slug && 'hover:opacity-80', className)}
+      imageRender={
+        avatarUrl ? (
+          <Image src={avatarUrl} alt={name} fill className="object-cover" />
+        ) : undefined
+      }
+    />
   );
 
   return withLink && slug ? (
@@ -56,7 +57,7 @@ export const DecisionAvatarSkeleton = ({
 }) => {
   return (
     <div>
-      <AvatarSkeleton size="lg" className={className} />
+      <Skeleton className={cn('size-10 rounded-full', className)} />
     </div>
   );
 };

--- a/apps/app/src/components/DecisionAvatar/index.tsx
+++ b/apps/app/src/components/DecisionAvatar/index.tsx
@@ -1,11 +1,9 @@
 import { getPublicUrl } from '@/utils';
 import { Profile } from '@op/api/encoders';
-import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { Skeleton } from '@op/sense/Skeleton';
 import { cn } from '@op/sense/lib/utils';
-import Image from 'next/image';
 
-import { Link } from '@/lib/i18n';
+import { ProfileAvatarLink } from '../ProfileAvatarLink';
 
 export const DecisionAvatar = ({
   profile,
@@ -26,27 +24,15 @@ export const DecisionAvatar = ({
     : undefined;
   const slug = profile?.slug;
 
-  const avatar = (
-    <ProfileAvatar
+  return (
+    <ProfileAvatarLink
+      href={withLink && slug ? `/decisions/${slug}` : undefined}
       name={name}
       src={avatarUrl}
       alt={name}
       size="lg"
-      className={cn(withLink && slug && 'hover:opacity-80', className)}
-      imageRender={
-        avatarUrl ? (
-          <Image src={avatarUrl} alt={name} fill className="object-cover" />
-        ) : undefined
-      }
+      className={className}
     />
-  );
-
-  return withLink && slug ? (
-    <Link href={`/decisions/${slug}`} className="hover:no-underline">
-      {avatar}
-    </Link>
-  ) : (
-    <div>{avatar}</div>
   );
 };
 

--- a/apps/app/src/components/Feed/index.tsx
+++ b/apps/app/src/components/Feed/index.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@op/ui/utils';
+import { cn } from '@op/sense/lib/utils';
 import { ReactNode } from 'react';
 
 export const FeedItem = ({
@@ -68,7 +68,7 @@ export const FeedMain = ({
   return (
     <div
       className={cn(
-        'flex w-full flex-col items-start justify-start gap-0.5 overflow-hidden',
+        'flex w-full flex-col items-start justify-start gap-2 overflow-hidden',
         className,
       )}
       {...props}

--- a/apps/app/src/components/JoinProfileRequestsNotifications/index.tsx
+++ b/apps/app/src/components/JoinProfileRequestsNotifications/index.tsx
@@ -2,17 +2,17 @@
 
 import { trpc } from '@op/api/client';
 import { JoinProfileRequestStatus } from '@op/api/encoders';
-import { Button } from '@op/ui/Button';
-import { LoadingSpinner } from '@op/ui/LoadingSpinner';
+import { Button } from '@op/sense/Button';
 import {
   NotificationPanel,
   NotificationPanelActions,
   NotificationPanelHeader,
   NotificationPanelItem,
   NotificationPanelList,
-} from '@op/ui/NotificationPanel';
-import { ProfileItem } from '@op/ui/ProfileItem';
-import { toast } from '@op/ui/Toast';
+} from '@op/sense/NotificationPanel';
+import { ProfileItem } from '@op/sense/ProfileItem';
+import { toast } from '@op/sense/Sonner';
+import { Spinner } from '@op/sense/Spinner';
 import { Suspense } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -52,18 +52,15 @@ const JoinProfileRequestsNotificationsSuspense = ({
 
   const updateRequestMutation = trpc.profile.updateJoinRequest.useMutation({
     onSuccess: (_, variables) => {
-      toast.success({
-        title:
-          variables.status === JoinProfileRequestStatus.APPROVED
-            ? t('Request accepted')
-            : t('Request declined'),
-      });
+      toast.success(
+        variables.status === JoinProfileRequestStatus.APPROVED
+          ? t('Request accepted')
+          : t('Request declined'),
+      );
       utils.profile.listJoinRequests.invalidate();
     },
     onError: () => {
-      toast.error({
-        title: t('Failed to update request'),
-      });
+      toast.error(t('Failed to update request'));
     },
   });
 
@@ -118,31 +115,39 @@ const JoinProfileRequestsNotificationsSuspense = ({
               />
               <NotificationPanelActions>
                 <Button
-                  size="small"
-                  color="secondary"
+                  size="sm"
+                  variant="outline"
                   className="w-full sm:w-auto"
-                  onPress={() =>
+                  onClick={() =>
                     handleUpdateRequest(
                       request.id,
                       JoinProfileRequestStatus.REJECTED,
                     )
                   }
-                  isDisabled={isPendingForRequest}
+                  disabled={isPendingForRequest}
                 >
-                  {isLoadingReject ? <LoadingSpinner /> : t('Decline')}
+                  {isLoadingReject ? (
+                    <Spinner className="size-6" />
+                  ) : (
+                    t('Decline')
+                  )}
                 </Button>
                 <Button
-                  size="small"
+                  size="sm"
                   className="w-full sm:w-auto"
-                  onPress={() =>
+                  onClick={() =>
                     handleUpdateRequest(
                       request.id,
                       JoinProfileRequestStatus.APPROVED,
                     )
                   }
-                  isDisabled={isPendingForRequest}
+                  disabled={isPendingForRequest}
                 >
-                  {isLoadingApprove ? <LoadingSpinner /> : t('Accept')}
+                  {isLoadingApprove ? (
+                    <Spinner className="size-6" />
+                  ) : (
+                    t('Accept')
+                  )}
                 </Button>
               </NotificationPanelActions>
             </NotificationPanelItem>

--- a/apps/app/src/components/JoinProfileRequestsNotifications/index.tsx
+++ b/apps/app/src/components/JoinProfileRequestsNotifications/index.tsx
@@ -12,7 +12,6 @@ import {
 } from '@op/sense/NotificationPanel';
 import { ProfileItem } from '@op/sense/ProfileItem';
 import { toast } from '@op/sense/Sonner';
-import { Spinner } from '@op/sense/Spinner';
 import { Suspense } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -124,13 +123,10 @@ const JoinProfileRequestsNotificationsSuspense = ({
                       JoinProfileRequestStatus.REJECTED,
                     )
                   }
+                  loading={isLoadingReject}
                   disabled={isPendingForRequest}
                 >
-                  {isLoadingReject ? (
-                    <Spinner className="size-6" />
-                  ) : (
-                    t('Decline')
-                  )}
+                  {t('Decline')}
                 </Button>
                 <Button
                   size="sm"
@@ -141,13 +137,10 @@ const JoinProfileRequestsNotificationsSuspense = ({
                       JoinProfileRequestStatus.APPROVED,
                     )
                   }
+                  loading={isLoadingApprove}
                   disabled={isPendingForRequest}
                 >
-                  {isLoadingApprove ? (
-                    <Spinner className="size-6" />
-                  ) : (
-                    t('Accept')
-                  )}
+                  {t('Accept')}
                 </Button>
               </NotificationPanelActions>
             </NotificationPanelItem>

--- a/apps/app/src/components/JoinProfileRequestsNotifications/index.tsx
+++ b/apps/app/src/components/JoinProfileRequestsNotifications/index.tsx
@@ -114,7 +114,6 @@ const JoinProfileRequestsNotificationsSuspense = ({
               />
               <NotificationPanelActions>
                 <Button
-                  size="sm"
                   variant="outline"
                   className="w-full sm:w-auto"
                   onClick={() =>
@@ -129,7 +128,6 @@ const JoinProfileRequestsNotificationsSuspense = ({
                   {t('Decline')}
                 </Button>
                 <Button
-                  size="sm"
                   className="w-full sm:w-auto"
                   onClick={() =>
                     handleUpdateRequest(

--- a/apps/app/src/components/NewOrganizations/index.tsx
+++ b/apps/app/src/components/NewOrganizations/index.tsx
@@ -26,7 +26,7 @@ export const NewOrganizationsSuspense = async ({
     return (
       <div className="flex flex-col gap-4">
         <OrganizationList organizations={organizations} />
-        <div className="px-8 sm:px-0">
+        <div className="px-4 sm:px-0">
           <Link href="/org" className="text-teal">
             <TranslatedText text="See more" />
           </Link>

--- a/apps/app/src/components/NewlyJoinedModal/index.tsx
+++ b/apps/app/src/components/NewlyJoinedModal/index.tsx
@@ -2,7 +2,12 @@
 
 import { Button } from '@op/sense/Button';
 import { Confetti } from '@op/sense/Confetti';
-import { Dialog, DialogContent, DialogTitle } from '@op/sense/Dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogPortal,
+  DialogTitle,
+} from '@op/sense/Dialog';
 import { Header1 } from '@op/sense/Header';
 import { CheckIcon } from '@op/sense/icons';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -16,10 +21,18 @@ export const NewlyJoinedModal = () => {
   const router = useRouter();
   const isNew = searchParams.get('new');
   const [modalOpen, setModalOpen] = useState(!!isNew);
+  // Bumped each open so the Confetti remounts and replays.
+  const [burst, setBurst] = useState(0);
 
   useEffect(() => {
     setModalOpen(!!isNew);
   }, [isNew]);
+
+  useEffect(() => {
+    if (modalOpen) {
+      setBurst((n) => n + 1);
+    }
+  }, [modalOpen]);
 
   const handleModalChange = (open: boolean) => {
     setModalOpen(open);
@@ -37,13 +50,22 @@ export const NewlyJoinedModal = () => {
 
   return (
     <Dialog open={modalOpen} onOpenChange={handleModalChange}>
+      {modalOpen ? (
+        <DialogPortal>
+          {/* Viewport-fixed overlay portaled to <body>, layered between the
+              backdrop (z-50) and the card (z-60) so confetti fills the screen
+              behind the modal, not clipped inside the card. */}
+          <div className="pointer-events-none fixed inset-0 isolate z-55">
+            <Confetti key={burst} />
+          </div>
+        </DialogPortal>
+      ) : null}
       <DialogContent
-        className="shadow-green inset-shadow-none"
+        className="z-60 shadow-green inset-shadow-none"
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">{t("You're all set!")}</DialogTitle>
-        <Confetti />
-        <div className="z-10 p-12 text-center">
+        <div className="p-12 text-center">
           <div className="flex flex-col gap-6">
             <div className="flex flex-col items-center justify-center gap-4">
               <CheckIcon />

--- a/apps/app/src/components/NewlyJoinedModal/index.tsx
+++ b/apps/app/src/components/NewlyJoinedModal/index.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Button } from '@op/ui/Button';
-import { CheckIcon } from '@op/ui/CheckIcon';
-import { Header1 } from '@op/ui/Header';
-import { Modal } from '@op/ui/Modal';
+import { Button } from '@op/sense/Button';
+import { Confetti } from '@op/sense/Confetti';
+import { Dialog, DialogContent, DialogTitle } from '@op/sense/Dialog';
+import { Header1 } from '@op/sense/Header';
+import { CheckIcon } from '@op/sense/icons';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -35,30 +36,32 @@ export const NewlyJoinedModal = () => {
   };
 
   return (
-    <Modal
-      className="shadow-green inset-shadow-none"
-      isOpen={modalOpen}
-      onOpenChange={handleModalChange}
-      confetti
-    >
-      <div className="z-10 p-12 text-center">
-        <div className="flex flex-col gap-6">
-          <div className="flex flex-col items-center justify-center gap-4">
-            <CheckIcon />
-            <div className="flex flex-col gap-2">
-              <Header1 className="sm:text-title-lg">
-                {t("You're all set!")}
-              </Header1>
-              {t(
-                "You've successfully joined Common. Your organization's profile is now visible to aligned collaborators and funders.",
-              )}
+    <Dialog open={modalOpen} onOpenChange={handleModalChange}>
+      <DialogContent
+        className="shadow-green inset-shadow-none"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">{t("You're all set!")}</DialogTitle>
+        <Confetti />
+        <div className="z-10 p-12 text-center">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col items-center justify-center gap-4">
+              <CheckIcon />
+              <div className="flex flex-col gap-2">
+                <Header1 className="sm:text-title-lg">
+                  {t("You're all set!")}
+                </Header1>
+                {t(
+                  "You've successfully joined Common. Your organization's profile is now visible to aligned collaborators and funders.",
+                )}
+              </div>
             </div>
+            <Button className="w-full" onClick={() => handleModalChange(false)}>
+              {t('Take me to Common')}
+            </Button>
           </div>
-          <Button className="w-full" onPress={() => handleModalChange(false)}>
-            {t('Take me to Common')}
-          </Button>
         </div>
-      </div>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/apps/app/src/components/NewlyJoinedModal/index.tsx
+++ b/apps/app/src/components/NewlyJoinedModal/index.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { Button } from '@op/sense/Button';
-import { Confetti } from '@op/sense/Confetti';
-import {
-  Dialog,
-  DialogContent,
-  DialogPortal,
-  DialogTitle,
-} from '@op/sense/Dialog';
+import { Dialog, DialogContent, DialogTitle } from '@op/sense/Dialog';
 import { Header1 } from '@op/sense/Header';
 import { CheckIcon } from '@op/sense/icons';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -21,18 +15,10 @@ export const NewlyJoinedModal = () => {
   const router = useRouter();
   const isNew = searchParams.get('new');
   const [modalOpen, setModalOpen] = useState(!!isNew);
-  // Bumped each open so the Confetti remounts and replays.
-  const [burst, setBurst] = useState(0);
 
   useEffect(() => {
     setModalOpen(!!isNew);
   }, [isNew]);
-
-  useEffect(() => {
-    if (modalOpen) {
-      setBurst((n) => n + 1);
-    }
-  }, [modalOpen]);
 
   const handleModalChange = (open: boolean) => {
     setModalOpen(open);
@@ -50,18 +36,9 @@ export const NewlyJoinedModal = () => {
 
   return (
     <Dialog open={modalOpen} onOpenChange={handleModalChange}>
-      {modalOpen ? (
-        <DialogPortal>
-          {/* Viewport-fixed overlay portaled to <body>, layered between the
-              backdrop (z-50) and the card (z-60) so confetti fills the screen
-              behind the modal, not clipped inside the card. */}
-          <div className="pointer-events-none fixed inset-0 isolate z-55">
-            <Confetti key={burst} />
-          </div>
-        </DialogPortal>
-      ) : null}
       <DialogContent
-        className="z-60 shadow-green inset-shadow-none"
+        confetti
+        className="shadow-green inset-shadow-none"
         showCloseButton={false}
       >
         <DialogTitle className="sr-only">{t("You're all set!")}</DialogTitle>

--- a/apps/app/src/components/OrganizationAvatar/index.tsx
+++ b/apps/app/src/components/OrganizationAvatar/index.tsx
@@ -36,7 +36,7 @@ export const OrganizationAvatar = ({
       name={name}
       src={avatarUrl}
       alt={name}
-      className={cn('size-10', linked && 'hover:opacity-80', className)}
+      className={cn(linked && 'hover:opacity-80', className)}
       imageRender={
         avatarUrl ? (
           <Image src={avatarUrl} alt={name} fill className="object-cover" />

--- a/apps/app/src/components/OrganizationAvatar/index.tsx
+++ b/apps/app/src/components/OrganizationAvatar/index.tsx
@@ -36,8 +36,7 @@ export const OrganizationAvatar = ({
       name={name}
       src={avatarUrl}
       alt={name}
-      size="lg"
-      className={cn(linked && 'hover:opacity-80', className)}
+      className={cn('size-10', linked && 'hover:opacity-80', className)}
       imageRender={
         avatarUrl ? (
           <Image src={avatarUrl} alt={name} fill className="object-cover" />

--- a/apps/app/src/components/OrganizationAvatar/index.tsx
+++ b/apps/app/src/components/OrganizationAvatar/index.tsx
@@ -1,12 +1,10 @@
 import { useCanLinkToProfile } from '@/hooks/useCanLinkToProfile';
 import { getPublicUrl } from '@/utils';
 import { Profile } from '@op/api/encoders';
-import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { Skeleton } from '@op/sense/Skeleton';
 import { cn } from '@op/sense/lib/utils';
-import Image from 'next/image';
 
-import { Link } from '@/lib/i18n';
+import { ProfileAvatarLink } from '../ProfileAvatarLink';
 
 export const OrganizationAvatar = ({
   profile,
@@ -31,26 +29,14 @@ export const OrganizationAvatar = ({
   // Public/non-member viewers can't reach the profile page, so drop the link.
   const linked = withLink && canLinkToProfile && Boolean(slug);
 
-  const avatar = (
-    <ProfileAvatar
+  return (
+    <ProfileAvatarLink
+      href={linked ? `/profile/${slug}` : undefined}
       name={name}
       src={avatarUrl}
       alt={name}
-      className={cn(linked && 'hover:opacity-80', className)}
-      imageRender={
-        avatarUrl ? (
-          <Image src={avatarUrl} alt={name} fill className="object-cover" />
-        ) : undefined
-      }
+      className={className}
     />
-  );
-
-  return linked ? (
-    <Link href={`/profile/${slug}`} className="hover:no-underline">
-      {avatar}
-    </Link>
-  ) : (
-    <div>{avatar}</div>
   );
 };
 

--- a/apps/app/src/components/OrganizationAvatar/index.tsx
+++ b/apps/app/src/components/OrganizationAvatar/index.tsx
@@ -1,8 +1,9 @@
 import { useCanLinkToProfile } from '@/hooks/useCanLinkToProfile';
 import { getPublicUrl } from '@/utils';
 import { Profile } from '@op/api/encoders';
-import { Avatar, AvatarSkeleton } from '@op/ui/Avatar';
-import { cn } from '@op/ui/utils';
+import { ProfileAvatar } from '@op/sense/ProfileAvatar';
+import { Skeleton } from '@op/sense/Skeleton';
+import { cn } from '@op/sense/lib/utils';
 import Image from 'next/image';
 
 import { Link } from '@/lib/i18n';
@@ -23,26 +24,26 @@ export const OrganizationAvatar = ({
   }
 
   const name = profile?.name ?? '';
-  const avatarImage = profile?.avatarImage;
+  const avatarUrl = profile?.avatarImage?.name
+    ? (getPublicUrl(profile.avatarImage.name) ?? undefined)
+    : undefined;
   const slug = profile?.slug;
   // Public/non-member viewers can't reach the profile page, so drop the link.
   const linked = withLink && canLinkToProfile && Boolean(slug);
 
   const avatar = (
-    <Avatar
-      className={cn(linked && 'hover:opacity-80', className)}
+    <ProfileAvatar
+      name={name}
+      src={avatarUrl}
+      alt={name}
       size="lg"
-      placeholder={name ?? ''}
-    >
-      {avatarImage?.name ? (
-        <Image
-          src={getPublicUrl(avatarImage?.name) ?? ''}
-          alt={name ?? ''}
-          fill
-          className="object-cover"
-        />
-      ) : null}
-    </Avatar>
+      className={cn(linked && 'hover:opacity-80', className)}
+      imageRender={
+        avatarUrl ? (
+          <Image src={avatarUrl} alt={name} fill className="object-cover" />
+        ) : undefined
+      }
+    />
   );
 
   return linked ? (
@@ -61,7 +62,7 @@ export const OrganizationAvatarSkeleton = ({
 }) => {
   return (
     <div>
-      <AvatarSkeleton size="lg" className={className} />
+      <Skeleton className={cn('size-10 rounded-full', className)} />
     </div>
   );
 };

--- a/apps/app/src/components/OrganizationList/index.tsx
+++ b/apps/app/src/components/OrganizationList/index.tsx
@@ -47,7 +47,7 @@ export const OrganizationList = ({
 
       {/* mobile */}
       <div className="flex flex-col gap-6 sm:hidden">
-        <HorizontalList className="scroll-px-8">
+        <HorizontalList className="scroll-px-4">
           {organizations?.map((org) => {
             const { avatarImage, headerImage } = org.profile;
             const avatarUrl = getPublicUrl(avatarImage?.name);
@@ -63,7 +63,7 @@ export const OrganizationList = ({
             return (
               <HorizontalListItem
                 key={org.id}
-                className="snap-start first:ms-8 last:me-8"
+                className="snap-start first:ms-4 last:me-4"
               >
                 <Link
                   className="flex size-48"

--- a/apps/app/src/components/OrganizationList/index.tsx
+++ b/apps/app/src/components/OrganizationList/index.tsx
@@ -2,11 +2,12 @@
 
 import { getPublicUrl } from '@/utils';
 import { Organization } from '@op/api/encoders';
-import { Avatar } from '@op/ui/Avatar';
-import { HorizontalList, HorizontalListItem } from '@op/ui/HorizontalList';
-import { Skeleton, SkeletonLine } from '@op/ui/Skeleton';
-import { Surface } from '@op/ui/Surface';
-import { cn, getGradientForString } from '@op/ui/utils';
+import { Card } from '@op/sense/Card';
+import { HorizontalList, HorizontalListItem } from '@op/sense/HorizontalList';
+import { ProfileAvatar } from '@op/sense/ProfileAvatar';
+import { Skeleton } from '@op/sense/Skeleton';
+import { cn } from '@op/sense/lib/utils';
+import { getGradientForString } from '@op/styles/constants';
 import Image from 'next/image';
 
 import { Link } from '@/lib/i18n';
@@ -68,7 +69,7 @@ export const OrganizationList = ({
                   className="flex size-48"
                   href={`/org/${org.profile.slug}`}
                 >
-                  <Surface className="flex size-full flex-col gap-3">
+                  <Card className="size-full gap-3 py-0">
                     <ImageHeader
                       headerImage={
                         headerUrl ? (
@@ -102,7 +103,7 @@ export const OrganizationList = ({
                         <bdi>{org.profile.name}</bdi>
                       </span>
                     </div>
-                  </Surface>
+                  </Card>
                 </Link>
               </HorizontalListItem>
             );
@@ -173,6 +174,11 @@ export const OrganizationSummaryList = ({
             ? `${org.profile.bio.slice(0, 325)}...`
             : org.profile.bio;
 
+        const orgAvatarUrl =
+          getPublicUrl(
+            org.profile.avatarImage?.name ?? org.avatarImage?.name,
+          ) ?? '';
+
         return (
           <div key={org.id}>
             <div className="flex items-start gap-2 py-2 sm:gap-6">
@@ -180,24 +186,22 @@ export const OrganizationSummaryList = ({
                 href={`/org/${org.profile.slug}`}
                 className="hover:no-underline"
               >
-                <Avatar
+                <ProfileAvatar
+                  name={org.profile.name ?? ''}
+                  src={orgAvatarUrl}
+                  alt={org.profile.name ?? ''}
                   className="size-8 hover:opacity-80 sm:size-12"
-                  placeholder={org.profile.name ?? ''}
-                >
-                  {org.profile?.name ? (
-                    <Image
-                      src={
-                        getPublicUrl(
-                          org.profile.avatarImage?.name ??
-                            org.avatarImage?.name,
-                        ) ?? ''
-                      }
-                      alt={org.profile.name ?? ''}
-                      fill
-                      className="object-cover"
-                    />
-                  ) : null}
-                </Avatar>
+                  imageRender={
+                    orgAvatarUrl ? (
+                      <Image
+                        src={orgAvatarUrl}
+                        alt={org.profile.name ?? ''}
+                        width={48}
+                        height={48}
+                      />
+                    ) : undefined
+                  }
+                />
               </Link>
 
               <div className="flex flex-col gap-3 text-neutral-black">
@@ -237,8 +241,9 @@ export const OrganizationListSkeleton = () => {
           <div className="flex items-center gap-4">
             <OrganizationAvatarSkeleton className="size-8" />
 
-            <div className="flex w-full flex-col text-sm">
-              <SkeletonLine className="w-full" lines={2} />
+            <div className="flex w-full flex-col gap-2 text-sm">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-2/3" />
             </div>
           </div>
         </div>
@@ -260,7 +265,11 @@ export const OrganizationCardListSkeleton = () => {
               <div className="flex flex-col gap-2">
                 <Skeleton className="h-6 w-3/4" />
               </div>
-              <SkeletonLine lines={3} randomWidth={true} className="w-full" />
+              <div className="flex w-full flex-col gap-2">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
             </div>
           </div>
         </div>

--- a/apps/app/src/components/OrganizationList/index.tsx
+++ b/apps/app/src/components/OrganizationList/index.tsx
@@ -4,7 +4,6 @@ import { getPublicUrl } from '@/utils';
 import { Organization } from '@op/api/encoders';
 import { Card } from '@op/sense/Card';
 import { HorizontalList, HorizontalListItem } from '@op/sense/HorizontalList';
-import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { Skeleton } from '@op/sense/Skeleton';
 import { cn } from '@op/sense/lib/utils';
 import { getGradientForString } from '@op/styles/constants';
@@ -17,6 +16,7 @@ import {
   OrganizationAvatar,
   OrganizationAvatarSkeleton,
 } from '@/components/OrganizationAvatar';
+import { ProfileAvatarLink } from '@/components/ProfileAvatarLink';
 
 export const OrganizationList = ({
   organizations,
@@ -182,27 +182,13 @@ export const OrganizationSummaryList = ({
         return (
           <div key={org.id}>
             <div className="flex items-start gap-2 py-2 sm:gap-6">
-              <Link
+              <ProfileAvatarLink
                 href={`/org/${org.profile.slug}`}
-                className="hover:no-underline"
-              >
-                <ProfileAvatar
-                  name={org.profile.name ?? ''}
-                  src={orgAvatarUrl}
-                  alt={org.profile.name ?? ''}
-                  className="size-8 hover:opacity-80 sm:size-12"
-                  imageRender={
-                    orgAvatarUrl ? (
-                      <Image
-                        src={orgAvatarUrl}
-                        alt={org.profile.name ?? ''}
-                        fill
-                        className="object-cover"
-                      />
-                    ) : undefined
-                  }
-                />
-              </Link>
+                name={org.profile.name ?? ''}
+                src={orgAvatarUrl}
+                alt={org.profile.name ?? ''}
+                className="size-8 sm:size-12"
+              />
 
               <div className="flex flex-col gap-3 text-neutral-black">
                 <div className="flex flex-col gap-2">

--- a/apps/app/src/components/OrganizationList/index.tsx
+++ b/apps/app/src/components/OrganizationList/index.tsx
@@ -177,7 +177,7 @@ export const OrganizationSummaryList = ({
         const orgAvatarUrl =
           getPublicUrl(
             org.profile.avatarImage?.name ?? org.avatarImage?.name,
-          ) ?? '';
+          ) ?? undefined;
 
         return (
           <div key={org.id}>
@@ -196,8 +196,8 @@ export const OrganizationSummaryList = ({
                       <Image
                         src={orgAvatarUrl}
                         alt={org.profile.name ?? ''}
-                        width={48}
-                        height={48}
+                        fill
+                        className="object-cover"
                       />
                     ) : undefined
                   }

--- a/apps/app/src/components/PendingDecisionInvites/index.tsx
+++ b/apps/app/src/components/PendingDecisionInvites/index.tsx
@@ -91,7 +91,6 @@ const PendingDecisionInvitesSuspense = () => {
               />
               <NotificationPanelActions>
                 <Button
-                  size="sm"
                   className="w-full sm:w-auto"
                   onClick={() =>
                     acceptInvite

--- a/apps/app/src/components/PendingDecisionInvites/index.tsx
+++ b/apps/app/src/components/PendingDecisionInvites/index.tsx
@@ -15,7 +15,6 @@ import {
 import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { ProfileItem } from '@op/sense/ProfileItem';
 import { toast } from '@op/sense/Sonner';
-import { Spinner } from '@op/sense/Spinner';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { Suspense } from 'react';
@@ -107,9 +106,10 @@ const PendingDecisionInvitesSuspense = () => {
                         toast.error(t('Failed to accept invitation'));
                       })
                   }
+                  loading={isAccepting}
                   disabled={acceptInvite.isPending}
                 >
-                  {isAccepting ? <Spinner className="size-6" /> : t('Accept')}
+                  {t('Accept')}
                 </Button>
               </NotificationPanelActions>
             </NotificationPanelItem>

--- a/apps/app/src/components/PendingDecisionInvites/index.tsx
+++ b/apps/app/src/components/PendingDecisionInvites/index.tsx
@@ -4,18 +4,18 @@ import { getPublicUrl } from '@/utils';
 import { trpc } from '@op/api/client';
 import { EntityType } from '@op/api/encoders';
 import { getTextPreview } from '@op/core';
-import { Avatar } from '@op/ui/Avatar';
-import { Button } from '@op/ui/Button';
-import { LoadingSpinner } from '@op/ui/LoadingSpinner';
+import { Button } from '@op/sense/Button';
 import {
   NotificationPanel,
   NotificationPanelActions,
   NotificationPanelHeader,
   NotificationPanelItem,
   NotificationPanelList,
-} from '@op/ui/NotificationPanel';
-import { ProfileItem } from '@op/ui/ProfileItem';
-import { toast } from '@op/ui/Toast';
+} from '@op/sense/NotificationPanel';
+import { ProfileAvatar } from '@op/sense/ProfileAvatar';
+import { ProfileItem } from '@op/sense/ProfileItem';
+import { toast } from '@op/sense/Sonner';
+import { Spinner } from '@op/sense/Spinner';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { Suspense } from 'react';
@@ -55,6 +55,9 @@ const PendingDecisionInvitesSuspense = () => {
         {invites.map((invite) => {
           const profile = invite.profile;
           const description = profile.processInstance?.description;
+          const avatarUrl = profile.avatarImage?.name
+            ? getPublicUrl(profile.avatarImage.name)
+            : undefined;
           const isAccepting =
             acceptInvite.isPending &&
             acceptInvite.variables?.inviteId === invite.id;
@@ -63,16 +66,22 @@ const PendingDecisionInvitesSuspense = () => {
             <NotificationPanelItem key={invite.id}>
               <ProfileItem
                 avatar={
-                  <Avatar className="size-12" placeholder={profile.name ?? ''}>
-                    {profile.avatarImage?.name ? (
-                      <Image
-                        src={getPublicUrl(profile.avatarImage.name) ?? ''}
-                        alt={profile.name ?? ''}
-                        fill
-                        className="object-cover"
-                      />
-                    ) : null}
-                  </Avatar>
+                  <ProfileAvatar
+                    name={profile.name ?? ''}
+                    src={avatarUrl}
+                    alt={profile.name ?? ''}
+                    className="size-12"
+                    imageRender={
+                      avatarUrl ? (
+                        <Image
+                          src={avatarUrl}
+                          alt={profile.name ?? ''}
+                          fill
+                          className="object-cover"
+                        />
+                      ) : undefined
+                    }
+                  />
                 }
                 title={profile.name ?? ''}
                 description={
@@ -83,28 +92,24 @@ const PendingDecisionInvitesSuspense = () => {
               />
               <NotificationPanelActions>
                 <Button
-                  size="small"
+                  size="sm"
                   className="w-full sm:w-auto"
-                  onPress={() =>
+                  onClick={() =>
                     acceptInvite
                       .mutateAsync({ inviteId: invite.id })
                       .then(() => {
-                        toast.success({
-                          message: t('Invitation accepted'),
-                        });
+                        toast.success(t('Invitation accepted'));
                         if (profile.slug) {
                           router.push(`/decisions/${profile.slug}`);
                         }
                       })
                       .catch(() => {
-                        toast.error({
-                          message: t('Failed to accept invitation'),
-                        });
+                        toast.error(t('Failed to accept invitation'));
                       })
                   }
-                  isDisabled={acceptInvite.isPending}
+                  disabled={acceptInvite.isPending}
                 >
-                  {isAccepting ? <LoadingSpinner /> : t('Accept')}
+                  {isAccepting ? <Spinner className="size-6" /> : t('Accept')}
                 </Button>
               </NotificationPanelActions>
             </NotificationPanelItem>

--- a/apps/app/src/components/PendingRelationships/index.tsx
+++ b/apps/app/src/components/PendingRelationships/index.tsx
@@ -9,7 +9,6 @@ import {
   NotificationPanelItem,
   NotificationPanelList,
 } from '@op/sense/NotificationPanel';
-import { Spinner } from '@op/sense/Spinner';
 import { relationshipMap } from '@op/types/relationships';
 import { Suspense, useState } from 'react';
 
@@ -125,13 +124,10 @@ const PendingRelationshipsSuspense = ({ slug }: { slug: string }) => {
                           ids: org.relationships?.map((r) => r.id) ?? [],
                         });
                       }}
+                      loading={remove.isPending}
                       disabled={isPending}
                     >
-                      {remove.isPending ? (
-                        <Spinner className="size-6" />
-                      ) : (
-                        t('Decline')
-                      )}
+                      {t('Decline')}
                     </Button>
                     <Button
                       size="sm"
@@ -142,13 +138,10 @@ const PendingRelationshipsSuspense = ({ slug }: { slug: string }) => {
                           targetOrganizationId: organization.id,
                         })
                       }
+                      loading={approve.isPending}
                       disabled={isPending}
                     >
-                      {approve.isPending ? (
-                        <Spinner className="size-6" />
-                      ) : (
-                        t('Accept')
-                      )}
+                      {t('Accept')}
                     </Button>
                   </>
                 ) : null}

--- a/apps/app/src/components/PendingRelationships/index.tsx
+++ b/apps/app/src/components/PendingRelationships/index.tsx
@@ -116,7 +116,6 @@ const PendingRelationshipsSuspense = ({ slug }: { slug: string }) => {
                   <>
                     <Button
                       variant="outline"
-                      size="sm"
                       className="w-full sm:w-auto"
                       onClick={() => {
                         remove.mutate({
@@ -130,7 +129,6 @@ const PendingRelationshipsSuspense = ({ slug }: { slug: string }) => {
                       {t('Decline')}
                     </Button>
                     <Button
-                      size="sm"
                       className="w-full sm:w-auto"
                       onClick={() =>
                         approve.mutate({

--- a/apps/app/src/components/PendingRelationships/index.tsx
+++ b/apps/app/src/components/PendingRelationships/index.tsx
@@ -1,16 +1,16 @@
 'use client';
 
 import { skipBatch, trpc } from '@op/api/client';
-import { relationshipMap } from '@op/types/relationships';
-import { Button } from '@op/ui/Button';
-import { LoadingSpinner } from '@op/ui/LoadingSpinner';
+import { Button } from '@op/sense/Button';
 import {
   NotificationPanel,
   NotificationPanelActions,
   NotificationPanelHeader,
   NotificationPanelItem,
   NotificationPanelList,
-} from '@op/ui/NotificationPanel';
+} from '@op/sense/NotificationPanel';
+import { Spinner } from '@op/sense/Spinner';
+import { relationshipMap } from '@op/types/relationships';
 import { Suspense, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -116,31 +116,39 @@ const PendingRelationshipsSuspense = ({ slug }: { slug: string }) => {
                 {!isAccepted ? (
                   <>
                     <Button
-                      color="secondary"
-                      size="small"
+                      variant="outline"
+                      size="sm"
                       className="w-full sm:w-auto"
-                      onPress={() => {
+                      onClick={() => {
                         remove.mutate({
                           targetOrganizationId: organization.id,
                           ids: org.relationships?.map((r) => r.id) ?? [],
                         });
                       }}
-                      isDisabled={isPending}
+                      disabled={isPending}
                     >
-                      {remove.isPending ? <LoadingSpinner /> : t('Decline')}
+                      {remove.isPending ? (
+                        <Spinner className="size-6" />
+                      ) : (
+                        t('Decline')
+                      )}
                     </Button>
                     <Button
-                      size="small"
+                      size="sm"
                       className="w-full sm:w-auto"
-                      onPress={() =>
+                      onClick={() =>
                         approve.mutate({
                           sourceOrganizationId: org.id,
                           targetOrganizationId: organization.id,
                         })
                       }
-                      isDisabled={isPending}
+                      disabled={isPending}
                     >
-                      {approve.isPending ? <LoadingSpinner /> : t('Accept')}
+                      {approve.isPending ? (
+                        <Spinner className="size-6" />
+                      ) : (
+                        t('Accept')
+                      )}
                     </Button>
                   </>
                 ) : null}

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -5,13 +5,17 @@ import { trpc } from '@op/api/client';
 import { Avatar, AvatarFallback } from '@op/sense/Avatar';
 import { Card } from '@op/sense/Card';
 import { GrowingFacePile } from '@op/sense/FacePile';
-import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { cn } from '@op/sense/lib/utils';
 import { useTranslations } from 'next-intl';
-import Image from 'next/image';
 import { ReactNode, Suspense } from 'react';
 
 import { Link } from '@/lib/i18n';
+
+import {
+  AvatarLinkHoverTint,
+  ProfileAvatarLink,
+  avatarLinkClassName,
+} from '../ProfileAvatarLink';
 
 export const PlatformHighlights = () => {
   const [stats] = trpc.platform.getStats.useSuspenseQuery();
@@ -117,46 +121,29 @@ const OrganizationFacePile = ({ children }: { children?: ReactNode }) => {
     t.platform.getStats(),
   ]);
 
-  const items = organizations.map((org) => {
-    const avatarUrl = getPublicUrl(org.profile.avatarImage?.name);
-    return (
-      <Link
-        key={org.id}
-        href={`/org/${org.profile.slug}`}
-        className="hover:no-underline"
-      >
-        <ProfileAvatar
-          name={org.profile.name}
-          src={avatarUrl}
-          alt={org.profile.name}
-          imageRender={
-            avatarUrl ? (
-              <Image
-                src={avatarUrl}
-                alt={org.profile.name}
-                fill
-                className="object-cover"
-              />
-            ) : undefined
-          }
-        />
-        <div className="absolute start-0 top-0 h-full w-full cursor-pointer rounded-full bg-white opacity-0 transition-opacity duration-100 ease-in-out hover:opacity-15 active:bg-black" />
-      </Link>
-    );
-  });
+  const items = organizations.map((org) => (
+    <ProfileAvatarLink
+      key={org.id}
+      href={`/org/${org.profile.slug}`}
+      name={org.profile.name}
+      src={getPublicUrl(org.profile.avatarImage?.name)}
+      alt={org.profile.name}
+    />
+  ));
 
   return (
     <GrowingFacePile
       items={items}
       totalCount={stats.totalOrganizations}
       renderOverflow={(count) => (
-        <Link href="/org" className="hover:no-underline">
+        <Link href="/org" className={avatarLinkClassName}>
           <Avatar>
             <AvatarFallback className="bg-neutral-charcoal text-sm text-neutral-offWhite">
               <span className="align-super">+</span>
               {count}
             </AvatarFallback>
           </Avatar>
+          <AvatarLinkHoverTint />
         </Link>
       )}
     >

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -59,7 +59,7 @@ export const PlatformHighlights = () => {
           <HighlightLabel>{t('people on Common')}</HighlightLabel>
         </Highlight>
       </div>
-      <div className="flex flex-col justify-center gap-2 border-0 border-t bg-neutral-offWhite p-6 text-sm text-neutral-charcoal sm:flex-row sm:items-center">
+      <div className="flex flex-col justify-center gap-2 border-0 border-t bg-neutral-offWhite p-6 text-sm sm:flex-row sm:items-center">
         <Suspense>
           <div className="flex max-w-full items-center gap-2">
             <OrganizationFacePile>

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -2,10 +2,11 @@
 
 import { getPublicUrl } from '@/utils';
 import { trpc } from '@op/api/client';
-import { Avatar } from '@op/ui/Avatar';
-import { FacePile } from '@op/ui/FacePile';
-import { Surface } from '@op/ui/Surface';
-import { cn } from '@op/ui/utils';
+import { Avatar, AvatarFallback } from '@op/sense/Avatar';
+import { Card } from '@op/sense/Card';
+import { FacePile } from '@op/sense/FacePile';
+import { ProfileAvatar } from '@op/sense/ProfileAvatar';
+import { cn } from '@op/sense/lib/utils';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import { ReactNode, Suspense, useEffect, useRef, useState } from 'react';
@@ -17,7 +18,7 @@ export const PlatformHighlights = () => {
   const t = useTranslations();
 
   return (
-    <Surface className="shadow-light">
+    <Card className="gap-0 py-0 shadow-light">
       <div className="flex flex-col items-center justify-between gap-6 px-10 py-6 sm:flex-row sm:gap-4">
         <Highlight>
           <HighlightNumber className="bg-tealGreen">
@@ -63,7 +64,7 @@ export const PlatformHighlights = () => {
           </div>
         </Suspense>
       </div>
-    </Surface>
+    </Card>
   );
 };
 
@@ -141,16 +142,21 @@ const OrganizationFacePile = ({ children }: { children?: ReactNode }) => {
           href={`/org/${org.profile.slug}`}
           className="hover:no-underline"
         >
-          <Avatar placeholder={org.profile.name}>
-            {avatarUrl ? (
-              <Image
-                src={avatarUrl}
-                alt={org.profile.name}
-                fill
-                className="object-cover"
-              />
-            ) : null}
-          </Avatar>
+          <ProfileAvatar
+            name={org.profile.name}
+            src={avatarUrl}
+            alt={org.profile.name}
+            imageRender={
+              avatarUrl ? (
+                <Image
+                  src={avatarUrl}
+                  alt={org.profile.name}
+                  width={32}
+                  height={32}
+                />
+              ) : undefined
+            }
+          />
           <div className="absolute start-0 top-0 h-full w-full cursor-pointer rounded-full bg-white opacity-0 transition-opacity duration-100 ease-in-out hover:opacity-15 active:bg-black" />
         </Link>
       );
@@ -160,9 +166,11 @@ const OrganizationFacePile = ({ children }: { children?: ReactNode }) => {
   if (stats.totalOrganizations > numItems) {
     items.push(
       <Link key="more" href="/org" className="hover:no-underline">
-        <Avatar className="bg-neutral-charcoal text-sm text-neutral-offWhite">
-          <span className="align-super">+</span>
-          {stats.totalOrganizations - numItems}
+        <Avatar>
+          <AvatarFallback className="bg-neutral-charcoal text-sm text-neutral-offWhite">
+            <span className="align-super">+</span>
+            {stats.totalOrganizations - numItems}
+          </AvatarFallback>
         </Avatar>
       </Link>,
     );

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -18,15 +18,21 @@ export const PlatformHighlights = () => {
   const t = useTranslations();
 
   return (
-    <Card className="gap-0 py-0 shadow-light">
+    <Card className="gap-0 py-0">
       <div className="flex flex-col items-center justify-between gap-6 px-10 py-6 sm:flex-row sm:gap-4">
-        <Highlight>
-          <HighlightNumber className="bg-tealGreen">
-            {stats.newOrganizations}
-          </HighlightNumber>
-          <HighlightLabel>{t('new organizations to explore')}</HighlightLabel>
-        </Highlight>
-        <hr className="hidden h-20 w-0.5 border-0 bg-neutral-gray1 sm:block" />
+        {stats.newOrganizations > 0 && (
+          <>
+            <Highlight>
+              <HighlightNumber className="bg-tealGreen">
+                {stats.newOrganizations}
+              </HighlightNumber>
+              <HighlightLabel>
+                {t('new organizations to explore')}
+              </HighlightLabel>
+            </Highlight>
+            <hr className="hidden h-20 w-0.5 border-0 bg-neutral-gray1 sm:block" />
+          </>
+        )}
         <Highlight>
           <HighlightNumber className="bg-orange">
             {stats.totalRelationships}

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -4,12 +4,12 @@ import { getPublicUrl } from '@/utils';
 import { trpc } from '@op/api/client';
 import { Avatar, AvatarFallback } from '@op/sense/Avatar';
 import { Card } from '@op/sense/Card';
-import { FacePile } from '@op/sense/FacePile';
+import { GrowingFacePile } from '@op/sense/FacePile';
 import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { cn } from '@op/sense/lib/utils';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
-import { ReactNode, Suspense, useEffect, useRef, useState } from 'react';
+import { ReactNode, Suspense } from 'react';
 
 import { Link } from '@/lib/i18n';
 
@@ -116,75 +116,51 @@ const OrganizationFacePile = ({ children }: { children?: ReactNode }) => {
     t.organization.list({ limit: 100 }),
     t.platform.getStats(),
   ]);
-  const facePileRef = useRef<HTMLDivElement>(null);
-  const [numItems, setNumItems] = useState(20);
 
-  useEffect(() => {
-    if (!facePileRef.current) {
-      return;
-    }
-
-    const resizeObserver = new ResizeObserver((e) => {
-      // divide by 2 rem - 0.5 rem overlap
-      setNumItems(
-        Math.min(Math.floor((e[0]?.contentRect.width ?? 1) / (32 - 8)), 20),
-      );
-    });
-
-    resizeObserver.observe(facePileRef.current);
-
-    return () => {
-      resizeObserver.disconnect();
-    };
-  }, [facePileRef]);
-
-  const items = organizations
-    .map((org) => {
-      const { avatarImage } = org.profile;
-      const avatarUrl = getPublicUrl(avatarImage?.name);
-      return (
-        <Link
-          key={org.id}
-          href={`/org/${org.profile.slug}`}
-          className="hover:no-underline"
-        >
-          <ProfileAvatar
-            name={org.profile.name}
-            src={avatarUrl}
-            alt={org.profile.name}
-            imageRender={
-              avatarUrl ? (
-                <Image
-                  src={avatarUrl}
-                  alt={org.profile.name}
-                  width={32}
-                  height={32}
-                />
-              ) : undefined
-            }
-          />
-          <div className="absolute start-0 top-0 h-full w-full cursor-pointer rounded-full bg-white opacity-0 transition-opacity duration-100 ease-in-out hover:opacity-15 active:bg-black" />
-        </Link>
-      );
-    })
-    .slice(0, numItems);
-
-  if (stats.totalOrganizations > numItems) {
-    items.push(
-      <Link key="more" href="/org" className="hover:no-underline">
-        <Avatar>
-          <AvatarFallback className="bg-neutral-charcoal text-sm text-neutral-offWhite">
-            <span className="align-super">+</span>
-            {stats.totalOrganizations - numItems}
-          </AvatarFallback>
-        </Avatar>
-      </Link>,
+  const items = organizations.map((org) => {
+    const avatarUrl = getPublicUrl(org.profile.avatarImage?.name);
+    return (
+      <Link
+        key={org.id}
+        href={`/org/${org.profile.slug}`}
+        className="hover:no-underline"
+      >
+        <ProfileAvatar
+          name={org.profile.name}
+          src={avatarUrl}
+          alt={org.profile.name}
+          imageRender={
+            avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                alt={org.profile.name}
+                fill
+                className="object-cover"
+              />
+            ) : undefined
+          }
+        />
+        <div className="absolute start-0 top-0 h-full w-full cursor-pointer rounded-full bg-white opacity-0 transition-opacity duration-100 ease-in-out hover:opacity-15 active:bg-black" />
+      </Link>
     );
-  }
+  });
 
   return (
-    <FacePile items={items} ref={facePileRef}>
+    <GrowingFacePile
+      items={items}
+      totalCount={stats.totalOrganizations}
+      renderOverflow={(count) => (
+        <Link href="/org" className="hover:no-underline">
+          <Avatar>
+            <AvatarFallback className="bg-neutral-charcoal text-sm text-neutral-offWhite">
+              <span className="align-super">+</span>
+              {count}
+            </AvatarFallback>
+          </Avatar>
+        </Link>
+      )}
+    >
       {children}
-    </FacePile>
+    </GrowingFacePile>
   );
 };

--- a/apps/app/src/components/PostFeed/DeletePostMenuItem.tsx
+++ b/apps/app/src/components/PostFeed/DeletePostMenuItem.tsx
@@ -3,8 +3,8 @@
 import { createCommentsQueryKey } from '@/utils/queryKeys';
 import { trpc } from '@op/api/client';
 import type { Post } from '@op/api/encoders';
-import { MenuItem } from '@op/ui/Menu';
-import { toast } from '@op/ui/Toast';
+import { DropdownMenuItem } from '@op/sense/DropdownMenu';
+import { toast } from '@op/sense/Sonner';
 import { useRouter } from 'next/navigation';
 
 import { useTranslations } from '@/lib/i18n';
@@ -37,7 +37,7 @@ export const DeletePostMenuItem = ({ post }: { post: Post }) => {
       void utils.organization.listPosts.invalidate();
       void utils.organization.listAllPosts.invalidate();
       router.refresh();
-      toast.success({ message: t('Post deleted') });
+      toast.success(t('Post deleted'));
     },
     onError: (error, _variables, context) => {
       if (post.parentPostId && context?.previousComments) {
@@ -45,20 +45,20 @@ export const DeletePostMenuItem = ({ post }: { post: Post }) => {
         utils.posts.getPosts.setData(queryKey, context.previousComments);
       }
 
-      toast.error({ message: error.message || t('Failed to delete post') });
+      toast.error(error.message || t('Failed to delete post'));
     },
   });
 
   return (
-    <MenuItem
-      className="px-3 py-1 text-functional-red"
-      onAction={() => {
+    <DropdownMenuItem
+      variant="destructive"
+      onClick={() => {
         if (post.id) {
           deletePost.mutate({ id: post.id });
         }
       }}
     >
       {t('Delete')}
-    </MenuItem>
+    </DropdownMenuItem>
   );
 };

--- a/apps/app/src/components/PostFeed/ReportPostModal.tsx
+++ b/apps/app/src/components/PostFeed/ReportPostModal.tsx
@@ -1,9 +1,15 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { Button } from '@op/ui/Button';
-import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
-import { toast } from '@op/ui/Toast';
+import { Button } from '@op/sense/Button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@op/sense/Dialog';
+import { toast } from '@op/sense/Sonner';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -26,45 +32,47 @@ export function ReportPostModal({
 
   const reportMutation = trpc.moderation.flagItem.useMutation({
     onSuccess: () => {
-      toast.success({ message: t('Reported for moderation review') });
+      toast.success(t('Reported for moderation review'));
       onOpenChange(false);
     },
     onError: () => {
-      toast.error({
-        message: t('Could not report this content. Please try again.'),
-      });
+      toast.error(t('Could not report this content. Please try again.'));
     },
   });
 
   return (
-    <Modal isDismissable isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalHeader>{t('Report this comment')}</ModalHeader>
-      <ModalBody>
-        <p>
-          {t(
-            "This comment will be sent to an independent moderation service for review. It stays visible while the review is in progress. If it violates Common's Code of Conduct, it will be hidden and the author will be notified.",
-          )}
-        </p>
-      </ModalBody>
-      <ModalFooter>
-        <Button
-          color="secondary"
-          className="w-full sm:w-fit"
-          onPress={() => onOpenChange(false)}
-        >
-          {t('Cancel')}
-        </Button>
-        <Button
-          color="destructive"
-          className="w-full sm:w-fit"
-          onPress={() =>
-            reportMutation.mutate({ itemType: 'post', itemId: postId })
-          }
-          isDisabled={reportMutation.isPending}
-        >
-          {t('Report')}
-        </Button>
-      </ModalFooter>
-    </Modal>
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('Report this comment')}</DialogTitle>
+        </DialogHeader>
+        <div className="px-6 py-4">
+          <p>
+            {t(
+              "This comment will be sent to an independent moderation service for review. It stays visible while the review is in progress. If it violates Common's Code of Conduct, it will be hidden and the author will be notified.",
+            )}
+          </p>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            className="w-full sm:w-fit"
+            onClick={() => onOpenChange(false)}
+          >
+            {t('Cancel')}
+          </Button>
+          <Button
+            variant="destructive"
+            className="w-full sm:w-fit"
+            onClick={() =>
+              reportMutation.mutate({ itemType: 'post', itemId: postId })
+            }
+            disabled={reportMutation.isPending}
+          >
+            {t('Report')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -12,20 +12,24 @@ import type {
   PostAttachment,
 } from '@op/api/encoders';
 import { useRelativeTime } from '@op/hooks';
+import { Button } from '@op/sense/Button';
+import { CommentButton } from '@op/sense/CommentButton';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@op/sense/DropdownMenu';
+import { Header3 } from '@op/sense/Header';
+import { MediaDisplay } from '@op/sense/MediaDisplay';
+import { ReactionsButton } from '@op/sense/ReactionsButton';
+import { Skeleton } from '@op/sense/Skeleton';
+import { toast } from '@op/sense/Sonner';
+import { cn } from '@op/sense/lib/utils';
 import { REACTION_OPTIONS } from '@op/types';
-import { AvatarSkeleton } from '@op/ui/Avatar';
-import { CommentButton } from '@op/ui/CommentButton';
-import { Header3 } from '@op/ui/Header';
-import { MediaDisplay } from '@op/ui/MediaDisplay';
-import { MenuItem } from '@op/ui/Menu';
-import { OptionMenu } from '@op/ui/OptionMenu';
-import { ReactionsButton } from '@op/ui/ReactionsButton';
-import { Skeleton, SkeletonLine } from '@op/ui/Skeleton';
-import { toast } from '@op/ui/Toast';
-import { cn } from '@op/ui/utils';
 import Image from 'next/image';
 import { ReactNode, memo, useCallback, useMemo, useState } from 'react';
-import { LuFlag, LuLeaf } from 'react-icons/lu';
+import { LuEllipsis, LuFlag, LuLeaf } from 'react-icons/lu';
 
 import { Link, useTranslations } from '@/lib/i18n';
 
@@ -226,7 +230,7 @@ const PostCommentButton = ({
     <CommentButton
       count={count}
       label={t('{count} comments', { count })}
-      onPress={onCommentClick}
+      onClick={onCommentClick}
     />
   );
 };
@@ -261,15 +265,26 @@ const PostMenu = ({
 
   return (
     <>
-      <OptionMenu
-        aria-label={t('Post options')}
-        className="absolute end-0 top-0"
-      >
-        {canModerate ? <DeletePostMenuItem post={post} /> : null}
-        <MenuItem className="px-3 py-1" onAction={() => setIsReportOpen(true)}>
-          {t('Report')}
-        </MenuItem>
-      </OptionMenu>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label={t('Post options')}
+              className="absolute end-0 top-0 aspect-square aria-expanded:bg-neutral-gray1"
+            >
+              <LuEllipsis className="size-4" />
+            </Button>
+          }
+        />
+        <DropdownMenuContent side="bottom" align="end" className="min-w-28">
+          {canModerate ? <DeletePostMenuItem post={post} /> : null}
+          <DropdownMenuItem onClick={() => setIsReportOpen(true)}>
+            {t('Report')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <ReportPostModal
         postId={post.id}
         isOpen={isReportOpen}
@@ -425,8 +440,8 @@ export const PostItem = ({
       />
       <FeedMain>
         <FeedHeader className="relative w-full justify-between">
-          <div className="flex items-baseline gap-2">
-            <Header3 className="font-sans leading-3 font-semibold">
+          <div className="flex flex-col items-baseline gap-2">
+            <Header3 className="font-sans text-base leading-3 font-normal">
               <PostDisplayName
                 displayName={displayName}
                 displaySlug={displaySlug}
@@ -530,7 +545,7 @@ export const PostItemOnDetailPage = ({
             <CommentButton
               count={commentCount}
               label={t('{count} comments', { count: commentCount })}
-              isDisabled
+              disabled
             />
           </div>
         </FeedContent>
@@ -585,7 +600,7 @@ export const usePostFeedActions = () => {
       void utils.posts.listProfilePosts.invalidate();
     },
     onError: (err) => {
-      toast.error({ message: err.message || t('Failed to update reaction') });
+      toast.error(err.message || t('Failed to update reaction'));
     },
   });
 
@@ -631,7 +646,7 @@ export const PostFeed = ({
   className?: string;
 }) => {
   return (
-    <div className={cn('flex flex-col gap-4 pb-8', className)}>{children}</div>
+    <div className={cn('flex flex-col gap-8 pb-8', className)}>{children}</div>
   );
 };
 
@@ -646,16 +661,20 @@ export const PostFeedSkeleton = ({
     <div className={cn('flex flex-col gap-8 pb-8', className)}>
       {new Array(numPosts).fill(0).map((_, i) => (
         <FeedItem key={i}>
-          <AvatarSkeleton className="!size-8 max-h-8 max-w-8 rounded-full" />
+          <Skeleton className="!size-8 max-h-8 max-w-8 rounded-full" />
           <FeedMain>
             <FeedHeader className="w-1/2">
               <Header3 className="w-full pb-1 font-sans leading-5 font-medium">
-                <Skeleton />
+                <Skeleton className="h-4 w-full" />
               </Header3>
-              <Skeleton />
+              <Skeleton className="h-4 w-full" />
             </FeedHeader>
             <FeedContent>
-              <SkeletonLine lines={3} />
+              <div className="flex flex-col gap-2">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+              </div>
             </FeedContent>
           </FeedMain>
         </FeedItem>

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -629,7 +629,7 @@ const PostUpdateWithUser = ({
         <div className="flex min-w-0 flex-1 flex-col">
           <InputGroupTextarea
             ref={textareaRef as RefObject<HTMLTextAreaElement>}
-            className="field-sizing-fixed min-h-0 overflow-y-hidden ps-1 pt-1 [unicode-bidi:plaintext]"
+            className="min-h-0 overflow-y-hidden ps-1 pt-1 [unicode-bidi:plaintext]"
             placeholder={placeholder || t('Post an update…')}
             value={content}
             onChange={(e) => handleContentChange(e.target.value ?? '')}

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -9,14 +9,17 @@ import { userCanInteract } from '@/utils/userCanInteract';
 import { trpc } from '@op/api/client';
 import type { Organization, Post } from '@op/api/encoders';
 import { logger } from '@op/logging/client';
-import { Button } from '@op/ui/Button';
-import { TextArea } from '@op/ui/Field';
-import { Form } from '@op/ui/Form';
-import { LoadingSpinner } from '@op/ui/LoadingSpinner';
-import { MediaDisplay } from '@op/ui/MediaDisplay';
-import { Skeleton } from '@op/ui/Skeleton';
-import { toast } from '@op/ui/Toast';
-import { cn } from '@op/ui/utils';
+import { Button } from '@op/sense/Button';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupTextarea,
+} from '@op/sense/InputGroup';
+import { MediaDisplay } from '@op/sense/MediaDisplay';
+import { Skeleton } from '@op/sense/Skeleton';
+import { toast } from '@op/sense/Sonner';
+import { cn } from '@op/sense/lib/utils';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode, RefObject } from 'react';
@@ -24,7 +27,6 @@ import { LuImage, LuX } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
-import { FeedItem, FeedMain } from '@/components/Feed';
 import { LinkPreview } from '@/components/LinkPreview';
 
 import { OrganizationAvatar } from '../OrganizationAvatar';
@@ -125,11 +127,9 @@ const PostUpdateWithUser = ({
           attachmentIds: fileUpload.getUploadedAttachmentIds(),
         });
 
-        toast.error({
-          message: errorInfo.message + ' Use the retry button to try again.',
-        });
+        toast.error(errorInfo.message + ' Use the retry button to try again.');
       } else {
-        toast.error({ message: errorInfo.message });
+        toast.error(errorInfo.message);
       }
 
       logger.error('Failed to create organization post', {
@@ -294,11 +294,9 @@ const PostUpdateWithUser = ({
           attachmentIds: fileUpload.getUploadedAttachmentIds(),
         });
 
-        toast.error({
-          message: errorInfo.message + ' Use the retry button to try again.',
-        });
+        toast.error(errorInfo.message + ' Use the retry button to try again.');
       } else {
-        toast.error({ message: errorInfo.message });
+        toast.error(errorInfo.message);
       }
 
       logger.error('Failed to create post', {
@@ -507,11 +505,9 @@ const PostUpdateWithUser = ({
     if (content.trim() || fileUpload.hasUploadedFiles()) {
       // Check if offline
       if (!isOnline) {
-        toast.error({
-          message: t(
-            'You are offline. Please check your connection and try again.',
-          ),
-        });
+        toast.error(
+          t('You are offline. Please check your connection and try again.'),
+        );
         return;
       }
 
@@ -605,35 +601,42 @@ const PostUpdateWithUser = ({
   }
 
   return (
-    <div className={cn('flex flex-col gap-2 sm:flex', className)}>
-      <FeedItem>
-        {organization ? (
-          <OrganizationAvatar
-            profile={organization.profile}
-            className="size-8 bg-white"
-          />
-        ) : user.currentProfile ? (
-          <OrganizationAvatar
-            profile={user.currentProfile}
-            className="size-8 bg-white"
-          />
-        ) : (
-          <div className="size-8 rounded-full bg-neutral-gray1" />
+    <form onSubmit={handleSubmit} className="w-full">
+      <InputGroup
+        className={cn(
+          'h-auto flex-row items-start gap-2 border-border p-3',
+          className,
         )}
-        <FeedMain className="relative">
-          <Form onSubmit={handleSubmit} className="flex w-full flex-col gap-2">
-            <TextArea
-              className="size-full h-6 overflow-y-hidden"
-              variant="borderless"
-              ref={textareaRef as RefObject<HTMLTextAreaElement>}
-              placeholder={placeholder || t('Post an update…')}
-              value={content}
-              onChange={(e) => handleContentChange(e.target.value ?? '')}
-              onKeyDown={handleKeyDown}
+      >
+        <InputGroupAddon
+          align="inline-start"
+          className="cursor-default items-start p-0"
+        >
+          {organization ? (
+            <OrganizationAvatar
+              profile={organization.profile}
+              className="size-8 bg-white"
             />
-          </Form>
+          ) : user.currentProfile ? (
+            <OrganizationAvatar
+              profile={user.currentProfile}
+              className="size-8 bg-white"
+            />
+          ) : (
+            <div className="size-8 rounded-full bg-neutral-gray1" />
+          )}
+        </InputGroupAddon>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <InputGroupTextarea
+            ref={textareaRef as RefObject<HTMLTextAreaElement>}
+            className="field-sizing-fixed min-h-0 overflow-y-hidden ps-1 pt-1 [unicode-bidi:plaintext]"
+            placeholder={placeholder || t('Post an update…')}
+            value={content}
+            onChange={(e) => handleContentChange(e.target.value ?? '')}
+            onKeyDown={handleKeyDown}
+          />
           {fileUpload.filePreviews?.length > 0 && (
-            <div className="w-full">
+            <div className="w-full px-3">
               {fileUpload.filePreviews.map((filePreview) => (
                 <div key={filePreview.id} className="relative">
                   {filePreview.uploading ? (
@@ -650,10 +653,10 @@ const PostUpdateWithUser = ({
                         />
                       )}
                       <Button
-                        onPress={() => fileUpload.removeFile(filePreview.id)}
+                        onClick={() => fileUpload.removeFile(filePreview.id)}
                         className="absolute end-2 top-2 size-6 rounded-full p-0 opacity-80 hover:opacity-100 focus-visible:outline-1"
-                        size="small"
-                        color="neutral"
+                        size="sm"
+                        variant="outline"
                       >
                         <LuX className="size-4" />
                       </Button>
@@ -667,10 +670,10 @@ const PostUpdateWithUser = ({
                         size={filePreview.file.size}
                       />
                       <Button
-                        onPress={() => fileUpload.removeFile(filePreview.id)}
+                        onClick={() => fileUpload.removeFile(filePreview.id)}
                         className="absolute end-2 top-2 size-6 rounded-full p-0 opacity-80 hover:opacity-100 focus-visible:outline-1"
-                        size="small"
-                        color="neutral"
+                        size="sm"
+                        variant="outline"
                       >
                         <LuX className="size-3" />
                       </Button>
@@ -681,19 +684,22 @@ const PostUpdateWithUser = ({
             </div>
           )}
           {detectedUrls.length > 0 && (
-            <div className="max-w-full">
+            <div className="w-full px-3">
               {detectedUrls.map((url, index) => (
                 <LinkPreview key={index} url={url} />
               ))}
             </div>
           )}
-          <div
+          <InputGroupAddon
+            align="block-end"
             className={cn(
-              'flex w-full items-center justify-between gap-2',
-              (content || fileUpload.filePreviews?.length) && 'border-t py-2',
+              'justify-between border-t p-0',
+              content ? 'border-border' : 'border-transparent',
             )}
           >
-            <button
+            <InputGroupButton
+              size="md"
+              className="-ms-3 text-primary"
               onClick={() => {
                 const input = document.createElement('input');
                 input.type = 'file';
@@ -712,48 +718,46 @@ const PostUpdateWithUser = ({
                 };
                 input.click();
               }}
-              className="flex items-center gap-2 text-base text-neutral-charcoal transition-colors hover:text-black"
               disabled={fileUpload.filePreviews.length >= 1}
             >
-              <LuImage className="size-4" />
-              {t('Media')}
-            </button>
+              <LuImage /> {t('Media')}
+            </InputGroupButton>
             <div className="flex items-center gap-2 text-neutral-charcoal">
               <TextCounter text={content} max={characterLimit} />
               {lastFailedPost && (
-                <Button
-                  size="small"
-                  color="secondary"
-                  onPress={retryFailedPost}
-                  isDisabled={
+                <InputGroupButton
+                  size="sm"
+                  variant="outline"
+                  onClick={retryFailedPost}
+                  disabled={
                     createPost.isPending || createOrganizationPost.isPending
                   }
                 >
                   {createPost.isPending || createOrganizationPost.isPending
                     ? t('Retrying...')
                     : t('Retry Failed Post')}
-                </Button>
+                </InputGroupButton>
               )}
-              <Button
-                size="small"
-                isDisabled={
+              <InputGroupButton
+                type="submit"
+                size="md"
+                variant="default"
+                disabled={
                   !(content.length > 0 || fileUpload.hasUploadedFiles()) ||
                   content.length > characterLimit ||
                   !isOnline
                 }
-                onPress={createNewPostUpdate}
+                loading={
+                  createPost.isPending || createOrganizationPost.isPending
+                }
               >
-                {createPost.isPending || createOrganizationPost.isPending ? (
-                  <LoadingSpinner />
-                ) : (
-                  label
-                )}
-              </Button>
+                {label}
+              </InputGroupButton>
             </div>
-          </div>
-        </FeedMain>
-      </FeedItem>
-    </div>
+          </InputGroupAddon>
+        </div>
+      </InputGroup>
+    </form>
   );
 };
 

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -726,7 +726,7 @@ const PostUpdateWithUser = ({
               <TextCounter text={content} max={characterLimit} />
               {lastFailedPost && (
                 <InputGroupButton
-                  size="sm"
+                  size="md"
                   variant="outline"
                   onClick={retryFailedPost}
                   disabled={

--- a/apps/app/src/components/ProfileAvatarLink/index.tsx
+++ b/apps/app/src/components/ProfileAvatarLink/index.tsx
@@ -1,0 +1,80 @@
+import { ProfileAvatar } from '@op/sense/ProfileAvatar';
+import Image from 'next/image';
+
+import { Link } from '@/lib/i18n';
+
+/**
+ * Focus/hover treatment for a circular avatar link. `group` + `relative` let a
+ * child overlay tint on hover; the ring sits on an offset so it clears an inner
+ * separation ring (e.g. in a facepile). Exported so bare avatar links (e.g. a
+ * facepile "+N" bubble) match.
+ */
+export const avatarLinkClassName =
+  // size-fit gives the link a definite size so a flex parent's align-items:
+  // stretch can't stretch it taller than the avatar (which would oval the ring).
+  'group relative inline-flex size-fit rounded-full outline-none hover:no-underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+
+/**
+ * Hover tint for a circular avatar link — a darkening overlay clipped to the
+ * circle. Used instead of opacity so overlapping facepile avatars don't go
+ * see-through and reveal their neighbor. Exported so bare avatar links match.
+ */
+export const AvatarLinkHoverTint = () => (
+  <span
+    aria-hidden
+    className="pointer-events-none absolute inset-0 rounded-full bg-foreground/0 transition-colors duration-200 group-hover:bg-background/20"
+  />
+);
+
+interface ProfileAvatarLinkProps {
+  /** Destination. When omitted the avatar renders without a link. */
+  href?: string | null;
+  /** Display name — seeds the fallback initial + gradient when no image. */
+  name?: string | null;
+  /** Resolved image URL (callers resolve storage paths, e.g. getPublicUrl). */
+  src?: string | null;
+  alt: string;
+  size?: 'default' | 'sm' | 'lg';
+  className?: string;
+}
+
+/**
+ * A `ProfileAvatar` wrapped in the locale-aware `Link` — the linked avatar we
+ * render all over the app. Owns the circular focus ring, hover tint, and the
+ * `next/image` passthrough so callers just supply `href`/`name`/`src`. Without
+ * `href` it's a plain, non-interactive avatar.
+ */
+export const ProfileAvatarLink = ({
+  href,
+  name,
+  src,
+  alt,
+  size,
+  className,
+}: ProfileAvatarLinkProps) => {
+  const avatar = (
+    <ProfileAvatar
+      name={name}
+      src={src}
+      alt={alt}
+      size={size}
+      className={className}
+      imageRender={
+        src ? (
+          <Image src={src} alt={alt} fill className="object-cover" />
+        ) : undefined
+      }
+    />
+  );
+
+  if (!href) {
+    return avatar;
+  }
+
+  return (
+    <Link href={href} className={avatarLinkClassName}>
+      {avatar}
+      <AvatarLinkHoverTint />
+    </Link>
+  );
+};

--- a/apps/app/src/components/RelationshipList/index.tsx
+++ b/apps/app/src/components/RelationshipList/index.tsx
@@ -2,8 +2,9 @@
 
 import { useCanLinkToProfile } from '@/hooks/useCanLinkToProfile';
 import { getPublicUrl } from '@/utils';
-import { Tag, TagGroup } from '@op/ui/TagGroup';
-import { cn, getGradientForString } from '@op/ui/utils';
+import { Tag, TagGroup } from '@op/sense/TagGroup';
+import { cn } from '@op/sense/lib/utils';
+import { getGradientForString } from '@op/styles/constants';
 import Image from 'next/image';
 import React from 'react';
 

--- a/apps/app/src/components/SearchInput/index.tsx
+++ b/apps/app/src/components/SearchInput/index.tsx
@@ -240,6 +240,9 @@ export const SearchInput = ({ onBlur }: { onBlur?: () => void } = {}) => {
         </InputGroupAddon>
         <CommandPrimitive.Input
           ref={inputRef}
+          // Tag as the InputGroup control so the group's focus-visible ring/
+          // border styles (has-[[data-slot=input-group-control]...]) apply.
+          data-slot="input-group-control"
           value={query}
           onValueChange={(value) => {
             setQuery(value);

--- a/apps/app/src/components/screens/LandingScreen/Welcome.tsx
+++ b/apps/app/src/components/screens/LandingScreen/Welcome.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { CommonUser } from '@op/api/encoders';
-import { Header1 } from '@op/ui/Header';
+import { Header1 } from '@op/sense/Header';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { useMemo } from 'react';

--- a/apps/app/src/components/screens/LandingScreen/index.tsx
+++ b/apps/app/src/components/screens/LandingScreen/index.tsx
@@ -123,12 +123,12 @@ export const LandingScreenSkeleton: React.FC = async () => {
 
 const NewOrganizationsList = () => {
   return (
-    <Card className="-mx-8 flex flex-col gap-6 border-0 py-0 sm:mx-0 sm:border sm:p-6">
-      <Header3 className="px-8 font-serif text-title-sm sm:px-0">
+    <div className="flex flex-col gap-6 border-0 py-0 sm:mx-0 sm:border sm:p-5">
+      <Header3 className="px-4 font-serif text-title-sm sm:px-0">
         <TranslatedText text="New Organizations" />
       </Header3>
       <NewOrganizations />
-    </Card>
+    </div>
   );
 };
 
@@ -195,7 +195,7 @@ const LandingScreenFeeds = ({
             <TranslatedText text="Recent" />
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="discover" className="p-0">
+        <TabsContent value="discover" className="-mx-4 p-0">
           <NewOrganizationsList />
         </TabsContent>
         <TabsContent value="recent" className="p-0">

--- a/apps/app/src/components/screens/LandingScreen/index.tsx
+++ b/apps/app/src/components/screens/LandingScreen/index.tsx
@@ -6,10 +6,10 @@ import {
   dehydrate,
 } from '@op/api/server';
 import { logger } from '@op/logging';
-import { Header1, Header3 } from '@op/ui/Header';
-import { Skeleton, SkeletonLine } from '@op/ui/Skeleton';
-import { Surface } from '@op/ui/Surface';
-import { Tab, TabList, TabPanel, Tabs } from '@op/ui/Tabs';
+import { Card } from '@op/sense/Card';
+import { Header1, Header3 } from '@op/sense/Header';
+import { Skeleton } from '@op/sense/Skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@op/sense/Tabs';
 import { Suspense } from 'react';
 
 import { ActiveDecisionsNotifications } from '@/components/ActiveDecisionsNotifications';
@@ -34,16 +34,16 @@ import { Welcome } from './Welcome';
  */
 export const LandingScreen = () => {
   return (
-    <div className="container flex min-h-0 grow flex-col gap-4 pt-8 sm:gap-10 sm:pt-14">
+    <div className="mx-auto flex min-h-0 w-full max-w-[1400px] grow flex-col gap-4 px-4 pt-8 sm:gap-10 sm:px-8 sm:pt-14">
       <Suspense fallback={<WelcomeSkeleton />}>
         <WelcomeSection />
       </Suspense>
       <ErrorBoundary fallback={null}>
         <Suspense
           fallback={
-            <Surface>
+            <Card className="gap-0 py-0">
               <Skeleton className="h-52 w-full" />
-            </Surface>
+            </Card>
           }
         >
           <PlatformHighlights />
@@ -59,7 +59,7 @@ export const LandingScreen = () => {
 
 export const LandingScreenSkeleton: React.FC = async () => {
   return (
-    <div className="container flex min-h-0 grow flex-col gap-4 pt-8 sm:gap-10 sm:pt-14">
+    <div className="mx-auto flex min-h-0 w-full max-w-[1400px] grow flex-col gap-4 px-4 pt-8 sm:gap-10 sm:px-8 sm:pt-14">
       <div className="flex flex-col gap-2">
         <Skeleton>
           <Header1 className="text-center text-title-md text-transparent sm:text-title-xl">
@@ -71,9 +71,9 @@ export const LandingScreenSkeleton: React.FC = async () => {
         </Skeleton>
       </div>
 
-      <Surface>
+      <Card className="gap-0 py-0">
         <Skeleton className="h-52 w-full" />
-      </Surface>
+      </Card>
 
       <hr />
 
@@ -83,33 +83,39 @@ export const LandingScreenSkeleton: React.FC = async () => {
         </div>
         <span />
         <div className="col-span-5">
-          <Surface className="flex flex-col gap-6 border-0 sm:border sm:p-6">
-            <Skeleton className="text-title-sm">
+          <Card className="flex flex-col gap-6 border-0 py-0 sm:border sm:p-6">
+            <Skeleton className="text-title-sm text-transparent">
               <TranslatedText text="New Organizations" />
             </Skeleton>
             <OrganizationListSkeleton />
-          </Surface>
+          </Card>
         </div>
       </div>
 
-      <Tabs className="pb-8 sm:hidden">
-        <TabList variant="pill">
-          <Tab id="discover" variant="pill">
+      <Tabs defaultValue="discover" className="pb-8 sm:hidden">
+        <TabsList>
+          <TabsTrigger value="discover">
             <TranslatedText text="Discover" />
-          </Tab>
-          <Tab id="recent" variant="pill">
+          </TabsTrigger>
+          <TabsTrigger value="recent">
             <TranslatedText text="Recent" />
-          </Tab>
-        </TabList>
+          </TabsTrigger>
+        </TabsList>
 
-        <TabPanel id="discover" className="p-0">
-          <Surface className="flex flex-col gap-6 border-0 sm:border sm:p-6">
-            <Skeleton className="text-title-sm">
+        <TabsContent value="discover" className="p-0">
+          <Card className="flex flex-col gap-6 border-0 py-0 sm:border sm:p-6">
+            <Skeleton className="text-title-sm text-transparent">
               <TranslatedText text="New Organizations" />
             </Skeleton>
-            <SkeletonLine lines={5} />
-          </Surface>
-        </TabPanel>
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+          </Card>
+        </TabsContent>
       </Tabs>
     </div>
   );
@@ -117,12 +123,12 @@ export const LandingScreenSkeleton: React.FC = async () => {
 
 const NewOrganizationsList = () => {
   return (
-    <Surface className="-mx-8 flex flex-col gap-6 border-0 sm:mx-0 sm:border sm:p-6">
+    <Card className="-mx-8 flex flex-col gap-6 border-0 py-0 sm:mx-0 sm:border sm:p-6">
       <Header3 className="px-8 font-serif text-title-sm sm:px-0">
         <TranslatedText text="New Organizations" />
       </Header3>
       <NewOrganizations />
-    </Surface>
+    </Card>
   );
 };
 
@@ -145,9 +151,9 @@ const PostFeedSection = async ({
       {showPostUpdate ? (
         <>
           <Suspense fallback={<Skeleton className="h-full w-full" />}>
-            <Surface className="mb-8 border-0 p-0 pt-5 sm:mb-4 sm:border sm:p-4">
+            <Card className="mb-8 gap-0 border-0 p-0 pt-5 sm:mb-4 sm:border sm:p-4">
               <PostUpdate label={<TranslatedText text="Post" />} />
-            </Surface>
+            </Card>
           </Suspense>
           <hr />
         </>
@@ -187,21 +193,21 @@ const LandingScreenFeeds = ({
           <NewOrganizationsList />
         </div>
       </div>
-      <Tabs className="gap-8 pb-8 sm:hidden">
-        <TabList variant="pill">
-          <Tab id="discover" variant="pill">
+      <Tabs defaultValue="discover" className="gap-8 pb-8 sm:hidden">
+        <TabsList>
+          <TabsTrigger value="discover">
             <TranslatedText text="Discover" />
-          </Tab>
-          <Tab id="recent" variant="pill">
+          </TabsTrigger>
+          <TabsTrigger value="recent">
             <TranslatedText text="Recent" />
-          </Tab>
-        </TabList>
-        <TabPanel id="discover" className="p-0">
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="discover" className="p-0">
           <NewOrganizationsList />
-        </TabPanel>
-        <TabPanel id="recent" className="p-0">
+        </TabsContent>
+        <TabsContent value="recent" className="p-0">
           <PostFeedSection showPostUpdate={showPostUpdate} />
-        </TabPanel>
+        </TabsContent>
       </Tabs>
     </>
   );
@@ -283,12 +289,12 @@ const UserContentSkeleton = () => {
         </div>
         <span />
         <div className="col-span-5">
-          <Surface className="flex flex-col gap-6 border-0 sm:border sm:p-6">
-            <Skeleton className="text-title-sm">
+          <Card className="flex flex-col gap-6 border-0 py-0 sm:border sm:p-6">
+            <Skeleton className="text-title-sm text-transparent">
               <TranslatedText text="New Organizations" />
             </Skeleton>
             <OrganizationListSkeleton />
-          </Surface>
+          </Card>
         </div>
       </div>
     </>

--- a/apps/app/src/components/screens/LandingScreen/index.tsx
+++ b/apps/app/src/components/screens/LandingScreen/index.tsx
@@ -149,30 +149,23 @@ const PostFeedSection = async ({
   return (
     <>
       {showPostUpdate ? (
-        <>
-          <Suspense fallback={<Skeleton className="h-full w-full" />}>
-            <Card className="mb-8 gap-0 border-0 p-0 pt-5 sm:mb-4 sm:border sm:p-4">
-              <PostUpdate label={<TranslatedText text="Post" />} />
-            </Card>
-          </Suspense>
-          <hr />
-        </>
+        <Suspense fallback={<Skeleton className="h-full w-full" />}>
+          <PostUpdate label={<TranslatedText text="Post" />} />
+        </Suspense>
       ) : null}
-      <div className="mt-4 sm:mt-0">
-        <ErrorBoundary
-          fallback={
-            <div className="flex flex-col items-center justify-center py-8">
-              <span className="text-neutral-charcoal">
-                <TranslatedText text="Unable to load posts. Please try refreshing." />
-              </span>
-            </div>
-          }
-        >
-          <HydrationBoundary state={dehydrate(queryClient)}>
-            <Feed />
-          </HydrationBoundary>
-        </ErrorBoundary>
-      </div>
+      <ErrorBoundary
+        fallback={
+          <div className="flex flex-col items-center justify-center py-8">
+            <span className="text-neutral-charcoal">
+              <TranslatedText text="Unable to load posts. Please try refreshing." />
+            </span>
+          </div>
+        }
+      >
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <Feed />
+        </HydrationBoundary>
+      </ErrorBoundary>
     </>
   );
 };
@@ -185,7 +178,7 @@ const LandingScreenFeeds = ({
   return (
     <>
       <div className="hidden grid-cols-15 sm:grid">
-        <div className="col-span-9 flex flex-col gap-4">
+        <div className="col-span-9 flex flex-col gap-8">
           <PostFeedSection showPostUpdate={showPostUpdate} />
         </div>
         <span />
@@ -206,7 +199,9 @@ const LandingScreenFeeds = ({
           <NewOrganizationsList />
         </TabsContent>
         <TabsContent value="recent" className="p-0">
-          <PostFeedSection showPostUpdate={showPostUpdate} />
+          <div className="flex flex-col gap-8">
+            <PostFeedSection showPostUpdate={showPostUpdate} />
+          </div>
         </TabsContent>
       </Tabs>
     </>

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -43,7 +43,7 @@
   "Common now works with a third-party service that automatically reviews content posted on the platform to keep the community safe and uphold our Code of Conduct. Our Terms of Use and Privacy Policy now explain how this works and what it means for your data.": "Common travaille désormais avec un service tiers qui examine automatiquement le contenu publié sur la plateforme afin de préserver la sécurité de la communauté et de faire respecter notre Code de conduite. Nos Conditions d'utilisation et notre Politique de confidentialité expliquent maintenant comment cela fonctionne et ce que cela signifie pour vos données.",
   "I have read and agree to the <terms>Terms of Use</terms>, <privacy>Privacy Policy</privacy>, and <conduct>Code of Conduct</conduct>.": "J'ai lu et j'accepte les <terms>Conditions d'utilisation</terms>, la <privacy>Politique de confidentialité</privacy> et le <conduct>Code de conduite</conduct>.",
   "Agree and continue": "Accepter et continuer",
-  "Media": "Moyens de communication",
+  "Media": "Média",
   "We've found your organization": "Nous avons trouvé votre organisation",
   "join_subheader": "En fonction du domaine de votre courriel, vous avez accès pour rejoindre cette organisation.",
   "Confirm Administrator Access": "Confirmer l'accès administrateur",

--- a/packages/sense/src/components/FacePile/index.tsx
+++ b/packages/sense/src/components/FacePile/index.tsx
@@ -32,12 +32,17 @@ function FacePile({
         className={cn(
           // Ring each face in the background color so overlapping avatars read
           // as distinct instead of blurring together.
-          'flex [&_[data-slot=avatar]]:ring-2 [&_[data-slot=avatar]]:ring-background',
+          'flex [&_[data-slot=avatar]]:ring-1 [&_[data-slot=avatar]]:ring-background',
           listClassName,
         )}
       >
         {items.map((node, index) => (
-          <li key={index} className="relative -ms-2 first:ms-0">
+          // focus-within raises the focused face above its neighbors so an
+          // offset focus ring isn't clipped by the overlapping next item.
+          <li
+            key={index}
+            className="relative -ms-2 first:ms-0 focus-within:z-10"
+          >
             {node}
           </li>
         ))}

--- a/packages/sense/src/components/FacePile/index.tsx
+++ b/packages/sense/src/components/FacePile/index.tsx
@@ -28,7 +28,14 @@ function FacePile({
       )}
       {...props}
     >
-      <ul className={cn('flex', listClassName)}>
+      <ul
+        className={cn(
+          // Ring each face in the background color so overlapping avatars read
+          // as distinct instead of blurring together.
+          'flex [&_[data-slot=avatar]]:ring-2 [&_[data-slot=avatar]]:ring-background',
+          listClassName,
+        )}
+      >
         {items.map((node, index) => (
           <li key={index} className="relative -ms-2 first:ms-0">
             {node}
@@ -49,6 +56,11 @@ interface GrowingFacePileProps {
    * (totalCount - rendered), so a few avatars can still convey a large total.
    */
   totalCount?: number;
+  /**
+   * Render the "+N" overflow bubble yourself — e.g. to wrap it in a link. Gets
+   * the overflow count. Falls back to a plain foreground bubble when omitted.
+   */
+  renderOverflow?: (count: number) => React.ReactNode;
 }
 
 function GrowingFacePile({
@@ -56,6 +68,7 @@ function GrowingFacePile({
   items,
   maxItems = 20,
   totalCount,
+  renderOverflow,
 }: GrowingFacePileProps) {
   const facePileRef = React.useRef<HTMLDivElement>(null);
   const [numItems, setNumItems] = React.useState(maxItems);
@@ -91,11 +104,15 @@ function GrowingFacePile({
 
   if (overflowCount > 0) {
     renderedItems.push(
-      <Avatar>
-        <AvatarFallback className="bg-foreground text-sm text-background">
-          +{overflowCount}
-        </AvatarFallback>
-      </Avatar>,
+      renderOverflow ? (
+        renderOverflow(overflowCount)
+      ) : (
+        <Avatar>
+          <AvatarFallback className="bg-foreground text-sm text-background">
+            +{overflowCount}
+          </AvatarFallback>
+        </Avatar>
+      ),
     );
   }
 

--- a/packages/sense/src/components/MediaDisplay/index.tsx
+++ b/packages/sense/src/components/MediaDisplay/index.tsx
@@ -30,10 +30,13 @@ function MediaDisplay({
   size,
 }: MediaDisplayProps) {
   const isPdf = Boolean(mimeType?.match(/application\/pdf/));
+  const isImage = Boolean(mimeType?.startsWith('image/'));
 
   const details: React.ReactNode[] = [];
 
-  if (title) {
+  // Images are shown on their own — the filename-as-title is noise. Link
+  // previews (no mimeType) and documents still surface their title.
+  if (title && !isImage) {
     details.push(
       <p key="title" className="text-base font-strong">
         {title}

--- a/packages/sense/src/components/NotificationPanel/index.tsx
+++ b/packages/sense/src/components/NotificationPanel/index.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react';
 
 import { cn } from '../../lib/utils';
+import { Header2 } from '../Header';
+import { BadgeNumber } from '../ui/badge';
 
 /**
  * A bordered notification surface with a serif header (title + count badge),
@@ -23,12 +25,10 @@ function NotificationPanelHeader({
   count: number;
 }) {
   return (
-    <h2 className="flex items-center gap-1 p-6 font-serif text-title text-foreground">
-      {title}{' '}
-      <span className="flex size-4 items-center justify-center rounded-full bg-destructive text-xs text-destructive-foreground">
-        {count}
-      </span>
-    </h2>
+    <div className="flex items-center gap-1 p-6 text-foreground">
+      <Header2 className="text-title">{title}</Header2>
+      <BadgeNumber>{count}</BadgeNumber>
+    </div>
   );
 }
 

--- a/packages/sense/src/components/ProfileAvatar/index.tsx
+++ b/packages/sense/src/components/ProfileAvatar/index.tsx
@@ -1,26 +1,34 @@
+import type { ComponentProps } from 'react';
+
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 
 interface ProfileAvatarProps {
-  /** Display name — seeds the fallback initials + gradient when no image. */
+  /** Display name — seeds the fallback initial + gradient when no image. */
   name?: string | null;
   /** Resolved image URL. Callers resolve storage paths (e.g. getPublicUrl). */
   src?: string | null;
   alt: string;
   size?: 'default' | 'sm' | 'lg';
   className?: string;
+  /**
+   * Element to render the image through — e.g. a Next.js `<Image>` — so
+   * consumers keep image optimization. Forwarded to AvatarImage's `render`.
+   */
+  imageRender?: ComponentProps<typeof AvatarImage>['render'];
 }
 
-/** Avatar with an image when available, initials/gradient fallback otherwise. */
+/** Avatar with an image when available, initial/gradient fallback otherwise. */
 function ProfileAvatar({
   name,
   src,
   alt,
   size,
   className,
+  imageRender,
 }: ProfileAvatarProps) {
   return (
     <Avatar size={size} className={className}>
-      {src ? <AvatarImage src={src} alt={alt} /> : null}
+      {src ? <AvatarImage src={src} alt={alt} render={imageRender} /> : null}
       <AvatarFallback name={name ?? undefined} />
     </Avatar>
   );

--- a/packages/sense/src/components/ui/avatar.tsx
+++ b/packages/sense/src/components/ui/avatar.tsx
@@ -41,7 +41,9 @@ function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
 
 /** Single initial: the first letter of the name. */
 function initialsFromName(name: string) {
-  return (name.trim()[0] ?? '').toUpperCase();
+  // First code point, not the first UTF-16 unit — an emoji (or other astral
+  // char) is a surrogate pair, and `[0]` returns half of it as a broken glyph.
+  return (Array.from(name.trim())[0] ?? '').toUpperCase();
 }
 
 function AvatarFallback({

--- a/packages/sense/src/components/ui/avatar.tsx
+++ b/packages/sense/src/components/ui/avatar.tsx
@@ -39,15 +39,9 @@ function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
   );
 }
 
-/** Up-to-two initials: first + last word's first letter (single word → one). */
+/** Single initial: the first letter of the name. */
 function initialsFromName(name: string) {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) {
-    return '';
-  }
-  const first = parts[0]?.[0] ?? '';
-  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
-  return (first + last).toUpperCase();
+  return (name.trim()[0] ?? '').toUpperCase();
 }
 
 function AvatarFallback({
@@ -58,8 +52,8 @@ function AvatarFallback({
 }: AvatarPrimitive.Fallback.Props & {
   /**
    * Display name for the "no image" fallback. Seeds the deterministic gradient
-   * fill and, when no children are given, renders derived initials (Frida
-   * Kahlo → FK). Without a name (or string children) the fill stays muted.
+   * fill and, when no children are given, renders the first initial (Frida
+   * Kahlo → F). Without a name (or string children) the fill stays muted.
    */
   name?: string;
 }) {

--- a/packages/sense/src/components/ui/badge.tsx
+++ b/packages/sense/src/components/ui/badge.tsx
@@ -50,4 +50,18 @@ function Badge({
   });
 }
 
-export { Badge, badgeVariants };
+/**
+ * A count badge — the `Badge/Number` Figma component. A circular/pill `Badge`
+ * sized for 1+ digit counts (`min-w-5` grows into a pill for two digits).
+ * Defaults to the primary variant; pass `variant` for other colors.
+ */
+function BadgeNumber({
+  className,
+  ...props
+}: useRender.ComponentProps<'span'> & VariantProps<typeof badgeVariants>) {
+  return (
+    <Badge className={cn('min-w-5 rounded-full px-1', className)} {...props} />
+  );
+}
+
+export { Badge, BadgeNumber, badgeVariants };

--- a/packages/sense/src/components/ui/button.tsx
+++ b/packages/sense/src/components/ui/button.tsx
@@ -2,9 +2,10 @@ import { Button as ButtonPrimitive } from '@base-ui/react/button';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '../../lib/utils';
+import { Spinner } from './spinner';
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg text-base font-strong whitespace-nowrap transition-all outline-none select-none focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button relative inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg text-base font-strong whitespace-nowrap no-underline transition-all outline-none select-none hover:no-underline focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -54,14 +55,41 @@ function Button({
   className,
   variant = 'default',
   size = 'default',
+  loading = false,
+  children,
   ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+}: ButtonPrimitive.Props &
+  VariantProps<typeof buttonVariants> & {
+    /**
+     * Show a centered spinner over the label and block interaction. Keeps the
+     * button's fill and width (the label stays laid out but invisible). Works
+     * for any variant and when the button is rendered as a link (`render`).
+     */
+    loading?: boolean;
+  }) {
   return (
     <ButtonPrimitive
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(
+        buttonVariants({ variant, size, className }),
+        loading && 'pointer-events-none',
+      )}
+      aria-busy={loading || undefined}
       {...props}
-    />
+    >
+      {loading ? (
+        <>
+          <span className="invisible flex items-center gap-1.5">
+            {children}
+          </span>
+          <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <Spinner />
+          </span>
+        </>
+      ) : (
+        children
+      )}
+    </ButtonPrimitive>
   );
 }
 

--- a/packages/sense/src/components/ui/button.tsx
+++ b/packages/sense/src/components/ui/button.tsx
@@ -56,6 +56,7 @@ function Button({
   variant = 'default',
   size = 'default',
   loading = false,
+  disabled,
   children,
   ...props
 }: ButtonPrimitive.Props &
@@ -72,8 +73,12 @@ function Button({
       data-slot="button"
       className={cn(
         buttonVariants({ variant, size, className }),
-        loading && 'pointer-events-none',
+        // `disabled` blocks the button natively (mouse + keyboard); keep
+        // pointer-events-none for the link-rendered case (an <a> ignores
+        // disabled). opacity-80 keeps the spinner readable, not greyed out.
+        loading && 'pointer-events-none disabled:opacity-80',
       )}
+      disabled={loading || disabled}
       aria-busy={loading || undefined}
       {...props}
     >

--- a/packages/sense/src/components/ui/dialog.tsx
+++ b/packages/sense/src/components/ui/dialog.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { LuX } from 'react-icons/lu';
 
 import { cn } from '../../lib/utils';
+import { Confetti } from '../Confetti';
 import { Button } from './button';
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
@@ -44,14 +45,30 @@ function DialogContent({
   children,
   showCloseButton = true,
   container,
+  confetti = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean;
   container?: DialogPrimitive.Portal.Props['container'];
+  /**
+   * Burst confetti behind the card while the dialog is open. Rendered inside
+   * the backdrop so it fills the screen (not clipped to the card) and fades
+   * with the backdrop on close. Replays on each open (the backdrop remounts).
+   */
+  confetti?: boolean;
 }) {
   return (
     <DialogPortal container={container}>
-      <DialogOverlay />
+      <DialogOverlay>
+        {/* Inside the backdrop so it inherits the open/close transition — on an
+            early close the confetti fades out with the backdrop instead of
+            being cut. pointer-events-none keeps click-to-dismiss working. */}
+        {confetti ? (
+          <div className="pointer-events-none absolute inset-0">
+            <Confetti />
+          </div>
+        ) : null}
+      </DialogOverlay>
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(

--- a/packages/sense/src/components/ui/input-group.tsx
+++ b/packages/sense/src/components/ui/input-group.tsx
@@ -74,6 +74,7 @@ const inputGroupButtonVariants = cva(
         // Explicit: was '' when Button's default was 32px; Button's default is
         // now 44px, so sm must set its own height.
         sm: 'h-8 rounded-md px-2.5',
+        md: 'h-10 rounded-md px-4',
         'icon-xs':
           'size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0',
         'icon-sm': 'size-8 p-0 has-[>svg]:p-0',

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -69,12 +69,6 @@
   /* sm, md, lg, xl, 2xl use Tailwind defaults */
 
   /* ============================================
-   * Container
-   * Note: Container config requires plugin or custom CSS
-   * center: true, padding: 2rem, screens: { '2xl': '1400px' }
-   * ============================================ */
-
-  /* ============================================
    * Border Radius
    * Only the steps that deviate from Tailwind v4 defaults are declared;
    * sm/md/lg/xl/2xl match Tailwind and are inherited. --radius is the shadcn
@@ -408,16 +402,6 @@
  * Original: darkMode: ['class', 'data-theme']
  * ============================================ */
 @custom-variant dark (&:where(.dark, [data-theme="dark"] *));
-
-/* ============================================
- * Container Configuration
- * Original: center: true, padding: 2rem, screens: { '2xl': '1400px' }
- * ============================================ */
-@utility container {
-  margin-inline: auto;
-  padding-inline: 2rem;
-  max-width: 1400px;
-}
 
 /* ============================================
  * Base Layer Styles

--- a/packages/ui/stories-sense/Confetti.stories.tsx
+++ b/packages/ui/stories-sense/Confetti.stories.tsx
@@ -7,7 +7,6 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogPortal,
   DialogTitle,
   DialogTrigger,
 } from '@op/sense/Dialog';
@@ -27,35 +26,16 @@ export default meta;
 
 type Story = StoryObj<typeof Confetti>;
 
-// How it's used in the app: a success modal that bursts confetti on open. The
-// effect is a viewport-fixed overlay portaled to `<body>` (alongside the
-// dialog) so Storybook's story wrapper doesn't trap it. It's layered between
-// the dimmed backdrop (`z-50`) and the modal card (bumped to `z-[60]`) via an
-// `isolate` wrapper, so confetti bursts behind the card, not over its text.
-// Remounted via `key` each open so it replays.
+// How it's used in the app: a success modal that bursts confetti on open. Pass
+// `confetti` to `DialogContent` — it renders the viewport-fixed overlay behind
+// the card (between backdrop and card) and replays on each open.
 const CelebrationDemo = () => {
   const [open, setOpen] = useState(false);
-  const [burst, setBurst] = useState(0);
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (next) {
-          setBurst((n) => n + 1);
-        }
-      }}
-    >
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger render={<Button />}>Complete setup</DialogTrigger>
-      {open ? (
-        <DialogPortal>
-          <div className="pointer-events-none fixed inset-0 isolate z-[55]">
-            <Confetti key={burst} />
-          </div>
-        </DialogPortal>
-      ) : null}
-      <DialogContent className="sense z-[60]">
+      <DialogContent confetti className="sense">
         <DialogHeader>
           <DialogTitle>🎉 You’re all set!</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
Migrates the landing / home page from `@op/ui` to `@op/sense`.

**Core** (`0ed31c6`)
- LandingScreen, PlatformHighlights, OrganizationList swapped — Header/Skeleton/Tabs; `Surface` → flat `Card` (border + rounding, no extra chrome) to match Figma
- `Avatar` single-letter fallback (global); `ProfileAvatar` composite gains an `imageRender` passthrough so consumers keep `next/image`
- Landing wrappers use explicit `mx-auto`/`max-w`/`px` utilities (custom mobile padding); drop the now-unused `@op/styles` `container` utility

**Notifications + Button** (`7938030`)
- ActiveDecisions / JoinProfileRequests / PendingDecisionInvites / PendingRelationships → `@op/sense` (NotificationPanel, ProfileItem, Button, Spinner, Sonner)
- OrganizationAvatar + DecisionAvatar → `ProfileAvatar`
- `Button` gains a `loading` prop (centered spinner overlay, keeps fill + width, blocks clicks, `aria-busy`); base `no-underline` so link-rendered buttons don't underline (link variant still underlines on hover)
- PlatformHighlights hides the new-orgs stat when the count is 0

**Feeds + composer** (`454989b`)
- PostFeed (feed / ReportPostModal / DeletePostMenuItem), NewlyJoinedModal, RelationshipList, Feed → `@op/sense` (DropdownMenu, Dialog, Reactions/Comment/MediaDisplay/TagGroup, Sonner)
- Rebuild the PostUpdate composer on the InputGroup pattern: avatar as an inline-start addon, textarea + previews + block-end action bar inside the box
- MediaDisplay no longer renders the title for images (`isImage` gate)
- `InputGroupButton` gains an `md` size; fr `Media` → `Média` (was overflowing on mobile)

**QA refinements** (`fab0926`, `f83417d`)
- `Badge` gains a `BadgeNumber` preset (circular/pill count badge, `min-w-5`, color via `variant`) matching Figma's Badge/Number; NotificationPanelHeader uses it and moves the badge out of the `<h2>` (heading now via `Header2`, badge is a sibling). Count color: destructive-red → default primary
- Add app-level `ButtonLink` (sense `Button` rendered as the i18n `Link`); ActiveDecisions Participate/Revise now use it
- PostUpdate textarea auto-grows natively (drop `field-sizing-fixed`); OrganizationAvatar drops its default `size-10` so consumers set size
