### PR TITLE
fix(decision): reconcile category-keyed rows when a category is renamed

### DIFF
--- a/packages/common/src/services/decision/reconcileCategoryRename.ts
+++ b/packages/common/src/services/decision/reconcileCategoryRename.ts
@@ -1,0 +1,336 @@
+import { type DbClient, and, eq, inArray } from '@op/db/client';
+import {
+  categoryReviewers,
+  proposalCategories,
+  proposals,
+  taxonomyTerms,
+} from '@op/db/schema';
+import { logger } from '@op/logging';
+
+import { categoryTermUri } from './proposalTaxonomy';
+import { reconcileReviewAssignments } from './reconcileReviewAssignments';
+import type { ProposalCategory } from './schemas/types';
+
+/**
+ * A category rename detected in the Process Builder: same config-local `id`,
+ * different label. Config id detects the rename; the slug (derived from the
+ * label) locates the taxonomy terms to move rows between.
+ */
+export interface CategoryRename {
+  oldLabel: string;
+  newLabel: string;
+}
+
+/** A rename with both taxonomy terms resolved, so the writes are unambiguous. */
+interface ResolvedRename extends CategoryRename {
+  oldTermId: string;
+  newTermId: string;
+}
+
+/**
+ * Detects category renames between two config category arrays.
+ *
+ * Keys on the config-local `id`: a category present before with the same id but
+ * a different label was renamed, whereas delete + add changes the id. Pure, so
+ * it's testable without a database.
+ */
+export function detectCategoryRenames(
+  previous: ProposalCategory[],
+  next: ProposalCategory[],
+): CategoryRename[] {
+  const previousLabelById = new Map(
+    previous.map((category) => [category.id, category.label]),
+  );
+
+  return next.flatMap((category) => {
+    const previousLabel = previousLabelById.get(category.id);
+    if (previousLabel === undefined || previousLabel === category.label) {
+      return [];
+    }
+    return [{ oldLabel: previousLabel, newLabel: category.label }];
+  });
+}
+
+/**
+ * Re-points a decision instance's category-keyed rows after categories are
+ * renamed.
+ *
+ * A category label joins to a global, slug-keyed `taxonomyTerms` row, and three
+ * tables key on that term: `proposalCategories` (table `decision_categories`),
+ * `categoryReviewers` (reviews-by-category scope), and the proposal's own
+ * `proposalData.category` label copy. Renaming a category makes
+ * `ensureProposalTaxonomyTerms` mint a *new* term for the new label; every
+ * holder must move together or they stop agreeing with each other. Moving only
+ * the proposal links would sever the term-id equi-join in
+ * `getCategoryReviewersByProposal`, silently dropping reviewer coverage of the
+ * renamed category (`categoryReviewers` documents its key as append-only for
+ * exactly this reason).
+ *
+ * All reads happen before all writes: renames are applied from one immutable
+ * snapshot, so a cascade (`A→B` and `B→C` in a single save) can't sweep A's
+ * proposals through B into C, and a swap (`A↔B`) can't collapse both into one.
+ *
+ * Must run inside the same transaction that writes the renamed `instanceData`,
+ * so config and rows commit together.
+ */
+export async function reconcileCategoryRenames({
+  tx,
+  instanceId,
+  renames,
+}: {
+  tx: DbClient;
+  instanceId: string;
+  renames: CategoryRename[];
+}): Promise<void> {
+  const resolved = await resolveRenames({ tx, instanceId, renames });
+  if (resolved.length === 0) {
+    return;
+  }
+
+  const newTermIdByOldTermId = new Map(
+    resolved.map((rename) => [rename.oldTermId, rename.newTermId]),
+  );
+  const oldTermIds = [...newTermIdByOldTermId.keys()];
+
+  // Snapshot every row to move before touching anything, so later renames read
+  // the original state rather than what an earlier one just wrote.
+  const [linkSnapshot, scopeSnapshot] = await Promise.all([
+    tx
+      .select({
+        proposalId: proposalCategories.proposalId,
+        taxonomyTermId: proposalCategories.taxonomyTermId,
+      })
+      .from(proposalCategories)
+      // Scope to THIS instance's proposals: taxonomy terms are shared across
+      // decisions, so another decision still using the old label keeps its rows.
+      .innerJoin(proposals, eq(proposals.id, proposalCategories.proposalId))
+      .where(
+        and(
+          inArray(proposalCategories.taxonomyTermId, oldTermIds),
+          eq(proposals.processInstanceId, instanceId),
+        ),
+      ),
+    tx
+      .select({
+        id: categoryReviewers.id,
+        taxonomyTermId: categoryReviewers.taxonomyTermId,
+        reviewerProfileId: categoryReviewers.reviewerProfileId,
+        phaseId: categoryReviewers.phaseId,
+      })
+      .from(categoryReviewers)
+      .where(
+        and(
+          inArray(categoryReviewers.taxonomyTermId, oldTermIds),
+          eq(categoryReviewers.processInstanceId, instanceId),
+        ),
+      ),
+  ]);
+
+  if (linkSnapshot.length === 0 && scopeSnapshot.length === 0) {
+    return;
+  }
+
+  const proposalIds = [...new Set(linkSnapshot.map((link) => link.proposalId))];
+
+  if (linkSnapshot.length > 0) {
+    // Delete before insert: with a swap, inserting first would then delete the
+    // rows just written. Deleting by (old term, snapshot proposal) can only
+    // match pairs that are in the snapshot, since the snapshot already holds
+    // every old-term row belonging to these proposals.
+    await tx
+      .delete(proposalCategories)
+      .where(
+        and(
+          inArray(proposalCategories.taxonomyTermId, oldTermIds),
+          inArray(proposalCategories.proposalId, proposalIds),
+        ),
+      );
+
+    // Idempotent on the composite PK (proposalId, taxonomyTermId): a proposal
+    // may already carry the new term (e.g. tagged after the rename).
+    await tx
+      .insert(proposalCategories)
+      .values(
+        linkSnapshot.map((link) => ({
+          proposalId: link.proposalId,
+          taxonomyTermId: newTermIdByOldTermId.get(link.taxonomyTermId)!,
+        })),
+      )
+      .onConflictDoNothing();
+  }
+
+  if (scopeSnapshot.length > 0) {
+    // Same delete-then-insert, keyed on the surrogate id. An UPDATE would risk
+    // `category_reviewers_unique` when the reviewer already covers the new
+    // term, and drizzle can't express onConflictDoNothing for an update.
+    await tx.delete(categoryReviewers).where(
+      inArray(
+        categoryReviewers.id,
+        scopeSnapshot.map((scope) => scope.id),
+      ),
+    );
+
+    await tx
+      .insert(categoryReviewers)
+      .values(
+        scopeSnapshot.map((scope) => ({
+          processInstanceId: instanceId,
+          taxonomyTermId: newTermIdByOldTermId.get(scope.taxonomyTermId)!,
+          reviewerProfileId: scope.reviewerProfileId,
+          phaseId: scope.phaseId,
+        })),
+      )
+      .onConflictDoNothing();
+  }
+
+  await migrateProposalDataLabels({ tx, proposalIds, renames: resolved });
+
+  logger.info('Re-pointed category-keyed rows after category rename', {
+    instanceId,
+    renameCount: resolved.length,
+    proposalCount: proposalIds.length,
+    scopeRowCount: scopeSnapshot.length,
+  });
+
+  // Assignments are derived from scope rows ⨝ proposal categories, so both
+  // sides having moved is not enough — proposals already on the new term gain
+  // the arriving reviewers. Reconciling by the new term covers the moved and
+  // pre-existing proposals in one pass.
+  for (const newTermId of new Set(resolved.map((r) => r.newTermId))) {
+    await reconcileReviewAssignments({
+      db: tx,
+      instanceId,
+      affected: { taxonomyTermId: newTermId },
+    });
+  }
+}
+
+/**
+ * Resolves each rename's old and new taxonomy term in a single lookup, dropping
+ * renames with nothing to move.
+ */
+async function resolveRenames({
+  tx,
+  instanceId,
+  renames,
+}: {
+  tx: DbClient;
+  instanceId: string;
+  renames: CategoryRename[];
+}): Promise<ResolvedRename[]> {
+  // A case/whitespace-only edit slugs to the same term — nothing to move. The
+  // term keeps the old label text, which is a separate (pre-existing) problem.
+  const slugChanging = renames.filter(
+    ({ oldLabel, newLabel }) =>
+      categoryTermUri(oldLabel) !== categoryTermUri(newLabel),
+  );
+  if (slugChanging.length === 0) {
+    return [];
+  }
+
+  const termUris = slugChanging.flatMap(({ oldLabel, newLabel }) => [
+    categoryTermUri(oldLabel),
+    categoryTermUri(newLabel),
+  ]);
+
+  // taxonomyTerms V2 types are broken due to self-referential parentId, so use
+  // the v1 `_query` builder (as elsewhere in this service).
+  const terms = await tx._query.taxonomyTerms.findMany({
+    where: inArray(taxonomyTerms.termUri, termUris),
+  });
+  const termIdByUri = new Map(terms.map((term) => [term.termUri, term.id]));
+
+  return slugChanging.flatMap((rename) => {
+    const oldTermId = termIdByUri.get(categoryTermUri(rename.oldLabel));
+    const newTermId = termIdByUri.get(categoryTermUri(rename.newLabel));
+
+    // No old term means nothing was ever tagged with the old label.
+    if (!oldTermId) {
+      return [];
+    }
+
+    // No new term means creation didn't run — the caller ensures it, so this
+    // should be unreachable. Warn rather than skip silently: the config now
+    // holds the new label, so the rows are left orphaned on the old term.
+    if (!newTermId) {
+      logger.warn(
+        'Category rename reconciliation skipped: new taxonomy term not found',
+        { instanceId, oldLabel: rename.oldLabel, newLabel: rename.newLabel },
+      );
+      return [];
+    }
+
+    return [{ ...rename, oldTermId, newTermId }];
+  });
+}
+
+/**
+ * Rewrites the renamed labels inside each affected proposal's
+ * `proposalData.category`.
+ *
+ * The junction is not the only copy of a category: `proposalData` stores the
+ * labels, `setProposalCategories` resolves them by exact `taxonomyTerms.label`,
+ * and `updateProposal` re-runs that resolution on any `proposalData` write. Left
+ * stale, an ordinary draft edit (a title tweak, an autosave) would re-resolve
+ * the old label and move the link straight back to the old term.
+ */
+async function migrateProposalDataLabels({
+  tx,
+  proposalIds,
+  renames,
+}: {
+  tx: DbClient;
+  proposalIds: string[];
+  renames: ResolvedRename[];
+}): Promise<void> {
+  if (proposalIds.length === 0) {
+    return;
+  }
+
+  const newLabelByOldLabel = new Map(
+    renames.map(({ oldLabel, newLabel }) => [oldLabel, newLabel]),
+  );
+
+  const rows = await tx
+    .select({ id: proposals.id, proposalData: proposals.proposalData })
+    .from(proposals)
+    .where(inArray(proposals.id, proposalIds));
+
+  for (const row of rows) {
+    const proposalData = row.proposalData;
+    if (typeof proposalData !== 'object' || proposalData === null) {
+      continue;
+    }
+
+    const data: Record<string, unknown> = { ...proposalData };
+    // `category` is `string | string[] | null` before normalization.
+    const category = data.category;
+    const labels =
+      typeof category === 'string'
+        ? [category]
+        : Array.isArray(category)
+          ? category
+          : [];
+
+    const migrated = labels.map((label) =>
+      typeof label === 'string'
+        ? (newLabelByOldLabel.get(label) ?? label)
+        : label,
+    );
+
+    const changed = migrated.some((label, index) => label !== labels[index]);
+    if (!changed) {
+      continue;
+    }
+
+    await tx
+      .update(proposals)
+      .set({
+        proposalData: {
+          ...data,
+          category: typeof category === 'string' ? migrated[0] : migrated,
+        },
+      })
+      .where(eq(proposals.id, row.id));
+  }
+}

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -17,6 +17,11 @@ import { assertProfileAccess, assertProfileAdmin } from '../assert';
 import { generateUniqueProfileSlug } from '../profile/utils';
 import { createTransitionsForProcess } from './createTransitionsForProcess';
 import { ensureProposalTaxonomyTerms } from './proposalTaxonomy';
+import {
+  type CategoryRename,
+  detectCategoryRenames,
+  reconcileCategoryRenames,
+} from './reconcileCategoryRename';
 import { schemaValidator } from './schemaValidator';
 import type {
   DecisionInstanceData,
@@ -108,6 +113,11 @@ export const updateDecisionInstance = async ({
     }
   }
 
+  // Category renames detected in this update (same config-local `id`, new
+  // label). Collected while merging config, then applied inside the write
+  // transaction so the re-point commits with the config that caused it.
+  const categoryRenames: CategoryRename[] = [];
+
   // Build update data
   const updateData: Record<string, unknown> = {};
 
@@ -172,6 +182,15 @@ export const updateDecisionInstance = async ({
       const categories = normalizedCategories.map((category) => category.label);
 
       await ensureProposalTaxonomyTerms(categories);
+
+      // The new terms now exist; the transaction re-points this instance's
+      // category-keyed rows from each old term to its replacement.
+      categoryRenames.push(
+        ...detectCategoryRenames(
+          existingInstanceData.config?.categories ?? [],
+          normalizedCategories,
+        ),
+      );
 
       updatedInstanceData.config = {
         ...existingInstanceData.config,
@@ -291,6 +310,17 @@ export const updateDecisionInstance = async ({
 
     if (!updatedInstance) {
       throw new CommonError('Failed to update decision process instance');
+    }
+
+    // Re-point the category-keyed rows for any renamed categories so proposals
+    // tagged before the rename stay discoverable under the new label and their
+    // reviewers keep covering them.
+    if (categoryRenames.length > 0) {
+      await reconcileCategoryRenames({
+        tx,
+        instanceId,
+        renames: categoryRenames,
+      });
     }
 
     // Determine the final status (updated or existing)

--- a/services/api/src/routers/decision/instances/categoryRenameOrphansLinks.test.ts
+++ b/services/api/src/routers/decision/instances/categoryRenameOrphansLinks.test.ts
@@ -1,0 +1,422 @@
+import { db, and, eq } from '@op/db/client';
+import { categoryReviewers, proposals } from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  cleanupTermsByLabel,
+  ensureProposalTaxonomy,
+  labelSuffix,
+  linkedTermIds,
+} from '../../../test/helpers/categoryTaxonomyTestUtils';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+/** The taxonomy term ids a reviewer's scope rows cover in an instance. */
+async function scopedTermIds(
+  processInstanceId: string,
+  reviewerProfileId: string,
+): Promise<string[]> {
+  const rows = await db
+    .select({ taxonomyTermId: categoryReviewers.taxonomyTermId })
+    .from(categoryReviewers)
+    .where(
+      and(
+        eq(categoryReviewers.processInstanceId, processInstanceId),
+        eq(categoryReviewers.reviewerProfileId, reviewerProfileId),
+      ),
+    );
+  return rows.map((r) => r.taxonomyTermId);
+}
+
+/** The category labels stored in a proposal's `proposalData`. */
+async function storedCategoryLabels(proposalId: string): Promise<string[]> {
+  const row = await db
+    .select({ proposalData: proposals.proposalData })
+    .from(proposals)
+    .where(eq(proposals.id, proposalId));
+  const category = (row[0]?.proposalData as { category?: unknown } | null)
+    ?.category;
+  if (typeof category === 'string') {
+    return [category];
+  }
+  return Array.isArray(category) ? category.filter(isString) : [];
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/**
+ * Regression for "Renaming a category creates a new taxonomy term and orphans
+ * existing proposal links" (Asana 1216981737476857).
+ *
+ * A category has three identities that don't line up: the config-local `id` in
+ * `instanceData.config.categories`, the label→slug join key, and the global,
+ * slug-keyed `taxonomyTerms` row. Renaming a category makes
+ * `ensureProposalTaxonomyTerms` mint a *new* term for the new label, and every
+ * holder of the old term has to move with it: `decision_categories` links,
+ * `decision_category_reviewers` scope rows, and the `proposalData.category`
+ * label copy that `setProposalCategories` resolves against. Moving only a subset
+ * trades the orphaned-category bug for a worse one — divergent join keys.
+ */
+describe.concurrent('category rename reconciles category-keyed rows', () => {
+  it('re-points existing proposal category links when a category is renamed', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instance;
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const suffix = labelSuffix(task.id);
+    const originalLabel = `Parks ${suffix}`;
+    const renamedLabel = `Parks and Recreation ${suffix}`;
+    cleanupTermsByLabel([originalLabel, renamedLabel], onTestFinished);
+    await ensureProposalTaxonomy();
+
+    // 1. Admin defines a category in the Process Builder. This runs the real
+    //    `ensureProposalTaxonomyTerms`, minting the taxonomy term for "Parks".
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [
+          { id: 'cat-1', label: originalLabel, description: 'Parks proposals' },
+        ],
+      },
+    });
+
+    const before = await caller.decision.getCategories({
+      processInstanceId: instance.instance.id,
+    });
+    expect(before.categories).toHaveLength(1);
+    const originalTermId = before.categories[0]!.id;
+
+    // 2. A member tags a proposal with that category. `createProposal` matches
+    //    the label to the taxonomy term and writes a `proposalCategories` row.
+    const proposal = await caller.decision.createProposal({
+      processInstanceId: instance.instance.id,
+      proposalData: {
+        title: `Fix the playground ${suffix}`,
+        category: [originalLabel],
+      },
+    });
+    testData.trackProfileForCleanup(proposal.profileId);
+
+    // Sanity: the proposal is discoverable under the category it was tagged with.
+    expect(await linkedTermIds(proposal.id)).toEqual([originalTermId]);
+    expect(before.categories.map((c) => c.id)).toContain(originalTermId);
+
+    // 3. Admin renames the category (same config-local `id`, new label).
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [
+          { id: 'cat-1', label: renamedLabel, description: 'Parks proposals' },
+        ],
+      },
+    });
+
+    const after = await caller.decision.getCategories({
+      processInstanceId: instance.instance.id,
+    });
+    expect(after.categories).toHaveLength(1);
+    const renamedTermId = after.categories[0]!.id;
+
+    // The rename minted a brand-new term (the root cause of the orphaning).
+    expect(renamedTermId).not.toBe(originalTermId);
+
+    // The proposal's link is re-pointed to the renamed term, so it stays
+    // discoverable under a category `getCategories` actually returns.
+    const links = await linkedTermIds(proposal.id);
+    expect(links).toEqual([renamedTermId]);
+    expect(after.categories.map((c) => c.id)).toContain(links[0]);
+  });
+
+  it("leaves another instance's links untouched when this instance renames a shared category", async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    // Two instances under the same process/org, both using the same category
+    // label. Taxonomy terms are global, so both proposals share one term.
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 2,
+      grantAccess: true,
+    });
+    const [instanceA, instanceB] = setup.instances;
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const suffix = labelSuffix(task.id);
+    const sharedLabel = `Housing ${suffix}`;
+    const renamedLabel = `Affordable Housing ${suffix}`;
+    cleanupTermsByLabel([sharedLabel, renamedLabel], onTestFinished);
+    await ensureProposalTaxonomy();
+
+    for (const inst of [instanceA!, instanceB!]) {
+      await caller.decision.updateDecisionInstance({
+        instanceId: inst.instance.id,
+        config: {
+          categories: [
+            { id: 'cat-1', label: sharedLabel, description: 'Housing' },
+          ],
+        },
+      });
+    }
+
+    const sharedCategories = await caller.decision.getCategories({
+      processInstanceId: instanceB!.instance.id,
+    });
+    const sharedTermId = sharedCategories.categories[0]!.id;
+
+    const proposalB = await caller.decision.createProposal({
+      processInstanceId: instanceB!.instance.id,
+      proposalData: { title: `B proposal ${suffix}`, category: [sharedLabel] },
+    });
+    testData.trackProfileForCleanup(proposalB.profileId);
+    expect(await linkedTermIds(proposalB.id)).toEqual([sharedTermId]);
+
+    // Instance A renames its category — instance B must be unaffected.
+    await caller.decision.updateDecisionInstance({
+      instanceId: instanceA!.instance.id,
+      config: {
+        categories: [
+          { id: 'cat-1', label: renamedLabel, description: 'Housing' },
+        ],
+      },
+    });
+
+    // B's proposal still points at the original shared term.
+    expect(await linkedTermIds(proposalB.id)).toEqual([sharedTermId]);
+  });
+
+  it("moves a reviewer's category scope row so coverage survives the rename", async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instance;
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const suffix = labelSuffix(task.id);
+    const originalLabel = `Transit ${suffix}`;
+    const renamedLabel = `Public Transit ${suffix}`;
+    cleanupTermsByLabel([originalLabel, renamedLabel], onTestFinished);
+    await ensureProposalTaxonomy();
+
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [
+          { id: 'cat-1', label: originalLabel, description: 'Transit' },
+        ],
+      },
+    });
+
+    const before = await caller.decision.getCategories({
+      processInstanceId: instance.instance.id,
+    });
+    const originalTermId = before.categories[0]!.id;
+
+    // A reviewer is scoped to the category. `categoryReviewers` keys on the
+    // taxonomy term, and `getCategoryReviewersByProposal` joins it directly to
+    // `proposalCategories.taxonomyTermId` — so if only the proposal links move,
+    // that equi-join stops matching and the reviewer silently loses coverage.
+    const reviewer = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+    const reviewerProfileId = reviewer.profileId;
+    await db.insert(categoryReviewers).values({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: originalTermId,
+      reviewerProfileId,
+      phaseId: null,
+    });
+
+    expect(
+      await scopedTermIds(instance.instance.id, reviewerProfileId),
+    ).toEqual([originalTermId]);
+
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [
+          { id: 'cat-1', label: renamedLabel, description: 'Transit' },
+        ],
+      },
+    });
+
+    const after = await caller.decision.getCategories({
+      processInstanceId: instance.instance.id,
+    });
+    const renamedTermId = after.categories[0]!.id;
+    expect(renamedTermId).not.toBe(originalTermId);
+
+    // The scope row followed the category, so the reviewer still covers it.
+    expect(
+      await scopedTermIds(instance.instance.id, reviewerProfileId),
+    ).toEqual([renamedTermId]);
+  });
+
+  it('rewrites the renamed label in proposalData so a later edit cannot undo the re-point', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instance;
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const suffix = labelSuffix(task.id);
+    const originalLabel = `Arts ${suffix}`;
+    const renamedLabel = `Arts and Culture ${suffix}`;
+    cleanupTermsByLabel([originalLabel, renamedLabel], onTestFinished);
+    await ensureProposalTaxonomy();
+
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [
+          { id: 'cat-1', label: originalLabel, description: 'Arts' },
+        ],
+      },
+    });
+
+    const proposal = await caller.decision.createProposal({
+      processInstanceId: instance.instance.id,
+      proposalData: {
+        title: `Mural program ${suffix}`,
+        category: [originalLabel],
+      },
+    });
+    testData.trackProfileForCleanup(proposal.profileId);
+    expect(await storedCategoryLabels(proposal.id)).toEqual([originalLabel]);
+
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [{ id: 'cat-1', label: renamedLabel, description: 'Arts' }],
+      },
+    });
+
+    const renamedTermId = (
+      await caller.decision.getCategories({
+        processInstanceId: instance.instance.id,
+      })
+    ).categories[0]!.id;
+
+    // `proposalData` carries the labels that `setProposalCategories` resolves
+    // against, so a stale copy would re-point the link back to the old term.
+    expect(await storedCategoryLabels(proposal.id)).toEqual([renamedLabel]);
+
+    // Prove it: an edit that touches only the title must leave the link alone.
+    await caller.decision.updateProposal({
+      proposalId: proposal.id,
+      data: {
+        proposalData: {
+          title: `Mural program revised ${suffix}`,
+          category: await storedCategoryLabels(proposal.id),
+        },
+      },
+    });
+
+    expect(await linkedTermIds(proposal.id)).toEqual([renamedTermId]);
+  });
+
+  it('does not cascade links through a chained rename applied in one save', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instance = setup.instance;
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const suffix = labelSuffix(task.id);
+    const labelA = `Alpha ${suffix}`;
+    const labelB = `Bravo ${suffix}`;
+    const labelC = `Charlie ${suffix}`;
+    cleanupTermsByLabel([labelA, labelB, labelC], onTestFinished);
+    await ensureProposalTaxonomy();
+
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [
+          { id: 'cat-1', label: labelA, description: 'A' },
+          { id: 'cat-2', label: labelB, description: 'B' },
+        ],
+      },
+    });
+
+    const proposalA = await caller.decision.createProposal({
+      processInstanceId: instance.instance.id,
+      proposalData: { title: `In A ${suffix}`, category: [labelA] },
+    });
+    testData.trackProfileForCleanup(proposalA.profileId);
+
+    const proposalB = await caller.decision.createProposal({
+      processInstanceId: instance.instance.id,
+      proposalData: { title: `In B ${suffix}`, category: [labelB] },
+    });
+    testData.trackProfileForCleanup(proposalB.profileId);
+
+    // One save renames A→B and B→C. Applied sequentially against live rows, the
+    // first move would put A's proposal on term B and the second would then
+    // sweep it onward to C. Reads are snapshotted, so each lands exactly once.
+    await caller.decision.updateDecisionInstance({
+      instanceId: instance.instance.id,
+      config: {
+        categories: [
+          { id: 'cat-1', label: labelB, description: 'A' },
+          { id: 'cat-2', label: labelC, description: 'B' },
+        ],
+      },
+    });
+
+    const categories = await caller.decision.getCategories({
+      processInstanceId: instance.instance.id,
+    });
+    const termIdByName = new Map(
+      categories.categories.map((category) => [category.name, category.id]),
+    );
+
+    expect(await linkedTermIds(proposalA.id)).toEqual([
+      termIdByName.get(labelB),
+    ]);
+    expect(await linkedTermIds(proposalB.id)).toEqual([
+      termIdByName.get(labelC),
+    ]);
+  });
+});

--- a/services/api/src/routers/decision/instances/categorySlugParity.test.ts
+++ b/services/api/src/routers/decision/instances/categorySlugParity.test.ts
@@ -1,9 +1,12 @@
-import { db, inArray } from '@op/db/client';
-import { taxonomies, taxonomyTerms } from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { appRouter } from '../..';
 import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  cleanupTermsByLabel,
+  ensureProposalTaxonomy,
+  labelSuffix,
+} from '../../../test/helpers/categoryTaxonomyTestUtils';
 import {
   createIsolatedSession,
   createTestContextWithSession,
@@ -15,53 +18,6 @@ const createCaller = createCallerFactory(appRouter);
 async function createAuthenticatedCaller(email: string) {
   const { session } = await createIsolatedSession(email);
   return createCaller(await createTestContextWithSession(session));
-}
-
-/**
- * Derives a short alphanumeric suffix from the vitest task id so category
- * labels (and therefore their taxonomy `termUri`s) stay unique across the
- * concurrently-running tests that share the global `proposal` taxonomy.
- */
-function labelSuffix(taskId: string): string {
-  return taskId.replace(/[^a-z0-9]/gi, '').slice(-8) || 'x';
-}
-
-/**
- * Ensures the shared `proposal` taxonomy row exists before any category is
- * defined. The real `ensureProposalTaxonomyTerms` does a find-then-insert that
- * is not concurrency-safe, so two tests defining their first category at once
- * would otherwise collide on `taxonomies_name_unique`. `onConflictDoNothing`
- * lets every concurrent test converge on the same row. (`taxonomies` is exempt
- * from the teardown empty-table check, so the row is left behind.)
- */
-async function ensureProposalTaxonomy(): Promise<void> {
-  await db
-    .insert(taxonomies)
-    .values({ name: 'proposal' })
-    .onConflictDoNothing({ target: taxonomies.name });
-}
-
-/**
- * Deletes any taxonomy terms created for the given labels once the test
- * finishes. Terms live in the global (non-seeded) `taxonomy_terms` table, which
- * the teardown requires to be empty, and they aren't tied to a profile so the
- * TestDecisionsDataManager cascade never reaches them.
- */
-function cleanupTermsByLabel(
-  labels: string[],
-  onTestFinished: (fn: () => void | Promise<void>) => void,
-): void {
-  onTestFinished(async () => {
-    const terms = await db
-      .select({ id: taxonomyTerms.id })
-      .from(taxonomyTerms)
-      .where(inArray(taxonomyTerms.label, labels));
-    const ids = terms.map((t) => t.id);
-    if (ids.length === 0) {
-      return;
-    }
-    await db.delete(taxonomyTerms).where(inArray(taxonomyTerms.id, ids));
-  });
 }
 
 /**

--- a/services/api/src/test/helpers/categoryTaxonomyTestUtils.ts
+++ b/services/api/src/test/helpers/categoryTaxonomyTestUtils.ts
@@ -1,0 +1,69 @@
+import { db, eq, inArray } from '@op/db/client';
+import { proposalCategories, taxonomies, taxonomyTerms } from '@op/db/schema';
+
+/**
+ * Shared setup for tests that drive decision categories through the real
+ * `ensureProposalTaxonomyTerms` path. Category labels key a *global*,
+ * slug-derived `taxonomyTerms` row, so concurrent tests contend on one taxonomy
+ * and must both isolate their labels and clean up the terms they mint.
+ */
+
+/**
+ * Derives a short alphanumeric suffix from the vitest task id so category
+ * labels (and therefore their taxonomy `termUri`s) stay unique across the
+ * concurrently-running tests that share the global `proposal` taxonomy.
+ */
+export function labelSuffix(taskId: string): string {
+  return taskId.replace(/[^a-z0-9]/gi, '').slice(-8) || 'x';
+}
+
+/**
+ * Ensures the shared `proposal` taxonomy row exists before any category is
+ * defined. The real `ensureProposalTaxonomyTerms` does a find-then-insert that
+ * is not concurrency-safe, so two tests defining their first category at once
+ * would otherwise collide on `taxonomies_name_unique`. `onConflictDoNothing`
+ * lets every concurrent test converge on the same row. (`taxonomies` is exempt
+ * from the teardown empty-table check, so the row is left behind.)
+ */
+export async function ensureProposalTaxonomy(): Promise<void> {
+  await db
+    .insert(taxonomies)
+    .values({ name: 'proposal' })
+    .onConflictDoNothing({ target: taxonomies.name });
+}
+
+/**
+ * Deletes any taxonomy terms created for the given labels once the test
+ * finishes. Terms live in the global (non-seeded) `taxonomy_terms` table, which
+ * the teardown requires to be empty, and they aren't tied to a profile so the
+ * TestDecisionsDataManager cascade never reaches them. Dependent
+ * `proposalCategories` rows are cleared first so the delete can't hit an FK.
+ */
+export function cleanupTermsByLabel(
+  labels: string[],
+  onTestFinished: (fn: () => void | Promise<void>) => void,
+): void {
+  onTestFinished(async () => {
+    const terms = await db
+      .select({ id: taxonomyTerms.id })
+      .from(taxonomyTerms)
+      .where(inArray(taxonomyTerms.label, labels));
+    const ids = terms.map((t) => t.id);
+    if (ids.length === 0) {
+      return;
+    }
+    await db
+      .delete(proposalCategories)
+      .where(inArray(proposalCategories.taxonomyTermId, ids));
+    await db.delete(taxonomyTerms).where(inArray(taxonomyTerms.id, ids));
+  });
+}
+
+/** The taxonomy term ids a proposal's `proposalCategories` rows point at. */
+export async function linkedTermIds(proposalId: string): Promise<string[]> {
+  const rows = await db
+    .select({ taxonomyTermId: proposalCategories.taxonomyTermId })
+    .from(proposalCategories)
+    .where(eq(proposalCategories.proposalId, proposalId));
+  return rows.map((r) => r.taxonomyTermId);
+}


### PR DESCRIPTION
Renaming a category in the Process Builder made `ensureProposalTaxonomyTerms`
mint a new, slug-keyed `taxonomyTerms` row for the new label. Existing
`proposalCategories` (table `decision_categories`) rows kept pointing at the
old term, so proposals tagged before the rename silently dropped out of the
renamed (now empty-looking) category and its review-queue filter.

Add a rename-reconciliation hook to `updateDecisionInstance`: the config-local
`id` distinguishes a rename (same id, new label) from delete+add, so on rename
we re-point this instance's links from the old term to the new one.

- reconcileCategoryRename.ts: `repointRenamedCategoryLinks` runs inside the
  instanceData write transaction. It resolves the old/new terms via the shared
  `categoryTermUri`, skips no-op (same-slug) edits, and moves links with an
  insert-then-delete (idempotent on the composite PK). Scoped to this
  instance's proposals so shared terms used by other decisions are untouched.
- Reviewer scope rows will share these term keys and need the same treatment
  once they exist.
- categoryRenameOrphansLinks.test.ts: covers the re-point and the
  cross-instance isolation of a shared term.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>