### PR TITLE
feat(decision): generate review assignments by category scope

### DIFF
--- a/packages/common/src/services/decision/backfillReviewAssignments.ts
+++ b/packages/common/src/services/decision/backfillReviewAssignments.ts
@@ -2,11 +2,15 @@ import { db } from '@op/db/client';
 import { ProcessStatus, ProposalStatus } from '@op/db/schema';
 import { logger } from '@op/logging';
 
+import { getCategoryReviewersByProposal } from './getCategoryReviewersByProposal';
 import { getEligibleReviewerProfileIds } from './getEligibleReviewerProfileIds';
-import { insertReviewAssignments } from './insertReviewAssignments';
+import {
+  type AssignableProposal,
+  insertReviewAssignments,
+} from './insertReviewAssignments';
 import type { DecisionInstanceData } from './schemas/instanceData';
 import { assertInstancePhase } from './utils/instance';
-import { isReviewPhase } from './utils/phaseSettings';
+import { getPhaseReviewSettings, isReviewPhase } from './utils/phaseSettings';
 
 export interface BackfillReviewAssignmentsInput {
   instanceId: string;
@@ -107,15 +111,40 @@ export async function backfillReviewAssignments({
     ? eligibleReviewerProfileIds.filter((id) => reviewerProfileIds.includes(id))
     : eligibleReviewerProfileIds;
 
-  const inserted = await insertReviewAssignments({
-    instanceId,
-    phaseId: currentPhaseId,
-    reviewerProfileIds: targetReviewerIds,
-    assignableProposals: attachedProposals.map((row) => ({
+  const scope = getPhaseReviewSettings(instanceData, currentPhaseId).scope;
+
+  let assignableProposals: AssignableProposal[];
+  if (scope === 'by_category') {
+    // Only backfill proposals in categories the target reviewers are scoped to.
+    const scopedByProposal = await getCategoryReviewersByProposal({
+      instanceId,
+      phaseId: currentPhaseId,
+      proposalIds: attachedProposals.map((row) => row.proposalId),
+    });
+    const targetSet = new Set(targetReviewerIds);
+
+    assignableProposals = attachedProposals.map((row) => {
+      const scoped = scopedByProposal.get(row.proposalId) ?? new Set<string>();
+      return {
+        proposalId: row.proposalId,
+        submittedByProfileId: row.proposal.submittedByProfileId,
+        assignedProposalHistoryId: row.proposalHistoryId,
+        reviewerProfileIds: [...scoped].filter((id) => targetSet.has(id)),
+      };
+    });
+  } else {
+    assignableProposals = attachedProposals.map((row) => ({
       proposalId: row.proposalId,
       submittedByProfileId: row.proposal.submittedByProfileId,
       assignedProposalHistoryId: row.proposalHistoryId,
-    })),
+      reviewerProfileIds: targetReviewerIds,
+    }));
+  }
+
+  const inserted = await insertReviewAssignments({
+    instanceId,
+    phaseId: currentPhaseId,
+    assignableProposals,
   });
 
   return {

--- a/packages/common/src/services/decision/generateReviewAssignments.ts
+++ b/packages/common/src/services/decision/generateReviewAssignments.ts
@@ -2,8 +2,14 @@ import { db } from '@op/db/client';
 import { logger } from '@op/logging';
 
 import { CommonError } from '../../utils';
+import { getCategoryReviewersByProposal } from './getCategoryReviewersByProposal';
 import { getEligibleReviewerProfileIds } from './getEligibleReviewerProfileIds';
-import { insertReviewAssignments } from './insertReviewAssignments';
+import {
+  type AssignableProposal,
+  insertReviewAssignments,
+} from './insertReviewAssignments';
+import type { DecisionInstanceData } from './schemas/instanceData';
+import { getPhaseReviewSettings } from './utils/phaseSettings';
 
 export interface GenerateReviewAssignmentsInput {
   instanceId: string;
@@ -12,14 +18,20 @@ export interface GenerateReviewAssignmentsInput {
   transitionHistoryId: string;
 }
 
+interface SelectedProposal {
+  id: string;
+  submittedByProfileId: string | null;
+}
+
 /**
  * Generate review assignment rows for proposals entering a review-capable phase.
  *
  * Only members with the REVIEW capability on the `decisions` access zone are
  * eligible. Reviewers are never assigned their own proposals.
  *
- * Currently supports the `full_coverage` policy (every eligible reviewer is
- * assigned every proposal). Throws for unsupported policies.
+ * Scope `all`: every eligible reviewer is assigned every proposal. Scope
+ * `by_category`: each proposal is assigned only the eligible reviewers whose
+ * scope rows cover its categories. Insert-only — never prunes.
  */
 export async function generateReviewAssignments({
   instanceId,
@@ -73,14 +85,100 @@ export async function generateReviewAssignments({
     transitionProposalRows.map((r) => [r.proposalId, r.proposalHistoryId]),
   );
 
+  const scope = getPhaseReviewSettings(
+    instance.instanceData as DecisionInstanceData,
+    phaseId,
+  ).scope;
+
+  const assignableProposals =
+    scope === 'by_category'
+      ? await buildByCategoryProposals({
+          instanceId,
+          phaseId,
+          selectedProposalIds,
+          selectedProposals,
+          eligibleReviewerProfileIds: reviewerProfileIds,
+          historyByProposalId,
+        })
+      : selectedProposals.map((proposal) => ({
+          proposalId: proposal.id,
+          submittedByProfileId: proposal.submittedByProfileId,
+          assignedProposalHistoryId:
+            historyByProposalId.get(proposal.id) ?? null,
+          reviewerProfileIds,
+        }));
+
   await insertReviewAssignments({
     instanceId,
     phaseId,
-    reviewerProfileIds,
-    assignableProposals: selectedProposals.map((proposal) => ({
+    assignableProposals,
+  });
+}
+
+/**
+ * Builds per-proposal reviewer sets for the `by_category` scope: scope rows
+ * covering the proposal's categories ∩ eligible reviewers. Proposals that end
+ * up with zero reviewers (uncategorized, or a category with no eligible scoped
+ * reviewer) are logged but still proceed with an empty set — never blocked.
+ */
+async function buildByCategoryProposals({
+  instanceId,
+  phaseId,
+  selectedProposalIds,
+  selectedProposals,
+  eligibleReviewerProfileIds,
+  historyByProposalId,
+}: {
+  instanceId: string;
+  phaseId: string;
+  selectedProposalIds: string[];
+  selectedProposals: SelectedProposal[];
+  eligibleReviewerProfileIds: string[];
+  historyByProposalId: Map<string, string>;
+}): Promise<AssignableProposal[]> {
+  const [scopedByProposal, categorizedRows] = await Promise.all([
+    getCategoryReviewersByProposal({
+      instanceId,
+      phaseId,
+      proposalIds: selectedProposalIds,
+    }),
+    db.query.proposalCategories.findMany({
+      where: { proposalId: { in: selectedProposalIds } },
+      columns: { proposalId: true },
+    }),
+  ]);
+
+  const categorizedProposalIds = new Set(
+    categorizedRows.map((row) => row.proposalId),
+  );
+  const eligibleSet = new Set(eligibleReviewerProfileIds);
+
+  return selectedProposals.map((proposal) => {
+    const scoped = scopedByProposal.get(proposal.id) ?? new Set<string>();
+    const reviewerProfileIds = [...scoped].filter((id) => eligibleSet.has(id));
+
+    // Mirror the downstream self-review exclusion to detect a truly
+    // uncoverable proposal.
+    const coveringReviewers = reviewerProfileIds.filter(
+      (id) => id !== proposal.submittedByProfileId,
+    );
+
+    if (coveringReviewers.length === 0) {
+      logger.warn('generateReviewAssignments: proposal has zero reviewers', {
+        instanceId,
+        phaseId,
+        proposalId: proposal.id,
+        reason: categorizedProposalIds.has(proposal.id)
+          ? 'category_has_no_eligible_reviewers'
+          : 'uncategorized',
+      });
+    }
+
+    return {
       proposalId: proposal.id,
       submittedByProfileId: proposal.submittedByProfileId,
       assignedProposalHistoryId: historyByProposalId.get(proposal.id) ?? null,
-    })),
+      reviewerProfileIds,
+    };
   });
 }

--- a/packages/common/src/services/decision/getCategoryReviewersByProposal.ts
+++ b/packages/common/src/services/decision/getCategoryReviewersByProposal.ts
@@ -1,0 +1,58 @@
+import { and, db, eq, inArray, isNull, or } from '@op/db/client';
+import { categoryReviewers, proposalCategories } from '@op/db/schema';
+
+/**
+ * System-context resolution of which scoped reviewers cover each proposal, for
+ * the `by_category` scope. Returns Map<proposalId, Set<reviewerProfileId>>;
+ * proposals with no covering scope row are absent from the map.
+ *
+ * Runs no access check (generation is a system-context phase transition, not a
+ * user action). Callers MUST still intersect with getEligibleReviewerProfileIds
+ * — a scope row alone grants nothing (fail-closed). Scope rows resolve
+ * instance-wide (`phaseId IS NULL`) unioned with rows for this review phase.
+ */
+export async function getCategoryReviewersByProposal({
+  instanceId,
+  phaseId,
+  proposalIds,
+}: {
+  instanceId: string;
+  phaseId: string;
+  proposalIds: string[];
+}): Promise<Map<string, Set<string>>> {
+  const reviewersByProposalId = new Map<string, Set<string>>();
+
+  if (proposalIds.length === 0) {
+    return reviewersByProposalId;
+  }
+
+  const rows = await db
+    .select({
+      proposalId: proposalCategories.proposalId,
+      reviewerProfileId: categoryReviewers.reviewerProfileId,
+    })
+    .from(categoryReviewers)
+    .innerJoin(
+      proposalCategories,
+      eq(proposalCategories.taxonomyTermId, categoryReviewers.taxonomyTermId),
+    )
+    .where(
+      and(
+        eq(categoryReviewers.processInstanceId, instanceId),
+        or(
+          isNull(categoryReviewers.phaseId),
+          eq(categoryReviewers.phaseId, phaseId),
+        ),
+        inArray(proposalCategories.proposalId, proposalIds),
+      ),
+    );
+
+  for (const row of rows) {
+    const bucket =
+      reviewersByProposalId.get(row.proposalId) ?? new Set<string>();
+    bucket.add(row.reviewerProfileId);
+    reviewersByProposalId.set(row.proposalId, bucket);
+  }
+
+  return reviewersByProposalId;
+}

--- a/packages/common/src/services/decision/insertReviewAssignments.ts
+++ b/packages/common/src/services/decision/insertReviewAssignments.ts
@@ -5,27 +5,32 @@ export interface AssignableProposal {
   proposalId: string;
   submittedByProfileId: string | null;
   assignedProposalHistoryId: string | null;
+  /**
+   * The reviewers to assign this proposal. For `all` coverage the caller fans
+   * the shared eligible list into every proposal; for `by_category` each
+   * proposal carries only its category-scoped reviewers.
+   */
+  reviewerProfileIds: string[];
 }
 
 /**
- * Fans proposals × reviewers into assignment rows — excluding self-review —
- * and inserts them. `onConflictDoNothing` on the (instance, proposal,
- * reviewer, phase) unique constraint makes re-runs safe. Returns the number
- * of rows actually inserted. Shared by generation and backfill.
+ * Fans proposals × their reviewers into assignment rows — excluding
+ * self-review — and inserts them. `onConflictDoNothing` on the (instance,
+ * proposal, reviewer, phase) unique constraint makes re-runs safe and dedupes
+ * overlapping per-proposal sets. Returns the number of rows inserted. Shared
+ * by generation and backfill.
  */
 export async function insertReviewAssignments({
   instanceId,
   phaseId,
-  reviewerProfileIds,
   assignableProposals,
 }: {
   instanceId: string;
   phaseId: string;
-  reviewerProfileIds: string[];
   assignableProposals: AssignableProposal[];
 }): Promise<number> {
   const values = assignableProposals.flatMap((proposal) =>
-    reviewerProfileIds
+    proposal.reviewerProfileIds
       // NOTE: we should revisit this logic when we have multiple authors per proposal
       .filter((profileId) => profileId !== proposal.submittedByProfileId)
       .map((profileId) => ({

--- a/services/api/src/routers/decision/instances/generateReviewAssignmentsByCategory.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignmentsByCategory.test.ts
@@ -1,0 +1,973 @@
+import {
+  type DecisionInstanceData,
+  type ReviewsScope,
+  advancePhase,
+  backfillReviewAssignments,
+  createDecisionRole,
+  generateReviewAssignments,
+} from '@op/common';
+import { db, eq, inArray } from '@op/db/client';
+import {
+  ProcessStatus,
+  ProposalStatus,
+  categoryReviewers,
+  proposalCategories,
+  proposalReviewAssignments,
+  taxonomies,
+  taxonomyTerms,
+} from '@op/db/schema';
+import { logger } from '@op/logging';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+
+/** The schema shape createDecisionSetup accepts (encoder-inferred, not exported). */
+type TestProcessSchema = NonNullable<
+  NonNullable<
+    Parameters<TestDecisionsDataManager['createDecisionSetup']>[0]
+  >['processSchema']
+>;
+
+/**
+ * Schema whose review phase carries a configurable `reviews.scope`. The review
+ * phase also accepts submissions so backfill tests can add mid-phase proposals.
+ * submission → review → results
+ */
+function schemaWithScope(scope: ReviewsScope): TestProcessSchema {
+  return {
+    id: `review-by-category-schema-${scope}`,
+    version: '1.0.0',
+    name: 'Review By Category Schema',
+    description: 'Schema with a by-category review phase for testing',
+    config: {
+      reviewsPolicy: 'full_coverage',
+    },
+    phases: [
+      {
+        id: 'submission',
+        name: 'Submission',
+        description: 'Submit proposals',
+        rules: {
+          proposals: { submit: true },
+          advancement: { method: 'manual' },
+        },
+        // Pass-all: every submitted proposal advances into review.
+        selectionPipeline: { version: '1.0.0', blocks: [] },
+      },
+      {
+        id: 'review',
+        name: 'Review',
+        description: 'Review proposals',
+        rules: {
+          proposals: { review: true, submit: true },
+          reviews: { submit: true, scope },
+          advancement: { method: 'manual' },
+        },
+      },
+      {
+        id: 'results',
+        name: 'Results',
+        description: 'Final results',
+        rules: {
+          proposals: { submit: false },
+          advancement: { method: 'manual' },
+        },
+      },
+    ],
+  } satisfies TestProcessSchema;
+}
+
+async function createReviewInstance(
+  testData: TestDecisionsDataManager,
+  scope: ReviewsScope,
+) {
+  const setup = await testData.createDecisionSetup({
+    instanceCount: 1,
+    processSchema: schemaWithScope(scope),
+    status: ProcessStatus.PUBLISHED,
+  });
+
+  return { setup, instance: setup.instance };
+}
+
+/** A "Reviewer" role on the given decision profile with only the REVIEW bit. */
+async function createReviewerRole(instanceProfileId: string) {
+  return createDecisionRole({
+    name: 'Reviewer',
+    profileId: instanceProfileId,
+    permissions: {
+      decisions: {
+        type: 'decision',
+        value: {
+          create: false,
+          read: true,
+          update: false,
+          delete: false,
+          admin: false,
+          inviteMembers: false,
+          review: true,
+          submitProposals: false,
+          vote: false,
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Appends uniquely-labeled terms to the shared "proposal" taxonomy. Labels are
+ * per-call unique so concurrent tests don't collide on (taxonomyId, termUri).
+ */
+async function seedTerms(
+  count: number,
+  onTestFinished: (fn: () => void | Promise<void>) => void,
+) {
+  const taxonomyId = randomUUID();
+  const [inserted] = await db
+    .insert(taxonomies)
+    .values({ id: taxonomyId, name: 'proposal' })
+    .onConflictDoNothing({ target: taxonomies.name })
+    .returning({ id: taxonomies.id });
+
+  let resolvedTaxonomyId: string;
+  if (inserted) {
+    resolvedTaxonomyId = inserted.id;
+  } else {
+    const [existing] = await db
+      .select({ id: taxonomies.id })
+      .from(taxonomies)
+      .where(eq(taxonomies.name, 'proposal'));
+    if (!existing) {
+      throw new Error('proposal taxonomy not found after conflict');
+    }
+    resolvedTaxonomyId = existing.id;
+  }
+
+  const suffix = randomUUID().slice(0, 8);
+  const termRecords = Array.from({ length: count }, (_, i) => ({
+    id: randomUUID(),
+    taxonomyId: resolvedTaxonomyId,
+    termUri: `district-${suffix}-${i}`,
+    label: `District ${suffix} ${i}`,
+  }));
+
+  await db.insert(taxonomyTerms).values(termRecords);
+
+  onTestFinished(async () => {
+    await db.delete(taxonomyTerms).where(
+      inArray(
+        taxonomyTerms.id,
+        termRecords.map((t) => t.id),
+      ),
+    );
+  });
+
+  return termRecords;
+}
+
+/** Tags a proposal with a taxonomy term (a submission category). */
+async function tagProposal(proposalId: string, taxonomyTermId: string) {
+  await db
+    .insert(proposalCategories)
+    .values({ proposalId, taxonomyTermId })
+    .onConflictDoNothing();
+}
+
+/** Directly inserts a scope row (system context — no admin caller needed). */
+async function scopeReviewer({
+  processInstanceId,
+  taxonomyTermId,
+  reviewerProfileId,
+  phaseId,
+}: {
+  processInstanceId: string;
+  taxonomyTermId: string;
+  reviewerProfileId: string;
+  phaseId?: string | null;
+}) {
+  await db
+    .insert(categoryReviewers)
+    .values({
+      processInstanceId,
+      taxonomyTermId,
+      reviewerProfileId,
+      phaseId: phaseId ?? null,
+    })
+    .onConflictDoNothing();
+}
+
+async function advanceToReviewPhase(instanceId: string) {
+  const dbInstance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+  if (!dbInstance) {
+    throw new Error('Instance not found');
+  }
+
+  const result = await db.transaction(async (tx) =>
+    advancePhase({
+      db: tx,
+      instance: {
+        id: dbInstance.id,
+        instanceData: dbInstance.instanceData as DecisionInstanceData,
+      },
+      fromPhaseId: 'submission',
+      toPhaseId: 'review',
+      triggeredByProfileId: null,
+    }),
+  );
+
+  if (result.conflict) {
+    throw new Error('Unexpected conflict during advance');
+  }
+
+  return result;
+}
+
+async function getAssignments(instanceId: string) {
+  return db
+    .select()
+    .from(proposalReviewAssignments)
+    .where(eq(proposalReviewAssignments.processInstanceId, instanceId));
+}
+
+/** Map proposalId → set of reviewerProfileIds actually assigned. */
+function reviewersByProposal(
+  assignments: Array<{ proposalId: string; reviewerProfileId: string }>,
+) {
+  const map = new Map<string, Set<string>>();
+  for (const a of assignments) {
+    const bucket = map.get(a.proposalId) ?? new Set<string>();
+    bucket.add(a.reviewerProfileId);
+    map.set(a.proposalId, bucket);
+  }
+  return map;
+}
+
+describe.concurrent('generateReviewAssignments — by_category scope', () => {
+  it("scope 'all' still assigns every eligible reviewer to every proposal, ignoring category scope", async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(testData, 'all');
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    const [reviewerA, reviewerB] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+    ]);
+
+    const [p1, p2] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'P1' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'P2' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ]);
+
+    // reviewerA is scoped only to category A — under 'all' this must be ignored.
+    await tagProposal(p1!.id, termA!.id);
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerA.profileId,
+    });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
+    });
+
+    const byProposal = reviewersByProposal(
+      await getAssignments(instance.instance.id),
+    );
+
+    // Full coverage ignores category scope: both reviewers cover both proposals
+    // despite reviewerA's cat-A-only scope row (note reviewerA gets p2, not in
+    // cat A). Superset check — the creator-admin also holds REVIEW.
+    for (const p of [p1!, p2!]) {
+      const reviewers = byProposal.get(p.id);
+      expect(reviewers?.has(reviewerA.profileId)).toBe(true);
+      expect(reviewers?.has(reviewerB.profileId)).toBe(true);
+    }
+    expect(byProposal.get(p2!.id)?.has(reviewerA.profileId)).toBe(true);
+  });
+
+  it('assigns each proposal only its category-scoped, eligible reviewers', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA, termB] = await seedTerms(2, onTestFinished);
+
+    const [reviewerA, reviewerB] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+    ]);
+
+    const [pA, pB] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Cat A proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Cat B proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ]);
+
+    await tagProposal(pA!.id, termA!.id);
+    await tagProposal(pB!.id, termB!.id);
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerA.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termB!.id,
+      reviewerProfileId: reviewerB.profileId,
+    });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
+    });
+
+    const byProposal = reviewersByProposal(
+      await getAssignments(instance.instance.id),
+    );
+
+    // reviewerA covers cat-A proposal only; reviewerB covers cat-B only.
+    expect(byProposal.get(pA!.id)).toEqual(new Set([reviewerA.profileId]));
+    expect(byProposal.get(pB!.id)).toEqual(new Set([reviewerB.profileId]));
+  });
+
+  it('unions reviewers across a multi-category proposal without duplicate rows', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA, termB] = await seedTerms(2, onTestFinished);
+
+    // reviewerBoth is scoped to BOTH categories — the dedupe target.
+    const [reviewerA, reviewerB, reviewerBoth] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+    ]);
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Multi-category proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    await tagProposal(proposal.id, termA!.id);
+    await tagProposal(proposal.id, termB!.id);
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerA.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termB!.id,
+      reviewerProfileId: reviewerB.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerBoth.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termB!.id,
+      reviewerProfileId: reviewerBoth.profileId,
+    });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
+    });
+
+    const assignments = await getAssignments(instance.instance.id);
+    const proposalAssignments = assignments.filter(
+      (a) => a.proposalId === proposal.id,
+    );
+
+    // Union of both categories' reviewers, and reviewerBoth appears once — the
+    // (instance, proposal, reviewer, phase) unique constraint dedupes.
+    expect(reviewersByProposal(assignments).get(proposal.id)).toEqual(
+      new Set([
+        reviewerA.profileId,
+        reviewerB.profileId,
+        reviewerBoth.profileId,
+      ]),
+    );
+    expect(proposalAssignments).toHaveLength(3);
+  });
+
+  it('excludes a scoped reviewer who lacks the REVIEW role (fail-closed intersection)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    // reviewer has the role; nonReviewer is scoped but has no REVIEW role.
+    const [reviewer, nonReviewer] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+    ]);
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Cat A proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    await tagProposal(proposal.id, termA!.id);
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewer.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: nonReviewer.profileId,
+    });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
+    });
+
+    const byProposal = reviewersByProposal(
+      await getAssignments(instance.instance.id),
+    );
+
+    // Only the role-holding reviewer is assigned; the scope row alone grants nothing.
+    expect(byProposal.get(proposal.id)).toEqual(new Set([reviewer.profileId]));
+  });
+
+  it('still excludes self-review when the author is scoped to their own proposal category', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    // Author is also a reviewer scoped to cat A; another reviewer covers cat A too.
+    const [author, otherReviewer] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+    ]);
+
+    const ownProposal = await testData.createProposal({
+      userEmail: author.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: "Author's own proposal" },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    await tagProposal(ownProposal.id, termA!.id);
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: author.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: otherReviewer.profileId,
+    });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
+    });
+
+    const byProposal = reviewersByProposal(
+      await getAssignments(instance.instance.id),
+    );
+
+    // Author is scoped to their own category but never reviews their own work.
+    expect(byProposal.get(ownProposal.id)).toEqual(
+      new Set([otherReviewer.profileId]),
+    );
+  });
+
+  it('warns and inserts no rows for 0-reviewer-category and uncategorized proposals, without blocking the transition', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termCovered, termEmpty] = await seedTerms(2, onTestFinished);
+
+    const reviewer = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+      roleIds: { [instance.profileId]: reviewerRole.id },
+    });
+
+    const [covered, emptyCategory, uncategorized] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Covered' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Empty category' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Uncategorized' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ]);
+
+    // Only `covered` has a scoped reviewer; `emptyCategory` has a category with
+    // no scope rows; `uncategorized` has no category at all.
+    await tagProposal(covered.id, termCovered!.id);
+    await tagProposal(emptyCategory.id, termEmpty!.id);
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termCovered!.id,
+      reviewerProfileId: reviewer.profileId,
+    });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+    await expect(
+      generateReviewAssignments({
+        instanceId: instance.instance.id,
+        phaseId: 'review',
+        selectedProposalIds: advanceResult.selectedProposalIds,
+        transitionHistoryId: advanceResult.transitionHistoryId,
+      }),
+    ).resolves.toBeUndefined();
+
+    const assignments = await getAssignments(instance.instance.id);
+
+    // The covered proposal is assigned; the two gap proposals get no rows.
+    expect(reviewersByProposal(assignments).get(covered.id)).toEqual(
+      new Set([reviewer.profileId]),
+    );
+    expect(
+      assignments.filter((a) => a.proposalId === emptyCategory.id),
+    ).toHaveLength(0);
+    expect(
+      assignments.filter((a) => a.proposalId === uncategorized.id),
+    ).toHaveLength(0);
+
+    // Both gap proposals are surfaced via logger.warn with their reason.
+    const warnCalls = vi.mocked(logger.warn).mock.calls;
+    const warnFor = (proposalId: string) =>
+      warnCalls.find(
+        ([, meta]) =>
+          (meta as { proposalId?: string } | undefined)?.proposalId ===
+          proposalId,
+      );
+
+    expect(warnFor(emptyCategory.id)?.[1]).toMatchObject({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      reason: 'category_has_no_eligible_reviewers',
+    });
+    expect(warnFor(uncategorized.id)?.[1]).toMatchObject({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      reason: 'uncategorized',
+    });
+    // The covered proposal must NOT warn.
+    expect(warnFor(covered.id)).toBeUndefined();
+  });
+
+  it('resolves active-phase and instance-wide scope rows, excludes other-phase rows, and dedupes their overlap', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    const [reviewerPhase, reviewerOther, reviewerWide, reviewerDual] =
+      await Promise.all([
+        testData.createMemberUser({
+          organization: setup.organization,
+          instanceProfileIds: [instance.profileId],
+          roleIds: { [instance.profileId]: reviewerRole.id },
+        }),
+        testData.createMemberUser({
+          organization: setup.organization,
+          instanceProfileIds: [instance.profileId],
+          roleIds: { [instance.profileId]: reviewerRole.id },
+        }),
+        testData.createMemberUser({
+          organization: setup.organization,
+          instanceProfileIds: [instance.profileId],
+          roleIds: { [instance.profileId]: reviewerRole.id },
+        }),
+        testData.createMemberUser({
+          organization: setup.organization,
+          instanceProfileIds: [instance.profileId],
+          roleIds: { [instance.profileId]: reviewerRole.id },
+        }),
+      ]);
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Cat A proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    await tagProposal(proposal.id, termA!.id);
+    // Scoped to the active review phase → resolves.
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerPhase.profileId,
+      phaseId: 'review',
+    });
+    // Scoped to a DIFFERENT phase → must NOT leak into the review phase.
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerOther.profileId,
+      phaseId: 'submission',
+    });
+    // Instance-wide (phaseId NULL) → resolves for the review phase.
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerWide.profileId,
+      phaseId: null,
+    });
+    // Both instance-wide AND active-phase rows for the same term → the OR union
+    // matches twice but must collapse to a single assignment row.
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerDual.profileId,
+      phaseId: null,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerDual.profileId,
+      phaseId: 'review',
+    });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
+    });
+
+    const assignments = await getAssignments(instance.instance.id);
+
+    // Active-phase + instance-wide rows resolve; the other-phase row does not.
+    expect(reviewersByProposal(assignments).get(proposal.id)).toEqual(
+      new Set([
+        reviewerPhase.profileId,
+        reviewerWide.profileId,
+        reviewerDual.profileId,
+      ]),
+    );
+
+    // reviewerDual's overlapping NULL + 'review' rows dedupe to one assignment.
+    expect(
+      assignments.filter(
+        (a) =>
+          a.proposalId === proposal.id &&
+          a.reviewerProfileId === reviewerDual.profileId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('scopes reviewers per instance: an instance-one scope row never covers an identical-category proposal in instance two', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 2,
+      processSchema: schemaWithScope('by_category'),
+      status: ProcessStatus.PUBLISHED,
+    });
+    const instanceOne = setup.instances[0]!;
+    const instanceTwo = setup.instances[1]!;
+
+    // The reviewer holds REVIEW in BOTH instances, so eligibility cannot explain
+    // the instance-two exclusion — only the per-instance scope filter can.
+    const [roleOne, roleTwo] = await Promise.all([
+      createReviewerRole(instanceOne.profileId),
+      createReviewerRole(instanceTwo.profileId),
+    ]);
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    const reviewer = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instanceOne.profileId, instanceTwo.profileId],
+      roleIds: {
+        [instanceOne.profileId]: roleOne.id,
+        [instanceTwo.profileId]: roleTwo.id,
+      },
+    });
+
+    const [proposalOne, proposalTwo] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instanceOne.instance.id,
+        proposalData: { title: 'Instance one proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instanceTwo.instance.id,
+        proposalData: { title: 'Instance two proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ]);
+
+    // Both proposals share the SAME category term...
+    await tagProposal(proposalOne.id, termA!.id);
+    await tagProposal(proposalTwo.id, termA!.id);
+    // ...but only instance one has a scope row for it.
+    await scopeReviewer({
+      processInstanceId: instanceOne.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewer.profileId,
+    });
+
+    // Generation runs for BOTH instances.
+    const advanceOne = await advanceToReviewPhase(instanceOne.instance.id);
+    await generateReviewAssignments({
+      instanceId: instanceOne.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceOne.selectedProposalIds,
+      transitionHistoryId: advanceOne.transitionHistoryId,
+    });
+    const advanceTwo = await advanceToReviewPhase(instanceTwo.instance.id);
+    await generateReviewAssignments({
+      instanceId: instanceTwo.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceTwo.selectedProposalIds,
+      transitionHistoryId: advanceTwo.transitionHistoryId,
+    });
+
+    // Instance one: the scope row applies.
+    expect(
+      reviewersByProposal(await getAssignments(instanceOne.instance.id)).get(
+        proposalOne.id,
+      ),
+    ).toEqual(new Set([reviewer.profileId]));
+
+    // Instance two: same term, same eligible reviewer, generation ran — but the
+    // scope row belongs to instance one, so nothing is assigned here.
+    expect(await getAssignments(instanceTwo.instance.id)).toHaveLength(0);
+  });
+});
+
+describe.concurrent('backfillReviewAssignments — by_category scope', () => {
+  it('backfills a mid-phase reviewer only for proposals in their scoped categories', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA, termB] = await seedTerms(2, onTestFinished);
+
+    // initialReviewer covers cat A from the start; lateReviewer joins mid-phase
+    // scoped only to cat A.
+    const [initialReviewer, lateReviewer] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+      }),
+    ]);
+
+    const [pA, pB] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Cat A proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Cat B proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ]);
+
+    await tagProposal(pA!.id, termA!.id);
+    await tagProposal(pB!.id, termB!.id);
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: initialReviewer.profileId,
+    });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
+    });
+    const afterGeneration = await getAssignments(instance.instance.id);
+
+    // lateReviewer gains the role AND a cat-A scope row mid-phase.
+    await testData.assignRole(
+      lateReviewer.authUserId,
+      instance.profileId,
+      reviewerRole.id,
+    );
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: lateReviewer.profileId,
+    });
+
+    const result = await backfillReviewAssignments({
+      instanceId: instance.instance.id,
+      reviewerProfileIds: [lateReviewer.profileId],
+    });
+
+    // Only the cat-A proposal is backfilled for lateReviewer; cat-B is out of scope.
+    expect(result).toMatchObject({ inserted: 1, reviewerCount: 1 });
+
+    const assignments = await getAssignments(instance.instance.id);
+    const lateAssignments = assignments.filter(
+      (a) => a.reviewerProfileId === lateReviewer.profileId,
+    );
+    expect(lateAssignments).toHaveLength(1);
+    expect(lateAssignments[0]?.proposalId).toBe(pA!.id);
+
+    // Add-only: exactly one new row over the generation baseline.
+    expect(assignments).toHaveLength(afterGeneration.length + 1);
+  });
+});


### PR DESCRIPTION
Honor the phase-level reviews scope 'by_category' when generating and backfilling review assignments, so each proposal is reviewed only by the eligible reviewers scoped to its categories; scope 'all' behavior is unchanged. Scope rows alone grant nothing (fail-closed), zero-reviewer proposals are warned but never block the transition, and generation stays insert-only.

feat(decision): generate and backfill review assignments by category scope
refactor(decision): require per-proposal reviewer sets in insertReviewAssignments
test(decision): cover phase-scoped scope rows and cross-instance isolation

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>