### PR TITLE
refactor(decision): adopt shared instance-phase schemas in review + proposal input schemas

### DIFF
--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -4,6 +4,12 @@
 export * from './money';
 export * from './services/decision/proposalDataSchema';
 export * from './services/decision/schemas/reviews';
+export {
+  instancePhaseRefSchema,
+  instanceOptionalPhaseRefSchema,
+  type InstancePhaseRef,
+  type InstanceOptionalPhaseRef,
+} from './services/decision/schemas/instance';
 // Re-exported from the decision utils so client components can resolve
 // phase-level settings without pulling in the server-only utils barrel.
 export {

--- a/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
@@ -11,16 +11,16 @@ import {
   getSubmittedReviewScore,
   proposalRelations,
 } from './listProposalsWithReviewAggregates';
+import { instanceOptionalPhaseRefSchema } from './schemas/instance';
 import {
   type ProposalWithSubmittedReviews,
   proposalWithSubmittedReviewsSchema,
 } from './schemas/reviews';
 
-export const getProposalWithReviewAggregatesInputSchema = z.object({
-  processInstanceId: z.uuid(),
-  proposalId: z.uuid(),
-  phaseId: z.string().optional(),
-});
+export const getProposalWithReviewAggregatesInputSchema =
+  instanceOptionalPhaseRefSchema.extend({
+    proposalId: z.uuid(),
+  });
 
 export type GetProposalWithReviewAggregatesInput = z.infer<
   typeof getProposalWithReviewAggregatesInputSchema

--- a/packages/common/src/services/decision/listProposalsWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/listProposalsWithReviewAggregates.ts
@@ -21,6 +21,7 @@ import {
   OVERALL_RECOMMENDATION_KEY,
   getRubricScoringInfo,
 } from './getRubricScoringInfo';
+import { instanceOptionalPhaseRefSchema } from './schemas/instance';
 import {
   type ProposalCategoryItem,
   type ProposalsWithReviewAggregatesList,
@@ -35,14 +36,10 @@ import {
  *   - paginated: phase-scoped, cursor-paginated.
  */
 export const listProposalsWithReviewAggregatesInputSchema = z.union([
-  z.object({
-    processInstanceId: z.uuid(),
-    phaseId: z.string().optional(),
+  instanceOptionalPhaseRefSchema.extend({
     proposalIds: z.array(z.uuid()).min(1),
   }),
-  z.object({
-    processInstanceId: z.uuid(),
-    phaseId: z.string().optional(),
+  instanceOptionalPhaseRefSchema.extend({
     limit: z.number().int().min(1).max(100).default(50),
     cursor: z.string().optional(),
   }),

--- a/packages/common/src/services/decision/schemas/reviews.ts
+++ b/packages/common/src/services/decision/schemas/reviews.ts
@@ -10,7 +10,10 @@ import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
 import type { RubricTemplateSchema } from '../types';
-import { instanceOptionalPhaseRefSchema } from './instance';
+import {
+  instanceOptionalPhaseRefSchema,
+  instancePhaseRefSchema,
+} from './instance';
 import { proposalProfileSchema, proposalSchema } from './proposal';
 
 export {
@@ -86,10 +89,8 @@ export type RubricReviewData = z.infer<typeof rubricReviewDataSchema>;
 
 // ── Review assignment schemas ───────────────────────────────────────────
 
-export const proposalReviewAssignmentSchema = z.object({
+export const proposalReviewAssignmentSchema = instancePhaseRefSchema.extend({
   id: z.uuid(),
-  processInstanceId: z.uuid(),
-  phaseId: z.string(),
   status: z.enum(ProposalReviewAssignmentStatus),
   proposal: proposalSchema,
 });

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -1,6 +1,7 @@
 import {
   REVIEWS_POLICIES,
   checkpointVersionSchema,
+  instanceOptionalPhaseRefSchema,
   phaseReviewSettingsSchema,
   proposalSchema,
   rubricTemplateSchema,
@@ -660,14 +661,11 @@ export const instanceFilterSchema = z
   })
   .extend(paginationInputSchema.shape);
 
-export const proposalFilterSchema = z.object({
-  processInstanceId: z.uuid(),
+export const proposalFilterSchema = instanceOptionalPhaseRefSchema.extend({
   submittedByProfileId: z.uuid().optional(),
   status: z.enum(ProposalStatus).optional(),
   categoryId: z.string().optional(),
   dir: z.enum(['asc', 'desc']).optional(),
-  /** Phase ID to scope proposals to. Defaults to the current phase when omitted. */
-  phaseId: z.string().optional(),
   /**
    * Restrict results to proposals voted on by this profile. Bypasses phase
    * scoping so a user's ballot remains accessible after the process moves
@@ -692,16 +690,15 @@ export const proposalFilterSchema = z.object({
  * `proposalFilterSchema` minus pagination (the endpoint returns every located
  * proposal in scope) so the map applies the same filters as the list.
  */
-export const proposalLocationsFilterSchema = z.object({
-  processInstanceId: z.uuid(),
-  submittedByProfileId: z.uuid().optional(),
-  status: z.enum(ProposalStatus).optional(),
-  categoryId: z.string().optional(),
-  phaseId: z.string().optional(),
-  votedByProfileId: z.uuid().optional(),
-  excludeAssignedForReview: z.boolean().optional(),
-  phase: z.enum(['results']).optional(),
-});
+export const proposalLocationsFilterSchema =
+  instanceOptionalPhaseRefSchema.extend({
+    submittedByProfileId: z.uuid().optional(),
+    status: z.enum(ProposalStatus).optional(),
+    categoryId: z.string().optional(),
+    votedByProfileId: z.uuid().optional(),
+    excludeAssignedForReview: z.boolean().optional(),
+    phase: z.enum(['results']).optional(),
+  });
 
 // Decision Profile Encoder (profile with processInstance)
 export const decisionProfileEncoder = baseProfileEncoder.extend({


### PR DESCRIPTION
Dedupe the inline `{ processInstanceId, phaseId }` zod declarations across the review and proposal input schemas onto the shared `instancePhaseRefSchema` / `instanceOptionalPhaseRefSchema` (already on dev), and export those two from `@op/common/client` so the API encoder layer can reuse them.

Behavior note: schemas that previously accepted `phaseId: ''` (`z.string().optional()`) now reject it (`min(1)`), guarding against collision with the instance-wide NULL-phase key. No caller passes `''`.