### PR TITLE
feat(decision): per-phase reviews scope field and Scope radio in builder

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import type { ReviewsPolicy } from '@op/common';
+import type { InstancePhaseData } from '@op/api/encoders';
+import type { ReviewsScope } from '@op/common';
+import { isReviewPhase } from '@op/common/client';
+import { Chip } from '@op/ui/Chip';
 import { Header2, Header3 } from '@op/ui/Header';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { ToggleButton } from '@op/ui/ToggleButton';
@@ -16,7 +19,7 @@ import type { SectionProps } from '../../contentRegistry';
 import { useProcessBuilderStore } from '../../stores/useProcessBuilderStore';
 
 interface ReviewSettings {
-  reviewsPolicy: ReviewsPolicy;
+  scope: ReviewsScope;
   reviewsAllowRevisions: boolean;
 }
 
@@ -28,27 +31,65 @@ export function ReviewSettingsContent({
 
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   const config = instance.instanceData?.config;
+  const instancePhases = instance.instanceData?.phases;
 
-  const instanceData = useProcessBuilderStore(
+  const storeInstance = useProcessBuilderStore(
     (s) => s.instances[decisionProfileId],
   );
+  const storePhases = storeInstance?.phases;
   const { saveChanges, autosaveStatus } = useProcessBuilderAutosave();
 
+  // Store-first so unsaved phase edits (e.g. toggling review capability in the
+  // phase editor) are reflected here, matching PhaseDetailPage's resolution.
+  const sourcePhases: InstancePhaseData[] =
+    (storePhases?.length ? storePhases : instancePhases) ?? [];
+
+  // Scope is a per-phase review setting: there is exactly one review-capable
+  // phase today (the Reviews step is only shown when one exists).
+  const reviewPhase = sourcePhases.find(isReviewPhase);
+
   const [settings, setSettings] = useState<ReviewSettings>({
-    reviewsPolicy:
-      instanceData?.config?.reviewsPolicy ??
-      config?.reviewsPolicy ??
-      'full_coverage',
+    scope: reviewPhase?.rules?.reviews?.scope ?? 'all',
     reviewsAllowRevisions:
-      instanceData?.config?.reviewsAllowRevisions ??
+      storeInstance?.config?.reviewsAllowRevisions ??
       config?.reviewsAllowRevisions ??
       true,
   });
 
+  // The write replaces the full phases array, so every phase must be sent.
+  // Only the review phase's rules change; sibling rules keys (and other
+  // phases) are preserved untouched.
+  const phasesWithScope = (nextScope: ReviewsScope): InstancePhaseData[] =>
+    sourcePhases.map((phase) => ({
+      phaseId: phase.phaseId,
+      name: phase.name,
+      description: phase.description,
+      headline: phase.headline,
+      additionalInfo: phase.additionalInfo,
+      startDate: phase.startDate,
+      endDate: phase.endDate,
+      rules:
+        phase.phaseId === reviewPhase?.phaseId
+          ? {
+              ...phase.rules,
+              reviews: { ...phase.rules?.reviews, scope: nextScope },
+            }
+          : phase.rules,
+    }));
+
   const updateSettings = (updates: Partial<ReviewSettings>) => {
     setSettings((prev) => {
       const updated = { ...prev, ...updates };
-      saveChanges({ config: updated });
+      // scope and revisions write to different places: scope to the review
+      // phase's rules, revisions to legacy config. Route each independently.
+      if (updates.scope !== undefined && reviewPhase) {
+        saveChanges({ phases: phasesWithScope(updated.scope) });
+      }
+      if (updates.reviewsAllowRevisions !== undefined) {
+        saveChanges({
+          config: { reviewsAllowRevisions: updated.reviewsAllowRevisions },
+        });
+      }
       return updated;
     });
   };
@@ -63,26 +104,37 @@ export function ReviewSettingsContent({
         />
       </div>
 
-      {/* Coverage */}
+      {/* Scope */}
       <section className="space-y-4">
-        <Header3 className="font-serif text-title-sm">{t('Coverage')}</Header3>
+        <Header3 className="font-serif text-title-sm">{t('Scope')}</Header3>
         <RadioGroup
-          value={settings.reviewsPolicy}
-          onChange={(value) =>
-            updateSettings({ reviewsPolicy: value as ReviewsPolicy })
-          }
-          aria-label={t('Coverage')}
-          label={t('How should proposals get distributed to reviewers?')}
+          value={settings.scope}
+          onChange={(value) => updateSettings({ scope: value as ReviewsScope })}
+          aria-label={t('Scope')}
+          label={t('What should each reviewer be responsible for?')}
           labelClassName="text-sm font-normal text-neutral-gray4"
           orientation="vertical"
         >
-          <Radio value="full_coverage">
+          <Radio value="all">
             <div className="flex flex-col">
               <span className="text-base text-neutral-charcoal">
-                {t('Full coverage')}
+                {t('All proposals')}
               </span>
               <span className="text-sm text-neutral-gray4">
-                {t('Every reviewer scores every proposal')}
+                {t('Reviewers can review any submission')}
+              </span>
+            </div>
+          </Radio>
+          <Radio value="by_category" isDisabled className="opacity-50">
+            <div className="flex flex-col">
+              <span className="flex items-center gap-2 text-base text-neutral-charcoal">
+                {t('By category')}
+                <Chip>{t('Coming soon')}</Chip>
+              </span>
+              <span className="text-sm text-neutral-gray4">
+                {t(
+                  'Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.',
+                )}
               </span>
             </div>
           </Radio>

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1405,5 +1405,11 @@
   "You're already signed in. Reload the page to continue.": "لقد سجّلت الدخول بالفعل. أعد تحميل الصفحة للمتابعة.",
   "An account with this email already exists. Try logging in instead.": "يوجد حساب بهذا البريد الإلكتروني بالفعل. حاول تسجيل الدخول بدلاً من ذلك.",
   "Join Common to comment on this proposal.": "انضم إلى Common للتعليق على هذا المقترح.",
-  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "الموازنة التشاركية في كولومبوس مفتوحة الآن. <participate>شارك الآن</participate>"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "الموازنة التشاركية في كولومبوس مفتوحة الآن. <participate>شارك الآن</participate>",
+  "Scope": "النطاق",
+  "What should each reviewer be responsible for?": "عن ماذا يجب أن يكون كل مراجع مسؤولاً؟",
+  "Reviewers can review any submission": "يمكن للمراجعين مراجعة أي مقترح",
+  "By category": "حسب الفئة",
+  "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "يتم تعيين كل مراجع لفئة واحدة أو أكثر. تعرض قائمته المقترحات ضمن تلك الفئات فقط.",
+  "Coming soon": "قريبًا"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1408,5 +1408,11 @@
   "You're already signed in. Reload the page to continue.": "আপনি ইতিমধ্যে সাইন ইন করেছেন। চালিয়ে যেতে পৃষ্ঠাটি পুনরায় লোড করুন।",
   "An account with this email already exists. Try logging in instead.": "এই ইমেল দিয়ে ইতিমধ্যে একটি অ্যাকাউন্ট রয়েছে। পরিবর্তে লগ ইন করার চেষ্টা করুন।",
   "Join Common to comment on this proposal.": "এই প্রস্তাবে মন্তব্য করতে Common-এ যোগ দিন।",
-  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "কলম্বাসের অংশগ্রহণমূলক বাজেট এখন উন্মুক্ত। <participate>অংশ নিন</participate>"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "কলম্বাসের অংশগ্রহণমূলক বাজেট এখন উন্মুক্ত। <participate>অংশ নিন</participate>",
+  "Scope": "পরিধি",
+  "What should each reviewer be responsible for?": "প্রতিটি পর্যালোচক কীসের জন্য দায়ী থাকবেন?",
+  "Reviewers can review any submission": "পর্যালোচকরা যেকোনো প্রস্তাব পর্যালোচনা করতে পারেন",
+  "By category": "বিভাগ অনুসারে",
+  "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "প্রতিটি পর্যালোচককে এক বা একাধিক বিভাগে নিযুক্ত করা হয়। তাদের সারিতে শুধুমাত্র সেই বিভাগগুলির প্রস্তাব দেখানো হয়।",
+  "Coming soon": "শীঘ্রই আসছে"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1414,5 +1414,11 @@
   "You're already signed in. Reload the page to continue.": "You're already signed in. Reload the page to continue.",
   "An account with this email already exists. Try logging in instead.": "An account with this email already exists. Try logging in instead.",
   "Join Common to comment on this proposal.": "Join Common to comment on this proposal.",
-  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "Columbus' participatory budgeting is now open. <participate>Participate</participate>"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "Columbus' participatory budgeting is now open. <participate>Participate</participate>",
+  "Scope": "Scope",
+  "What should each reviewer be responsible for?": "What should each reviewer be responsible for?",
+  "Reviewers can review any submission": "Reviewers can review any submission",
+  "By category": "By category",
+  "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.",
+  "Coming soon": "Coming soon"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1405,5 +1405,11 @@
   "You're already signed in. Reload the page to continue.": "Ya has iniciado sesión. Recarga la página para continuar.",
   "An account with this email already exists. Try logging in instead.": "Ya existe una cuenta con este correo electrónico. Intenta iniciar sesión.",
   "Join Common to comment on this proposal.": "Únete a Common para comentar esta propuesta.",
-  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "El presupuesto participativo de Columbus ya está abierto. <participate>Participa</participate>"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "El presupuesto participativo de Columbus ya está abierto. <participate>Participa</participate>",
+  "Scope": "Alcance",
+  "What should each reviewer be responsible for?": "¿De qué debe ser responsable cada persona revisora?",
+  "Reviewers can review any submission": "Las personas revisoras pueden revisar cualquier propuesta",
+  "By category": "Por categoría",
+  "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Cada persona revisora se asigna a una o más categorías. Su cola muestra solo las propuestas de esas categorías.",
+  "Coming soon": "Próximamente"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1405,5 +1405,11 @@
   "You're already signed in. Reload the page to continue.": "Vous êtes déjà connecté. Rechargez la page pour continuer.",
   "An account with this email already exists. Try logging in instead.": "Un compte avec cet e-mail existe déjà. Essayez plutôt de vous connecter.",
   "Join Common to comment on this proposal.": "Rejoignez Common pour commenter cette proposition.",
-  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "Le budget participatif de Columbus est maintenant ouvert. <participate>Participez</participate>"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "Le budget participatif de Columbus est maintenant ouvert. <participate>Participez</participate>",
+  "Scope": "Portée",
+  "What should each reviewer be responsible for?": "De quoi chaque évaluateur doit-il être responsable ?",
+  "Reviewers can review any submission": "Les évaluateurs peuvent évaluer n’importe quelle proposition",
+  "By category": "Par catégorie",
+  "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Chaque évaluateur est affecté à une ou plusieurs catégories. Sa file d’attente n’affiche que les propositions de ces catégories.",
+  "Coming soon": "Bientôt disponible"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1405,5 +1405,11 @@
   "You're already signed in. Reload the page to continue.": "Você já está com a sessão iniciada. Recarregue a página para continuar.",
   "An account with this email already exists. Try logging in instead.": "Já existe uma conta com este e-mail. Tente fazer login.",
   "Join Common to comment on this proposal.": "Junte-se ao Common para comentar esta proposta.",
-  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "O orçamento participativo de Columbus já está aberto. <participate>Participe</participate>"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "O orçamento participativo de Columbus já está aberto. <participate>Participe</participate>",
+  "Scope": "Escopo",
+  "What should each reviewer be responsible for?": "Pelo que cada avaliador deve ser responsável?",
+  "Reviewers can review any submission": "Os avaliadores podem avaliar qualquer proposta",
+  "By category": "Por categoria",
+  "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Cada avaliador é atribuído a uma ou mais categorias. Sua fila mostra apenas as propostas dessas categorias.",
+  "Coming soon": "Em breve"
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1407,5 +1407,11 @@
   "You're already signed in. Reload the page to continue.": "Horeyba waad u soo gashay. Dib u shub bogga si aad u sii wadato.",
   "An account with this email already exists. Try logging in instead.": "Akoon leh emailkan ayaa horey u jiray. Isku day inaad gasho.",
   "Join Common to comment on this proposal.": "Ku biir Common si aad faallo uga bixiso soo-jeedintan.",
-  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "Miisaaniyadda wadajirka ah ee Columbus hadda waa furan tahay. <participate>Ka qaybqaado</participate>"
+  "Columbus' participatory budgeting is now open. <participate>Participate</participate>": "Miisaaniyadda wadajirka ah ee Columbus hadda waa furan tahay. <participate>Ka qaybqaado</participate>",
+  "Scope": "Baaxadda",
+  "What should each reviewer be responsible for?": "Maxaa dib-u-eege kastaa masuul ka noqon lahaa?",
+  "Reviewers can review any submission": "Dib-u-eegayaashu waxay dib u eegi karaan soo jeedin kasta",
+  "By category": "Qaybta ahaan",
+  "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Dib-u-eege kasta waxaa loo xilsaaraa hal ama in ka badan oo qaybo ah. Safkiisu wuxuu tusayaa oo kaliya soo jeedinta qaybahaas ku jira.",
+  "Coming soon": "Waa iman doonaa dhakhso"
 }

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -121,8 +121,10 @@ export {
 } from './services/decision/getRubricScoringInfo';
 export {
   REVIEWS_POLICIES,
+  REVIEWS_SCOPES,
   phaseReviewSettingsSchema,
   type PhaseReviewSettings,
+  type ReviewsScope,
 } from './services/decision/schemas/types';
 export { isLastPhase } from './services/decision/schemas/instanceData';
 export {

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -152,9 +152,12 @@ export type {
   PhaseRules,
   ProcessConfig,
   ReviewsPolicy,
+  ReviewsScope,
 } from './schemas/types';
 export {
   DEFAULT_REVIEWS_POLICY,
+  DEFAULT_REVIEWS_SCOPE,
   REVIEWS_POLICIES,
+  REVIEWS_SCOPES,
   phaseReviewSettingsSchema,
 } from './schemas/types';

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -73,6 +73,13 @@ export type ReviewsPolicy = (typeof REVIEWS_POLICIES)[number];
 /** Coverage policy applied when neither phase rules nor legacy config set one. */
 export const DEFAULT_REVIEWS_POLICY: ReviewsPolicy = 'full_coverage';
 
+export const REVIEWS_SCOPES = ['all', 'by_category'] as const;
+
+export type ReviewsScope = (typeof REVIEWS_SCOPES)[number];
+
+/** Reviewer responsibility scope applied when phase rules don't set one. */
+export const DEFAULT_REVIEWS_SCOPE: ReviewsScope = 'all';
+
 /**
  * `PhaseRules.reviews` shape — single source for the interface, the API
  * encoder, and the resolved `ReviewSettings`.
@@ -80,6 +87,13 @@ export const DEFAULT_REVIEWS_POLICY: ReviewsPolicy = 'full_coverage';
 export const phaseReviewSettingsSchema = z.object({
   /** Enablement, like `voting.submit`. */
   submit: z.boolean().optional(),
+  /**
+   * What each reviewer is responsible for. Absent = `'all'` (any reviewer may
+   * review any submission). `'by_category'` scopes reviewers to assigned
+   * categories.
+   */
+  scope: z.enum(REVIEWS_SCOPES).optional(),
+  /** How proposals are distributed to reviewers within `scope`. */
   policy: z.enum(REVIEWS_POLICIES).optional(),
   allowRevisions: z.boolean().optional(),
   anonymousFeedback: z.boolean().optional(),

--- a/packages/common/src/services/decision/utils/phaseSettings.test.ts
+++ b/packages/common/src/services/decision/utils/phaseSettings.test.ts
@@ -49,6 +49,7 @@ describe('getPhaseReviewSettings', () => {
     expect(result).toEqual({
       submit: false,
       policy: 'full_coverage',
+      scope: 'all',
       allowRevisions: true,
       anonymousFeedback: undefined,
     });
@@ -80,6 +81,7 @@ describe('getPhaseReviewSettings', () => {
     expect(result).toEqual({
       submit: false,
       policy: 'full_coverage',
+      scope: 'all',
       allowRevisions: false,
       anonymousFeedback: true,
     });
@@ -110,6 +112,7 @@ describe('getPhaseReviewSettings', () => {
     expect(result).toEqual({
       submit: false,
       policy: 'full_coverage',
+      scope: 'all',
       allowRevisions: false,
       anonymousFeedback: true,
     });
@@ -137,6 +140,7 @@ describe('getPhaseReviewSettings', () => {
     expect(result).toEqual({
       submit: false,
       policy: 'full_coverage',
+      scope: 'all',
       allowRevisions: true,
       anonymousFeedback: true,
     });
@@ -186,5 +190,30 @@ describe('getPhaseReviewSettings', () => {
         'review',
       ),
     ).toThrow();
+  });
+
+  it("defaults scope to 'all' when the phase has no review setting", () => {
+    const result = getPhaseReviewSettings(
+      { phases: [{ phaseId: 'review', rules: { reviews: { submit: true } } }] },
+      'review',
+    );
+
+    expect(result.scope).toBe('all');
+  });
+
+  it('round-trips a saved phase-level scope (no legacy config fallback)', () => {
+    const result = getPhaseReviewSettings(
+      {
+        phases: [
+          {
+            phaseId: 'review',
+            rules: { reviews: { submit: true, scope: 'by_category' } },
+          },
+        ],
+      },
+      'review',
+    );
+
+    expect(result.scope).toBe('by_category');
   });
 });

--- a/packages/common/src/services/decision/utils/phaseSettings.ts
+++ b/packages/common/src/services/decision/utils/phaseSettings.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_REVIEWS_POLICY } from '../schemas/types';
+import {
+  DEFAULT_REVIEWS_POLICY,
+  DEFAULT_REVIEWS_SCOPE,
+} from '../schemas/types';
 import type { PhaseReviewSettings, ReviewsPolicy } from '../schemas/types';
 import { assertInstancePhase } from './instance';
 
@@ -30,7 +33,7 @@ export function isVotingPhase(phase: {
 
 /** `PhaseReviewSettings` with defaults applied (`anonymousFeedback` has none). */
 export type ReviewSettings = Required<
-  Pick<PhaseReviewSettings, 'submit' | 'policy' | 'allowRevisions'>
+  Pick<PhaseReviewSettings, 'submit' | 'policy' | 'scope' | 'allowRevisions'>
 > & { anonymousFeedback: PhaseReviewSettings['anonymousFeedback'] };
 
 /** Resolves review settings for `phaseId`; throws if the phase doesn't exist. */
@@ -52,6 +55,9 @@ export function getPhaseReviewSettings(
   return {
     submit: isReviewPhase(phase),
     policy: reviews?.policy ?? config?.reviewsPolicy ?? DEFAULT_REVIEWS_POLICY,
+    // Scope is phase-only (no legacy config counterpart), so it resolves from
+    // the phase rules or the default.
+    scope: reviews?.scope ?? DEFAULT_REVIEWS_SCOPE,
     allowRevisions:
       reviews?.allowRevisions ?? config?.reviewsAllowRevisions ?? true,
     anonymousFeedback:


### PR DESCRIPTION
Adds a per-phase reviews `scope` field ('all' | 'by_category') and flips the builder's Reviews step from Coverage to Scope, matching the design mock. 'By category' ships disabled ('Coming soon') until the scope table and reconciler exist, so the radio advertises the model without changing behavior.