### PR TITLE
fix(sense): SiteHeader UserAvatarMenu cleanup

### DIFF
--- a/apps/app/src/components/SiteHeader/UserAvatarMenu.tsx
+++ b/apps/app/src/components/SiteHeader/UserAvatarMenu.tsx
@@ -106,7 +106,7 @@ const ProfileMenuRow = ({
   };
 
   const className = cn(
-    'group/row grid h-auto w-full cursor-pointer grid-cols-[1fr_auto] items-center gap-4 rounded-lg border p-4 text-start outline-none',
+    'group/row grid h-auto w-full cursor-pointer grid-cols-[1fr_auto] items-center gap-4 rounded-lg border p-4 text-start outline-none hover:border-input hover:bg-muted',
     isCurrent ? 'border-accent-foreground bg-accent' : 'border-border',
   );
 
@@ -217,14 +217,12 @@ const LegalTrigger = ({
   onClick: () => void;
   children: ReactNode;
 }) => {
-  const className = 'h-auto w-full justify-start p-1 text-sm';
+  const className =
+    'h-auto w-full justify-start py-1 px-2 text-sm font-strong text-primary';
 
   if (asMenuItem) {
     return (
-      <DropdownMenuItem
-        render={<Button variant="link" size="sm" className={className} />}
-        onClick={onClick}
-      >
+      <DropdownMenuItem className={className} onClick={onClick}>
         {children}
       </DropdownMenuItem>
     );
@@ -254,7 +252,7 @@ const LinkRow = ({
   children: ReactNode;
 }) => {
   const shared = cn(
-    'flex h-auto w-full cursor-pointer items-center gap-1.5 rounded-md px-3 py-2 text-start no-underline outline-none',
+    'flex h-auto w-full cursor-pointer items-center gap-1.5 rounded-md px-3 py-2 text-start no-underline outline-none hover:no-underline',
     className,
   );
 
@@ -277,7 +275,7 @@ const LinkRow = ({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className={cn(shared, 'hover:bg-muted')}
+      className={shared}
       onClick={onClick}
     >
       {children}
@@ -362,7 +360,7 @@ const AvatarMenuContent = ({
 
       <MenuDivider asMenuItem={asMenuItem} />
 
-      <MenuSection asMenuItem={asMenuItem} className="flex flex-col gap-1 py-2">
+      <MenuSection asMenuItem={asMenuItem} className="flex flex-col gap-1 p-2">
         <LinkRow
           asMenuItem={asMenuItem}
           href="https://oneprojectorg.notion.site/Common-Support-Hub-a9ef0b6622538269927c01e51045638b"
@@ -409,14 +407,14 @@ const AvatarMenuContent = ({
         {deleteOrganizationEnabled ? (
           <ActionRow
             asMenuItem={asMenuItem}
-            className="justify-start p-1 text-sm font-strong text-foreground hover:underline"
+            className="justify-start px-2 py-1 text-sm font-strong text-foreground hover:bg-muted hover:underline"
             onClick={onDeleteAccount}
           >
             {t('Delete my account')}
           </ActionRow>
         ) : null}
 
-        <div className="flex gap-1 px-1 text-xs text-muted-foreground">
+        <div className="flex gap-1 px-2 text-xs text-muted-foreground">
           {asMenuItem ? (
             // A real menu link item (base-ui Menu.LinkItem) so it joins the
             // menu's roving focus — a bare link at the bottom made the menu
@@ -425,7 +423,7 @@ const AvatarMenuContent = ({
               href="https://github.com/oneprojectorg/common"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline h-auto rounded-none p-0 text-xs hover:underline"
+              className="inline h-auto rounded-none p-0 text-xs hover:bg-transparent hover:underline"
             >
               {t('Ethical Open Source')}
             </DropdownMenuLinkItem>

--- a/packages/sense/src/components/ui/dropdown-menu.tsx
+++ b/packages/sense/src/components/ui/dropdown-menu.tsx
@@ -91,7 +91,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-3 py-2 text-base outline-hidden select-none focus:bg-accent data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:ps-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive-muted data-[variant=destructive]:focus:text-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        "group/dropdown-menu-item relative flex cursor-default cursor-pointer items-center gap-1.5 rounded-md px-3 py-2 text-base outline-hidden select-none focus:bg-accent data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:ps-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive-muted data-[variant=destructive]:focus:text-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
         className,
       )}
       {...props}

--- a/packages/sense/src/components/ui/dropdown-menu.tsx
+++ b/packages/sense/src/components/ui/dropdown-menu.tsx
@@ -91,7 +91,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "group/dropdown-menu-item relative flex cursor-default cursor-pointer items-center gap-1.5 rounded-md px-3 py-2 text-base outline-hidden select-none focus:bg-accent data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:ps-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive-muted data-[variant=destructive]:focus:text-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        "group/dropdown-menu-item relative flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-2 text-base outline-hidden select-none focus:bg-accent data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:ps-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive-muted data-[variant=destructive]:focus:text-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
         className,
       )}
       {...props}


### PR DESCRIPTION
Cleanup pass on the migrated SiteHeader avatar menu.

- **LegalTrigger** — the desktop legal items (Privacy / ToS / Community Commitments) composed a `link` Button onto `DropdownMenuItem` via `render`, but the item's own `px-3 py-2 text-base` defaults won the class merge, so the Button's `size="sm"` and `p-1` never applied. Style the item directly (link look inline); no more `render` composition.

More UserAvatarMenu tweaks to follow on this branch.