### PR TITLE
feat(decision): phase-scoped review aggregates honoring each phase's openReviews

### DIFF
--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -20,6 +20,11 @@ export {
   type ReviewSettings,
 } from './services/decision/utils/phaseSettings';
 export {
+  getPhaseIndex,
+  getPreviousPhases,
+  isPhaseAtOrBefore,
+} from './services/decision/utils/phaseOrder';
+export {
   attachmentSchema,
   documentContentSchema,
   proposalAccessSchema,

--- a/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
@@ -2,7 +2,7 @@ import { and, db, eq, isNull } from '@op/db/client';
 import type { User } from '@op/supabase/lib';
 import { z } from 'zod';
 
-import { NotFoundError, UnauthorizedError } from '../../utils';
+import { NotFoundError } from '../../utils';
 import { getInstance } from './getInstance';
 import { getRubricScoringInfo } from './getRubricScoringInfo';
 import {
@@ -11,12 +11,12 @@ import {
   getSubmittedReviewScore,
   proposalRelations,
 } from './listProposalsWithReviewAggregates';
+import { assertCanReadPhaseReviews } from './reviewHelpers';
 import { instanceOptionalPhaseRefSchema } from './schemas/instance';
 import {
   type ProposalWithSubmittedReviews,
   proposalWithSubmittedReviewsSchema,
 } from './schemas/reviews';
-import { getPhaseReviewSettings } from './utils/phaseSettings';
 
 export const getProposalWithReviewAggregatesInputSchema =
   instanceOptionalPhaseRefSchema.extend({
@@ -30,36 +30,21 @@ export type GetProposalWithReviewAggregatesInput = z.infer<
 /**
  * Submitted-only by design: drafts and unstarted assignments contribute to
  * `aggregates.assignmentsCount` but are not surfaced in `reviews[]`.
+ *
+ * `phaseId` scopes the review set to assignments pinned to that phase, so all
+ * derived values (reviews[], aggregates) are per-source-phase. Omitted means
+ * all phases — admin-only; reviewers must always name a phase.
  */
 export async function getProposalWithReviewAggregates(
   input: GetProposalWithReviewAggregatesInput & { user: User },
 ): Promise<ProposalWithSubmittedReviews> {
-  const { user, processInstanceId, proposalId } = input;
+  const { user, processInstanceId, proposalId, phaseId } = input;
 
   const instance = await getInstance({ instanceId: processInstanceId, user });
 
-  // Admins always read the full review set. Resolve their access first and
-  // short-circuit before touching phase settings — `getPhaseReviewSettings`
-  // throws NotFound on an instance whose `currentStateId` matches no phase,
-  // and admins must keep reading regardless of phase configuration.
-  //
-  // Otherwise reviewers get proposal-wide read only when the instance's
-  // current phase opts into open reviews — and this grant is deliberately
-  // process-wide: ANY reviewer (access.review) of the process can read, not
-  // only those assigned to this proposal.
-  if (!instance.access.admin) {
-    const openReviewsForReviewers =
-      instance.access.review &&
-      instance.currentStateId != null &&
-      getPhaseReviewSettings(instance.instanceData, instance.currentStateId)
-        .openReviews;
-
-    if (!openReviewsForReviewers) {
-      throw new UnauthorizedError(
-        "You don't have access to read reviews for this process instance",
-      );
-    }
-  }
+  // Read gate: admin, or the process-wide reviewer grant on an open phase at
+  // or before the current one — see `canReadPhaseReviews` for the semantics.
+  assertCanReadPhaseReviews(instance, phaseId);
 
   const rubricTemplate = instance.instanceData.rubricTemplate;
   const scoredCriterionKeys = rubricTemplate
@@ -67,8 +52,6 @@ export async function getProposalWithReviewAggregates(
         .criteria.filter((c) => c.scored)
         .map((c) => c.key)
     : [];
-
-  const phaseId = input.phaseId ?? instance.currentStateId ?? undefined;
 
   const [proposal, categoriesByProposalId] = await Promise.all([
     db.query.proposals.findFirst({

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -132,6 +132,9 @@ export * from './utils/instance';
 // Phase-level settings resolution
 export * from './utils/phaseSettings';
 
+// Phase-order navigation
+export * from './utils/phaseOrder';
+
 // Voting management
 export * from './voting';
 

--- a/packages/common/src/services/decision/reviewHelpers.ts
+++ b/packages/common/src/services/decision/reviewHelpers.ts
@@ -9,7 +9,11 @@ import type { User } from '@op/supabase/lib';
 import { NotFoundError, UnauthorizedError, ValidationError } from '../../utils';
 import { assertUserByAuthId } from '../assert';
 import { getInstance } from './getInstance';
+import type { DecisionRolePermissions } from './permissions';
 import { type ProposalData, parseProposalData } from './proposalDataSchema';
+import type { DecisionInstanceData } from './schemas/instanceData';
+import { isPhaseAtOrBefore } from './utils/phaseOrder';
+import { getPhaseReviewSettings } from './utils/phaseSettings';
 
 /** Shared `with` config for review assignment queries. */
 export const reviewAssignmentWithConfig = {
@@ -90,6 +94,64 @@ export function getActiveRevisionRequest(
     requests[0] ??
     null
   );
+}
+
+/**
+ * The slice of a loaded decision instance (`getInstance`'s return) that the
+ * phase-reviews read gate needs: the viewer's resolved capabilities plus the
+ * instance's phase configuration.
+ */
+export interface PhaseReviewsReadContext {
+  access: DecisionRolePermissions;
+  currentStateId: string | null;
+  instanceData: DecisionInstanceData;
+}
+
+/**
+ * Whether the caller may read a phase's submitted review set on this
+ * instance. Admins always can — any phase, or all phases when `phaseId` is
+ * omitted — and return before any phase-settings resolution (which throws
+ * NotFound on a phase the instance doesn't have). Reviewers (`access.review`)
+ * must name a phase — without one the caller would read reviews blended
+ * across ALL phases — and that phase's resolved `openReviews` must be on. An
+ * open phase stays readable after it ends (later-phase reviewers read the
+ * earlier phase's reviews), but phases after the current one are never
+ * readable. The reviewer grant is deliberately process-wide: ANY reviewer of
+ * the process can read, not only those assigned to a given proposal.
+ */
+export function canReadPhaseReviews(
+  instance: PhaseReviewsReadContext,
+  phaseId: string | undefined,
+): boolean {
+  if (instance.access.admin) {
+    return true;
+  }
+
+  if (!instance.access.review || !phaseId || instance.currentStateId == null) {
+    return false;
+  }
+
+  // No peeking past the current phase: the target must be the current phase
+  // or an earlier one in the instance's phase ordering.
+  if (
+    !isPhaseAtOrBefore(instance.instanceData, phaseId, instance.currentStateId)
+  ) {
+    return false;
+  }
+
+  return getPhaseReviewSettings(instance.instanceData, phaseId).openReviews;
+}
+
+/** `canReadPhaseReviews`, but throws `UnauthorizedError` on denial. */
+export function assertCanReadPhaseReviews(
+  instance: PhaseReviewsReadContext,
+  phaseId: string | undefined,
+): void {
+  if (!canReadPhaseReviews(instance, phaseId)) {
+    throw new UnauthorizedError(
+      "You don't have access to read reviews for this process instance",
+    );
+  }
 }
 
 /** Loads and authorizes access to a single review assignment for the current reviewer. */

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -97,7 +97,10 @@ export const phaseReviewSettingsSchema = z.object({
   policy: z.enum(REVIEWS_POLICIES).optional(),
   allowRevisions: z.boolean().optional(),
   anonymousFeedback: z.boolean().optional(),
-  /** Reviewers can see each other's submitted reviews during this phase. */
+  /**
+   * The phase's submitted reviews are open: visible to peer reviewers while
+   * the phase is current, and to reviewers in later phases afterwards.
+   */
   openReviews: z.boolean().optional(),
 });
 

--- a/packages/common/src/services/decision/utils/phaseOrder.test.ts
+++ b/packages/common/src/services/decision/utils/phaseOrder.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getPhaseIndex,
+  getPreviousPhases,
+  isPhaseAtOrBefore,
+} from './phaseOrder';
+
+const instanceData = {
+  phases: [
+    { phaseId: 'submission' },
+    { phaseId: 'feasibility' },
+    { phaseId: 'community' },
+    { phaseId: 'results' },
+  ],
+};
+
+describe('getPhaseIndex', () => {
+  it('returns the position of the phase in the ordering', () => {
+    expect(getPhaseIndex(instanceData, 'submission')).toBe(0);
+    expect(getPhaseIndex(instanceData, 'community')).toBe(2);
+  });
+
+  it('returns -1 for a phase not configured on the instance', () => {
+    expect(getPhaseIndex(instanceData, 'missing')).toBe(-1);
+  });
+
+  it('returns -1 when the instance has no phases', () => {
+    expect(getPhaseIndex({ phases: [] }, 'submission')).toBe(-1);
+    expect(getPhaseIndex({}, 'submission')).toBe(-1);
+  });
+});
+
+describe('isPhaseAtOrBefore', () => {
+  it('is true for an earlier phase', () => {
+    expect(isPhaseAtOrBefore(instanceData, 'feasibility', 'community')).toBe(
+      true,
+    );
+  });
+
+  it('is true for the same phase', () => {
+    expect(isPhaseAtOrBefore(instanceData, 'community', 'community')).toBe(
+      true,
+    );
+  });
+
+  it('is false for a later phase', () => {
+    expect(isPhaseAtOrBefore(instanceData, 'results', 'community')).toBe(false);
+  });
+
+  it('fails closed when the target phase is not configured', () => {
+    expect(isPhaseAtOrBefore(instanceData, 'missing', 'community')).toBe(false);
+  });
+
+  it('fails closed when the reference phase is not configured', () => {
+    expect(isPhaseAtOrBefore(instanceData, 'submission', 'missing')).toBe(
+      false,
+    );
+  });
+});
+
+describe('getPreviousPhases', () => {
+  it('returns the earlier phases in phase order', () => {
+    expect(getPreviousPhases(instanceData, 'community')).toEqual([
+      { phaseId: 'submission' },
+      { phaseId: 'feasibility' },
+    ]);
+  });
+
+  it('returns an empty list for the first phase', () => {
+    expect(getPreviousPhases(instanceData, 'submission')).toEqual([]);
+  });
+
+  it('returns an empty list for a phase not configured on the instance', () => {
+    expect(getPreviousPhases(instanceData, 'missing')).toEqual([]);
+  });
+
+  it('preserves the full phase entries, not just ids', () => {
+    const withRules = {
+      phases: [
+        { phaseId: 'a', rules: { reviews: { submit: true } } },
+        { phaseId: 'b' },
+      ],
+    };
+
+    expect(getPreviousPhases(withRules, 'b')).toEqual([
+      { phaseId: 'a', rules: { reviews: { submit: true } } },
+    ]);
+  });
+});

--- a/packages/common/src/services/decision/utils/phaseOrder.ts
+++ b/packages/common/src/services/decision/utils/phaseOrder.ts
@@ -1,0 +1,48 @@
+/**
+ * Phase-order navigation over `instanceData.phases`. Phase order IS the array
+ * order (first = initial, last = final) — phases carry no explicit rank.
+ * Generic/structural like `assertInstancePhase`, so domain instance data and
+ * the API-encoder shape both pass. Client-safe: no server-only imports.
+ */
+
+interface PhaseOrderInstanceData<Phase extends { phaseId: string }> {
+  phases?: readonly Phase[];
+}
+
+/** Index of `phaseId` in the instance's phase ordering; `-1` when absent. */
+export function getPhaseIndex(
+  instanceData: PhaseOrderInstanceData<{ phaseId: string }>,
+  phaseId: string,
+): number {
+  return (instanceData.phases ?? []).findIndex((p) => p.phaseId === phaseId);
+}
+
+/**
+ * True when `phaseId` sits at or before `referencePhaseId` in the phase
+ * ordering. False when either phase is not configured on the instance, so
+ * gates using this fail closed on unknown phases.
+ */
+export function isPhaseAtOrBefore(
+  instanceData: PhaseOrderInstanceData<{ phaseId: string }>,
+  phaseId: string,
+  referencePhaseId: string,
+): boolean {
+  const target = getPhaseIndex(instanceData, phaseId);
+  const reference = getPhaseIndex(instanceData, referencePhaseId);
+  return target !== -1 && reference !== -1 && target <= reference;
+}
+
+/**
+ * The phases strictly before `phaseId` in the ordering, in phase order.
+ * Empty when `phaseId` is the first phase or is not configured.
+ */
+export function getPreviousPhases<Phase extends { phaseId: string }>(
+  instanceData: PhaseOrderInstanceData<Phase>,
+  phaseId: string,
+): Phase[] {
+  const index = getPhaseIndex(instanceData, phaseId);
+  if (index <= 0) {
+    return [];
+  }
+  return (instanceData.phases ?? []).slice(0, index);
+}

--- a/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
+++ b/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
@@ -1,4 +1,7 @@
-import type { RubricTemplateSchema } from '@op/common';
+import type {
+  DecisionSchemaDefinition,
+  RubricTemplateSchema,
+} from '@op/common';
 import { OVERALL_RECOMMENDATION_KEY } from '@op/common/client';
 import {
   ProposalReviewAssignmentStatus,
@@ -65,6 +68,105 @@ async function advanceToReviewPhase(instanceId: string) {
     .update(processInstances)
     .set({ currentStateId: 'review' })
     .where(eq(processInstances.id, instanceId));
+}
+
+// --- Two back-to-back review phases (Columbus: feasibility → community) ----
+
+const FEASIBILITY_PHASE = 'feasibility';
+const COMMUNITY_PHASE = 'community';
+
+const twoReviewPhaseSchema = {
+  id: 'two-review-phases',
+  version: '1.0.0',
+  name: 'Two Review Phases',
+  description: 'Feasibility review followed by a community impact review.',
+  phases: [
+    {
+      id: 'submission',
+      name: 'Proposal Submission',
+      rules: {
+        proposals: { submit: true },
+        advancement: { method: 'date' as const, endDate: '2026-01-01' },
+      },
+    },
+    {
+      id: FEASIBILITY_PHASE,
+      name: 'Feasibility Review',
+      rules: {
+        reviews: { submit: true },
+        advancement: { method: 'date' as const, endDate: '2026-01-02' },
+      },
+    },
+    {
+      id: COMMUNITY_PHASE,
+      name: 'Community Impact Review',
+      rules: {
+        reviews: { submit: true },
+        advancement: { method: 'date' as const, endDate: '2026-01-03' },
+      },
+    },
+  ],
+} satisfies DecisionSchemaDefinition;
+
+/**
+ * One proposal with a submitted review pinned to each of the two review
+ * phases; the instance ends up sitting in the community phase. `openReviews`
+ * is left unset (off) on both phases — tests flip it per scenario.
+ */
+async function seedTwoPhaseReviews(testData: TestReviewsDataManager) {
+  const context = await testData.createContext({
+    processSchema: twoReviewPhaseSchema,
+  });
+  await testData.setRubricTemplate(context, rubricTemplate);
+
+  const feasibilityScenario = await testData.createReviewAssignment({
+    context,
+    title: 'Two-phase reviews',
+    phaseId: FEASIBILITY_PHASE,
+  });
+  await createProposalReview({
+    assignmentId: feasibilityScenario.assignment.id,
+    state: ProposalReviewState.SUBMITTED,
+    reviewData: {
+      answers: {
+        impact: 7,
+        feasibility: 4,
+        [OVERALL_RECOMMENDATION_KEY]: 'yes',
+      },
+      rationales: {},
+    },
+    submittedAt: new Date().toISOString(),
+  });
+
+  const communityReviewer = await testData.createReviewer(context);
+  const communityAssignment = await createReviewAssignment({
+    processInstanceId: context.instance.instance.id,
+    proposalId: feasibilityScenario.proposal.id,
+    reviewerProfileId: communityReviewer.profileId,
+    phaseId: COMMUNITY_PHASE,
+  });
+  await createProposalReview({
+    assignmentId: communityAssignment.id,
+    state: ProposalReviewState.SUBMITTED,
+    reviewData: {
+      answers: {
+        impact: 3,
+        feasibility: 2,
+        [OVERALL_RECOMMENDATION_KEY]: 'no',
+      },
+      rationales: {},
+    },
+    submittedAt: new Date().toISOString(),
+  });
+
+  await testData.setCurrentPhase(context.instance.instance.id, COMMUNITY_PHASE);
+
+  return {
+    context,
+    proposal: feasibilityScenario.proposal,
+    feasibilityReviewerProfileId: feasibilityScenario.reviewer.profileId,
+    communityReviewerProfileId: communityReviewer.profileId,
+  };
 }
 
 describe.concurrent('getProposalWithReviewAggregates', () => {
@@ -308,8 +410,11 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
     });
   });
 
-  // --- Open Reviews read gate (PR 1/5) -------------------------------------
-  // Admin OR (REVIEW access AND the current phase's `openReviews` is on).
+  // --- Open Reviews read gate ------------------------------------------------
+  // Admin OR (REVIEW access AND an explicit `phaseId` whose `openReviews` is
+  // on). These cases exercise the single-review-phase shape where the named
+  // phase is the current one; the phase-scoping describe below covers the
+  // multi-phase matrix.
 
   it('admits an admin even when the current phase has openReviews off', async ({
     task,
@@ -386,6 +491,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
       reviewerCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: context.instance.instance.id,
         proposalId: scenario.proposal.id,
+        phaseId: 'review',
       }),
     ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
@@ -438,6 +544,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
       await reviewerCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: context.instance.instance.id,
         proposalId: scenario.proposal.id,
+        phaseId: 'review',
       });
 
     expect(result.reviews).toHaveLength(1);
@@ -489,6 +596,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
       await reviewerCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: context.instance.instance.id,
         proposalId: scenario.proposal.id,
+        phaseId: 'review',
       });
 
     expect(result.proposal.id).toBe(scenario.proposal.id);
@@ -522,6 +630,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
       memberCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: context.instance.instance.id,
         proposalId: scenario.proposal.id,
+        phaseId: 'review',
       }),
     ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
@@ -589,6 +698,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
       await reviewerCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: context.instance.instance.id,
         proposalId: scenario.proposal.id,
+        phaseId: 'review',
       });
 
     expect(result.reviews).toHaveLength(1);
@@ -596,6 +706,219 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
     expect(
       result.reviews.some((r) => r.reviewer.id === draftPeer.profileId),
     ).toBe(false);
+  });
+});
+
+// --- Phase-scoped aggregates + previous-phase visibility (PR 6) -------------
+// `phaseId` scopes the review set to that phase's assignments. Reviewers must
+// name a phase and get it only when THAT phase's `openReviews` is on — which
+// keeps an open earlier phase readable after it ends (Columbus budget
+// delegates reading feasibility reviews) without exposing any closed phase.
+
+describe.concurrent('getProposalWithReviewAggregates phase scoping', () => {
+  it('admin without phaseId reads submitted reviews across all phases', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const seeded = await seedTwoPhaseReviews(testData);
+
+    const adminCaller = await createAuthenticatedCaller(
+      seeded.context.defaultReviewer.email,
+    );
+
+    const result = await adminCaller.decision.getProposalWithReviewAggregates({
+      processInstanceId: seeded.context.instance.instance.id,
+      proposalId: seeded.proposal.id,
+    });
+
+    expect(result.aggregates.assignmentsCount).toBe(2);
+    expect(result.reviews).toHaveLength(2);
+    expect(result.reviews.map((r) => r.reviewer.id).sort()).toEqual(
+      [
+        seeded.feasibilityReviewerProfileId,
+        seeded.communityReviewerProfileId,
+      ].sort(),
+    );
+  });
+
+  it('admin with phaseId reads only that phase, aggregates included', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const seeded = await seedTwoPhaseReviews(testData);
+
+    const adminCaller = await createAuthenticatedCaller(
+      seeded.context.defaultReviewer.email,
+    );
+
+    const result = await adminCaller.decision.getProposalWithReviewAggregates({
+      processInstanceId: seeded.context.instance.instance.id,
+      proposalId: seeded.proposal.id,
+      phaseId: FEASIBILITY_PHASE,
+    });
+
+    expect(result.aggregates.assignmentsCount).toBe(1);
+    expect(result.aggregates.reviewsSubmittedCount).toBe(1);
+    expect(result.reviews).toHaveLength(1);
+    expect(result.reviews[0]!.reviewer.id).toBe(
+      seeded.feasibilityReviewerProfileId,
+    );
+  });
+
+  it('reviewer naming the current phase with openReviews on sees only current-phase reviews', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const seeded = await seedTwoPhaseReviews(testData);
+    await testData.setPhaseOpenReviews(
+      seeded.context.instance.instance.id,
+      COMMUNITY_PHASE,
+      true,
+    );
+
+    const reviewer = await testData.createInstanceReviewerWithRole(
+      seeded.context,
+    );
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+
+    const result =
+      await reviewerCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: seeded.context.instance.instance.id,
+        proposalId: seeded.proposal.id,
+        phaseId: COMMUNITY_PHASE,
+      });
+
+    // The feasibility review on the same proposal must NOT be blended in.
+    expect(result.reviews).toHaveLength(1);
+    expect(result.reviews[0]!.reviewer.id).toBe(
+      seeded.communityReviewerProfileId,
+    );
+  });
+
+  it('reviewer reads an earlier open phase even while the current phase is closed', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const seeded = await seedTwoPhaseReviews(testData);
+    // Feasibility ran open; the community phase (current) keeps its own
+    // reviews closed — the budget-delegate configuration.
+    await testData.setPhaseOpenReviews(
+      seeded.context.instance.instance.id,
+      FEASIBILITY_PHASE,
+      true,
+    );
+
+    const reviewer = await testData.createInstanceReviewerWithRole(
+      seeded.context,
+    );
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+
+    const result =
+      await reviewerCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: seeded.context.instance.instance.id,
+        proposalId: seeded.proposal.id,
+        phaseId: FEASIBILITY_PHASE,
+      });
+
+    expect(result.reviews).toHaveLength(1);
+    expect(result.reviews[0]!.reviewer.id).toBe(
+      seeded.feasibilityReviewerProfileId,
+    );
+  });
+
+  it('denies a reviewer naming an earlier phase whose openReviews is off', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const seeded = await seedTwoPhaseReviews(testData);
+    // The CURRENT phase being open must not leak the closed earlier phase.
+    await testData.setPhaseOpenReviews(
+      seeded.context.instance.instance.id,
+      COMMUNITY_PHASE,
+      true,
+    );
+
+    const reviewer = await testData.createInstanceReviewerWithRole(
+      seeded.context,
+    );
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+
+    await expect(
+      reviewerCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: seeded.context.instance.instance.id,
+        proposalId: seeded.proposal.id,
+        phaseId: FEASIBILITY_PHASE,
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+  });
+
+  it('denies a reviewer who names no phase, even when every phase is open', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const seeded = await seedTwoPhaseReviews(testData);
+    await testData.setPhaseOpenReviews(
+      seeded.context.instance.instance.id,
+      FEASIBILITY_PHASE,
+      true,
+    );
+    await testData.setPhaseOpenReviews(
+      seeded.context.instance.instance.id,
+      COMMUNITY_PHASE,
+      true,
+    );
+
+    const reviewer = await testData.createInstanceReviewerWithRole(
+      seeded.context,
+    );
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+
+    // No phaseId would blend reviews across ALL phases — reviewer-tier callers
+    // are rejected outright.
+    await expect(
+      reviewerCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: seeded.context.instance.instance.id,
+        proposalId: seeded.proposal.id,
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
+  });
+
+  it('denies a reviewer naming a phase later than the current one', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const seeded = await seedTwoPhaseReviews(testData);
+    // Wind the instance back to feasibility; the (open) community phase now
+    // lies in the future and must not be readable.
+    await testData.setPhaseOpenReviews(
+      seeded.context.instance.instance.id,
+      COMMUNITY_PHASE,
+      true,
+    );
+    await testData.setCurrentPhase(
+      seeded.context.instance.instance.id,
+      FEASIBILITY_PHASE,
+    );
+
+    const reviewer = await testData.createInstanceReviewerWithRole(
+      seeded.context,
+    );
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+
+    await expect(
+      reviewerCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: seeded.context.instance.instance.id,
+        proposalId: seeded.proposal.id,
+        phaseId: COMMUNITY_PHASE,
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
 });
 

--- a/services/api/src/test/helpers/TestReviewsDataManager.ts
+++ b/services/api/src/test/helpers/TestReviewsDataManager.ts
@@ -20,6 +20,10 @@ import { eq } from 'drizzle-orm';
 import { supabaseTestAdminClient } from '../supabase-utils';
 import { TestDecisionsDataManager } from './TestDecisionsDataManager';
 
+type DecisionProcessSchema = NonNullable<
+  Parameters<TestDecisionsDataManager['createDecisionSetup']>[0]
+>['processSchema'];
+
 interface ReviewParticipant {
   authUserId: string;
   email: string;
@@ -45,6 +49,8 @@ interface CreateReviewAssignmentOptions {
   title?: string;
   description?: string;
   status?: ProposalReviewAssignmentStatus;
+  /** Phase the assignment is pinned to (defaults to `'review'`). */
+  phaseId?: string;
 }
 
 /** Creates review-focused test fixtures on top of the decision test setup. */
@@ -61,11 +67,13 @@ export class TestReviewsDataManager {
   }
 
   /** Creates a configured review context for review API tests. */
-  async createContext(): Promise<ReviewAssignmentContext> {
+  async createContext(
+    opts: { processSchema?: DecisionProcessSchema } = {},
+  ): Promise<ReviewAssignmentContext> {
     const setup = await this.decisions.createDecisionSetup({
       instanceCount: 1,
       grantAccess: true,
-      processSchema: testSimpleVotingSchema,
+      processSchema: opts.processSchema ?? testSimpleVotingSchema,
     });
 
     const instance = setup.instance;
@@ -320,6 +328,7 @@ export class TestReviewsDataManager {
         ...(opts.description ? { description: opts.description } : {}),
       },
       assignmentStatus: opts.status,
+      phaseId: opts.phaseId,
     });
 
     this.decisions.trackProfileForCleanup(proposal.profileId);


### PR DESCRIPTION
Columbus runs two review phases back to back: an open feasibility review followed by a community impact review whose budget delegates must read the prior feasibility reviews without seeing each other's current-phase reviews. getProposalWithReviewAggregates now takes an optional phaseId that scopes the returned reviews (and the aggregates derived from them) to assignments pinned to that phase. Admins keep today's behavior: any phase, or all phases when no phaseId is given. Non-admin reviewers must name a phase and may read it only when that phase's resolved rules.reviews.openReviews is on and the phase is the current one or earlier — an open phase stays readable after it ends, a closed phase never leaks, and future phases are never readable. This also closes a latent hole in the #1694 gate where a reviewer on an open current phase could read reviews blended across all phases: reviewer calls without an explicit phaseId are now rejected (the reviewer tab from #1698 already passes the assignment's phase id). No new phase-level setting — openReviews itself is the cross-phase openness signal. PR 6 of the open-reviews stack (extends #1694–#1699); the builder control and phase-labeled tabs follow in PR 7.