### PR TITLE
feat(decision): reconcile by-category assignments on scope/category change

### DIFF
--- a/packages/common/src/services/decision/addCategoryReviewer.ts
+++ b/packages/common/src/services/decision/addCategoryReviewer.ts
@@ -4,6 +4,7 @@ import type { User } from '@op/supabase/lib';
 
 import { NotFoundError } from '../../utils';
 import { assertCategoryReviewerAdmin } from './categoryReviewerHelpers';
+import { reconcileReviewAssignments } from './reconcileReviewAssignments';
 
 /**
  * Adds a reviewer to a category's scope (admin-gated), idempotent via ON
@@ -35,25 +36,33 @@ export async function addCategoryReviewer({
     .onConflictDoNothing()
     .returning();
 
-  if (inserted) {
-    return inserted;
-  }
-
-  // Conflict: the row already existed (RETURNING is empty on DO NOTHING), so
-  // re-select it to stay idempotent.
-  const row = await db.query.categoryReviewers.findFirst({
-    where: {
-      processInstanceId,
-      taxonomyTermId,
-      reviewerProfileId,
-      phaseId: phaseId ?? { isNull: true },
-    },
-  });
+  // On conflict RETURNING is empty (DO NOTHING), so re-select the pre-existing
+  // row to stay idempotent.
+  const row =
+    inserted ??
+    (await db.query.categoryReviewers.findFirst({
+      where: {
+        processInstanceId,
+        taxonomyTermId,
+        reviewerProfileId,
+        phaseId: phaseId ?? { isNull: true },
+      },
+    }));
 
   if (!row) {
     // Only reachable if the row was removed concurrently between the two statements.
     throw new NotFoundError('Category reviewer could not be resolved');
   }
+
+  // Mid-phase add: immediately create the newly-justified assignments for this
+  // category's in-phase proposals (add-only — the reconcile prunes nothing on
+  // an add). Runs on both the fresh-insert and already-present paths so a
+  // first-time scope add backfills. A no-op unless the instance is in a live
+  // by_category review phase.
+  await reconcileReviewAssignments({
+    instanceId: processInstanceId,
+    affected: { taxonomyTermId },
+  });
 
   return row;
 }

--- a/packages/common/src/services/decision/getCategoryReviewersByProposal.ts
+++ b/packages/common/src/services/decision/getCategoryReviewersByProposal.ts
@@ -1,4 +1,12 @@
-import { and, db, eq, inArray, isNull, or } from '@op/db/client';
+import {
+  type DbClient,
+  and,
+  db as defaultDb,
+  eq,
+  inArray,
+  isNull,
+  or,
+} from '@op/db/client';
 import { categoryReviewers, proposalCategories } from '@op/db/schema';
 
 /**
@@ -10,15 +18,21 @@ import { categoryReviewers, proposalCategories } from '@op/db/schema';
  * user action). Callers MUST still intersect with getEligibleReviewerProfileIds
  * — a scope row alone grants nothing (fail-closed). Scope rows resolve
  * instance-wide (`phaseId IS NULL`) unioned with rows for this review phase.
+ *
+ * The optional `db` client lets the reconciler run this join inside the same
+ * transaction that just mutated `proposalCategories`, so it reads the new
+ * category set rather than the committed one.
  */
 export async function getCategoryReviewersByProposal({
   instanceId,
   phaseId,
   proposalIds,
+  db = defaultDb,
 }: {
   instanceId: string;
   phaseId: string;
   proposalIds: string[];
+  db?: DbClient;
 }): Promise<Map<string, Set<string>>> {
   const reviewersByProposalId = new Map<string, Set<string>>();
 

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -69,6 +69,7 @@ export * from './listAllProposals';
 export * from './generateReviewAssignments';
 export * from './runGenerateReviewAssignments';
 export * from './backfillReviewAssignments';
+export * from './reconcileReviewAssignments';
 export * from './getEligibleReviewerProfileIds';
 export * from './listProposalSubmitters';
 export * from './getReviewAssignment';

--- a/packages/common/src/services/decision/insertReviewAssignments.ts
+++ b/packages/common/src/services/decision/insertReviewAssignments.ts
@@ -1,4 +1,4 @@
-import { db } from '@op/db/client';
+import { type DbClient, db as defaultDb } from '@op/db/client';
 import { proposalReviewAssignments } from '@op/db/schema';
 
 export interface AssignableProposal {
@@ -18,16 +18,19 @@ export interface AssignableProposal {
  * self-review — and inserts them. `onConflictDoNothing` on the (instance,
  * proposal, reviewer, phase) unique constraint makes re-runs safe and dedupes
  * overlapping per-proposal sets. Returns the number of rows inserted. Shared
- * by generation and backfill.
+ * by generation, backfill, and the on-change reconciler — the optional `db`
+ * client lets a caller run the insert inside its own transaction.
  */
 export async function insertReviewAssignments({
   instanceId,
   phaseId,
   assignableProposals,
+  db = defaultDb,
 }: {
   instanceId: string;
   phaseId: string;
   assignableProposals: AssignableProposal[];
+  db?: DbClient;
 }): Promise<number> {
   const values = assignableProposals.flatMap((proposal) =>
     proposal.reviewerProfileIds

--- a/packages/common/src/services/decision/reconcileReviewAssignments.ts
+++ b/packages/common/src/services/decision/reconcileReviewAssignments.ts
@@ -1,0 +1,282 @@
+import {
+  type DbClient,
+  and,
+  db as defaultDb,
+  eq,
+  inArray,
+} from '@op/db/client';
+import {
+  ProcessStatus,
+  ProposalReviewAssignmentStatus,
+  ProposalStatus,
+  proposalCategories,
+  proposalReviewAssignments,
+} from '@op/db/schema';
+import { logger } from '@op/logging';
+
+import { getCategoryReviewersByProposal } from './getCategoryReviewersByProposal';
+import { getEligibleReviewerProfileIds } from './getEligibleReviewerProfileIds';
+import {
+  type AssignableProposal,
+  insertReviewAssignments,
+} from './insertReviewAssignments';
+import type { DecisionInstanceData } from './schemas/instanceData';
+import { assertInstancePhase } from './utils/instance';
+import { getPhaseReviewSettings, isReviewPhase } from './utils/phaseSettings';
+
+/**
+ * What triggered the reconcile, and therefore which proposals to re-diff:
+ * a set of proposals directly (a proposal changed its categories), or a
+ * category whose scope rows changed (reconcile that category's in-phase
+ * proposals).
+ */
+export type ReconcileAffected =
+  | { proposalIds: string[] }
+  | { taxonomyTermId: string };
+
+export interface ReconcileReviewAssignmentsInput {
+  instanceId: string;
+  affected: ReconcileAffected;
+  /**
+   * Run the reconcile inside a caller-supplied transaction — used by the
+   * `setProposalCategories` callers so a category change and its assignment
+   * fix-up commit atomically. Defaults to the shared client.
+   */
+  db?: DbClient;
+}
+
+export type ReconcileReviewAssignmentsResult =
+  | { skipped: string }
+  | { inserted: number; deleted: number; proposalCount: number };
+
+/** Only `pending` assignments may be pruned (§3) — see {@link reconcileReviewAssignments}. */
+const PRUNABLE_STATUS = ProposalReviewAssignmentStatus.PENDING;
+
+/**
+ * Declarative, on-change reconcile of `by_category` review assignments for the
+ * proposals touched by a category-related change (a scope-row add/remove, or a
+ * proposal's category set changing) mid-phase.
+ *
+ * For each affected proposal the expected reviewer set is its scope rows ⨝ its
+ * current categories, intersected with the eligible reviewers
+ * (`getEligibleReviewerProfileIds`, Decision 7 fail-closed) and minus the
+ * author. The diff against the existing assignment rows is applied as:
+ *   - INSERT the newly-justified assignments (add-only, `onConflictDoNothing`);
+ *   - DELETE existing-but-no-longer-expected assignments — but ONLY status
+ *     `pending` (§3). A non-pending assignment owns `proposalReviews` /
+ *     `proposal_review_requests` rows that cascade-delete with it, so removal
+ *     never retracts submitted or in-flight work; it only stops future work.
+ *
+ * A no-op (logged skip) unless the instance is published, in a review-capable
+ * phase, with `scope === 'by_category'`. The proposal universe is the phase's
+ * inbound-transition attachment set (matching generation/backfill), so inserts
+ * carry the same `assignedProposalHistoryId` and proposals not in the phase are
+ * ignored.
+ */
+export async function reconcileReviewAssignments({
+  instanceId,
+  affected,
+  db = defaultDb,
+}: ReconcileReviewAssignmentsInput): Promise<ReconcileReviewAssignmentsResult> {
+  const skip = (reason: string): ReconcileReviewAssignmentsResult => {
+    logger.info('reconcileReviewAssignments: skipped', { instanceId, reason });
+    return { skipped: reason };
+  };
+
+  const instance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+
+  if (!instance) {
+    return skip('instance not found');
+  }
+  if (instance.status !== ProcessStatus.PUBLISHED) {
+    return skip(`instance is not published (status: ${instance.status})`);
+  }
+  if (!instance.profileId) {
+    return skip('instance has no profileId');
+  }
+  const currentPhaseId = instance.currentStateId;
+  if (!currentPhaseId) {
+    return skip('instance has no current phase');
+  }
+
+  const instanceData = instance.instanceData as DecisionInstanceData;
+  const currentPhase = assertInstancePhase({
+    instance: { instanceData },
+    phaseId: currentPhaseId,
+  });
+  if (!isReviewPhase(currentPhase)) {
+    return skip('current phase is not review-capable');
+  }
+  if (
+    getPhaseReviewSettings(instanceData, currentPhaseId).scope !== 'by_category'
+  ) {
+    return skip('current phase scope is not by_category');
+  }
+
+  // Most recent transition INTO the current phase — its attachment set defines
+  // the proposal universe (and the assigned history ids), exactly as
+  // generation/backfill see it.
+  const inboundTransition = await db.query.stateTransitionHistory.findFirst({
+    where: { processInstanceId: instanceId, toStateId: currentPhaseId },
+    orderBy: { transitionedAt: 'desc' },
+    columns: { id: true },
+  });
+  if (!inboundTransition) {
+    return skip('current phase has no inbound transition');
+  }
+
+  const attachedProposals = await db.query.decisionTransitionProposals.findMany(
+    {
+      where: {
+        transitionHistoryId: inboundTransition.id,
+        proposal: {
+          status: { ne: ProposalStatus.DRAFT },
+          deletedAt: { isNull: true },
+          moderationDetachedAt: { isNull: true },
+        },
+      },
+      columns: { proposalId: true, proposalHistoryId: true },
+      with: { proposal: { columns: { submittedByProfileId: true } } },
+    },
+  );
+
+  const attachedByProposalId = new Map(
+    attachedProposals.map((row) => [row.proposalId, row]),
+  );
+  const attachedIds = [...attachedByProposalId.keys()];
+
+  const affectedIds = await resolveAffectedProposalIds({
+    db,
+    affected,
+    attachedByProposalId,
+    attachedIds,
+  });
+
+  if (affectedIds.length === 0) {
+    return { inserted: 0, deleted: 0, proposalCount: 0 };
+  }
+
+  const [scopedByProposal, eligibleReviewerProfileIds, existingRows] =
+    await Promise.all([
+      getCategoryReviewersByProposal({
+        db,
+        instanceId,
+        phaseId: currentPhaseId,
+        proposalIds: affectedIds,
+      }),
+      getEligibleReviewerProfileIds({ decisionProfileId: instance.profileId }),
+      db.query.proposalReviewAssignments.findMany({
+        where: {
+          processInstanceId: instanceId,
+          phaseId: currentPhaseId,
+          proposalId: { in: affectedIds },
+        },
+        columns: {
+          id: true,
+          proposalId: true,
+          reviewerProfileId: true,
+          status: true,
+        },
+      }),
+    ]);
+
+  const eligibleSet = new Set(eligibleReviewerProfileIds);
+
+  const existingByProposalId = new Map<string, typeof existingRows>();
+  for (const row of existingRows) {
+    const bucket = existingByProposalId.get(row.proposalId) ?? [];
+    bucket.push(row);
+    existingByProposalId.set(row.proposalId, bucket);
+  }
+
+  const assignableProposals: AssignableProposal[] = affectedIds.map(
+    (proposalId) => {
+      const attached = attachedByProposalId.get(proposalId)!;
+      const scoped = scopedByProposal.get(proposalId) ?? new Set<string>();
+      return {
+        proposalId,
+        submittedByProfileId: attached.proposal.submittedByProfileId,
+        assignedProposalHistoryId: attached.proposalHistoryId,
+        reviewerProfileIds: [...scoped].filter((id) => eligibleSet.has(id)),
+      };
+    },
+  );
+
+  const inserted = await insertReviewAssignments({
+    db,
+    instanceId,
+    phaseId: currentPhaseId,
+    assignableProposals,
+  });
+
+  // Prune existing-but-no-longer-expected assignments — pending only (§3). Self
+  // is never in the expected set (insertReviewAssignments excludes it), so an
+  // author never has a prunable self-assignment to begin with.
+  const idsToDelete: string[] = [];
+  for (const proposal of assignableProposals) {
+    const expected = new Set(
+      proposal.reviewerProfileIds.filter(
+        (id) => id !== proposal.submittedByProfileId,
+      ),
+    );
+    for (const row of existingByProposalId.get(proposal.proposalId) ?? []) {
+      if (
+        row.status === PRUNABLE_STATUS &&
+        !expected.has(row.reviewerProfileId)
+      ) {
+        idsToDelete.push(row.id);
+      }
+    }
+  }
+
+  let deleted = 0;
+  if (idsToDelete.length > 0) {
+    const deletedRows = await db
+      .delete(proposalReviewAssignments)
+      .where(inArray(proposalReviewAssignments.id, idsToDelete))
+      .returning({ id: proposalReviewAssignments.id });
+    deleted = deletedRows.length;
+  }
+
+  return { inserted, deleted, proposalCount: affectedIds.length };
+}
+
+/**
+ * Narrows the reconcile to the proposals the triggering change actually
+ * touched, always within the phase's attachment set: a direct proposal set
+ * (recategorization), or the in-phase proposals tagged with a changed category
+ * (a scope-row add/remove).
+ */
+async function resolveAffectedProposalIds({
+  db,
+  affected,
+  attachedByProposalId,
+  attachedIds,
+}: {
+  db: DbClient;
+  affected: ReconcileAffected;
+  attachedByProposalId: Map<string, unknown>;
+  attachedIds: string[];
+}): Promise<string[]> {
+  if ('proposalIds' in affected) {
+    return affected.proposalIds.filter((id) => attachedByProposalId.has(id));
+  }
+
+  if (attachedIds.length === 0) {
+    return [];
+  }
+
+  const rows = await db
+    .select({ proposalId: proposalCategories.proposalId })
+    .from(proposalCategories)
+    .where(
+      and(
+        eq(proposalCategories.taxonomyTermId, affected.taxonomyTermId),
+        inArray(proposalCategories.proposalId, attachedIds),
+      ),
+    );
+
+  return [...new Set(rows.map((row) => row.proposalId))];
+}

--- a/packages/common/src/services/decision/removeCategoryReviewer.ts
+++ b/packages/common/src/services/decision/removeCategoryReviewer.ts
@@ -3,10 +3,13 @@ import { categoryReviewers } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 
 import { assertCategoryReviewerAdmin } from './categoryReviewerHelpers';
+import { reconcileReviewAssignments } from './reconcileReviewAssignments';
 
 /**
  * Removes a reviewer from a category's scope (admin-gated), idempotent (no
- * match reports `removed: false`). Only the scope row is touched.
+ * match reports `removed: false`). The scope row is deleted, then the
+ * reconciler prunes this category's now-unjustified `pending` assignments
+ * (§3 — non-pending assignments are kept). `phaseId` omitted = instance-wide.
  */
 export async function removeCategoryReviewer({
   processInstanceId,
@@ -37,5 +40,17 @@ export async function removeCategoryReviewer({
     )
     .returning({ id: categoryReviewers.id });
 
-  return { removed: deleted.length > 0 };
+  const removed = deleted.length > 0;
+
+  // Only reconcile when a scope row actually went away: prune the pending
+  // assignments this category no longer justifies. A no-op unless the instance
+  // is in a live by_category review phase.
+  if (removed) {
+    await reconcileReviewAssignments({
+      instanceId: processInstanceId,
+      affected: { taxonomyTermId },
+    });
+  }
+
+  return { removed };
 }

--- a/packages/common/src/services/decision/submitProposal.test.ts
+++ b/packages/common/src/services/decision/submitProposal.test.ts
@@ -64,6 +64,10 @@ vi.mock('./setProposalCategories', () => ({
   setProposalCategories: vi.fn(),
 }));
 
+vi.mock('./reconcileReviewAssignments', () => ({
+  reconcileReviewAssignments: vi.fn(),
+}));
+
 vi.mock('./syncProposalProfileLocation', () => ({
   syncProposalProfileLocation: vi.fn(),
 }));

--- a/packages/common/src/services/decision/submitProposal.ts
+++ b/packages/common/src/services/decision/submitProposal.ts
@@ -12,6 +12,7 @@ import {
   normalizeProposalCategories,
   parseProposalData,
 } from './proposalDataSchema';
+import { reconcileReviewAssignments } from './reconcileReviewAssignments';
 import { hasDecisionBoundaries, resolveBoundary } from './resolveBoundary';
 import { resolveProposalTemplate } from './resolveProposalTemplate';
 import type { DecisionInstanceData } from './schemas/instanceData';
@@ -221,6 +222,15 @@ export const submitProposal = async ({
         tx,
         proposalId: submittedProposal.id,
         labels: categoryLabels,
+      });
+      // Keep by-category assignments consistent with the freshly-persisted
+      // categories, in the same tx. Normally a no-op here — submission happens
+      // before the review phase — but correct if this proposal is already in a
+      // live by_category review phase.
+      await reconcileReviewAssignments({
+        db: tx,
+        instanceId: instance.id,
+        affected: { proposalIds: [submittedProposal.id] },
       });
     }
 

--- a/packages/common/src/services/decision/updateProposal.ts
+++ b/packages/common/src/services/decision/updateProposal.ts
@@ -26,6 +26,7 @@ import type {
   ProposalDataInput,
 } from './proposalDataSchema';
 import { parseProposalData } from './proposalDataSchema';
+import { reconcileReviewAssignments } from './reconcileReviewAssignments';
 import { resolveProposalTemplate } from './resolveProposalTemplate';
 import { type DecisionInstanceData, isLastPhase } from './schemas/instanceData';
 import { setProposalCategories } from './setProposalCategories';
@@ -224,6 +225,14 @@ export const updateProposal = async ({
     // Mirror the resolved category set (manual + district) into the junction.
     if (categoryLabels) {
       await setProposalCategories({ tx, proposalId, labels: categoryLabels });
+      // Reconcile this proposal's by-category assignments in the same tx so a
+      // category change can't commit and leave stale assignments behind:
+      // add reviewers for new categories, prune pending for dropped ones.
+      await reconcileReviewAssignments({
+        db: tx,
+        instanceId: processInstance.id,
+        affected: { proposalIds: [proposalId] },
+      });
     }
 
     const proposal = await tx.query.proposals.findFirst({

--- a/services/api/src/routers/decision/instances/reconcileReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/reconcileReviewAssignments.test.ts
@@ -1,0 +1,684 @@
+import {
+  type DecisionInstanceData,
+  type ReviewsScope,
+  addCategoryReviewer,
+  advancePhase,
+  createDecisionRole,
+  generateReviewAssignments,
+  reconcileReviewAssignments,
+  removeCategoryReviewer,
+} from '@op/common';
+import { and, db, eq, inArray } from '@op/db/client';
+import {
+  ProcessStatus,
+  ProposalReviewAssignmentStatus,
+  ProposalStatus,
+  categoryReviewers,
+  proposalCategories,
+  proposalReviewAssignments,
+  proposalReviews,
+  taxonomies,
+  taxonomyTerms,
+} from '@op/db/schema';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { TestDecisionsDataManager } from '../../../test/helpers/TestDecisionsDataManager';
+
+/** The schema shape createDecisionSetup accepts (encoder-inferred, not exported). */
+type TestProcessSchema = NonNullable<
+  NonNullable<
+    Parameters<TestDecisionsDataManager['createDecisionSetup']>[0]
+  >['processSchema']
+>;
+
+/**
+ * submission → review → results, review phase carrying a configurable
+ * `reviews.scope`. The review phase also accepts submissions so mid-phase
+ * proposal writes are representable.
+ */
+function schemaWithScope(scope: ReviewsScope): TestProcessSchema {
+  return {
+    id: `reconcile-by-category-schema-${scope}`,
+    version: '1.0.0',
+    name: 'Reconcile By Category Schema',
+    description: 'Schema with a by-category review phase for reconcile testing',
+    config: {
+      reviewsPolicy: 'full_coverage',
+    },
+    phases: [
+      {
+        id: 'submission',
+        name: 'Submission',
+        description: 'Submit proposals',
+        rules: {
+          proposals: { submit: true },
+          advancement: { method: 'manual' },
+        },
+        // Pass-all: every submitted proposal advances into review.
+        selectionPipeline: { version: '1.0.0', blocks: [] },
+      },
+      {
+        id: 'review',
+        name: 'Review',
+        description: 'Review proposals',
+        rules: {
+          proposals: { review: true, submit: true },
+          reviews: { submit: true, scope },
+          advancement: { method: 'manual' },
+        },
+      },
+      {
+        id: 'results',
+        name: 'Results',
+        description: 'Final results',
+        rules: {
+          proposals: { submit: false },
+          advancement: { method: 'manual' },
+        },
+      },
+    ],
+  } satisfies TestProcessSchema;
+}
+
+async function createReviewInstance(
+  testData: TestDecisionsDataManager,
+  scope: ReviewsScope,
+  status: ProcessStatus = ProcessStatus.PUBLISHED,
+) {
+  const setup = await testData.createDecisionSetup({
+    instanceCount: 1,
+    processSchema: schemaWithScope(scope),
+    status,
+  });
+
+  return { setup, instance: setup.instance };
+}
+
+/** A "Reviewer" role on the given decision profile with only the REVIEW bit. */
+async function createReviewerRole(instanceProfileId: string) {
+  return createDecisionRole({
+    name: 'Reviewer',
+    profileId: instanceProfileId,
+    permissions: {
+      decisions: {
+        type: 'decision',
+        value: {
+          create: false,
+          read: true,
+          update: false,
+          delete: false,
+          admin: false,
+          inviteMembers: false,
+          review: true,
+          submitProposals: false,
+          vote: false,
+        },
+      },
+    },
+  });
+}
+
+/**
+ * Appends uniquely-labeled terms to the shared "proposal" taxonomy. Labels are
+ * per-call unique so concurrent tests don't collide on (taxonomyId, termUri).
+ */
+async function seedTerms(
+  count: number,
+  onTestFinished: (fn: () => void | Promise<void>) => void,
+) {
+  const taxonomyId = randomUUID();
+  const [inserted] = await db
+    .insert(taxonomies)
+    .values({ id: taxonomyId, name: 'proposal' })
+    .onConflictDoNothing({ target: taxonomies.name })
+    .returning({ id: taxonomies.id });
+
+  let resolvedTaxonomyId: string;
+  if (inserted) {
+    resolvedTaxonomyId = inserted.id;
+  } else {
+    const [existing] = await db
+      .select({ id: taxonomies.id })
+      .from(taxonomies)
+      .where(eq(taxonomies.name, 'proposal'));
+    if (!existing) {
+      throw new Error('proposal taxonomy not found after conflict');
+    }
+    resolvedTaxonomyId = existing.id;
+  }
+
+  const suffix = randomUUID().slice(0, 8);
+  const termRecords = Array.from({ length: count }, (_, i) => ({
+    id: randomUUID(),
+    taxonomyId: resolvedTaxonomyId,
+    termUri: `district-${suffix}-${i}`,
+    label: `District ${suffix} ${i}`,
+  }));
+
+  await db.insert(taxonomyTerms).values(termRecords);
+
+  onTestFinished(async () => {
+    await db.delete(taxonomyTerms).where(
+      inArray(
+        taxonomyTerms.id,
+        termRecords.map((t) => t.id),
+      ),
+    );
+  });
+
+  return termRecords;
+}
+
+/** Tags a proposal with a taxonomy term (a submission category). */
+async function tagProposal(proposalId: string, taxonomyTermId: string) {
+  await db
+    .insert(proposalCategories)
+    .values({ proposalId, taxonomyTermId })
+    .onConflictDoNothing();
+}
+
+/** Directly inserts a scope row (system context — no admin caller needed). */
+async function scopeReviewer({
+  processInstanceId,
+  taxonomyTermId,
+  reviewerProfileId,
+  phaseId,
+}: {
+  processInstanceId: string;
+  taxonomyTermId: string;
+  reviewerProfileId: string;
+  phaseId?: string | null;
+}) {
+  await db
+    .insert(categoryReviewers)
+    .values({
+      processInstanceId,
+      taxonomyTermId,
+      reviewerProfileId,
+      phaseId: phaseId ?? null,
+    })
+    .onConflictDoNothing();
+}
+
+async function advanceToReviewPhase(instanceId: string) {
+  const dbInstance = await db.query.processInstances.findFirst({
+    where: { id: instanceId },
+  });
+  if (!dbInstance) {
+    throw new Error('Instance not found');
+  }
+
+  const result = await db.transaction(async (tx) =>
+    advancePhase({
+      db: tx,
+      instance: {
+        id: dbInstance.id,
+        instanceData: dbInstance.instanceData as DecisionInstanceData,
+      },
+      fromPhaseId: 'submission',
+      toPhaseId: 'review',
+      triggeredByProfileId: null,
+    }),
+  );
+
+  if (result.conflict) {
+    throw new Error('Unexpected conflict during advance');
+  }
+
+  return result;
+}
+
+/** Advance into review and materialize the by-category assignment baseline. */
+async function generateBaseline(instanceId: string) {
+  const advanceResult = await advanceToReviewPhase(instanceId);
+  await generateReviewAssignments({
+    instanceId,
+    phaseId: 'review',
+    selectedProposalIds: advanceResult.selectedProposalIds,
+    transitionHistoryId: advanceResult.transitionHistoryId,
+  });
+}
+
+async function getAssignments(instanceId: string) {
+  return db
+    .select()
+    .from(proposalReviewAssignments)
+    .where(eq(proposalReviewAssignments.processInstanceId, instanceId));
+}
+
+/** Map proposalId → set of reviewerProfileIds actually assigned. */
+function reviewersByProposal(
+  assignments: Array<{ proposalId: string; reviewerProfileId: string }>,
+) {
+  const map = new Map<string, Set<string>>();
+  for (const a of assignments) {
+    const bucket = map.get(a.proposalId) ?? new Set<string>();
+    bucket.add(a.reviewerProfileId);
+    map.set(a.proposalId, bucket);
+  }
+  return map;
+}
+
+describe.concurrent('reconcileReviewAssignments — 6b-add', () => {
+  it('adds a reviewer to a category mid-phase and backfills that category’s in-phase proposals (add-only)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA, termB] = await seedTerms(2, onTestFinished);
+
+    const reviewer = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+      roleIds: { [instance.profileId]: reviewerRole.id },
+    });
+
+    const [pA, pB] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Cat A proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Cat B proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ]);
+
+    await tagProposal(pA!.id, termA!.id);
+    await tagProposal(pB!.id, termB!.id);
+
+    // No scope rows for `reviewer` at generation time → they get no assignments.
+    await generateBaseline(instance.instance.id);
+    const baseline = await getAssignments(instance.instance.id);
+    expect(
+      baseline.filter((a) => a.reviewerProfileId === reviewer.profileId),
+    ).toHaveLength(0);
+
+    // Admin adds `reviewer` to category A mid-phase — this fires the reconciler.
+    await addCategoryReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewer.profileId,
+      user: setup.user,
+    });
+
+    const assignments = await getAssignments(instance.instance.id);
+    const reviewerAssignments = assignments.filter(
+      (a) => a.reviewerProfileId === reviewer.profileId,
+    );
+
+    // Exactly one new row — the cat-A proposal only. Cat-B is out of their scope.
+    expect(reviewerAssignments).toHaveLength(1);
+    expect(reviewerAssignments[0]?.proposalId).toBe(pA!.id);
+    // Add-only: the baseline rows are untouched.
+    expect(assignments).toHaveLength(baseline.length + 1);
+  });
+
+  it('excludes a scoped reviewer who lacks the REVIEW role (fail-closed intersection)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    // nonReviewer has instance access but no REVIEW role.
+    const nonReviewer = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Cat A proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+    await tagProposal(proposal.id, termA!.id);
+
+    await generateBaseline(instance.instance.id);
+
+    await addCategoryReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: nonReviewer.profileId,
+      user: setup.user,
+    });
+
+    const assignments = await getAssignments(instance.instance.id);
+    // A scope row alone grants nothing — the eligibility intersection is empty.
+    expect(
+      assignments.filter((a) => a.reviewerProfileId === nonReviewer.profileId),
+    ).toHaveLength(0);
+  });
+
+  it('never adds a self-review assignment when the author is scoped to their own proposal’s category', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    const author = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+      roleIds: { [instance.profileId]: reviewerRole.id },
+    });
+
+    const ownProposal = await testData.createProposal({
+      userEmail: author.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: "Author's own proposal" },
+      status: ProposalStatus.SUBMITTED,
+    });
+    await tagProposal(ownProposal.id, termA!.id);
+
+    await generateBaseline(instance.instance.id);
+
+    // Author (a reviewer) is added to their own proposal's category.
+    await addCategoryReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: author.profileId,
+      user: setup.user,
+    });
+
+    const assignments = await getAssignments(instance.instance.id);
+    // Self-review stays excluded — no assignment of the author to their own work.
+    expect(
+      assignments.filter(
+        (a) =>
+          a.reviewerProfileId === author.profileId &&
+          a.proposalId === ownProposal.id,
+      ),
+    ).toHaveLength(0);
+  });
+});
+
+describe.concurrent('reconcileReviewAssignments — 6b-prune', () => {
+  it('removing a reviewer from a category prunes their pending assignments but keeps non-pending ones (and their reviews)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    const reviewer = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+      roleIds: { [instance.profileId]: reviewerRole.id },
+    });
+
+    // Two cat-A proposals: one stays pending (pruned), one goes in_progress (kept).
+    const [pPending, pInProgress] = await Promise.all([
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'Pending proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+      testData.createProposal({
+        userEmail: setup.userEmail,
+        processInstanceId: instance.instance.id,
+        proposalData: { title: 'In-progress proposal' },
+        status: ProposalStatus.SUBMITTED,
+      }),
+    ]);
+
+    await tagProposal(pPending!.id, termA!.id);
+    await tagProposal(pInProgress!.id, termA!.id);
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewer.profileId,
+    });
+
+    await generateBaseline(instance.instance.id);
+
+    // Move the in-progress proposal's assignment past `pending` and attach a
+    // rubric review row — the cascade that makes a non-pending delete destructive.
+    const [inProgressAssignment] = await db
+      .update(proposalReviewAssignments)
+      .set({ status: ProposalReviewAssignmentStatus.IN_PROGRESS })
+      .where(
+        and(
+          eq(proposalReviewAssignments.processInstanceId, instance.instance.id),
+          eq(proposalReviewAssignments.proposalId, pInProgress!.id),
+          eq(proposalReviewAssignments.reviewerProfileId, reviewer.profileId),
+        ),
+      )
+      .returning({ id: proposalReviewAssignments.id });
+
+    await db.insert(proposalReviews).values({
+      assignmentId: inProgressAssignment!.id,
+      reviewData: { score: 5 },
+    });
+
+    // Admin removes the reviewer from category A — fires the prune reconcile.
+    const result = await removeCategoryReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewer.profileId,
+      user: setup.user,
+    });
+    expect(result.removed).toBe(true);
+
+    const assignments = await getAssignments(instance.instance.id);
+    const reviewerAssignments = assignments.filter(
+      (a) => a.reviewerProfileId === reviewer.profileId,
+    );
+
+    // The pending assignment is gone; the in-progress one survives.
+    expect(reviewerAssignments).toHaveLength(1);
+    expect(reviewerAssignments[0]?.proposalId).toBe(pInProgress!.id);
+    expect(reviewerAssignments[0]?.status).toBe(
+      ProposalReviewAssignmentStatus.IN_PROGRESS,
+    );
+
+    // The rubric review the kept assignment owns is intact (no cascade fired).
+    const survivingReview = await db
+      .select()
+      .from(proposalReviews)
+      .where(eq(proposalReviews.assignmentId, inProgressAssignment!.id));
+    expect(survivingReview).toHaveLength(1);
+  });
+});
+
+describe.concurrent('reconcileReviewAssignments — recategorization', () => {
+  it('adds new-category reviewers, prunes dropped-category pending, and keeps dropped-category non-pending', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA, termB] = await seedTerms(2, onTestFinished);
+
+    // Cat A: one pending reviewer (pruned) + one in-progress reviewer (kept).
+    // Cat B: a reviewer the proposal will gain (added).
+    const [pendingReviewer, keptReviewer, newReviewer] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+    ]);
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Recategorized proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    await tagProposal(proposal.id, termA!.id);
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: pendingReviewer.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: keptReviewer.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termB!.id,
+      reviewerProfileId: newReviewer.profileId,
+    });
+
+    await generateBaseline(instance.instance.id);
+
+    // keptReviewer starts working — their assignment leaves `pending`.
+    await db
+      .update(proposalReviewAssignments)
+      .set({ status: ProposalReviewAssignmentStatus.IN_PROGRESS })
+      .where(
+        and(
+          eq(proposalReviewAssignments.proposalId, proposal.id),
+          eq(
+            proposalReviewAssignments.reviewerProfileId,
+            keptReviewer.profileId,
+          ),
+        ),
+      );
+
+    // Recategorize A → B inside a tx and reconcile in the same tx — exactly the
+    // path updateProposal takes after setProposalCategories.
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(proposalCategories)
+        .where(eq(proposalCategories.proposalId, proposal.id));
+      await tx
+        .insert(proposalCategories)
+        .values({ proposalId: proposal.id, taxonomyTermId: termB!.id });
+      await reconcileReviewAssignments({
+        db: tx,
+        instanceId: instance.instance.id,
+        affected: { proposalIds: [proposal.id] },
+      });
+    });
+
+    const byProposal = reviewersByProposal(
+      await getAssignments(instance.instance.id),
+    );
+    const reviewers = byProposal.get(proposal.id) ?? new Set<string>();
+
+    // New cat-B reviewer added; kept (in-progress) cat-A reviewer survives even
+    // though cat A was dropped; pending cat-A reviewer pruned.
+    expect(reviewers.has(newReviewer.profileId)).toBe(true);
+    expect(reviewers.has(keptReviewer.profileId)).toBe(true);
+    expect(reviewers.has(pendingReviewer.profileId)).toBe(false);
+  });
+});
+
+describe.concurrent('reconcileReviewAssignments — no-op guards', () => {
+  it("skips when scope is 'all' and touches no assignments", async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(testData, 'all');
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    // The creator-admin holds REVIEW, so full coverage produces a baseline.
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Full-coverage proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+    await tagProposal(proposal.id, termA!.id);
+
+    await generateBaseline(instance.instance.id);
+    const baseline = await getAssignments(instance.instance.id);
+
+    const result = await reconcileReviewAssignments({
+      instanceId: instance.instance.id,
+      affected: { taxonomyTermId: termA!.id },
+    });
+
+    expect(result).toEqual({
+      skipped: 'current phase scope is not by_category',
+    });
+    expect(await getAssignments(instance.instance.id)).toHaveLength(
+      baseline.length,
+    );
+  });
+
+  it('skips when the current phase is not a review phase', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instance } = await createReviewInstance(testData, 'by_category');
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    // Never advanced out of the submission phase.
+    const result = await reconcileReviewAssignments({
+      instanceId: instance.instance.id,
+      affected: { taxonomyTermId: termA!.id },
+    });
+
+    expect(result).toEqual({ skipped: 'current phase is not review-capable' });
+  });
+
+  it('skips when the instance is a draft (not published)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { instance } = await createReviewInstance(
+      testData,
+      'by_category',
+      ProcessStatus.DRAFT,
+    );
+    const [termA] = await seedTerms(1, onTestFinished);
+
+    const result = await reconcileReviewAssignments({
+      instanceId: instance.instance.id,
+      affected: { taxonomyTermId: termA!.id },
+    });
+
+    expect(result).toMatchObject({
+      skipped: expect.stringContaining('published'),
+    });
+  });
+});

--- a/services/api/src/routers/decision/instances/reconcileReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/reconcileReviewAssignments.test.ts
@@ -7,6 +7,7 @@ import {
   generateReviewAssignments,
   reconcileReviewAssignments,
   removeCategoryReviewer,
+  updateProposal,
 } from '@op/common';
 import { and, db, eq, inArray } from '@op/db/client';
 import {
@@ -505,6 +506,85 @@ describe.concurrent('reconcileReviewAssignments — 6b-prune', () => {
       .where(eq(proposalReviews.assignmentId, inProgressAssignment!.id));
     expect(survivingReview).toHaveLength(1);
   });
+
+  it('keeps a pending assignment still justified by another category (full recompute, not delta-prune)', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA, termB] = await seedTerms(2, onTestFinished);
+
+    // dualReviewer covers cats A AND B; soloReviewer covers cat A only.
+    const [dualReviewer, soloReviewer] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+    ]);
+
+    // The proposal wears BOTH categories.
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Dual-category proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+    await tagProposal(proposal.id, termA!.id);
+    await tagProposal(proposal.id, termB!.id);
+
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: dualReviewer.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termB!.id,
+      reviewerProfileId: dualReviewer.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: soloReviewer.profileId,
+    });
+
+    await generateBaseline(instance.instance.id);
+
+    // Both reviewers assigned, both still `pending`.
+    await removeCategoryReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: dualReviewer.profileId,
+      user: setup.user,
+    });
+    await removeCategoryReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: soloReviewer.profileId,
+      user: setup.user,
+    });
+
+    const reviewers =
+      reviewersByProposal(await getAssignments(instance.instance.id)).get(
+        proposal.id,
+      ) ?? new Set<string>();
+
+    // dualReviewer's pending assignment survives — the recompute still finds
+    // the cat-B justification. soloReviewer's is pruned — nothing justifies it.
+    expect(reviewers.has(dualReviewer.profileId)).toBe(true);
+    expect(reviewers.has(soloReviewer.profileId)).toBe(false);
+  });
 });
 
 describe.concurrent('reconcileReviewAssignments — recategorization', () => {
@@ -606,6 +686,74 @@ describe.concurrent('reconcileReviewAssignments — recategorization', () => {
     expect(reviewers.has(newReviewer.profileId)).toBe(true);
     expect(reviewers.has(keptReviewer.profileId)).toBe(true);
     expect(reviewers.has(pendingReviewer.profileId)).toBe(false);
+  });
+
+  it('updateProposal itself reconciles: editing categories moves the assignments in the same call', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(
+      testData,
+      'by_category',
+    );
+    const reviewerRole = await createReviewerRole(instance.profileId);
+    const [termA, termB] = await seedTerms(2, onTestFinished);
+
+    const [reviewerA, reviewerB] = await Promise.all([
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+      testData.createMemberUser({
+        organization: setup.organization,
+        instanceProfileIds: [instance.profileId],
+        roleIds: { [instance.profileId]: reviewerRole.id },
+      }),
+    ]);
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Edited proposal' },
+      status: ProposalStatus.SUBMITTED,
+    });
+    await tagProposal(proposal.id, termA!.id);
+
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termA!.id,
+      reviewerProfileId: reviewerA.profileId,
+    });
+    await scopeReviewer({
+      processInstanceId: instance.instance.id,
+      taxonomyTermId: termB!.id,
+      reviewerProfileId: reviewerB.profileId,
+    });
+
+    await generateBaseline(instance.instance.id);
+
+    // The real service path: updateProposal → setProposalCategories →
+    // reconcileReviewAssignments, all inside its own write transaction.
+    // Categories resolve by term LABEL here (setProposalCategories contract).
+    await updateProposal({
+      proposalId: proposal.id,
+      data: {
+        proposalData: { title: 'Edited proposal', category: [termB!.label] },
+      },
+      user: setup.user,
+    });
+
+    const reviewers =
+      reviewersByProposal(await getAssignments(instance.instance.id)).get(
+        proposal.id,
+      ) ?? new Set<string>();
+
+    // A → B took effect without any explicit reconcile call: B's reviewer
+    // assigned, A's pending reviewer pruned.
+    expect(reviewers.has(reviewerB.profileId)).toBe(true);
+    expect(reviewers.has(reviewerA.profileId)).toBe(false);
   });
 });
 


### PR DESCRIPTION
By-category review assignments were only materialized at phase transitions, so mid-phase changes (adding/removing a category reviewer, or a proposal's categories changing) left assignments stale until the next transition. This reconciles assignments immediately on every category-changing write, pruning only pending assignments so submitted or in-flight review work is never retracted.