### PR TITLE
refactor(sense): clean up legacy tokens in search results tree

### DIFF
--- a/apps/app/src/app/[locale]/(main)/decisions/page.tsx
+++ b/apps/app/src/app/[locale]/(main)/decisions/page.tsx
@@ -1,12 +1,10 @@
+import { Header1 } from '@op/sense/Header';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
 import { TranslatedText } from '@/components/TranslatedText';
 import { AllDecisions } from '@/components/decisions/AllDecisions';
-import {
-  ListPageLayout,
-  ListPageLayoutHeader,
-} from '@/components/layout/ListPageLayout';
+import { ListPageLayout } from '@/components/layout/ListPageLayout';
 
 export async function generateMetadata({
   params,
@@ -22,9 +20,9 @@ const DecisionsListingPage = () => {
   return (
     <ListPageLayout className="gap-4 pt-8 sm:gap-6 sm:pt-12">
       <div className="flex flex-col gap-2">
-        <ListPageLayoutHeader>
+        <Header1 className="text-headline">
           <TranslatedText text="Decision-making processes" />
-        </ListPageLayoutHeader>
+        </Header1>
         <p className="text-neutral-charcoal">
           <TranslatedText text="Discover new ways to collectively decide together." />
         </p>

--- a/apps/app/src/app/[locale]/(main)/decisions/page.tsx
+++ b/apps/app/src/app/[locale]/(main)/decisions/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({
 
 const DecisionsListingPage = () => {
   return (
-    <ListPageLayout className="gap-4 pt-8 sm:gap-6 sm:pt-12">
+    <ListPageLayout className="max-w-none gap-4 pt-8 sm:gap-6 sm:pt-12">
       <div className="flex flex-col gap-2">
         <Header1 className="text-headline">
           <TranslatedText text="Decision-making processes" />

--- a/apps/app/src/app/[locale]/(main)/org/page.tsx
+++ b/apps/app/src/app/[locale]/(main)/org/page.tsx
@@ -19,7 +19,14 @@ export async function generateMetadata({
   return { title: t('Organizations') };
 }
 
-const OrgListingPage = async () => {
+const OrgListingPage = async ({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) => {
+  const { locale } = await params;
+  const t = await getTranslations({ locale });
+
   try {
     const client = await createClient();
     const organizations = await client.profile.list({
@@ -29,16 +36,14 @@ const OrgListingPage = async () => {
 
     return (
       <ListPageLayout>
-        <Header1 className="text-headline">Organizations</Header1>
-
+        <Header1 className="text-headline">{t('Organizations')}</Header1>
         <AllOrganizations initialData={organizations} limit={20} />
       </ListPageLayout>
     );
   } catch (error) {
     return (
       <ListPageLayout>
-        <Header1 className="text-headline">Organizations</Header1>
-
+        <Header1 className="text-headline">{t('Organizations')}</Header1>
         <AllOrganizations initialData={{ items: [], next: null }} limit={20} />
       </ListPageLayout>
     );

--- a/apps/app/src/app/[locale]/(main)/org/page.tsx
+++ b/apps/app/src/app/[locale]/(main)/org/page.tsx
@@ -1,13 +1,11 @@
 import { EntityType } from '@op/api/encoders';
 import { createClient } from '@op/api/serverClient';
+import { Header1 } from '@op/sense/Header';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
 import { AllOrganizations } from '@/components/Organizations/AllOrganizations';
-import {
-  ListPageLayout,
-  ListPageLayoutHeader,
-} from '@/components/layout/ListPageLayout';
+import { ListPageLayout } from '@/components/layout/ListPageLayout';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,7 +29,7 @@ const OrgListingPage = async () => {
 
     return (
       <ListPageLayout>
-        <ListPageLayoutHeader>Organizations</ListPageLayoutHeader>
+        <Header1 className="text-headline">Organizations</Header1>
 
         <AllOrganizations initialData={organizations} limit={20} />
       </ListPageLayout>
@@ -39,7 +37,7 @@ const OrgListingPage = async () => {
   } catch (error) {
     return (
       <ListPageLayout>
-        <ListPageLayoutHeader>Organizations</ListPageLayoutHeader>
+        <Header1 className="text-headline">Organizations</Header1>
 
         <AllOrganizations initialData={{ items: [], next: null }} limit={20} />
       </ListPageLayout>

--- a/apps/app/src/app/[locale]/(main)/profile/page.tsx
+++ b/apps/app/src/app/[locale]/(main)/profile/page.tsx
@@ -1,13 +1,11 @@
 import { EntityType } from '@op/api/encoders';
 import { createClient } from '@op/api/serverClient';
+import { Header1 } from '@op/sense/Header';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
 import { AllOrganizations } from '@/components/Organizations/AllOrganizations';
-import {
-  ListPageLayout,
-  ListPageLayoutHeader,
-} from '@/components/layout/ListPageLayout';
+import { ListPageLayout } from '@/components/layout/ListPageLayout';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,7 +29,7 @@ const ProfileListingPage = async () => {
 
     return (
       <ListPageLayout>
-        <ListPageLayoutHeader>Organizations</ListPageLayoutHeader>
+        <Header1 className="text-headline">Organizations</Header1>
 
         <AllOrganizations
           initialData={organizations}
@@ -43,7 +41,7 @@ const ProfileListingPage = async () => {
   } catch (error) {
     return (
       <ListPageLayout>
-        <ListPageLayoutHeader>Organizations</ListPageLayoutHeader>
+        <Header1 className="text-headline">Organizations</Header1>
 
         <AllOrganizations
           initialData={{ items: [], next: null }}

--- a/apps/app/src/app/[locale]/(main)/profile/page.tsx
+++ b/apps/app/src/app/[locale]/(main)/profile/page.tsx
@@ -19,7 +19,13 @@ export async function generateMetadata({
   return { title: t('People') };
 }
 
-const ProfileListingPage = async () => {
+const ProfileListingPage = async ({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) => {
+  const { locale } = await params;
+  const t = await getTranslations({ locale });
   try {
     const client = await createClient();
     const organizations = await client.profile.list({
@@ -29,8 +35,7 @@ const ProfileListingPage = async () => {
 
     return (
       <ListPageLayout>
-        <Header1 className="text-headline">Organizations</Header1>
-
+        <Header1 className="text-headline">{t('People')}</Header1>
         <AllOrganizations
           initialData={organizations}
           types={[EntityType.INDIVIDUAL]}
@@ -41,8 +46,7 @@ const ProfileListingPage = async () => {
   } catch (error) {
     return (
       <ListPageLayout>
-        <Header1 className="text-headline">Organizations</Header1>
-
+        <Header1 className="text-headline">{t('People')}</Header1>
         <AllOrganizations
           initialData={{ items: [], next: null }}
           types={[EntityType.USER]}

--- a/apps/app/src/components/OrganizationsSearchResults/index.tsx
+++ b/apps/app/src/components/OrganizationsSearchResults/index.tsx
@@ -3,15 +3,22 @@
 import { trpc } from '@op/api/client';
 import { EntityType, SearchProfilesResult } from '@op/api/encoders';
 import { match } from '@op/core';
+import {
+  Empty,
+  EmptyMedia,
+  EmptyHeader,
+  EmptyDescription,
+} from '@op/sense/Empty';
+import { Header1 } from '@op/sense/Header';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@op/sense/Tabs';
 import { Suspense } from 'react';
+import { LuUsers, LuUser } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
 
 import { ProfileListSkeleton, ProfileSummaryList } from '../ProfileList';
-import { ListPageLayoutHeader } from '../layout/ListPageLayout';
 
 export const ProfileSearchResultsSuspense = ({
   query,
@@ -33,39 +40,41 @@ export const ProfileSearchResultsSuspense = ({
     0,
   );
 
-  return totalResults > 0 ? (
+  return (
     <>
-      <ListPageLayoutHeader>
-        <span className="text-muted-foreground">
-          {t.rich('Results for <highlight>{query}</highlight>', {
-            query: query,
-            highlight: (chunks: React.ReactNode) => (
-              <span className="text-foreground">{chunks}</span>
-            ),
-          })}
-        </span>
-      </ListPageLayoutHeader>
-      <TabbedProfileSearchResults profiles={profileSearchResults} />
-    </>
-  ) : (
-    <>
-      <ListPageLayoutHeader className="flex justify-center gap-2">
-        <span className="text-muted-foreground">
-          {t.rich('No results for <highlight>{query}</highlight>', {
-            query: query,
-            highlight: (chunks: React.ReactNode) => (
-              <span className="text-foreground">{chunks}</span>
-            ),
-          })}
-        </span>
-      </ListPageLayoutHeader>
-      <div className="flex justify-center">
-        <span className="max-w-96 text-center text-foreground">
-          {t(
-            'You may want to try using different keywords, checking for typos, or adjusting your filters.',
-          )}
-        </span>
-      </div>
+      <Header1 className="text-headline">
+        {totalResults > 0 ? (
+          <span className="text-muted-foreground">
+            {t.rich('Results for <highlight>{query}</highlight>', {
+              query: query,
+              highlight: (chunks: React.ReactNode) => (
+                <span className="text-foreground">{chunks}</span>
+              ),
+            })}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">
+            {t.rich('No results for <highlight>{query}</highlight>', {
+              query: query,
+              highlight: (chunks: React.ReactNode) => (
+                <span className="text-foreground">{chunks}</span>
+              ),
+            })}
+          </span>
+        )}
+      </Header1>
+
+      {totalResults > 0 ? (
+        <TabbedProfileSearchResults profiles={profileSearchResults} />
+      ) : (
+        <div className="flex justify-center">
+          <span className="max-w-96 text-center text-foreground">
+            {t(
+              'You may want to try using different keywords, checking for typos, or adjusting your filters.',
+            )}
+          </span>
+        </div>
+      )}
     </>
   );
 };
@@ -103,14 +112,23 @@ export const TabbedProfileSearchResults = ({
           [EntityType.INDIVIDUAL]: t('individuals'),
           [EntityType.ORG]: t('organizations'),
         });
+        const icon = match(type, {
+          [EntityType.INDIVIDUAL]: <LuUser />,
+          [EntityType.ORG]: <LuUsers />,
+        });
         return (
-          <TabsContent key={`${type}-panel`} value={type}>
+          <TabsContent key={`${type}-panel`} value={type} className="mt-6">
             {results.length > 0 ? (
               <ProfileSummaryList profiles={results} />
             ) : (
-              <div className="mt-2 w-full rounded p-8 text-center text-muted-foreground">
-                {t('No {type} found.', { type: label })}
-              </div>
+              <Empty className="rounded border">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">{icon}</EmptyMedia>
+                  <EmptyDescription>
+                    {t('No {type} found.', { type: label })}
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
             )}
           </TabsContent>
         );

--- a/apps/app/src/components/ProfileList/index.tsx
+++ b/apps/app/src/components/ProfileList/index.tsx
@@ -27,7 +27,7 @@ export const ProfileSummaryList = ({
   // avatars as plain text/images without links.
   const canLinkToProfile = useCanLinkToProfile();
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-10">
       {profiles.map((profile) => {
         const whereWeWork =
           profile.organization?.whereWeWork
@@ -56,17 +56,17 @@ export const ProfileSummaryList = ({
                 className="size-8 sm:size-12"
               />
 
-              <div className="flex flex-col gap-3 text-foreground">
-                <div className="flex flex-col gap-2">
+              <div className="flex flex-col gap-2 text-foreground">
+                <div className="flex flex-col gap-1">
                   {canLinkToProfile ? (
                     <Link
                       href={`/profile/${profile.slug}`}
-                      className="leading-base font-semibold"
+                      className="leading-5 font-strong"
                     >
                       <bdi>{profile.name}</bdi>
                     </Link>
                   ) : (
-                    <span className="leading-base font-semibold">
+                    <span className="leading-5 font-strong">
                       <bdi>{profile.name}</bdi>
                     </span>
                   )}
@@ -79,7 +79,7 @@ export const ProfileSummaryList = ({
                     </span>
                   ) : null}
                 </div>
-                <span dir="auto" className="text-foreground">
+                <span dir="auto" className="leading-5 text-foreground">
                   {trimmedBio}
                 </span>
               </div>

--- a/apps/app/src/components/ProfileList/index.tsx
+++ b/apps/app/src/components/ProfileList/index.tsx
@@ -2,12 +2,11 @@ import { useCanLinkToProfile } from '@/hooks/useCanLinkToProfile';
 import { getPublicUrl } from '@/utils';
 import { RouterOutput } from '@op/api/client';
 import { EntityType, Profile } from '@op/api/encoders';
-import { Avatar, AvatarFallback } from '@op/sense/Avatar';
 import { Skeleton } from '@op/sense/Skeleton';
-import { cn } from '@op/sense/lib/utils';
-import Image from 'next/image';
 
 import { Link } from '@/lib/i18n';
+
+import { ProfileAvatarLink } from '../ProfileAvatarLink';
 
 type Profiles = RouterOutput['profile']['list']['items'];
 
@@ -45,35 +44,17 @@ export const ProfileSummaryList = ({
             ? `/profile/${profile.slug}`
             : `/org/${profile.slug}`;
 
-        const avatar = (
-          <Avatar
-            className={cn(
-              'size-8 sm:size-12',
-              canLinkToProfile && 'hover:opacity-80',
-            )}
-          >
-            <AvatarFallback name={profile.name} />
-            {profile.avatarImage?.name ? (
-              <Image
-                src={getPublicUrl(profile.avatarImage.name) ?? ''}
-                alt={`${profile.name} avatar`}
-                fill
-                className="rounded-full object-cover"
-              />
-            ) : null}
-          </Avatar>
-        );
-
         return (
           <div key={profile.id}>
-            <div className="flex items-start gap-2 py-2 sm:gap-6">
-              {canLinkToProfile ? (
-                <Link href={profileHref} className="hover:no-underline">
-                  {avatar}
-                </Link>
-              ) : (
-                avatar
-              )}
+            <div className="flex items-start gap-2 py-2 sm:gap-4">
+              <ProfileAvatarLink
+                href={profileHref}
+                name={profile.name}
+                src={getPublicUrl(profile.avatarImage?.name) ?? ''}
+                alt={profile.name}
+                size="lg"
+                className="size-8 sm:size-12"
+              />
 
               <div className="flex flex-col gap-3 text-foreground">
                 <div className="flex flex-col gap-2">
@@ -112,7 +93,7 @@ export const ProfileSummaryList = ({
 
 export const ProfileListSkeleton = () => {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4">
       {Array.from({ length: 6 }).map((_, index) => (
         <div key={index} className="rounded-lg border bg-card p-4 shadow-xs">
           <div className="flex items-start gap-4">

--- a/apps/app/src/components/ProfileList/index.tsx
+++ b/apps/app/src/components/ProfileList/index.tsx
@@ -3,6 +3,7 @@ import { getPublicUrl } from '@/utils';
 import { RouterOutput } from '@op/api/client';
 import { EntityType, Profile } from '@op/api/encoders';
 import { Avatar, AvatarFallback } from '@op/sense/Avatar';
+import { Skeleton } from '@op/sense/Skeleton';
 import { cn } from '@op/sense/lib/utils';
 import Image from 'next/image';
 
@@ -74,7 +75,7 @@ export const ProfileSummaryList = ({
                 avatar
               )}
 
-              <div className="flex flex-col gap-3 text-neutral-black">
+              <div className="flex flex-col gap-3 text-foreground">
                 <div className="flex flex-col gap-2">
                   {canLinkToProfile ? (
                     <Link
@@ -91,13 +92,13 @@ export const ProfileSummaryList = ({
                   {whereWeWork?.length > 0 ? (
                     <span
                       dir="auto"
-                      className="text-sm text-neutral-gray4 sm:text-base"
+                      className="text-sm text-muted-foreground sm:text-base"
                     >
                       {whereWeWork}
                     </span>
                   ) : null}
                 </div>
-                <span dir="auto" className="text-neutral-charcoal">
+                <span dir="auto" className="text-foreground">
                   {trimmedBio}
                 </span>
               </div>
@@ -113,14 +114,14 @@ export const ProfileListSkeleton = () => {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {Array.from({ length: 6 }).map((_, index) => (
-        <div key={index} className="rounded-lg border bg-white p-4 shadow-xs">
+        <div key={index} className="rounded-lg border bg-card p-4 shadow-xs">
           <div className="flex items-start gap-4">
-            <div className="size-12 shrink-0 animate-pulse rounded-full bg-gray-200" />
+            <Skeleton className="size-12 shrink-0 rounded-full" />
             <div className="min-w-0 flex-1">
-              <div className="mb-2 h-4 animate-pulse rounded bg-gray-200" />
-              <div className="mb-2 h-3 w-2/3 animate-pulse rounded bg-gray-200" />
-              <div className="mb-1 h-3 w-full animate-pulse rounded bg-gray-200" />
-              <div className="h-3 w-3/4 animate-pulse rounded bg-gray-200" />
+              <Skeleton className="mb-2 h-4" />
+              <Skeleton className="mb-2 h-3 w-2/3" />
+              <Skeleton className="mb-1 h-3 w-full" />
+              <Skeleton className="h-3 w-3/4" />
             </div>
           </div>
         </div>

--- a/apps/app/src/components/ProfileList/index.tsx
+++ b/apps/app/src/components/ProfileList/index.tsx
@@ -48,7 +48,7 @@ export const ProfileSummaryList = ({
           <div key={profile.id}>
             <div className="flex items-start gap-2 py-2 sm:gap-4">
               <ProfileAvatarLink
-                href={profileHref}
+                href={canLinkToProfile ? profileHref : undefined}
                 name={profile.name}
                 src={getPublicUrl(profile.avatarImage?.name) ?? ''}
                 alt={profile.name}

--- a/apps/app/src/components/decisions/AllDecisions/index.tsx
+++ b/apps/app/src/components/decisions/AllDecisions/index.tsx
@@ -5,8 +5,8 @@ import { trpc } from '@op/api/client';
 import { ProcessStatus } from '@op/api/encoders';
 import { match } from '@op/core';
 import { useInfiniteScroll } from '@op/hooks';
-import { Skeleton } from '@op/ui/Skeleton';
-import { Tab, TabList, TabPanel, Tabs } from '@op/ui/Tabs';
+import { Skeleton } from '@op/sense/Skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@op/sense/Tabs';
 import { useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 
@@ -127,44 +127,38 @@ const AllDecisionsTabs = () => {
 
   return (
     <Tabs
-      selectedKey={selectedTab}
-      onSelectionChange={(key) => {
-        setTab(key === 'active' ? null : String(key));
+      value={selectedTab}
+      onValueChange={(value) => {
+        setTab(value === 'active' ? null : value);
       }}
     >
-      <TabList variant="pill" className="gap-4 border-none">
-        <Tab id="active" variant="pill">
-          {t('Your active processes')}
-        </Tab>
+      <TabsList>
+        <TabsTrigger value="active">{t('Your active processes')}</TabsTrigger>
         {hasDrafts && (
-          <Tab id="drafts" variant="pill">
-            {t('Your drafts')}
-          </Tab>
+          <TabsTrigger value="drafts">{t('Your drafts')}</TabsTrigger>
         )}
-        <Tab id="other" variant="pill">
-          {t('Other processes')}
-        </Tab>
-      </TabList>
-      <TabPanel id="active" className="p-0 sm:p-0">
+        <TabsTrigger value="other">{t('Other processes')}</TabsTrigger>
+      </TabsList>
+      <TabsContent value="active">
         <Suspense fallback={<DecisionsListSkeleton />}>
           <DecisionsListSuspense status={[ProcessStatus.PUBLISHED]} />
         </Suspense>
-      </TabPanel>
+      </TabsContent>
       {hasDrafts && (
-        <TabPanel id="drafts" className="p-0 sm:p-0">
+        <TabsContent value="drafts">
           <Suspense fallback={<DecisionsListSkeleton />}>
             <DecisionsListSuspense
               status={[ProcessStatus.DRAFT]}
               ownerProfileId={ownerProfileId}
             />
           </Suspense>
-        </TabPanel>
+        </TabsContent>
       )}
-      <TabPanel id="other" className="p-0 sm:p-0">
+      <TabsContent value="other">
         <Suspense fallback={<DecisionsListSkeleton />}>
           <DecisionsListSuspense status={[ProcessStatus.COMPLETED]} />
         </Suspense>
-      </TabPanel>
+      </TabsContent>
     </Tabs>
   );
 };

--- a/apps/app/src/components/layout/ListPageLayout/index.tsx
+++ b/apps/app/src/components/layout/ListPageLayout/index.tsx
@@ -30,10 +30,7 @@ export const ListPageLayoutHeader = ({
   return (
     <div className="flex flex-col px-0">
       <div
-        className={cn(
-          'font-serif !text-title-md text-neutral-black sm:!text-title-lg',
-          className,
-        )}
+        className={cn('font-serif text-headline text-foreground', className)}
       >
         {children}
       </div>

--- a/apps/app/src/components/layout/ListPageLayout/index.tsx
+++ b/apps/app/src/components/layout/ListPageLayout/index.tsx
@@ -11,29 +11,11 @@ export const ListPageLayout = ({
   return (
     <div
       className={cn(
-        'flex w-full flex-col gap-5 px-4 pt-5 pb-12 sm:gap-8 sm:pt-8',
+        'mx-auto flex w-full max-w-140 flex-col gap-5 px-4 pt-6 pb-12 sm:gap-8 sm:pt-13',
         className,
       )}
     >
       {children}
-    </div>
-  );
-};
-
-export const ListPageLayoutHeader = ({
-  className,
-  children,
-}: {
-  className?: string;
-  children?: ReactNode;
-}) => {
-  return (
-    <div className="flex flex-col px-0">
-      <div
-        className={cn('font-serif text-headline text-foreground', className)}
-      >
-        {children}
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
The @op/ui → @op/sense swap for the search route (`(main)/search`) already landed with #1693 — the shared `ProfileList` / `OrganizationsSearchResults` / `ListPageLayout` were migrated there. This sweeps the remaining legacy tokens in the reachable tree.

- **ProfileList**: `neutral-black`/`charcoal` → `text-foreground`, `neutral-gray4` → `text-muted-foreground`; `ProfileListSkeleton` rebuilt on `@op/sense/Skeleton` (`bg-white` → `bg-card`).
- **ListPageLayoutHeader**: dropped the @op/ui `text-title-md/lg` scale for sense `text-headline`.

Scoped to the search tree only; the app-wide `text-title-*` sweep (72 files) is a separate task.

**QA:** `ListPageLayoutHeader` size shifts `text-title-md/lg` (24→28px) → `text-headline` (20→30px), matching the migrated page-title convention. Affects the 5 list pages using it.