### PR TITLE
feat(decision): Open reviews phase toggle with confirm dialog behind reviews-v2 flag

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { parseAbsoluteToLocal, toCalendarDate } from '@internationalized/date';
 import { trpc } from '@op/api/client';
 import type { PhaseDefinition, PhaseRules } from '@op/api/encoders';
@@ -77,6 +78,7 @@ function PhaseDetailForm({
   onDelete: () => void;
 }) {
   const t = useTranslations();
+  const reviewsV2Enabled = useFeatureFlag('reviews-v2');
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   const instancePhases = instance.instanceData?.phases;
   const templatePhases = instance.process?.processSchema?.phases;
@@ -154,6 +156,10 @@ function PhaseDetailForm({
       };
     });
   };
+
+  // Open reviews opt-in is gated behind a confirmation dialog (enabling it
+  // changes reviewer behavior), so turning it ON opens this modal first.
+  const [showOpenReviewsModal, setShowOpenReviewsModal] = useState(false);
 
   // Delete phase
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -393,14 +399,45 @@ function PhaseDetailForm({
         >
           <ToggleButton
             isSelected={isReviewPhase(phase)}
-            onChange={(val) =>
-              updateRules({
-                reviews: { ...phase.rules?.reviews, submit: val },
-              })
-            }
+            onChange={(val) => {
+              const nextReviews: PhaseRules['reviews'] = {
+                ...phase.rules?.reviews,
+                submit: val,
+              };
+              // Clear any "open reviews" opt-in when review is disabled so a
+              // hidden-but-true setting can't silently re-open reviews if
+              // review is turned back on later.
+              if (!val && phase.rules?.reviews?.openReviews) {
+                nextReviews.openReviews = false;
+              }
+              updateRules({ reviews: nextReviews });
+            }}
             size="small"
           />
         </ToggleRow>
+        {reviewsV2Enabled && isReviewPhase(phase) && (
+          <ToggleRow
+            label={t('Open reviews')}
+            description={t(
+              "Reviewers can see each other's reviews on a proposal",
+            )}
+          >
+            <ToggleButton
+              isSelected={phase.rules?.reviews?.openReviews ?? false}
+              onChange={(val) => {
+                // Turning ON is confirmed via a dialog; turning OFF is immediate.
+                if (val) {
+                  setShowOpenReviewsModal(true);
+                } else {
+                  updateRules({
+                    reviews: { ...phase.rules?.reviews, openReviews: false },
+                  });
+                }
+              }}
+              size="small"
+            />
+          </ToggleRow>
+        )}
         <ToggleRow
           label={t('Voting')}
           description={t(
@@ -452,6 +489,46 @@ function PhaseDetailForm({
           {t('Delete phase')}
         </Button>
       </div>
+
+      <Modal
+        isDismissable
+        isOpen={showOpenReviewsModal}
+        onOpenChange={(open) => {
+          if (!open) {
+            setShowOpenReviewsModal(false);
+          }
+        }}
+      >
+        <ModalHeader>{t('Turn on Open Reviews?')}</ModalHeader>
+        <ModalBody>
+          <p>
+            {t(
+              'This can lead reviewers to agree with each other more than they would independently.',
+            )}
+          </p>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            color="secondary"
+            className="w-full sm:w-fit"
+            onPress={() => setShowOpenReviewsModal(false)}
+          >
+            {t('Cancel')}
+          </Button>
+          <Button
+            color="primary"
+            className="w-full sm:w-fit"
+            onPress={() => {
+              updateRules({
+                reviews: { ...phase.rules?.reviews, openReviews: true },
+              });
+              setShowOpenReviewsModal(false);
+            }}
+          >
+            {t('Enable')}
+          </Button>
+        </ModalFooter>
+      </Modal>
 
       <Modal
         isDismissable

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
@@ -32,7 +32,7 @@ export function ReviewSettingsContent({
   const t = useTranslations();
   // Gates the by-category scope. When off, the radio stays disabled with a
   // "Coming soon" chip (pre-flag behavior) and the reviewer cards never render.
-  const byCategoryEnabled = useFeatureFlag('reviews_by_category');
+  const byCategoryEnabled = useFeatureFlag('reviews-v2');
 
   const [instance] = trpc.decision.getInstance.useSuspenseQuery({ instanceId });
   const config = instance.instanceData?.config;

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1418,5 +1418,10 @@
   "Could not remove reviewer. Please try again.": "تعذّرت إزالة المراجع. يرجى المحاولة مرة أخرى.",
   "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "تأتي الفئات من <link>فئات المقترحات</link>. أضف مراجعين إلى كل فئة أو ادعُ شخصًا جديدًا.",
   "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "لم يتم العثور على فئات. أضفها في <link>فئات المقترحات</link> لتعيين المراجعين حسب الفئة.",
-  "Coming soon": "قريبًا"
+  "Coming soon": "قريبًا",
+  "Open reviews": "المراجعات المفتوحة",
+  "Reviewers can see each other's reviews on a proposal": "يمكن للمراجعين رؤية مراجعات بعضهم البعض على المقترح",
+  "Turn on Open Reviews?": "تفعيل المراجعات المفتوحة؟",
+  "This can lead reviewers to agree with each other more than they would independently.": "قد يؤدي ذلك إلى اتفاق المراجعين مع بعضهم البعض أكثر مما لو كانوا مستقلين.",
+  "Enable": "تفعيل"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1421,5 +1421,10 @@
   "Could not remove reviewer. Please try again.": "পর্যালোচক সরানো যায়নি। আবার চেষ্টা করুন।",
   "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "বিভাগগুলি <link>প্রস্তাব বিভাগসমূহ</link> থেকে আসে। প্রতিটিতে পর্যালোচক যোগ করুন, বা নতুন কাউকে আমন্ত্রণ জানান।",
   "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "কোনো বিভাগ পাওয়া যায়নি। বিভাগ অনুযায়ী পর্যালোচক নিযুক্ত করতে <link>প্রস্তাব বিভাগসমূহ</link>-এ সেগুলি যোগ করুন।",
-  "Coming soon": "শীঘ্রই আসছে"
+  "Coming soon": "শীঘ্রই আসছে",
+  "Open reviews": "উন্মুক্ত পর্যালোচনা",
+  "Reviewers can see each other's reviews on a proposal": "পর্যালোচকরা একটি প্রস্তাবে একে অপরের পর্যালোচনা দেখতে পারেন",
+  "Turn on Open Reviews?": "উন্মুক্ত পর্যালোচনা চালু করবেন?",
+  "This can lead reviewers to agree with each other more than they would independently.": "এটি পর্যালোচকদের স্বাধীনভাবে যতটা একমত হতেন তার চেয়ে বেশি একে অপরের সাথে একমত হতে পরিচালিত করতে পারে।",
+  "Enable": "চালু করুন"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1427,5 +1427,10 @@
   "Could not remove reviewer. Please try again.": "Could not remove reviewer. Please try again.",
   "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.",
   "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.",
-  "Coming soon": "Coming soon"
+  "Coming soon": "Coming soon",
+  "Open reviews": "Open reviews",
+  "Reviewers can see each other's reviews on a proposal": "Reviewers can see each other's reviews on a proposal",
+  "Turn on Open Reviews?": "Turn on Open Reviews?",
+  "This can lead reviewers to agree with each other more than they would independently.": "This can lead reviewers to agree with each other more than they would independently.",
+  "Enable": "Enable"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1418,5 +1418,10 @@
   "Could not remove reviewer. Please try again.": "No se pudo quitar la persona revisora. Inténtalo de nuevo.",
   "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "Las categorías provienen de <link>Categorías de propuestas</link>. Agrega personas revisoras a cada una o invita a alguien nuevo.",
   "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "No se encontraron categorías. Agrégalas en <link>Categorías de propuestas</link> para asignar personas revisoras por categoría.",
-  "Coming soon": "Próximamente"
+  "Coming soon": "Próximamente",
+  "Open reviews": "Revisiones abiertas",
+  "Reviewers can see each other's reviews on a proposal": "Las personas revisoras pueden ver las revisiones de las demás en una propuesta",
+  "Turn on Open Reviews?": "¿Activar las revisiones abiertas?",
+  "This can lead reviewers to agree with each other more than they would independently.": "Esto puede llevar a que las personas revisoras estén de acuerdo entre sí más de lo que lo harían de forma independiente.",
+  "Enable": "Activar"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1418,5 +1418,10 @@
   "Could not remove reviewer. Please try again.": "Impossible de retirer l’évaluateur. Veuillez réessayer.",
   "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "Les catégories proviennent de <link>Catégories de propositions</link>. Ajoutez des évaluateurs à chacune ou invitez une nouvelle personne.",
   "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "Aucune catégorie trouvée. Ajoutez-en dans <link>Catégories de propositions</link> pour affecter des évaluateurs par catégorie.",
-  "Coming soon": "Bientôt disponible"
+  "Coming soon": "Bientôt disponible",
+  "Open reviews": "Évaluations ouvertes",
+  "Reviewers can see each other's reviews on a proposal": "Les évaluateurs peuvent voir les évaluations des autres sur une proposition",
+  "Turn on Open Reviews?": "Activer les évaluations ouvertes ?",
+  "This can lead reviewers to agree with each other more than they would independently.": "Cela peut amener les évaluateurs à être davantage d’accord entre eux qu’ils ne le seraient de manière indépendante.",
+  "Enable": "Activer"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1418,5 +1418,10 @@
   "Could not remove reviewer. Please try again.": "Não foi possível remover o avaliador. Tente novamente.",
   "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "As categorias vêm de <link>Categorias de propostas</link>. Adicione avaliadores a cada uma ou convide alguém novo.",
   "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "Nenhuma categoria encontrada. Adicione-as em <link>Categorias de propostas</link> para atribuir avaliadores por categoria.",
-  "Coming soon": "Em breve"
+  "Coming soon": "Em breve",
+  "Open reviews": "Avaliações abertas",
+  "Reviewers can see each other's reviews on a proposal": "Os avaliadores podem ver as avaliações uns dos outros em uma proposta",
+  "Turn on Open Reviews?": "Ativar avaliações abertas?",
+  "This can lead reviewers to agree with each other more than they would independently.": "Isso pode levar os avaliadores a concordarem mais uns com os outros do que fariam de forma independente.",
+  "Enable": "Ativar"
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1420,5 +1420,10 @@
   "Could not remove reviewer. Please try again.": "Lama saarin dib-u-eegaha. Fadlan mar kale isku day.",
   "Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.": "Qaybaha waxay ka yimaadaan <link>Qaybaha Soo Jeedinta</link>. Ku dar dib-u-eegayaal mid kasta, ama ku casuum qof cusub.",
   "No categories found. Add them in <link>Proposal Categories</link> to assign reviewers by category.": "Lama helin qaybo. Ku dar <link>Qaybaha Soo Jeedinta</link> si aad u qoondayso dib-u-eegayaal qayb ahaan.",
-  "Coming soon": "Waa iman doonaa dhakhso"
+  "Coming soon": "Waa iman doonaa dhakhso",
+  "Open reviews": "Dib-u-eegisyada furan",
+  "Reviewers can see each other's reviews on a proposal": "Dib-u-eegayaashu waxay ku arki karaan dib-u-eegisyada midba midka kale ee soo jeedin",
+  "Turn on Open Reviews?": "Shid dib-u-eegisyada furan?",
+  "This can lead reviewers to agree with each other more than they would independently.": "Tani waxay u horseedi kartaa in dib-u-eegayaashu isku raacaan midba midka kale in ka badan intii ay si madax-bannaan u samayn lahaayeen.",
+  "Enable": "Shid"
 }


### PR DESCRIPTION
Adds an "Open reviews" per-phase toggle to the process builder's phase editor, shown directly below "Proposal review" and only when Proposal review is on. When enabled, reviewers can see each other's reviews on a proposal (writes rules.reviews.openReviews). Default off.

Turning it ON opens a confirm dialog ("Turn on Open Reviews?" — "This can lead reviewers to agree with each other more than they would independently.") with Cancel/Enable; only Enable writes openReviews: true. Turning it OFF is immediate. Disabling Proposal review also clears openReviews so a hidden-but-true setting can't silently re-open reviews if review is re-enabled later.

Unifies the feature flag: the by-category flag reviews_by_category is renamed to reviews-v2, now the single source of truth (REVIEWS_V2_FLAG) gating both the by-category review UI and this new toggle.

PostHog ops: create a reviews-v2 feature flag and enable it wherever reviews_by_category was enabled; the old reviews_by_category key is no longer read.

PR 2/5 of the open-reviews stack. Based on reviews-open-reviews-setting.