### PR TITLE
fix(decision): unify category slugification between term creation and lookup

### DIFF
--- a/packages/common/src/services/decision/getProcessCategories.ts
+++ b/packages/common/src/services/decision/getProcessCategories.ts
@@ -6,6 +6,7 @@ import { permission } from 'access-zones';
 
 import { UnauthorizedError } from '../../utils';
 import { assertInstanceProfileAccess } from '../access';
+import { categoryTermUri } from './proposalTaxonomy';
 import type { DecisionInstanceData } from './schemas';
 
 export interface ProcessCategory {
@@ -76,10 +77,10 @@ export const getProcessCategories = async ({
     const categories: ProcessCategory[] = [];
 
     for (const category of instanceCategories) {
-      const expectedTermUri = category.label
-        .toLowerCase()
-        .replace(/\s+/g, '-')
-        .replace(/[^a-z0-9-]/g, '');
+      // Same slug helper term creation uses, so accented/unicode labels resolve
+      // (see categoryTermUri). A hand-rolled regex here would strip accents the
+      // strict slugify folds, silently dropping the category.
+      const expectedTermUri = categoryTermUri(category.label);
 
       const taxonomyTerm = proposalTaxonomy.taxonomyTerms.find(
         (term: { termUri: string }) => term.termUri === expectedTermUri,

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -87,6 +87,7 @@ export * from './deleteProposal';
 export * from './detachProposalForModeration';
 export * from './deleteDecision';
 export * from './getProcessCategories';
+export { categoryTermUri } from './proposalTaxonomy';
 export * from './exportProposals';
 export * from './getExportStatus';
 export * from './exports';

--- a/packages/common/src/services/decision/proposalTaxonomy.ts
+++ b/packages/common/src/services/decision/proposalTaxonomy.ts
@@ -6,6 +6,18 @@ import { CommonError } from '../../utils';
 import { linkBoundaryToCategoryTerm } from './linkBoundaryToCategory';
 
 /**
+ * Canonical label → `taxonomyTerms.termUri` slug. This is the single join key
+ * between a config category label and its global taxonomy term, so term
+ * creation ({@link ensureProposalTaxonomyTerms}) and every lookup
+ * ({@link getProcessCategories}, rename reconciliation) MUST derive the slug
+ * the same way — otherwise a term can exist but resolve to nothing (e.g.
+ * "Café" folds to "cafe" here, but a hand-rolled regex would strip it to
+ * "caf").
+ */
+export const categoryTermUri = (label: string): string =>
+  slugify(label.trim(), { lower: true, strict: true, trim: true });
+
+/**
  * Ensures the proposal taxonomy exists and that each category label has a
  * matching taxonomy term.
  */
@@ -45,11 +57,7 @@ export async function ensureProposalTaxonomyTerms(
     }
 
     const categoryLabel = categoryName.trim();
-    const termUri = slugify(categoryLabel, {
-      lower: true,
-      strict: true,
-      trim: true,
-    });
+    const termUri = categoryTermUri(categoryLabel);
 
     // taxonomyTerms V2 types are broken due to self-referential parentId
     let existingTerm = await db._query.taxonomyTerms.findFirst({

--- a/services/api/src/routers/decision/instances/categorySlugParity.test.ts
+++ b/services/api/src/routers/decision/instances/categorySlugParity.test.ts
@@ -1,0 +1,157 @@
+import { db, inArray } from '@op/db/client';
+import { taxonomies, taxonomyTerms } from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+/**
+ * Derives a short alphanumeric suffix from the vitest task id so category
+ * labels (and therefore their taxonomy `termUri`s) stay unique across the
+ * concurrently-running tests that share the global `proposal` taxonomy.
+ */
+function labelSuffix(taskId: string): string {
+  return taskId.replace(/[^a-z0-9]/gi, '').slice(-8) || 'x';
+}
+
+/**
+ * Ensures the shared `proposal` taxonomy row exists before any category is
+ * defined. The real `ensureProposalTaxonomyTerms` does a find-then-insert that
+ * is not concurrency-safe, so two tests defining their first category at once
+ * would otherwise collide on `taxonomies_name_unique`. `onConflictDoNothing`
+ * lets every concurrent test converge on the same row. (`taxonomies` is exempt
+ * from the teardown empty-table check, so the row is left behind.)
+ */
+async function ensureProposalTaxonomy(): Promise<void> {
+  await db
+    .insert(taxonomies)
+    .values({ name: 'proposal' })
+    .onConflictDoNothing({ target: taxonomies.name });
+}
+
+/**
+ * Deletes any taxonomy terms created for the given labels once the test
+ * finishes. Terms live in the global (non-seeded) `taxonomy_terms` table, which
+ * the teardown requires to be empty, and they aren't tied to a profile so the
+ * TestDecisionsDataManager cascade never reaches them.
+ */
+function cleanupTermsByLabel(
+  labels: string[],
+  onTestFinished: (fn: () => void | Promise<void>) => void,
+): void {
+  onTestFinished(async () => {
+    const terms = await db
+      .select({ id: taxonomyTerms.id })
+      .from(taxonomyTerms)
+      .where(inArray(taxonomyTerms.label, labels));
+    const ids = terms.map((t) => t.id);
+    if (ids.length === 0) {
+      return;
+    }
+    await db.delete(taxonomyTerms).where(inArray(taxonomyTerms.id, ids));
+  });
+}
+
+/**
+ * Regression for the slugification half of "Renaming a category ... orphans
+ * existing proposal links" (Asana 1216981737476857): term creation and term
+ * lookup must derive `termUri` the same way. Term creation uses the `slugify`
+ * lib (accent-folding), while `getProcessCategories` used to hand-roll a regex
+ * that stripped accented chars instead — so a category could exist yet resolve
+ * to nothing. Both now share `categoryTermUri`.
+ */
+describe.concurrent('category slug parity between creation and lookup', () => {
+  it('resolves categories whose labels contain accented characters', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instance;
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const suffix = labelSuffix(task.id);
+    const accentedLabel = `Café ${suffix}`;
+    cleanupTermsByLabel([accentedLabel], onTestFinished);
+    await ensureProposalTaxonomy();
+
+    // Term creation slugifies "Café" -> "cafe".
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [
+          { id: 'cat-1', label: accentedLabel, description: 'Café proposals' },
+        ],
+      },
+    });
+
+    const result = await caller.decision.getCategories({
+      processInstanceId: instance.instance.id,
+    });
+
+    // Lookup now slugifies the same way, so the "cafe" term is found.
+    expect(result.categories).toHaveLength(1);
+    expect(result.categories[0]!.name).toBe(accentedLabel);
+    expect(result.categories[0]!.termUri).toBe(`cafe-${suffix.toLowerCase()}`);
+  });
+
+  it('resolves categories whose labels contain an ampersand', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instance;
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const suffix = labelSuffix(task.id);
+    const ampersandLabel = `Arts & Culture ${suffix}`;
+    cleanupTermsByLabel([ampersandLabel], onTestFinished);
+    await ensureProposalTaxonomy();
+
+    // slugify folds "&" to "and"; the old hand-rolled regex dropped it,
+    // producing "arts--culture" and a lookup miss.
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [
+          {
+            id: 'cat-1',
+            label: ampersandLabel,
+            description: 'Arts and culture proposals',
+          },
+        ],
+      },
+    });
+
+    const result = await caller.decision.getCategories({
+      processInstanceId: instance.instance.id,
+    });
+
+    expect(result.categories).toHaveLength(1);
+    expect(result.categories[0]!.name).toBe(ampersandLabel);
+    expect(result.categories[0]!.termUri).toBe(
+      `arts-and-culture-${suffix.toLowerCase()}`,
+    );
+  });
+});

--- a/services/api/src/routers/decision/instances/getCategories.test.ts
+++ b/services/api/src/routers/decision/instances/getCategories.test.ts
@@ -1,3 +1,4 @@
+import { categoryTermUri } from '@op/common';
 import { db, eq, inArray } from '@op/db/client';
 import {
   organizationUsers,
@@ -65,10 +66,9 @@ async function seedProposalTaxonomy(
   const termRecords = termLabels.map((label) => ({
     id: randomUUID(),
     taxonomyId: resolvedTaxonomyId,
-    termUri: label
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(/[^a-z0-9-]/g, ''),
+    // Mirror production term creation (ensureProposalTaxonomyTerms) — the same
+    // slug helper getProcessCategories looks terms up by.
+    termUri: categoryTermUri(label),
     label,
   }));
 
@@ -439,13 +439,13 @@ describe.concurrent('getCategories category matching', () => {
 
     const instance = setup.instance;
 
-    // The termUri for "Health & Wellness" after conversion:
-    // "health & wellness" -> "health--wellness" (& removed, spaces become -)
+    // The termUri for "Health & Wellness" via the strict slugify helper:
+    // "Health & Wellness" -> "health-and-wellness" (& folded to "and").
     const { termRecords } = await seedProposalTaxonomy(
       ['Health & Wellness'],
       onTestFinished,
     );
-    const expectedTermUri = 'health--wellness';
+    const expectedTermUri = 'health-and-wellness';
 
     await injectInstanceCategories(instance.instance.id, [
       {


### PR DESCRIPTION
A decision category's config label joins to its global taxonomy term through a
slug. Term creation (`ensureProposalTaxonomyTerms`) used the `slugify` lib
(accent-folding, `&`→`and`), while `getProcessCategories` hand-rolled a regex
that stripped those characters instead. They disagreed on accented/unicode
labels ("Café" → "cafe" vs "caf", "Arts & Culture" → "arts-and-culture" vs
"arts--culture"), so a category could exist yet resolve to nothing.

Introduce a single `categoryTermUri` helper (the `slugify` lib) and use it for
both term creation and lookup. Export it from `@op/common` so the one join key
has one source of truth.

- getCategories.test.ts: seed helper now derives termUri via the shared helper
  (mirroring production) and the special-characters case asserts the folded
  slug.
- categorySlugParity.test.ts: new regression coverage for accented and
  ampersand labels resolving through getCategories.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>