### PR TITLE
feat(decision): by-category reviewer cards in the Reviews builder step

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import type { RouterOutput } from '@op/api';
+import { trpc } from '@op/api/client';
+import { logger } from '@op/logging/client';
+import { Avatar } from '@op/ui/Avatar';
+import { IconButton } from '@op/ui/IconButton';
+import { LoadingSpinner } from '@op/ui/LoadingSpinner';
+import { MultiSelectComboBox } from '@op/ui/MultiSelectComboBox';
+import type { Option } from '@op/ui/MultiSelectComboBox';
+import { toast } from '@op/ui/Toast';
+import { useMemo } from 'react';
+import { LuX } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+type CategoryWithReviewers =
+  RouterOutput['decision']['listCategoryReviewers']['categories'][number];
+type EligibleReviewer =
+  RouterOutput['decision']['listEligibleReviewers']['reviewers'][number];
+
+export interface CategoryReviewerCardProps {
+  processInstanceId: string;
+  category: CategoryWithReviewers['category'];
+  reviewers: CategoryWithReviewers['reviewers'];
+  eligibleReviewers: EligibleReviewer[];
+}
+
+/**
+ * One flat category card: label + reviewer count, an "Add reviewer…" picker
+ * scoped to REVIEW role-holders, and removable reviewer chips. Assign-only —
+ * adding/removing only writes/deletes the scope row (PR 7); it never grants a
+ * role or retracts materialized assignments.
+ */
+export function CategoryReviewerCard({
+  processInstanceId,
+  category,
+  reviewers,
+  eligibleReviewers,
+}: CategoryReviewerCardProps) {
+  const t = useTranslations();
+  const utils = trpc.useUtils();
+
+  const invalidate = () =>
+    utils.decision.listCategoryReviewers.invalidate({ processInstanceId });
+
+  const addReviewer = trpc.decision.addCategoryReviewer.useMutation({
+    onError: (error) => {
+      logger.error('Failed to add category reviewer', { error });
+      toast.error({ message: t('Could not add reviewer. Please try again.') });
+    },
+    onSettled: () => {
+      void invalidate();
+    },
+  });
+
+  const removeReviewer = trpc.decision.removeCategoryReviewer.useMutation({
+    onError: (error) => {
+      logger.error('Failed to remove category reviewer', { error });
+      toast.error({
+        message: t('Could not remove reviewer. Please try again.'),
+      });
+    },
+    onSettled: () => {
+      void invalidate();
+    },
+  });
+
+  // Candidates for this card: eligible role-holders not already assigned here,
+  // so the same set can never be double-added. The in-flight add is excluded
+  // too, so it can't be re-picked before the refetch reflects it.
+  const options = useMemo<Option[]>(() => {
+    const assignedIds = new Set(reviewers.map((r) => r.reviewerProfileId));
+    const pendingId = addReviewer.isPending
+      ? addReviewer.variables?.reviewerProfileId
+      : undefined;
+    return eligibleReviewers
+      .filter(
+        (reviewer) =>
+          !assignedIds.has(reviewer.id) && reviewer.id !== pendingId,
+      )
+      .map((reviewer) => ({ id: reviewer.id, label: reviewer.name }));
+  }, [
+    eligibleReviewers,
+    reviewers,
+    addReviewer.isPending,
+    addReviewer.variables,
+  ]);
+
+  const handleAdd = (selected: Option[]) => {
+    // One add at a time — a second concurrent mutate would race the unique
+    // constraint and surface a spurious error toast.
+    if (addReviewer.isPending) {
+      return;
+    }
+    const added = selected[selected.length - 1];
+    if (!added) {
+      return;
+    }
+    addReviewer.mutate({
+      processInstanceId,
+      taxonomyTermId: category.id,
+      reviewerProfileId: added.id,
+    });
+  };
+
+  const count = reviewers.length;
+  const isEmpty = count === 0;
+  // Eligible reviewers exist decision-wide, but this category has already
+  // claimed all of them — the picker has nothing left to offer. (The
+  // decision-wide "no role-holders at all" case is surfaced once, above the
+  // cards, so it isn't repeated here.)
+  const allEligibleAssigned =
+    eligibleReviewers.length > 0 && options.length === 0;
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex items-end justify-between gap-2">
+        <span className="font-serif text-title-sm14 text-neutral-black">
+          {category.name}
+        </span>
+        <span
+          className={
+            isEmpty
+              ? 'text-sm text-primary-orange2'
+              : 'text-sm text-neutral-gray4'
+          }
+        >
+          {t(
+            '{count, plural, =0 {0 reviewers} =1 {1 reviewer} other {# reviewers}}',
+            {
+              count,
+            },
+          )}
+        </span>
+      </div>
+
+      <MultiSelectComboBox
+        items={options}
+        value={[]}
+        onChange={handleAdd}
+        placeholder={t('Add reviewer…')}
+        isLoading={addReviewer.isPending}
+      />
+
+      {allEligibleAssigned && (
+        <p className="text-sm text-neutral-gray4">
+          {t('Everyone who can review is already assigned here.')}
+        </p>
+      )}
+
+      {isEmpty ? (
+        <p className="text-sm text-primary-orange2">
+          {t(
+            'No reviewers yet. Proposals in this category can’t be reviewed until someone is added.',
+          )}
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {reviewers.map((reviewer) => {
+            const isRemoving =
+              removeReviewer.isPending &&
+              removeReviewer.variables?.reviewerProfileId ===
+                reviewer.reviewerProfileId;
+
+            return (
+              <div
+                key={reviewer.scopeId}
+                className="flex items-center gap-6 rounded-lg border border-neutral-gray1 bg-white px-3 py-2"
+              >
+                <div className="flex items-center gap-2">
+                  <Avatar
+                    placeholder={reviewer.profile.name}
+                    className="size-6 shrink-0"
+                  />
+                  <span className="text-base text-neutral-black">
+                    {reviewer.profile.name}
+                  </span>
+                </div>
+                <IconButton
+                  size="small"
+                  isDisabled={isRemoving}
+                  onPress={() =>
+                    removeReviewer.mutate({
+                      processInstanceId,
+                      taxonomyTermId: category.id,
+                      reviewerProfileId: reviewer.reviewerProfileId,
+                    })
+                  }
+                  aria-label={t('Remove {name}', {
+                    name: reviewer.profile.name,
+                  })}
+                >
+                  {isRemoving ? (
+                    <LoadingSpinner className="size-4" color="gray" />
+                  ) : (
+                    <LuX className="size-4" />
+                  )}
+                </IconButton>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCards.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCards.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { trpc } from '@op/api/client';
+import { AlertBanner } from '@op/ui/AlertBanner';
+import { useQueryState } from 'nuqs';
+import { Suspense } from 'react';
+
+import { useTranslations } from '@/lib/i18n';
+
+import ErrorBoundary from '@/components/ErrorBoundary';
+import { ErrorMessage } from '@/components/ErrorMessage';
+
+import { CategoryReviewerCard } from './CategoryReviewerCard';
+
+export interface CategoryReviewerCardsProps {
+  instanceId: string;
+}
+
+/**
+ * By-category reviewer assignment for the Reviews step. Rendered only when the
+ * Scope radio is set to `by_category`. Wraps its suspense-loaded content in a
+ * local error boundary so a cards failure never takes down the Scope radio.
+ */
+export function CategoryReviewerCards({
+  instanceId,
+}: CategoryReviewerCardsProps) {
+  return (
+    <ErrorBoundary fallback={<ErrorMessage />}>
+      <Suspense fallback={<CategoryReviewerCardsSkeleton />}>
+        <CategoryReviewerCardsContent instanceId={instanceId} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+function CategoryReviewerCardsContent({
+  instanceId,
+}: CategoryReviewerCardsProps) {
+  const t = useTranslations();
+  const [, setSection] = useQueryState('section', { history: 'push' });
+
+  const [{ categories }] = trpc.decision.listCategoryReviewers.useSuspenseQuery(
+    {
+      processInstanceId: instanceId,
+    },
+  );
+  const [{ reviewers: eligibleReviewers }] =
+    trpc.decision.listEligibleReviewers.useSuspenseQuery({
+      processInstanceId: instanceId,
+    });
+
+  // No categories to scope reviewers to yet — point the admin at the
+  // Proposal Categories section to define them first.
+  if (categories.length === 0) {
+    return (
+      <AlertBanner variant="banner" intent="warning">
+        {t.rich(
+          'No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.',
+          {
+            link: (chunks: React.ReactNode) => (
+              <button
+                type="button"
+                className="text-primary-teal underline"
+                onClick={() => void setSection('proposalCategories')}
+              >
+                {chunks}
+              </button>
+            ),
+          },
+        )}
+      </AlertBanner>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {eligibleReviewers.length === 0 ? (
+        // Replaces the intro entirely — the intro invites adding reviewers,
+        // which contradicts an alert saying no one can review yet.
+        <AlertBanner variant="banner" intent="warning">
+          {t.rich(
+            'No participants can review yet. Grant review access in <link>Manage Participants</link> to add reviewers here.',
+            {
+              link: (chunks: React.ReactNode) => (
+                <button
+                  type="button"
+                  className="text-primary-teal underline"
+                  onClick={() => void setSection('participants')}
+                >
+                  {chunks}
+                </button>
+              ),
+            },
+          )}
+        </AlertBanner>
+      ) : (
+        <p className="text-base text-neutral-black">
+          {t.rich(
+            'Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.',
+            {
+              link: (chunks: React.ReactNode) => (
+                <button
+                  type="button"
+                  className="text-primary-teal underline"
+                  onClick={() => void setSection('proposalCategories')}
+                >
+                  {chunks}
+                </button>
+              ),
+            },
+          )}
+        </p>
+      )}
+
+      {categories.map((entry) => (
+        <CategoryReviewerCard
+          key={entry.category.id}
+          processInstanceId={instanceId}
+          category={entry.category}
+          reviewers={entry.reviewers}
+          eligibleReviewers={eligibleReviewers}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CategoryReviewerCardsSkeleton() {
+  return (
+    <div className="flex animate-pulse flex-col gap-6">
+      <div className="h-4 w-80 rounded bg-neutral-gray1" />
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <div className="h-4 w-40 rounded bg-neutral-gray1" />
+            <div className="h-4 w-20 rounded bg-neutral-gray1" />
+          </div>
+          <div className="h-10 w-full rounded-lg bg-neutral-gray1" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { trpc } from '@op/api/client';
 import type { InstancePhaseData } from '@op/api/encoders';
 import type { ReviewsScope } from '@op/common';
@@ -17,6 +18,7 @@ import { SaveStatusIndicator } from '../../components/SaveStatusIndicator';
 import { ToggleRow } from '../../components/ToggleRow';
 import type { SectionProps } from '../../contentRegistry';
 import { useProcessBuilderStore } from '../../stores/useProcessBuilderStore';
+import { CategoryReviewerCards } from './CategoryReviewerCards';
 
 interface ReviewSettings {
   scope: ReviewsScope;
@@ -28,6 +30,9 @@ export function ReviewSettingsContent({
   decisionProfileId,
 }: SectionProps) {
   const t = useTranslations();
+  // Gates the by-category scope. When off, the radio stays disabled with a
+  // "Coming soon" chip (pre-flag behavior) and the reviewer cards never render.
+  const byCategoryEnabled = useFeatureFlag('reviews_by_category');
 
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   const config = instance.instanceData?.config;
@@ -125,11 +130,15 @@ export function ReviewSettingsContent({
               </span>
             </div>
           </Radio>
-          <Radio value="by_category" isDisabled className="opacity-50">
+          <Radio
+            value="by_category"
+            isDisabled={!byCategoryEnabled}
+            className={byCategoryEnabled ? undefined : 'opacity-50'}
+          >
             <div className="flex flex-col">
               <span className="flex items-center gap-2 text-base text-neutral-charcoal">
                 {t('By category')}
-                <Chip>{t('Coming soon')}</Chip>
+                {!byCategoryEnabled && <Chip>{t('Coming soon')}</Chip>}
               </span>
               <span className="text-sm text-neutral-gray4">
                 {t(
@@ -139,6 +148,13 @@ export function ReviewSettingsContent({
             </div>
           </Radio>
         </RadioGroup>
+
+        {byCategoryEnabled && settings.scope === 'by_category' && (
+          <>
+            <hr className="border-neutral-gray1" />
+            <CategoryReviewerCards instanceId={instanceId} />
+          </>
+        )}
       </section>
 
       <hr className="border-neutral-gray1" />

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1408,5 +1408,14 @@
   "Reviewers can review any submission": "يمكن للمراجعين مراجعة أي مقترح",
   "By category": "حسب الفئة",
   "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "يتم تعيين كل مراجع لفئة واحدة أو أكثر. تعرض قائمته المقترحات ضمن تلك الفئات فقط.",
+  "Add reviewer…": "إضافة مراجع…",
+  "No participants can review yet. Grant review access in <link>Manage Participants</link> to add reviewers here.": "لا يوجد مشاركون يمكنهم المراجعة بعد. امنح صلاحية المراجعة في <link>إدارة المشاركين</link> لإضافة مراجعين هنا.",
+  "Everyone who can review is already assigned here.": "جميع من يمكنهم المراجعة معيّنون هنا بالفعل.",
+  "No reviewers yet. Proposals in this category can’t be reviewed until someone is added.": "لا يوجد مراجعون بعد. لا يمكن مراجعة المقترحات في هذه الفئة حتى تتم إضافة شخص ما.",
+  "{count, plural, =0 {0 reviewers} =1 {1 reviewer} other {# reviewers}}": "{count, plural, =0 {0 مراجعين} =1 {مراجع واحد} other {# مراجعين}}",
+  "Could not add reviewer. Please try again.": "تعذّرت إضافة المراجع. يرجى المحاولة مرة أخرى.",
+  "Could not remove reviewer. Please try again.": "تعذّرت إزالة المراجع. يرجى المحاولة مرة أخرى.",
+  "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "تأتي الفئات من <link>فئات المقترحات</link>. أضف مراجعين إلى كل فئة أو ادعُ شخصًا جديدًا.",
+  "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "لم يتم العثور على فئات. أضفها في <link>فئات المقترحات</link> لتعيين المراجعين حسب الفئة.",
   "Coming soon": "قريبًا"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1411,5 +1411,14 @@
   "Reviewers can review any submission": "পর্যালোচকরা যেকোনো প্রস্তাব পর্যালোচনা করতে পারেন",
   "By category": "বিভাগ অনুসারে",
   "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "প্রতিটি পর্যালোচককে এক বা একাধিক বিভাগে নিযুক্ত করা হয়। তাদের সারিতে শুধুমাত্র সেই বিভাগগুলির প্রস্তাব দেখানো হয়।",
+  "Add reviewer…": "পর্যালোচক যোগ করুন…",
+  "No participants can review yet. Grant review access in <link>Manage Participants</link> to add reviewers here.": "এখনও কোনো অংশগ্রহণকারী পর্যালোচনা করতে পারেন না। এখানে পর্যালোচক যোগ করতে <link>অংশগ্রহণকারীদের পরিচালনা করুন</link>-এ পর্যালোচনার অ্যাক্সেস দিন।",
+  "Everyone who can review is already assigned here.": "যারা পর্যালোচনা করতে পারেন সবাই ইতিমধ্যে এখানে নিযুক্ত।",
+  "No reviewers yet. Proposals in this category can’t be reviewed until someone is added.": "এখনও কোনো পর্যালোচক নেই। কেউ যোগ না হওয়া পর্যন্ত এই বিভাগের প্রস্তাবগুলি পর্যালোচনা করা যাবে না।",
+  "{count, plural, =0 {0 reviewers} =1 {1 reviewer} other {# reviewers}}": "{count, plural, =0 {0 জন পর্যালোচক} =1 {1 জন পর্যালোচক} other {# জন পর্যালোচক}}",
+  "Could not add reviewer. Please try again.": "পর্যালোচক যোগ করা যায়নি। আবার চেষ্টা করুন।",
+  "Could not remove reviewer. Please try again.": "পর্যালোচক সরানো যায়নি। আবার চেষ্টা করুন।",
+  "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "বিভাগগুলি <link>প্রস্তাব বিভাগসমূহ</link> থেকে আসে। প্রতিটিতে পর্যালোচক যোগ করুন, বা নতুন কাউকে আমন্ত্রণ জানান।",
+  "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "কোনো বিভাগ পাওয়া যায়নি। বিভাগ অনুযায়ী পর্যালোচক নিযুক্ত করতে <link>প্রস্তাব বিভাগসমূহ</link>-এ সেগুলি যোগ করুন।",
   "Coming soon": "শীঘ্রই আসছে"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1417,5 +1417,14 @@
   "Reviewers can review any submission": "Reviewers can review any submission",
   "By category": "By category",
   "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.",
+  "Add reviewer…": "Add reviewer…",
+  "No participants can review yet. Grant review access in <link>Manage Participants</link> to add reviewers here.": "No participants can review yet. Grant review access in <link>Manage Participants</link> to add reviewers here.",
+  "Everyone who can review is already assigned here.": "Everyone who can review is already assigned here.",
+  "No reviewers yet. Proposals in this category can’t be reviewed until someone is added.": "No reviewers yet. Proposals in this category can’t be reviewed until someone is added.",
+  "{count, plural, =0 {0 reviewers} =1 {1 reviewer} other {# reviewers}}": "{count, plural, =0 {0 reviewers} =1 {1 reviewer} other {# reviewers}}",
+  "Could not add reviewer. Please try again.": "Could not add reviewer. Please try again.",
+  "Could not remove reviewer. Please try again.": "Could not remove reviewer. Please try again.",
+  "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.",
+  "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.",
   "Coming soon": "Coming soon"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1408,5 +1408,14 @@
   "Reviewers can review any submission": "Las personas revisoras pueden revisar cualquier propuesta",
   "By category": "Por categoría",
   "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Cada persona revisora se asigna a una o más categorías. Su cola muestra solo las propuestas de esas categorías.",
+  "Add reviewer…": "Agregar persona revisora…",
+  "No participants can review yet. Grant review access in <link>Manage Participants</link> to add reviewers here.": "Aún no hay participantes que puedan evaluar. Otorga acceso de evaluación en <link>Gestionar Participantes</link> para agregar personas revisoras aquí.",
+  "Everyone who can review is already assigned here.": "Todas las personas que pueden evaluar ya están asignadas aquí.",
+  "No reviewers yet. Proposals in this category can’t be reviewed until someone is added.": "Aún no hay personas revisoras. Las propuestas de esta categoría no se pueden evaluar hasta que se agregue a alguien.",
+  "{count, plural, =0 {0 reviewers} =1 {1 reviewer} other {# reviewers}}": "{count, plural, =0 {0 personas revisoras} =1 {1 persona revisora} other {# personas revisoras}}",
+  "Could not add reviewer. Please try again.": "No se pudo agregar la persona revisora. Inténtalo de nuevo.",
+  "Could not remove reviewer. Please try again.": "No se pudo quitar la persona revisora. Inténtalo de nuevo.",
+  "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "Las categorías provienen de <link>Categorías de propuestas</link>. Agrega personas revisoras a cada una o invita a alguien nuevo.",
+  "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "No se encontraron categorías. Agrégalas en <link>Categorías de propuestas</link> para asignar personas revisoras por categoría.",
   "Coming soon": "Próximamente"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1408,5 +1408,14 @@
   "Reviewers can review any submission": "Les évaluateurs peuvent évaluer n’importe quelle proposition",
   "By category": "Par catégorie",
   "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Chaque évaluateur est affecté à une ou plusieurs catégories. Sa file d’attente n’affiche que les propositions de ces catégories.",
+  "Add reviewer…": "Ajouter un évaluateur…",
+  "No participants can review yet. Grant review access in <link>Manage Participants</link> to add reviewers here.": "Aucun participant ne peut encore évaluer. Accordez l’accès d’évaluation dans <link>Gérer les Participants</link> pour ajouter des évaluateurs ici.",
+  "Everyone who can review is already assigned here.": "Toutes les personnes pouvant évaluer sont déjà affectées ici.",
+  "No reviewers yet. Proposals in this category can’t be reviewed until someone is added.": "Aucun évaluateur pour l’instant. Les propositions de cette catégorie ne peuvent pas être évaluées tant que personne n’est ajouté.",
+  "{count, plural, =0 {0 reviewers} =1 {1 reviewer} other {# reviewers}}": "{count, plural, =0 {0 évaluateur} =1 {1 évaluateur} other {# évaluateurs}}",
+  "Could not add reviewer. Please try again.": "Impossible d’ajouter l’évaluateur. Veuillez réessayer.",
+  "Could not remove reviewer. Please try again.": "Impossible de retirer l’évaluateur. Veuillez réessayer.",
+  "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "Les catégories proviennent de <link>Catégories de propositions</link>. Ajoutez des évaluateurs à chacune ou invitez une nouvelle personne.",
+  "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "Aucune catégorie trouvée. Ajoutez-en dans <link>Catégories de propositions</link> pour affecter des évaluateurs par catégorie.",
   "Coming soon": "Bientôt disponible"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1408,5 +1408,14 @@
   "Reviewers can review any submission": "Os avaliadores podem avaliar qualquer proposta",
   "By category": "Por categoria",
   "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Cada avaliador é atribuído a uma ou mais categorias. Sua fila mostra apenas as propostas dessas categorias.",
+  "Add reviewer…": "Adicionar avaliador…",
+  "No participants can review yet. Grant review access in <link>Manage Participants</link> to add reviewers here.": "Ainda não há participantes que possam avaliar. Conceda acesso de avaliação em <link>Gerenciar Participantes</link> para adicionar avaliadores aqui.",
+  "Everyone who can review is already assigned here.": "Todos que podem avaliar já estão atribuídos aqui.",
+  "No reviewers yet. Proposals in this category can’t be reviewed until someone is added.": "Ainda não há avaliadores. As propostas desta categoria não podem ser avaliadas até que alguém seja adicionado.",
+  "{count, plural, =0 {0 reviewers} =1 {1 reviewer} other {# reviewers}}": "{count, plural, =0 {0 avaliadores} =1 {1 avaliador} other {# avaliadores}}",
+  "Could not add reviewer. Please try again.": "Não foi possível adicionar o avaliador. Tente novamente.",
+  "Could not remove reviewer. Please try again.": "Não foi possível remover o avaliador. Tente novamente.",
+  "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "As categorias vêm de <link>Categorias de propostas</link>. Adicione avaliadores a cada uma ou convide alguém novo.",
+  "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "Nenhuma categoria encontrada. Adicione-as em <link>Categorias de propostas</link> para atribuir avaliadores por categoria.",
   "Coming soon": "Em breve"
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1410,5 +1410,14 @@
   "Reviewers can review any submission": "Dib-u-eegayaashu waxay dib u eegi karaan soo jeedin kasta",
   "By category": "Qaybta ahaan",
   "Each reviewer is assigned to one or more categories. Their queue shows only proposals in those categories.": "Dib-u-eege kasta waxaa loo xilsaaraa hal ama in ka badan oo qaybo ah. Safkiisu wuxuu tusayaa oo kaliya soo jeedinta qaybahaas ku jira.",
+  "Add reviewer…": "Ku dar dib-u-eege…",
+  "No participants can review yet. Grant review access in <link>Manage Participants</link> to add reviewers here.": "Weli ma jiraan ka-qaybgalayaal wax eegi kara. Sii fasax eegis <link>Maamul Ka qaybgalayaasha</link> si aad halkan ugu darto dib-u-eegayaal.",
+  "Everyone who can review is already assigned here.": "Dhammaan kuwa wax eegi kara horey ayaa halkan loogu xilsaaray.",
+  "No reviewers yet. Proposals in this category can’t be reviewed until someone is added.": "Weli dib-u-eege ma jiro. Soo jeedinta qaybtan lama eegi karo ilaa qof la daro.",
+  "{count, plural, =0 {0 reviewers} =1 {1 reviewer} other {# reviewers}}": "{count, plural, =0 {0 dib-u-eege} =1 {1 dib-u-eege} other {# dib-u-eege}}",
+  "Could not add reviewer. Please try again.": "Lama darin dib-u-eegaha. Fadlan mar kale isku day.",
+  "Could not remove reviewer. Please try again.": "Lama saarin dib-u-eegaha. Fadlan mar kale isku day.",
+  "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "Qaybaha waxay ka yimaadaan <link>Qaybaha Soo Jeedinta</link>. Ku dar dib-u-eegayaal mid kasta, ama ku casuum qof cusub.",
+  "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "Lama helin qaybo. Ku dar <link>Qaybaha Soo Jeedinta</link> si aad u qoondayso dib-u-eegayaal qayb ahaan.",
   "Coming soon": "Waa iman doonaa dhakhso"
 }

--- a/packages/common/src/services/decision/addCategoryReviewer.ts
+++ b/packages/common/src/services/decision/addCategoryReviewer.ts
@@ -20,7 +20,7 @@ export async function addCategoryReviewer({
   taxonomyTermId: string;
   reviewerProfileId: string;
   phaseId?: string;
-  user: User | undefined;
+  user: User;
 }): Promise<CategoryReviewer> {
   await assertCategoryReviewerAdmin({ processInstanceId, user });
 

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -74,6 +74,7 @@ export * from './listProposalSubmitters';
 export * from './getReviewAssignment';
 export * from './listReviewAssignments';
 export * from './listCategoryReviewers';
+export * from './listEligibleReviewers';
 export * from './addCategoryReviewer';
 export * from './removeCategoryReviewer';
 export * from './listProposalsWithReviewAggregates';

--- a/packages/common/src/services/decision/listCategoryReviewers.ts
+++ b/packages/common/src/services/decision/listCategoryReviewers.ts
@@ -34,7 +34,7 @@ export async function listCategoryReviewers({
 }: {
   processInstanceId: string;
   phaseId?: string;
-  user: User | undefined;
+  user: User;
 }): Promise<CategoryWithReviewers[]> {
   const categories = await getProcessCategories({ processInstanceId, user });
 

--- a/packages/common/src/services/decision/listEligibleReviewers.ts
+++ b/packages/common/src/services/decision/listEligibleReviewers.ts
@@ -1,0 +1,65 @@
+import { db } from '@op/db/client';
+import type { User } from '@op/supabase/lib';
+
+import { assertCategoryReviewerAdmin } from './categoryReviewerHelpers';
+import { getEligibleReviewerProfileIds } from './getEligibleReviewerProfileIds';
+import type { EligibleReviewerSchema } from './schemas/reviews';
+
+/** Picker row shape, derived from the API encoder so the two can't drift. */
+export type EligibleReviewer = EligibleReviewerSchema;
+
+/**
+ * Display data (name/slug/avatar/email) for every profile currently holding the
+ * REVIEW capability on the decision — the candidate set for the category
+ * reviewer picker (PR 7, assign-only). Purpose-built for the combobox: it does
+ * NOT reuse the unfiltered Participants list, so only role-holders can be added
+ * to a category's scope (scope ≠ capability, Decision 7). Admin-gated. Results
+ * are ordered by name in SQL. Category-level exclusion of already-assigned
+ * reviewers is done client-side by the card so the same candidate set serves
+ * every category.
+ */
+export async function listEligibleReviewers({
+  processInstanceId,
+  search,
+  user,
+}: {
+  processInstanceId: string;
+  search?: string;
+  user: User;
+}): Promise<EligibleReviewer[]> {
+  const instance = await assertCategoryReviewerAdmin({
+    processInstanceId,
+    user,
+  });
+
+  if (!instance.profileId) {
+    return [];
+  }
+
+  const eligibleIds = await getEligibleReviewerProfileIds({
+    decisionProfileId: instance.profileId,
+  });
+
+  if (eligibleIds.length === 0) {
+    return [];
+  }
+
+  const trimmed = search?.trim();
+  const searchPattern =
+    trimmed && trimmed.length >= 2 ? `%${trimmed}%` : undefined;
+
+  return db.query.profiles.findMany({
+    columns: {
+      id: true,
+      name: true,
+      slug: true,
+      avatarImageId: true,
+      email: true,
+    },
+    where: {
+      id: { in: eligibleIds },
+      ...(searchPattern && { name: { ilike: searchPattern } }),
+    },
+    orderBy: { name: 'asc' },
+  });
+}

--- a/packages/common/src/services/decision/removeCategoryReviewer.ts
+++ b/packages/common/src/services/decision/removeCategoryReviewer.ts
@@ -19,7 +19,7 @@ export async function removeCategoryReviewer({
   taxonomyTermId: string;
   reviewerProfileId: string;
   phaseId?: string;
-  user: User | undefined;
+  user: User;
 }): Promise<{ removed: boolean }> {
   await assertCategoryReviewerAdmin({ processInstanceId, user });
 

--- a/packages/common/src/services/decision/schemas/reviews.ts
+++ b/packages/common/src/services/decision/schemas/reviews.ts
@@ -327,3 +327,24 @@ export const categoryReviewerTargetSchema = z.object({
   // '' would collide with the instance-wide NULL key.
   phaseId: z.string().min(1).optional(),
 });
+
+/**
+ * Candidate reviewer surfaced in the "Add reviewer…" picker. email is included
+ * so the admin can disambiguate people sharing a display name.
+ */
+export const eligibleReviewerSchema = createSelectSchema(profiles)
+  .pick({
+    name: true,
+    slug: true,
+    avatarImageId: true,
+    email: true,
+  })
+  .extend({
+    id: z.uuid(),
+  });
+
+export type EligibleReviewerSchema = z.infer<typeof eligibleReviewerSchema>;
+
+export const eligibleReviewersListSchema = z.object({
+  reviewers: z.array(eligibleReviewerSchema),
+});

--- a/services/api/src/routers/decision/reviews/index.ts
+++ b/services/api/src/routers/decision/reviews/index.ts
@@ -3,6 +3,7 @@ import { addCategoryReviewerRouter } from './addCategoryReviewer';
 import { cancelRevisionRequestRouter } from './cancelRevisionRequest';
 import { getReviewAssignmentRouter } from './getReviewAssignment';
 import { listCategoryReviewersRouter } from './listCategoryReviewers';
+import { listEligibleReviewersRouter } from './listEligibleReviewers';
 import { listProposalRevisionRequestsRouter } from './listProposalRevisionRequests';
 import { listProposalsRevisionRequestsRouter } from './listProposalsRevisionRequests';
 import { listReviewAssignmentsRouter } from './listReviewAssignments';
@@ -17,6 +18,7 @@ export const reviewsRouter = mergeRouters(
   cancelRevisionRequestRouter,
   getReviewAssignmentRouter,
   listCategoryReviewersRouter,
+  listEligibleReviewersRouter,
   listProposalRevisionRequestsRouter,
   listProposalsRevisionRequestsRouter,
   listReviewAssignmentsRouter,

--- a/services/api/src/routers/decision/reviews/listEligibleReviewers.test.ts
+++ b/services/api/src/routers/decision/reviews/listEligibleReviewers.test.ts
@@ -1,0 +1,169 @@
+import { createDecisionRole } from '@op/common';
+import { db, eq } from '@op/db/client';
+import { profiles, users } from '@op/db/schema';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+/** A "Reviewer" role on the decision profile with only the REVIEW bit set. */
+async function createReviewerRole(instanceProfileId: string) {
+  return createDecisionRole({
+    name: 'Reviewer',
+    profileId: instanceProfileId,
+    permissions: {
+      decisions: {
+        type: 'decision',
+        value: {
+          create: false,
+          read: true,
+          update: false,
+          delete: false,
+          admin: false,
+          inviteMembers: false,
+          review: true,
+          submitProposals: false,
+          vote: false,
+        },
+      },
+    },
+  });
+}
+
+describe.concurrent('listEligibleReviewers', () => {
+  it('returns role-holders (incl. the admin) and excludes non-reviewers', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instanceId = setup.instance.instance.id;
+    const instanceProfileId = setup.instance.profileId;
+
+    const [creator] = await db
+      .select({ profileId: users.profileId })
+      .from(users)
+      .where(eq(users.authUserId, setup.user.id));
+
+    const reviewerRole = await createReviewerRole(instanceProfileId);
+
+    // reviewerA holds the REVIEW bit; memberC is a plain member without it.
+    const [reviewerA, memberC] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instanceProfileId],
+        roleIds: { [instanceProfileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instanceProfileId],
+      }),
+    ]);
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await adminCaller.decision.listEligibleReviewers({
+      processInstanceId: instanceId,
+    });
+
+    const ids = result.reviewers.map((r) => r.id);
+
+    // The admin's default decision role carries REVIEW, so the creator is
+    // eligible too.
+    expect(ids).toContain(creator!.profileId);
+    expect(ids).toContain(reviewerA.profileId);
+    // A member without the REVIEW capability must never surface as a candidate.
+    expect(ids).not.toContain(memberC.profileId);
+
+    // Display shape: purpose-built picker fields are present.
+    const entry = result.reviewers.find((r) => r.id === reviewerA.profileId);
+    expect(entry).toMatchObject({
+      id: reviewerA.profileId,
+      name: expect.any(String),
+      slug: expect.any(String),
+    });
+    expect(entry).toHaveProperty('avatarImageId');
+    expect(entry).toHaveProperty('email');
+  });
+
+  it('filters candidates by the search term', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instanceId = setup.instance.instance.id;
+    const instanceProfileId = setup.instance.profileId;
+
+    const reviewerRole = await createReviewerRole(instanceProfileId);
+    const reviewerA = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instanceProfileId],
+      roleIds: { [instanceProfileId]: reviewerRole.id },
+    });
+
+    const [reviewerProfile] = await db
+      .select({ name: profiles.name })
+      .from(profiles)
+      .where(eq(profiles.id, reviewerA.profileId));
+    const reviewerName = reviewerProfile!.name;
+
+    const adminCaller = await createAuthenticatedCaller(setup.userEmail);
+
+    const matched = await adminCaller.decision.listEligibleReviewers({
+      processInstanceId: instanceId,
+      search: reviewerName,
+    });
+    expect(matched.reviewers.map((r) => r.id)).toContain(reviewerA.profileId);
+
+    // A term that matches no name excludes the reviewer (and yields no rows).
+    const unmatched = await adminCaller.decision.listEligibleReviewers({
+      processInstanceId: instanceId,
+      search: 'zzz-no-such-reviewer-name',
+    });
+    expect(unmatched.reviewers.map((r) => r.id)).not.toContain(
+      reviewerA.profileId,
+    );
+  });
+
+  it('rejects non-admin callers', async ({ task, onTestFinished }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const instanceId = setup.instance.instance.id;
+
+    // Member has READ but no ADMIN on the instance profile.
+    const member = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [setup.instance.profileId],
+    });
+
+    const memberCaller = await createAuthenticatedCaller(member.email);
+
+    await expect(
+      memberCaller.decision.listEligibleReviewers({
+        processInstanceId: instanceId,
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+  });
+});

--- a/services/api/src/routers/decision/reviews/listEligibleReviewers.ts
+++ b/services/api/src/routers/decision/reviews/listEligibleReviewers.ts
@@ -1,0 +1,24 @@
+import { eligibleReviewersListSchema, listEligibleReviewers } from '@op/common';
+import { z } from 'zod';
+
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+
+export const listEligibleReviewersRouter = router({
+  listEligibleReviewers: networkAuthenticatedProcedure()
+    .input(
+      z.object({
+        processInstanceId: z.uuid(),
+        search: z.string().optional(),
+      }),
+    )
+    .output(eligibleReviewersListSchema)
+    .query(async ({ ctx, input }) => {
+      const reviewers = await listEligibleReviewers({
+        processInstanceId: input.processInstanceId,
+        search: input.search,
+        user: ctx.user,
+      });
+
+      return { reviewers };
+    }),
+});


### PR DESCRIPTION
Lets a decision admin assign reviewers per submission category from the Reviews builder step when scope is by_category, replacing the earlier "coming soon" placeholder.

The "Add reviewer…" picker lists only people who already hold the review role — adding writes a category-reviewer scope row and never grants a role, and removing a chip deletes the scope row only. Inviting someone new is intentionally out of scope here.