### PR TITLE
feat(decision): openReviews phase setting opens review aggregates to reviewers

### DIFF
--- a/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
@@ -16,6 +16,7 @@ import {
   type ProposalWithSubmittedReviews,
   proposalWithSubmittedReviewsSchema,
 } from './schemas/reviews';
+import { getPhaseReviewSettings } from './utils/phaseSettings';
 
 export const getProposalWithReviewAggregatesInputSchema =
   instanceOptionalPhaseRefSchema.extend({
@@ -37,10 +38,27 @@ export async function getProposalWithReviewAggregates(
 
   const instance = await getInstance({ instanceId: processInstanceId, user });
 
+  // Admins always read the full review set. Resolve their access first and
+  // short-circuit before touching phase settings — `getPhaseReviewSettings`
+  // throws NotFound on an instance whose `currentStateId` matches no phase,
+  // and admins must keep reading regardless of phase configuration.
+  //
+  // Otherwise reviewers get proposal-wide read only when the instance's
+  // current phase opts into open reviews — and this grant is deliberately
+  // process-wide: ANY reviewer (access.review) of the process can read, not
+  // only those assigned to this proposal.
   if (!instance.access.admin) {
-    throw new UnauthorizedError(
-      "You don't have admin access to this process instance",
-    );
+    const openReviewsForReviewers =
+      instance.access.review &&
+      instance.currentStateId != null &&
+      getPhaseReviewSettings(instance.instanceData, instance.currentStateId)
+        .openReviews;
+
+    if (!openReviewsForReviewers) {
+      throw new UnauthorizedError(
+        "You don't have access to read reviews for this process instance",
+      );
+    }
   }
 
   const rubricTemplate = instance.instanceData.rubricTemplate;

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -97,6 +97,8 @@ export const phaseReviewSettingsSchema = z.object({
   policy: z.enum(REVIEWS_POLICIES).optional(),
   allowRevisions: z.boolean().optional(),
   anonymousFeedback: z.boolean().optional(),
+  /** Reviewers can see each other's submitted reviews during this phase. */
+  openReviews: z.boolean().optional(),
 });
 
 export type PhaseReviewSettings = z.infer<typeof phaseReviewSettingsSchema>;

--- a/packages/common/src/services/decision/utils/phaseSettings.test.ts
+++ b/packages/common/src/services/decision/utils/phaseSettings.test.ts
@@ -75,6 +75,7 @@ describe('getPhaseReviewSettings', () => {
       scope: 'all',
       allowRevisions: true,
       anonymousFeedback: undefined,
+      openReviews: false,
     });
   });
 
@@ -107,6 +108,7 @@ describe('getPhaseReviewSettings', () => {
       scope: 'all',
       allowRevisions: false,
       anonymousFeedback: true,
+      openReviews: false,
     });
   });
 
@@ -138,6 +140,7 @@ describe('getPhaseReviewSettings', () => {
       scope: 'all',
       allowRevisions: false,
       anonymousFeedback: true,
+      openReviews: false,
     });
   });
 
@@ -166,6 +169,7 @@ describe('getPhaseReviewSettings', () => {
       scope: 'all',
       allowRevisions: true,
       anonymousFeedback: true,
+      openReviews: false,
     });
   });
 
@@ -238,5 +242,59 @@ describe('getPhaseReviewSettings', () => {
     );
 
     expect(result.scope).toBe('by_category');
+  });
+
+  it('defaults openReviews to false when the phase has no review setting', () => {
+    const result = getPhaseReviewSettings(
+      { phases: [{ phaseId: 'review', rules: { reviews: { submit: true } } }] },
+      'review',
+    );
+
+    expect(result.openReviews).toBe(false);
+  });
+
+  it('resolves openReviews true from the phase rules', () => {
+    const result = getPhaseReviewSettings(
+      {
+        phases: [
+          {
+            phaseId: 'review',
+            rules: { reviews: { submit: true, openReviews: true } },
+          },
+        ],
+      },
+      'review',
+    );
+
+    expect(result.openReviews).toBe(true);
+  });
+
+  it('resolves openReviews false when explicitly set on the phase', () => {
+    const result = getPhaseReviewSettings(
+      {
+        phases: [
+          {
+            phaseId: 'review',
+            rules: { reviews: { submit: true, openReviews: false } },
+          },
+        ],
+      },
+      'review',
+    );
+
+    expect(result.openReviews).toBe(false);
+  });
+
+  it('never reads a legacy config counterpart for openReviews (phase-only)', () => {
+    const result = getPhaseReviewSettings(
+      {
+        // A stray legacy-style flag must not leak into the phase-only resolution.
+        config: { reviewsAllowRevisions: false },
+        phases: [{ phaseId: 'review', rules: { reviews: { submit: true } } }],
+      },
+      'review',
+    );
+
+    expect(result.openReviews).toBe(false);
   });
 });

--- a/packages/common/src/services/decision/utils/phaseSettings.ts
+++ b/packages/common/src/services/decision/utils/phaseSettings.ts
@@ -43,7 +43,10 @@ export function hasVotingPhase(
 
 /** `PhaseReviewSettings` with defaults applied (`anonymousFeedback` has none). */
 export type ReviewSettings = Required<
-  Pick<PhaseReviewSettings, 'submit' | 'policy' | 'scope' | 'allowRevisions'>
+  Pick<
+    PhaseReviewSettings,
+    'submit' | 'policy' | 'scope' | 'allowRevisions' | 'openReviews'
+  >
 > & { anonymousFeedback: PhaseReviewSettings['anonymousFeedback'] };
 
 /** Resolves review settings for `phaseId`; throws if the phase doesn't exist. */
@@ -72,5 +75,8 @@ export function getPhaseReviewSettings(
       reviews?.allowRevisions ?? config?.reviewsAllowRevisions ?? true,
     anonymousFeedback:
       reviews?.anonymousFeedback ?? config?.reviewsAnonymousFeedback,
+    // Open reviews is phase-only (no legacy config counterpart), like scope,
+    // and defaults to false.
+    openReviews: reviews?.openReviews ?? false,
   };
 }

--- a/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
+++ b/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
@@ -307,6 +307,296 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
       feasibility: 2,
     });
   });
+
+  // --- Open Reviews read gate (PR 1/5) -------------------------------------
+  // Admin OR (REVIEW access AND the current phase's `openReviews` is on).
+
+  it('admits an admin even when the current phase has openReviews off', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    await testData.setRubricTemplate(context, rubricTemplate);
+    await testData.setPhaseOpenReviews(
+      context.instance.instance.id,
+      'review',
+      false,
+    );
+    await advanceToReviewPhase(context.instance.instance.id);
+
+    const scenario = await testData.createReviewAssignment({
+      context,
+      title: 'Admin reads with openReviews off',
+    });
+    await createProposalReview({
+      assignmentId: scenario.assignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          impact: 7,
+          feasibility: 4,
+          [OVERALL_RECOMMENDATION_KEY]: 'yes',
+        },
+        rationales: {},
+      },
+      submittedAt: new Date().toISOString(),
+    });
+
+    // defaultReviewer holds profile-admin access on the instance.
+    const adminCaller = await createAuthenticatedCaller(
+      context.defaultReviewer.email,
+    );
+
+    const result = await adminCaller.decision.getProposalWithReviewAggregates({
+      processInstanceId: context.instance.instance.id,
+      proposalId: scenario.proposal.id,
+    });
+
+    expect(result.proposal.id).toBe(scenario.proposal.id);
+    expect(result.reviews).toHaveLength(1);
+  });
+
+  it('denies a reviewer (REVIEW, no admin) when openReviews is off', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    await testData.setRubricTemplate(context, rubricTemplate);
+    await testData.setPhaseOpenReviews(
+      context.instance.instance.id,
+      'review',
+      false,
+    );
+    await advanceToReviewPhase(context.instance.instance.id);
+
+    const reviewer = await testData.createInstanceReviewerWithRole(context);
+    // The reviewer even holds an assignment on this proposal — still denied,
+    // because the own-assignment review flow is a separate gate.
+    const scenario = await testData.createReviewAssignment({
+      context,
+      reviewer,
+      title: 'Reviewer blocked while openReviews off',
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+
+    await expect(
+      reviewerCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: context.instance.instance.id,
+        proposalId: scenario.proposal.id,
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+  });
+
+  it('admits a reviewer with an assignment when openReviews is on, exposing peers reviews', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    await testData.setRubricTemplate(context, rubricTemplate);
+    await testData.setPhaseOpenReviews(
+      context.instance.instance.id,
+      'review',
+      true,
+    );
+    await advanceToReviewPhase(context.instance.instance.id);
+
+    const reviewer = await testData.createInstanceReviewerWithRole(context);
+    const scenario = await testData.createReviewAssignment({
+      context,
+      reviewer,
+      title: 'Open reviews visible to peer reviewer',
+    });
+
+    // A different reviewer submits a review on the same proposal.
+    const peerReviewer = await testData.createReviewer(context);
+    const peerAssignment = await createReviewAssignment({
+      processInstanceId: context.instance.instance.id,
+      proposalId: scenario.proposal.id,
+      reviewerProfileId: peerReviewer.profileId,
+    });
+    await createProposalReview({
+      assignmentId: peerAssignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          impact: 6,
+          feasibility: 3,
+          [OVERALL_RECOMMENDATION_KEY]: 'yes',
+        },
+        rationales: {},
+      },
+      submittedAt: new Date().toISOString(),
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+
+    const result =
+      await reviewerCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: context.instance.instance.id,
+        proposalId: scenario.proposal.id,
+      });
+
+    expect(result.reviews).toHaveLength(1);
+    expect(result.reviews[0]!.reviewer.id).toBe(peerReviewer.profileId);
+    expect(result.reviews[0]!.review.state).toBe(ProposalReviewState.SUBMITTED);
+  });
+
+  it('admits a reviewer with NO assignment on the proposal when openReviews is on', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    await testData.setRubricTemplate(context, rubricTemplate);
+    await testData.setPhaseOpenReviews(
+      context.instance.instance.id,
+      'review',
+      true,
+    );
+    await advanceToReviewPhase(context.instance.instance.id);
+
+    // Proposal + a submitted review owned by someone else entirely.
+    const scenario = await testData.createReviewAssignment({
+      context,
+      title: 'Process-wide open reviews',
+    });
+    await createProposalReview({
+      assignmentId: scenario.assignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          impact: 8,
+          feasibility: 5,
+          [OVERALL_RECOMMENDATION_KEY]: 'yes',
+        },
+        rationales: {},
+      },
+      submittedAt: new Date().toISOString(),
+    });
+
+    // An unrelated reviewer: REVIEW access in the process, no assignment here.
+    const outsideReviewer =
+      await testData.createInstanceReviewerWithRole(context);
+    const reviewerCaller = await createAuthenticatedCaller(
+      outsideReviewer.email,
+    );
+
+    const result =
+      await reviewerCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: context.instance.instance.id,
+        proposalId: scenario.proposal.id,
+      });
+
+    expect(result.proposal.id).toBe(scenario.proposal.id);
+    expect(result.reviews).toHaveLength(1);
+  });
+
+  it('denies a participant without REVIEW access even when openReviews is on', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    await testData.setRubricTemplate(context, rubricTemplate);
+    await testData.setPhaseOpenReviews(
+      context.instance.instance.id,
+      'review',
+      true,
+    );
+    await advanceToReviewPhase(context.instance.instance.id);
+
+    const scenario = await testData.createReviewAssignment({
+      context,
+      title: 'Member cannot read reviews',
+    });
+
+    // READ-only member: no REVIEW, no ADMIN.
+    const member = await testData.createInstanceMember(context);
+    const memberCaller = await createAuthenticatedCaller(member.email);
+
+    await expect(
+      memberCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: context.instance.instance.id,
+        proposalId: scenario.proposal.id,
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+  });
+
+  it('never surfaces draft reviews even when openReviews is on', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    await testData.setRubricTemplate(context, rubricTemplate);
+    await testData.setPhaseOpenReviews(
+      context.instance.instance.id,
+      'review',
+      true,
+    );
+    await advanceToReviewPhase(context.instance.instance.id);
+
+    const reviewer = await testData.createInstanceReviewerWithRole(context);
+    const scenario = await testData.createReviewAssignment({
+      context,
+      reviewer,
+      title: 'Draft stays hidden under open reviews',
+    });
+
+    // One peer with a SUBMITTED review, one with a DRAFT review.
+    const submittedPeer = await testData.createReviewer(context);
+    const submittedAssignment = await createReviewAssignment({
+      processInstanceId: context.instance.instance.id,
+      proposalId: scenario.proposal.id,
+      reviewerProfileId: submittedPeer.profileId,
+    });
+    await createProposalReview({
+      assignmentId: submittedAssignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          impact: 5,
+          feasibility: 2,
+          [OVERALL_RECOMMENDATION_KEY]: 'no',
+        },
+        rationales: {},
+      },
+      submittedAt: new Date().toISOString(),
+    });
+
+    const draftPeer = await testData.createReviewer(context);
+    const draftAssignment = await createReviewAssignment({
+      processInstanceId: context.instance.instance.id,
+      proposalId: scenario.proposal.id,
+      reviewerProfileId: draftPeer.profileId,
+    });
+    await createProposalReview({
+      assignmentId: draftAssignment.id,
+      state: ProposalReviewState.DRAFT,
+      reviewData: {
+        answers: { impact: 9, feasibility: 5 },
+        rationales: {},
+      },
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+
+    const result =
+      await reviewerCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: context.instance.instance.id,
+        proposalId: scenario.proposal.id,
+      });
+
+    expect(result.reviews).toHaveLength(1);
+    expect(result.reviews[0]!.reviewer.id).toBe(submittedPeer.profileId);
+    expect(
+      result.reviews.some((r) => r.reviewer.id === draftPeer.profileId),
+    ).toBe(false);
+  });
 });
 
 describeDecisionAccessTierGating('getProposalWithReviewAggregates', {

--- a/services/api/src/test/helpers/TestReviewsDataManager.ts
+++ b/services/api/src/test/helpers/TestReviewsDataManager.ts
@@ -1,4 +1,5 @@
 import { type RubricTemplateSchema, createDecisionRole } from '@op/common';
+import { assertInstancePhase } from '@op/common/src/services/decision';
 import { db } from '@op/db/client';
 import {
   ProposalReviewAssignmentStatus,
@@ -211,6 +212,48 @@ export class TestReviewsDataManager {
     const phases = (instanceData.phases ?? []).map((p) =>
       p?.phaseId === phaseId ? { ...p, endDate } : p,
     );
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...instanceData,
+          phases,
+        },
+      })
+      .where(eq(processInstances.id, instanceId));
+  }
+
+  /**
+   * Opts a phase into (or out of) open reviews by merging
+   * `rules.reviews.openReviews` into that phase entry in `instanceData.phases`.
+   */
+  async setPhaseOpenReviews(
+    instanceId: string,
+    phaseId: string,
+    openReviews: boolean,
+  ) {
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instanceId },
+    });
+    const instanceData =
+      (instanceRecord?.instanceData as {
+        phases?: Array<{ phaseId: string; rules?: Record<string, unknown> }>;
+      } | null) ?? {};
+    // Mirror the service posture: an unknown phase is a hard error, not a
+    // silent no-op. Throws NotFoundError, exactly like production reads.
+    assertInstancePhase({ instance: { instanceData }, phaseId });
+    const phases = (instanceData.phases ?? []).map((p) => {
+      if (p.phaseId !== phaseId) {
+        return p;
+      }
+      const rules = p.rules ?? {};
+      const reviews =
+        (rules.reviews as Record<string, unknown> | undefined) ?? {};
+      return {
+        ...p,
+        rules: { ...rules, reviews: { ...reviews, openReviews } },
+      };
+    });
     await db
       .update(processInstances)
       .set({


### PR DESCRIPTION
Open Reviews lets reviewers see each other's submitted reviews on a proposal, opted in per phase and off by default. A new `rules.reviews.openReviews` phase setting (phase-rules-only, no legacy config counterpart, defaults false) resolves through `getPhaseReviewSettings`.

This opens the read gate on `getProposalWithReviewAggregates`: an admin can always read, and otherwise any holder of REVIEW access on the instance can read when the instance's current phase has `openReviews` on. The grant is deliberately process-wide — every reviewer of the process, not only those assigned to this proposal — and remains submitted-only (drafts are never surfaced). `listProposalsWithReviewAggregates` and `getPhaseReviewProgress` stay admin-only.

PR 1/5 of the open-reviews stack. Backend only, no UI or schema changes.