### PR TITLE
feat(decision): show assigned review categories in reviewer queue header

### DIFF
--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -1,15 +1,18 @@
 'use client';
 
+import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { trpc } from '@op/api/client';
 import {
   ProposalReviewAssignmentStatus,
   REVIEW_ASSIGNMENT_SORTS,
+  getPhaseReviewSettings,
 } from '@op/common/client';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header3 } from '@op/ui/Header';
 import { Skeleton } from '@op/ui/Skeleton';
 import { Surface } from '@op/ui/Surface';
 import { parseAsStringLiteral, useQueryState } from 'nuqs';
+import { Suspense } from 'react';
 import { LuLeaf } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
@@ -70,7 +73,16 @@ export function ReviewAssignmentsList({
     <div className="flex flex-col gap-6">
       {/* Filter bar */}
       <div className="flex flex-wrap items-center justify-between gap-4">
-        <ProposalCount count={assignments.length} />
+        {/* min-w-0 + flex-1 lets the category suffix ellipsize before the filters */}
+        <div className="flex min-w-0 flex-1 items-baseline gap-1">
+          <ProposalCount count={assignments.length} />
+          {/* decorative — a failed lookup must not take down the queue */}
+          <APIErrorBoundary fallbacks={{ default: () => null }}>
+            <Suspense fallback={null}>
+              <AssignedCategoriesSuffix processInstanceId={processInstanceId} />
+            </Suspense>
+          </APIErrorBoundary>
+        </div>
         <div className="grid max-w-fit grid-cols-2 justify-end gap-2 sm:flex sm:flex-1 sm:flex-wrap sm:items-center sm:justify-end">
           <ResponsiveSelect
             selectedKey={statusFilter ?? 'all'}
@@ -140,6 +152,70 @@ export function ReviewAssignmentsList({
     </div>
   );
 }
+
+/** "in District 1, District 2" suffix after the count on by-category phases. */
+const AssignedCategoriesSuffix = ({
+  processInstanceId,
+}: {
+  processInstanceId: string;
+}) => {
+  // cached from the page-level suspense query — no extra request
+  const [instance] = trpc.decision.getInstance.useSuspenseQuery({
+    instanceId: processInstanceId,
+  });
+
+  const phases = instance.instanceData?.phases ?? [];
+  const currentPhase = phases.find(
+    (phase) => phase.phaseId === instance.currentStateId,
+  );
+
+  if (
+    !currentPhase ||
+    getPhaseReviewSettings({ phases }, currentPhase.phaseId).scope !==
+      'by_category'
+  ) {
+    return null;
+  }
+
+  return (
+    <AssignedCategoriesLabel
+      processInstanceId={processInstanceId}
+      phaseId={currentPhase.phaseId}
+    />
+  );
+};
+
+const AssignedCategoriesLabel = ({
+  processInstanceId,
+  phaseId,
+}: {
+  processInstanceId: string;
+  phaseId: string;
+}) => {
+  const t = useTranslations();
+
+  const [categories] = trpc.decision.listReviewerCategories.useSuspenseQuery({
+    processInstanceId,
+    phaseId,
+  });
+
+  if (categories.length === 0) {
+    return null;
+  }
+
+  const label = t('in {categories}', {
+    categories: categories.map((category) => category.name).join(', '),
+  });
+
+  return (
+    <span
+      className="min-w-0 truncate text-base text-neutral-gray4"
+      title={label}
+    >
+      {label}
+    </span>
+  );
+};
 
 const ReviewAssignmentCardSkeleton = () => (
   <Surface className="relative w-full space-y-3 p-4 pb-4">

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1162,6 +1162,7 @@
   "Needs Review": "يحتاج إلى مراجعة",
   "Revised": "تمت المراجعة",
   "Filter by status": "تصفية حسب الحالة",
+  "in {categories}": "في {categories}",
   "Sort order": "ترتيب الفرز",
   "{count} Reviewed": "تمت مراجعة {count}",
   "{count} of {total} completed": "{count} من {total} مكتمل",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1250,6 +1250,7 @@
   "Needs Review": "পর্যালোচনা প্রয়োজন",
   "Revised": "সংশোধিত",
   "Filter by status": "স্ট্যাটাস অনুযায়ী ফিল্টার",
+  "in {categories}": "{categories}-এ",
   "Sort order": "সাজানোর ক্রম",
   "{count} Reviewed": "{count} পর্যালোচিত",
   "{count} of {total} completed": "{count} / {total} সম্পন্ন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1262,6 +1262,7 @@
   "Needs Review": "Needs Review",
   "Revised": "Revised",
   "Filter by status": "Filter by status",
+  "in {categories}": "in {categories}",
   "Sort order": "Sort order",
   "{count} Reviewed": "{count} Reviewed",
   "{count} of {total} completed": "{count} of {total} completed",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1249,6 +1249,7 @@
   "Needs Review": "Necesita revisión",
   "Revised": "Revisado",
   "Filter by status": "Filtrar por estado",
+  "in {categories}": "en {categories}",
   "Sort order": "Orden",
   "{count} Reviewed": "{count} Revisados",
   "{count} of {total} completed": "{count} de {total} completados",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1249,6 +1249,7 @@
   "Needs Review": "À examiner",
   "Revised": "Révisé",
   "Filter by status": "Filtrer par statut",
+  "in {categories}": "dans {categories}",
   "Sort order": "Ordre de tri",
   "{count} Reviewed": "{count} Examinés",
   "{count} of {total} completed": "{count} sur {total} terminés",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1249,6 +1249,7 @@
   "Needs Review": "Precisa de revisão",
   "Revised": "Revisado",
   "Filter by status": "Filtrar por status",
+  "in {categories}": "em {categories}",
   "Sort order": "Ordenar",
   "{count} Reviewed": "{count} Revisados",
   "{count} of {total} completed": "{count} de {total} concluídos",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1181,6 +1181,7 @@
   "Needs Review": "Dib-u-eegis U Baahan",
   "Revised": "La dib-u-habeeyay",
   "Filter by status": "Ku shaandhee xaaladda",
+  "in {categories}": "gudaha {categories}",
   "Sort order": "Habka kala soocida",
   "{count} Reviewed": "{count} La dib u eegay",
   "{count} of {total} completed": "{count} ee {total} la dhammaystiray",

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -75,6 +75,7 @@ export * from './getReviewAssignment';
 export * from './listReviewAssignments';
 export * from './listCategoryReviewers';
 export * from './listEligibleReviewers';
+export * from './listReviewerCategories';
 export * from './addCategoryReviewer';
 export * from './removeCategoryReviewer';
 export * from './listProposalsWithReviewAggregates';

--- a/packages/common/src/services/decision/listReviewerCategories.ts
+++ b/packages/common/src/services/decision/listReviewerCategories.ts
@@ -1,0 +1,76 @@
+import { and, asc, db, eq, isNull, or } from '@op/db/client';
+import { categoryReviewers, taxonomyTerms } from '@op/db/schema';
+import type { User } from '@op/supabase/lib';
+import { permission } from 'access-zones';
+
+import { NotFoundError, UnauthorizedError } from '../../utils';
+import { assertInstanceProfileAccess } from '../access';
+import { assertUserByAuthId } from '../assert';
+import { decisionPermission } from './permissions';
+import type { ReviewerCategory } from './schemas/reviews';
+
+/**
+ * The categories the calling reviewer is scoped to in a phase. Instance-wide
+ * rows (`phaseId` NULL) always apply alongside rows scoped to the phase.
+ */
+export async function listReviewerCategories({
+  processInstanceId,
+  phaseId,
+  user,
+}: {
+  processInstanceId: string;
+  phaseId: string;
+  user: User;
+}): Promise<ReviewerCategory[]> {
+  const [instance, dbUser] = await Promise.all([
+    db.query.processInstances.findFirst({
+      where: { id: processInstanceId },
+      columns: { profileId: true, ownerProfileId: true },
+    }),
+    assertUserByAuthId(user.id),
+  ]);
+
+  if (!instance) {
+    throw new NotFoundError('Process instance not found');
+  }
+
+  if (!dbUser.profileId) {
+    throw new UnauthorizedError('User must have an active profile');
+  }
+
+  const reviewOrAdmin = [
+    { decisions: decisionPermission.REVIEW },
+    { decisions: permission.ADMIN },
+  ];
+
+  await assertInstanceProfileAccess({
+    user,
+    instance,
+    profilePermissions: reviewOrAdmin,
+    orgFallbackPermissions: reviewOrAdmin,
+  });
+
+  // Manual join: the relational API can't ORDER BY a joined column. DISTINCT
+  // because instance-wide and phase-scoped rows can cover the same term.
+  return await db
+    .selectDistinct({
+      id: taxonomyTerms.id,
+      name: taxonomyTerms.label,
+    })
+    .from(categoryReviewers)
+    .innerJoin(
+      taxonomyTerms,
+      eq(categoryReviewers.taxonomyTermId, taxonomyTerms.id),
+    )
+    .where(
+      and(
+        eq(categoryReviewers.processInstanceId, processInstanceId),
+        eq(categoryReviewers.reviewerProfileId, dbUser.profileId),
+        or(
+          isNull(categoryReviewers.phaseId),
+          eq(categoryReviewers.phaseId, phaseId),
+        ),
+      ),
+    )
+    .orderBy(asc(taxonomyTerms.label), asc(taxonomyTerms.id));
+}

--- a/packages/common/src/services/decision/schemas/instance.ts
+++ b/packages/common/src/services/decision/schemas/instance.ts
@@ -5,7 +5,19 @@ import { z } from 'zod';
  */
 export const instancePhaseRefSchema = z.object({
   processInstanceId: z.uuid(),
-  phaseId: z.string(),
+  phaseId: z.string().min(1),
 });
 
 export type InstancePhaseRef = z.infer<typeof instancePhaseRefSchema>;
+
+/**
+ * Same reference with the phase optional — for queries where no phase means
+ * instance-wide. '' stays rejected so it can't collide with a NULL phase key.
+ */
+export const instanceOptionalPhaseRefSchema = instancePhaseRefSchema.partial({
+  phaseId: true,
+});
+
+export type InstanceOptionalPhaseRef = z.infer<
+  typeof instanceOptionalPhaseRefSchema
+>;

--- a/packages/common/src/services/decision/schemas/reviews.ts
+++ b/packages/common/src/services/decision/schemas/reviews.ts
@@ -10,6 +10,7 @@ import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
 import type { RubricTemplateSchema } from '../types';
+import { instanceOptionalPhaseRefSchema } from './instance';
 import { proposalProfileSchema, proposalSchema } from './proposal';
 
 export {
@@ -320,13 +321,11 @@ export const removeCategoryReviewerResultSchema = z.object({
 });
 
 /** Target of an add/remove: a single (category, reviewer[, phase]) scope tuple. */
-export const categoryReviewerTargetSchema = z.object({
-  processInstanceId: z.uuid(),
-  taxonomyTermId: z.uuid(),
-  reviewerProfileId: z.uuid(),
-  // '' would collide with the instance-wide NULL key.
-  phaseId: z.string().min(1).optional(),
-});
+export const categoryReviewerTargetSchema =
+  instanceOptionalPhaseRefSchema.extend({
+    taxonomyTermId: z.uuid(),
+    reviewerProfileId: z.uuid(),
+  });
 
 /**
  * Candidate reviewer surfaced in the "Add reviewer…" picker. email is included
@@ -348,3 +347,13 @@ export type EligibleReviewerSchema = z.infer<typeof eligibleReviewerSchema>;
 export const eligibleReviewersListSchema = z.object({
   reviewers: z.array(eligibleReviewerSchema),
 });
+
+/** A category (taxonomy term id + label) the current reviewer is scoped to. */
+export const reviewerCategorySchema = z.object({
+  id: z.uuid(),
+  name: z.string(),
+});
+
+export type ReviewerCategory = z.infer<typeof reviewerCategorySchema>;
+
+export const reviewerCategoriesSchema = z.array(reviewerCategorySchema);

--- a/services/api/src/routers/decision/reviews/index.ts
+++ b/services/api/src/routers/decision/reviews/index.ts
@@ -7,6 +7,7 @@ import { listEligibleReviewersRouter } from './listEligibleReviewers';
 import { listProposalRevisionRequestsRouter } from './listProposalRevisionRequests';
 import { listProposalsRevisionRequestsRouter } from './listProposalsRevisionRequests';
 import { listReviewAssignmentsRouter } from './listReviewAssignments';
+import { listReviewerCategoriesRouter } from './listReviewerCategories';
 import { removeCategoryReviewerRouter } from './removeCategoryReviewer';
 import { requestRevisionRouter } from './requestRevision';
 import { saveReviewDraftRouter } from './saveReviewDraft';
@@ -19,6 +20,7 @@ export const reviewsRouter = mergeRouters(
   getReviewAssignmentRouter,
   listCategoryReviewersRouter,
   listEligibleReviewersRouter,
+  listReviewerCategoriesRouter,
   listProposalRevisionRequestsRouter,
   listProposalsRevisionRequestsRouter,
   listReviewAssignmentsRouter,

--- a/services/api/src/routers/decision/reviews/listCategoryReviewers.ts
+++ b/services/api/src/routers/decision/reviews/listCategoryReviewers.ts
@@ -1,17 +1,14 @@
-import { categoryReviewersListSchema, listCategoryReviewers } from '@op/common';
-import { z } from 'zod';
+import {
+  categoryReviewersListSchema,
+  instanceOptionalPhaseRefSchema,
+  listCategoryReviewers,
+} from '@op/common';
 
 import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
 
 export const listCategoryReviewersRouter = router({
   listCategoryReviewers: networkAuthenticatedProcedure()
-    .input(
-      z.object({
-        processInstanceId: z.uuid(),
-        // '' would collide with the instance-wide NULL key.
-        phaseId: z.string().min(1).optional(),
-      }),
-    )
+    .input(instanceOptionalPhaseRefSchema)
     .output(categoryReviewersListSchema)
     .query(async ({ ctx, input }) => {
       const categories = await listCategoryReviewers({

--- a/services/api/src/routers/decision/reviews/listReviewerCategories.test.ts
+++ b/services/api/src/routers/decision/reviews/listReviewerCategories.test.ts
@@ -1,0 +1,220 @@
+import { db, inArray } from '@op/db/client';
+import { categoryReviewers, taxonomyTerms } from '@op/db/schema';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestReviewsDataManager } from '../../../test/helpers/TestReviewsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+/** Inserts taxonomy terms; deleting them on cleanup cascade-deletes the scope rows. */
+async function seedCategoryTerms(
+  labels: string[],
+  onTestFinished: (fn: () => void | Promise<void>) => void,
+) {
+  const records = labels.map((label) => ({
+    id: randomUUID(),
+    termUri: `${label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')}-${randomUUID().slice(0, 8)}`,
+    label,
+  }));
+
+  await db.insert(taxonomyTerms).values(records);
+
+  onTestFinished(async () => {
+    await db.delete(taxonomyTerms).where(
+      inArray(
+        taxonomyTerms.id,
+        records.map((t) => t.id),
+      ),
+    );
+  });
+
+  return records;
+}
+
+describe.concurrent('listReviewerCategories', () => {
+  it('returns the reviewer’s categories ordered by label', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    const instanceId = context.instance.instance.id;
+    const reviewer = await testData.createInstanceReviewerWithRole(context);
+
+    const suffix = randomUUID().slice(0, 8);
+    // B-before-A so result order can only come from the SQL ORDER BY
+    const [termB, termA] = await seedCategoryTerms(
+      [`District ${suffix} B`, `District ${suffix} A`],
+      onTestFinished,
+    );
+
+    await db.insert(categoryReviewers).values([
+      {
+        processInstanceId: instanceId,
+        taxonomyTermId: termB!.id,
+        reviewerProfileId: reviewer.profileId,
+      },
+      {
+        processInstanceId: instanceId,
+        taxonomyTermId: termA!.id,
+        reviewerProfileId: reviewer.profileId,
+      },
+    ]);
+
+    const caller = await createAuthenticatedCaller(reviewer.email);
+    const result = await caller.decision.listReviewerCategories({
+      processInstanceId: instanceId,
+      phaseId: 'review',
+    });
+
+    expect(result).toEqual([
+      { id: termA!.id, name: termA!.label },
+      { id: termB!.id, name: termB!.label },
+    ]);
+  });
+
+  it('returns an empty list for a reviewer with no scope rows', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    const reviewer = await testData.createInstanceReviewerWithRole(context);
+
+    const caller = await createAuthenticatedCaller(reviewer.email);
+    const result = await caller.decision.listReviewerCategories({
+      processInstanceId: context.instance.instance.id,
+      phaseId: 'review',
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not return another reviewer’s scope rows', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    const instanceId = context.instance.instance.id;
+    const reviewer = await testData.createInstanceReviewerWithRole(context);
+    const otherReviewer = await testData.createReviewer(context);
+
+    const suffix = randomUUID().slice(0, 8);
+    const [ownTerm, otherTerm] = await seedCategoryTerms(
+      [`District ${suffix} Own`, `District ${suffix} Other`],
+      onTestFinished,
+    );
+
+    await db.insert(categoryReviewers).values([
+      {
+        processInstanceId: instanceId,
+        taxonomyTermId: ownTerm!.id,
+        reviewerProfileId: reviewer.profileId,
+      },
+      {
+        processInstanceId: instanceId,
+        taxonomyTermId: otherTerm!.id,
+        reviewerProfileId: otherReviewer.profileId,
+      },
+    ]);
+
+    const caller = await createAuthenticatedCaller(reviewer.email);
+    const result = await caller.decision.listReviewerCategories({
+      processInstanceId: instanceId,
+      phaseId: 'review',
+    });
+
+    expect(result).toEqual([{ id: ownTerm!.id, name: ownTerm!.label }]);
+  });
+
+  it('rejects callers without review access', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+
+    // READ on the instance profile, but no REVIEW and no ADMIN.
+    const member = await testData.createInstanceMember(context);
+
+    const caller = await createAuthenticatedCaller(member.email);
+
+    await expect(
+      caller.decision.listReviewerCategories({
+        processInstanceId: context.instance.instance.id,
+        phaseId: 'review',
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+  });
+
+  it('matches instance-wide (phaseId NULL) rows alongside the requested phase, deduplicated', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    const instanceId = context.instance.instance.id;
+    const reviewer = await testData.createInstanceReviewerWithRole(context);
+
+    const suffix = randomUUID().slice(0, 8);
+    const [termA, termB, termC] = await seedCategoryTerms(
+      [`District ${suffix} A`, `District ${suffix} B`, `District ${suffix} C`],
+      onTestFinished,
+    );
+
+    await db.insert(categoryReviewers).values([
+      // Instance-wide AND phase-scoped for the same term — must appear once.
+      {
+        processInstanceId: instanceId,
+        taxonomyTermId: termA!.id,
+        reviewerProfileId: reviewer.profileId,
+      },
+      {
+        processInstanceId: instanceId,
+        taxonomyTermId: termA!.id,
+        reviewerProfileId: reviewer.profileId,
+        phaseId: 'review',
+      },
+      // Scoped to the requested phase only.
+      {
+        processInstanceId: instanceId,
+        taxonomyTermId: termB!.id,
+        reviewerProfileId: reviewer.profileId,
+        phaseId: 'review',
+      },
+      // Scoped to a different phase — must not match.
+      {
+        processInstanceId: instanceId,
+        taxonomyTermId: termC!.id,
+        reviewerProfileId: reviewer.profileId,
+        phaseId: 'submission',
+      },
+    ]);
+
+    const caller = await createAuthenticatedCaller(reviewer.email);
+
+    const withPhase = await caller.decision.listReviewerCategories({
+      processInstanceId: instanceId,
+      phaseId: 'review',
+    });
+    expect(withPhase).toEqual([
+      { id: termA!.id, name: termA!.label },
+      { id: termB!.id, name: termB!.label },
+    ]);
+  });
+});

--- a/services/api/src/routers/decision/reviews/listReviewerCategories.ts
+++ b/services/api/src/routers/decision/reviews/listReviewerCategories.ts
@@ -1,0 +1,20 @@
+import {
+  instancePhaseRefSchema,
+  listReviewerCategories,
+  reviewerCategoriesSchema,
+} from '@op/common';
+
+import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
+
+export const listReviewerCategoriesRouter = router({
+  listReviewerCategories: networkAuthenticatedProcedure()
+    .input(instancePhaseRefSchema)
+    .output(reviewerCategoriesSchema)
+    .query(async ({ ctx, input }) => {
+      return await listReviewerCategories({
+        processInstanceId: input.processInstanceId,
+        phaseId: input.phaseId,
+        user: ctx.user,
+      });
+    }),
+});


### PR DESCRIPTION
When a phase's review scope is by_category, reviewers now see which categories they're assigned to in the "Proposals to review" header ("6 proposals in District 3") — comma-delimited for multi-category reviewers, truncating before it overflows into the filter dropdowns, with the full list in a tooltip. Per the design mock there is no per-card category tag, and all-scope phases render exactly as before. The queue query is deliberately unchanged: assignments are already generated in-category, and re-filtering by current categories would hide in-progress reviews on proposals recategorized mid-review.