### PR TITLE
feat(app): ProfileAvatarLink + avatar/focus fixes

### DIFF
--- a/apps/app/src/components/DecisionAvatar/index.tsx
+++ b/apps/app/src/components/DecisionAvatar/index.tsx
@@ -1,11 +1,9 @@
 import { getPublicUrl } from '@/utils';
 import { Profile } from '@op/api/encoders';
-import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { Skeleton } from '@op/sense/Skeleton';
 import { cn } from '@op/sense/lib/utils';
-import Image from 'next/image';
 
-import { Link } from '@/lib/i18n';
+import { ProfileAvatarLink } from '../ProfileAvatarLink';
 
 export const DecisionAvatar = ({
   profile,
@@ -26,27 +24,15 @@ export const DecisionAvatar = ({
     : undefined;
   const slug = profile?.slug;
 
-  const avatar = (
-    <ProfileAvatar
+  return (
+    <ProfileAvatarLink
+      href={withLink && slug ? `/decisions/${slug}` : undefined}
       name={name}
       src={avatarUrl}
       alt={name}
       size="lg"
-      className={cn(withLink && slug && 'hover:opacity-80', className)}
-      imageRender={
-        avatarUrl ? (
-          <Image src={avatarUrl} alt={name} fill className="object-cover" />
-        ) : undefined
-      }
+      className={className}
     />
-  );
-
-  return withLink && slug ? (
-    <Link href={`/decisions/${slug}`} className="hover:no-underline">
-      {avatar}
-    </Link>
-  ) : (
-    <div>{avatar}</div>
   );
 };
 

--- a/apps/app/src/components/OrganizationAvatar/index.tsx
+++ b/apps/app/src/components/OrganizationAvatar/index.tsx
@@ -1,12 +1,10 @@
 import { useCanLinkToProfile } from '@/hooks/useCanLinkToProfile';
 import { getPublicUrl } from '@/utils';
 import { Profile } from '@op/api/encoders';
-import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { Skeleton } from '@op/sense/Skeleton';
 import { cn } from '@op/sense/lib/utils';
-import Image from 'next/image';
 
-import { Link } from '@/lib/i18n';
+import { ProfileAvatarLink } from '../ProfileAvatarLink';
 
 export const OrganizationAvatar = ({
   profile,
@@ -31,26 +29,14 @@ export const OrganizationAvatar = ({
   // Public/non-member viewers can't reach the profile page, so drop the link.
   const linked = withLink && canLinkToProfile && Boolean(slug);
 
-  const avatar = (
-    <ProfileAvatar
+  return (
+    <ProfileAvatarLink
+      href={linked ? `/profile/${slug}` : undefined}
       name={name}
       src={avatarUrl}
       alt={name}
-      className={cn(linked && 'hover:opacity-80', className)}
-      imageRender={
-        avatarUrl ? (
-          <Image src={avatarUrl} alt={name} fill className="object-cover" />
-        ) : undefined
-      }
+      className={className}
     />
-  );
-
-  return linked ? (
-    <Link href={`/profile/${slug}`} className="hover:no-underline">
-      {avatar}
-    </Link>
-  ) : (
-    <div>{avatar}</div>
   );
 };
 

--- a/apps/app/src/components/OrganizationList/index.tsx
+++ b/apps/app/src/components/OrganizationList/index.tsx
@@ -4,7 +4,6 @@ import { getPublicUrl } from '@/utils';
 import { Organization } from '@op/api/encoders';
 import { Card } from '@op/sense/Card';
 import { HorizontalList, HorizontalListItem } from '@op/sense/HorizontalList';
-import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { Skeleton } from '@op/sense/Skeleton';
 import { cn } from '@op/sense/lib/utils';
 import { getGradientForString } from '@op/styles/constants';
@@ -17,6 +16,7 @@ import {
   OrganizationAvatar,
   OrganizationAvatarSkeleton,
 } from '@/components/OrganizationAvatar';
+import { ProfileAvatarLink } from '@/components/ProfileAvatarLink';
 
 export const OrganizationList = ({
   organizations,
@@ -182,27 +182,13 @@ export const OrganizationSummaryList = ({
         return (
           <div key={org.id}>
             <div className="flex items-start gap-2 py-2 sm:gap-6">
-              <Link
+              <ProfileAvatarLink
                 href={`/org/${org.profile.slug}`}
-                className="hover:no-underline"
-              >
-                <ProfileAvatar
-                  name={org.profile.name ?? ''}
-                  src={orgAvatarUrl}
-                  alt={org.profile.name ?? ''}
-                  className="size-8 hover:opacity-80 sm:size-12"
-                  imageRender={
-                    orgAvatarUrl ? (
-                      <Image
-                        src={orgAvatarUrl}
-                        alt={org.profile.name ?? ''}
-                        fill
-                        className="object-cover"
-                      />
-                    ) : undefined
-                  }
-                />
-              </Link>
+                name={org.profile.name ?? ''}
+                src={orgAvatarUrl}
+                alt={org.profile.name ?? ''}
+                className="size-8 sm:size-12"
+              />
 
               <div className="flex flex-col gap-3 text-neutral-black">
                 <div className="flex flex-col gap-2">

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -11,7 +11,11 @@ import { ReactNode, Suspense } from 'react';
 
 import { Link } from '@/lib/i18n';
 
-import { ProfileAvatarLink, avatarLinkClassName } from '../ProfileAvatarLink';
+import {
+  AvatarLinkHoverTint,
+  ProfileAvatarLink,
+  avatarLinkClassName,
+} from '../ProfileAvatarLink';
 
 export const PlatformHighlights = () => {
   const [stats] = trpc.platform.getStats.useSuspenseQuery();
@@ -139,6 +143,7 @@ const OrganizationFacePile = ({ children }: { children?: ReactNode }) => {
               {count}
             </AvatarFallback>
           </Avatar>
+          <AvatarLinkHoverTint />
         </Link>
       )}
     >

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -5,13 +5,13 @@ import { trpc } from '@op/api/client';
 import { Avatar, AvatarFallback } from '@op/sense/Avatar';
 import { Card } from '@op/sense/Card';
 import { GrowingFacePile } from '@op/sense/FacePile';
-import { ProfileAvatar } from '@op/sense/ProfileAvatar';
 import { cn } from '@op/sense/lib/utils';
 import { useTranslations } from 'next-intl';
-import Image from 'next/image';
 import { ReactNode, Suspense } from 'react';
 
 import { Link } from '@/lib/i18n';
+
+import { ProfileAvatarLink, avatarLinkClassName } from '../ProfileAvatarLink';
 
 export const PlatformHighlights = () => {
   const [stats] = trpc.platform.getStats.useSuspenseQuery();
@@ -117,40 +117,22 @@ const OrganizationFacePile = ({ children }: { children?: ReactNode }) => {
     t.platform.getStats(),
   ]);
 
-  const items = organizations.map((org) => {
-    const avatarUrl = getPublicUrl(org.profile.avatarImage?.name);
-    return (
-      <Link
-        key={org.id}
-        href={`/org/${org.profile.slug}`}
-        className="hover:no-underline"
-      >
-        <ProfileAvatar
-          name={org.profile.name}
-          src={avatarUrl}
-          alt={org.profile.name}
-          imageRender={
-            avatarUrl ? (
-              <Image
-                src={avatarUrl}
-                alt={org.profile.name}
-                fill
-                className="object-cover"
-              />
-            ) : undefined
-          }
-        />
-        <div className="absolute start-0 top-0 h-full w-full cursor-pointer rounded-full bg-white opacity-0 transition-opacity duration-100 ease-in-out hover:opacity-15 active:bg-black" />
-      </Link>
-    );
-  });
+  const items = organizations.map((org) => (
+    <ProfileAvatarLink
+      key={org.id}
+      href={`/org/${org.profile.slug}`}
+      name={org.profile.name}
+      src={getPublicUrl(org.profile.avatarImage?.name)}
+      alt={org.profile.name}
+    />
+  ));
 
   return (
     <GrowingFacePile
       items={items}
       totalCount={stats.totalOrganizations}
       renderOverflow={(count) => (
-        <Link href="/org" className="hover:no-underline">
+        <Link href="/org" className={avatarLinkClassName}>
           <Avatar>
             <AvatarFallback className="bg-neutral-charcoal text-sm text-neutral-offWhite">
               <span className="align-super">+</span>

--- a/apps/app/src/components/ProfileAvatarLink/index.tsx
+++ b/apps/app/src/components/ProfileAvatarLink/index.tsx
@@ -1,18 +1,30 @@
 import { ProfileAvatar } from '@op/sense/ProfileAvatar';
-import { cn } from '@op/sense/lib/utils';
 import Image from 'next/image';
 
 import { Link } from '@/lib/i18n';
 
 /**
- * Focus/hover treatment for a circular avatar link. The ring sits on an offset
- * so it clears an inner separation ring (e.g. in a facepile) and reads clearly.
- * Exported so bare avatar links (e.g. a facepile "+N" bubble) match.
+ * Focus/hover treatment for a circular avatar link. `group` + `relative` let a
+ * child overlay tint on hover; the ring sits on an offset so it clears an inner
+ * separation ring (e.g. in a facepile). Exported so bare avatar links (e.g. a
+ * facepile "+N" bubble) match.
  */
 export const avatarLinkClassName =
   // size-fit gives the link a definite size so a flex parent's align-items:
   // stretch can't stretch it taller than the avatar (which would oval the ring).
-  'inline-flex size-fit rounded-full outline-none hover:no-underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+  'group relative inline-flex size-fit rounded-full outline-none hover:no-underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+
+/**
+ * Hover tint for a circular avatar link — a darkening overlay clipped to the
+ * circle. Used instead of opacity so overlapping facepile avatars don't go
+ * see-through and reveal their neighbor. Exported so bare avatar links match.
+ */
+export const AvatarLinkHoverTint = () => (
+  <span
+    aria-hidden
+    className="pointer-events-none absolute inset-0 rounded-full bg-foreground/0 transition-colors duration-200 group-hover:bg-background/20"
+  />
+);
 
 interface ProfileAvatarLinkProps {
   /** Destination. When omitted the avatar renders without a link. */
@@ -28,7 +40,7 @@ interface ProfileAvatarLinkProps {
 
 /**
  * A `ProfileAvatar` wrapped in the locale-aware `Link` — the linked avatar we
- * render all over the app. Owns the circular focus ring, hover dim, and the
+ * render all over the app. Owns the circular focus ring, hover tint, and the
  * `next/image` passthrough so callers just supply `href`/`name`/`src`. Without
  * `href` it's a plain, non-interactive avatar.
  */
@@ -46,7 +58,7 @@ export const ProfileAvatarLink = ({
       src={src}
       alt={alt}
       size={size}
-      className={cn(href && 'hover:opacity-80', className)}
+      className={className}
       imageRender={
         src ? (
           <Image src={src} alt={alt} fill className="object-cover" />
@@ -62,6 +74,7 @@ export const ProfileAvatarLink = ({
   return (
     <Link href={href} className={avatarLinkClassName}>
       {avatar}
+      <AvatarLinkHoverTint />
     </Link>
   );
 };

--- a/apps/app/src/components/ProfileAvatarLink/index.tsx
+++ b/apps/app/src/components/ProfileAvatarLink/index.tsx
@@ -1,0 +1,67 @@
+import { ProfileAvatar } from '@op/sense/ProfileAvatar';
+import { cn } from '@op/sense/lib/utils';
+import Image from 'next/image';
+
+import { Link } from '@/lib/i18n';
+
+/**
+ * Focus/hover treatment for a circular avatar link. The ring sits on an offset
+ * so it clears an inner separation ring (e.g. in a facepile) and reads clearly.
+ * Exported so bare avatar links (e.g. a facepile "+N" bubble) match.
+ */
+export const avatarLinkClassName =
+  // size-fit gives the link a definite size so a flex parent's align-items:
+  // stretch can't stretch it taller than the avatar (which would oval the ring).
+  'inline-flex size-fit rounded-full outline-none hover:no-underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+
+interface ProfileAvatarLinkProps {
+  /** Destination. When omitted the avatar renders without a link. */
+  href?: string | null;
+  /** Display name — seeds the fallback initial + gradient when no image. */
+  name?: string | null;
+  /** Resolved image URL (callers resolve storage paths, e.g. getPublicUrl). */
+  src?: string | null;
+  alt: string;
+  size?: 'default' | 'sm' | 'lg';
+  className?: string;
+}
+
+/**
+ * A `ProfileAvatar` wrapped in the locale-aware `Link` — the linked avatar we
+ * render all over the app. Owns the circular focus ring, hover dim, and the
+ * `next/image` passthrough so callers just supply `href`/`name`/`src`. Without
+ * `href` it's a plain, non-interactive avatar.
+ */
+export const ProfileAvatarLink = ({
+  href,
+  name,
+  src,
+  alt,
+  size,
+  className,
+}: ProfileAvatarLinkProps) => {
+  const avatar = (
+    <ProfileAvatar
+      name={name}
+      src={src}
+      alt={alt}
+      size={size}
+      className={cn(href && 'hover:opacity-80', className)}
+      imageRender={
+        src ? (
+          <Image src={src} alt={alt} fill className="object-cover" />
+        ) : undefined
+      }
+    />
+  );
+
+  if (!href) {
+    return avatar;
+  }
+
+  return (
+    <Link href={href} className={avatarLinkClassName}>
+      {avatar}
+    </Link>
+  );
+};

--- a/apps/app/src/components/SearchInput/index.tsx
+++ b/apps/app/src/components/SearchInput/index.tsx
@@ -240,6 +240,9 @@ export const SearchInput = ({ onBlur }: { onBlur?: () => void } = {}) => {
         </InputGroupAddon>
         <CommandPrimitive.Input
           ref={inputRef}
+          // Tag as the InputGroup control so the group's focus-visible ring/
+          // border styles (has-[[data-slot=input-group-control]...]) apply.
+          data-slot="input-group-control"
           value={query}
           onValueChange={(value) => {
             setQuery(value);

--- a/packages/sense/src/components/FacePile/index.tsx
+++ b/packages/sense/src/components/FacePile/index.tsx
@@ -32,12 +32,17 @@ function FacePile({
         className={cn(
           // Ring each face in the background color so overlapping avatars read
           // as distinct instead of blurring together.
-          'flex [&_[data-slot=avatar]]:ring-2 [&_[data-slot=avatar]]:ring-background',
+          'flex [&_[data-slot=avatar]]:ring-1 [&_[data-slot=avatar]]:ring-background',
           listClassName,
         )}
       >
         {items.map((node, index) => (
-          <li key={index} className="relative -ms-2 first:ms-0">
+          // focus-within raises the focused face above its neighbors so an
+          // offset focus ring isn't clipped by the overlapping next item.
+          <li
+            key={index}
+            className="relative -ms-2 first:ms-0 focus-within:z-10"
+          >
             {node}
           </li>
         ))}

--- a/packages/sense/src/components/ui/avatar.tsx
+++ b/packages/sense/src/components/ui/avatar.tsx
@@ -41,7 +41,9 @@ function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
 
 /** Single initial: the first letter of the name. */
 function initialsFromName(name: string) {
-  return (name.trim()[0] ?? '').toUpperCase();
+  // First code point, not the first UTF-16 unit — an emoji (or other astral
+  // char) is a surrogate pair, and `[0]` returns half of it as a broken glyph.
+  return (Array.from(name.trim())[0] ?? '').toUpperCase();
 }
 
 function AvatarFallback({


### PR DESCRIPTION
Componentizes the linked-avatar pattern and fixes several focus-style bugs surfaced while testing landing.

- **`ProfileAvatarLink`** — one component for `ProfileAvatar` + i18n `Link`: owns the circular focus ring, hover dim, and `next/image` passthrough (no `href` → plain avatar). Exports `avatarLinkClassName` for bare avatar links to match. Migrated `DecisionAvatar`, `OrganizationAvatar`, `OrganizationList`, and the PlatformHighlights facepile onto it — kills the duplicated wrapper and the **square** browser focus outline (now a round ring).
- **FacePile** — thinner separation ring (`ring-1`); focus ring uses an offset so it clears the separation ring; `focus-within:z-10` so the focused face isn't clipped; "+N" overflow gets the same focus treatment. `size-fit` on the link so a flex parent can't stretch it into an oval.
- **Avatar initial** handles an emoji/astral first char (first code point, not first UTF-16 unit — was rendering a broken glyph).
- **Search input** now shows its focus ring — the cmdk input lacked `data-slot=input-group-control`, so `InputGroup`'s focus-visible ring never applied.

Base is `sense/landing` (depends on its migrated `ProfileAvatar`-based avatars).