### PR TITLE
feat(decision): "Reviews from [phase]" reviewer tab for earlier open review phases

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewLayout.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayout.tsx
@@ -5,7 +5,7 @@ import {
 } from '@op/api/server';
 import { createClient } from '@op/api/serverClient';
 import { CommonError } from '@op/common';
-import { getPhaseReviewSettings } from '@op/common/client';
+import { getPhaseReviewSettings, getPreviousPhases } from '@op/common/client';
 import { SplitPane } from '@op/ui/SplitPane';
 import { forbidden, notFound } from 'next/navigation';
 
@@ -15,6 +15,7 @@ import { ReviewFormProvider } from './ReviewFormContext';
 import { ReviewNavbar } from './ReviewNavbar';
 import { ReviewProposalPane } from './ReviewProposalPane';
 import { ReviewRubricForm } from './ReviewRubricForm';
+import type { PreviousReviewPhase } from './ReviewTabs';
 
 interface ReviewLayoutProps {
   decisionSlug: string;
@@ -32,18 +33,36 @@ export async function ReviewLayout({
 
   let allowRevisions: boolean;
   let openReviews: boolean;
+  let previousReviewPhases: PreviousReviewPhase[];
   try {
     const [decisionProfile, reviewAssignment] = await Promise.all([
       client.decision.getDecisionBySlug({ slug: decisionSlug }),
       utils.decision.getReviewAssignment.fetch({ assignmentId }),
     ]);
 
+    const instanceData = decisionProfile.processInstance.instanceData;
+    const assignmentPhaseId = reviewAssignment.assignment.phaseId;
+
     // Throws NotFoundError when the assignment's phase is no longer in the
     // instance's phase list (stale assignment) — mapped to notFound() below.
     ({ allowRevisions, openReviews } = getPhaseReviewSettings(
-      decisionProfile.processInstance.instanceData,
-      reviewAssignment.assignment.phaseId,
+      instanceData,
+      assignmentPhaseId,
     ));
+
+    // Earlier review phases whose `openReviews` keeps their reviews readable
+    // from this screen. Strictly before the assignment's phase in the
+    // instance's phase ordering, so the phase this screen reviews in never
+    // doubles up with its own "Other reviews" tab.
+    previousReviewPhases = getPreviousPhases(instanceData, assignmentPhaseId)
+      .filter((phase) => {
+        const settings = getPhaseReviewSettings(instanceData, phase.phaseId);
+        return settings.submit && settings.openReviews;
+      })
+      .map((phase) => ({
+        id: phase.phaseId,
+        name: phase.name ?? phase.phaseId,
+      }));
   } catch (error) {
     // tRPC errors carry the CommonError in `cause`; local throws are the error itself.
     const cause =
@@ -82,7 +101,10 @@ export async function ReviewLayout({
               id="review"
               label={<TranslatedText text="Review" />}
             >
-              <ReviewRubricForm openReviews={openReviews} />
+              <ReviewRubricForm
+                openReviews={openReviews}
+                previousReviewPhases={previousReviewPhases}
+              />
             </SplitPane.Pane>
           </SplitPane>
         </div>

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -25,21 +25,29 @@ import type { FieldDescriptor } from '../forms/types';
 import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
 import { useReviewForm } from './ReviewFormContext';
 import { FormShell, TotalScoreCard } from './ReviewFormShell';
-import { ReviewTabs } from './ReviewTabs';
+import { type PreviousReviewPhase, ReviewTabs } from './ReviewTabs';
 import { SubmittedReviewView } from './SubmittedReviewView';
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
 /**
- * Right-hand "Review Proposal" panel. When open reviews are enabled (reviews-v2
- * flag + the current phase's `openReviews` setting), the reviewer's own form is
- * shown under a "My review" tab alongside an "Other reviews" tab; otherwise the
- * form renders on its own exactly as before.
+ * Right-hand "Review Proposal" panel. Behind the reviews-v2 flag, the
+ * reviewer's own form is shown under a "My review" tab alongside an "Other
+ * reviews" tab (when the current phase's `openReviews` is on) and one
+ * "Reviews from {phase}" tab per earlier open review phase. With no tab
+ * beyond "My review", the form renders on its own exactly as before.
  */
-export function ReviewRubricForm({ openReviews }: { openReviews: boolean }) {
-  const reviewsV2Enabled = useFeatureFlag('reviews-v2');
-  const showTabs = reviewsV2Enabled && openReviews;
+export function ReviewRubricForm({
+  openReviews,
+  previousReviewPhases,
+}: {
+  openReviews: boolean;
+  previousReviewPhases: PreviousReviewPhase[];
+}) {
+  const reviewsV2Enabled = useFeatureFlag('reviews-v2') ?? false;
+  const showOtherReviews = reviewsV2Enabled && openReviews;
+  const previousPhases = reviewsV2Enabled ? previousReviewPhases : [];
 
-  if (!showTabs) {
+  if (!showOtherReviews && previousPhases.length === 0) {
     return (
       <FormShell>
         <MyReviewForm />
@@ -49,7 +57,11 @@ export function ReviewRubricForm({ openReviews }: { openReviews: boolean }) {
 
   return (
     <FormShell>
-      <ReviewTabs myReview={<MyReviewForm />} />
+      <ReviewTabs
+        myReview={<MyReviewForm />}
+        showOtherReviews={showOtherReviews}
+        previousPhases={previousPhases}
+      />
     </FormShell>
   );
 }

--- a/apps/app/src/components/decisions/Review/ReviewTabs.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewTabs.tsx
@@ -14,25 +14,52 @@ import { useReviewForm } from './ReviewFormContext';
 
 const MY_REVIEW_TAB = 'my-review';
 const OTHER_REVIEWS_TAB = 'other-reviews';
+const PHASE_TAB_PREFIX = 'phase-reviews-';
+
+/** An earlier review phase whose `openReviews` keeps its reviews readable here. */
+export interface PreviousReviewPhase {
+  id: string;
+  name: string;
+}
 
 /**
- * Two-tab shell for the "Review Proposal" panel when open reviews are enabled:
- * the reviewer's own form ("My review") and a read-only view of everyone else's
- * submitted reviews ("Other reviews").
+ * Tab shell for the "Review Proposal" panel:
  *
- * The "My review" panel is force-mounted so the form (autosave, submit, and
- * revision flows) keeps its state while the reviewer browses other reviews. The
- * "Other reviews" panel mounts lazily, so its aggregates query only runs once
- * the reviewer opens the tab.
+ * - "My review" — the reviewer's own form. Force-mounted so the form
+ *   (autosave, submit, and revision flows) keeps its state while the reviewer
+ *   browses the other tabs.
+ * - "Other reviews" — the current phase's submitted reviews with the viewer's
+ *   own excluded; rendered only when the current phase has open reviews.
+ * - "Reviews from {phase}" — one per earlier open review phase. These are a
+ *   historical record, so the viewer's own review (if any) is included.
+ *
+ * Every panel except "My review" mounts lazily, so its aggregates query only
+ * runs once the reviewer opens the tab.
  */
-export function ReviewTabs({ myReview }: { myReview: ReactNode }) {
+export function ReviewTabs({
+  myReview,
+  showOtherReviews,
+  previousPhases,
+}: {
+  myReview: ReactNode;
+  showOtherReviews: boolean;
+  previousPhases: PreviousReviewPhase[];
+}) {
   const t = useTranslations();
+  const { assignment } = useReviewForm();
 
   return (
     <Tabs defaultSelectedKey={MY_REVIEW_TAB}>
       <TabList aria-label={t('Review Proposal')}>
         <Tab id={MY_REVIEW_TAB}>{t('My review')}</Tab>
-        <Tab id={OTHER_REVIEWS_TAB}>{t('Other reviews')}</Tab>
+        {showOtherReviews ? (
+          <Tab id={OTHER_REVIEWS_TAB}>{t('Other reviews')}</Tab>
+        ) : null}
+        {previousPhases.map((phase) => (
+          <Tab key={phase.id} id={`${PHASE_TAB_PREFIX}${phase.id}`}>
+            {t('Reviews from {phase}', { phase: phase.name })}
+          </Tab>
+        ))}
       </TabList>
 
       {/* Force-mounted panels only get an `inert` attribute from React Aria
@@ -46,30 +73,74 @@ export function ReviewTabs({ myReview }: { myReview: ReactNode }) {
         {myReview}
       </TabPanel>
 
-      <TabPanel id={OTHER_REVIEWS_TAB} className="sm:p-0">
-        <APIErrorBoundary
-          fallbacks={{
-            default: () => (
-              <p className="py-8 text-center text-base text-neutral-gray4">
-                {t('Failed to load reviews')}
-              </p>
-            ),
-          }}
-        >
-          <Suspense fallback={<OtherReviewsSkeleton />}>
-            <OtherReviews />
-          </Suspense>
-        </APIErrorBoundary>
-      </TabPanel>
+      {showOtherReviews ? (
+        <ReviewsTabPanel id={OTHER_REVIEWS_TAB}>
+          <PhaseReviews
+            phaseId={assignment.phaseId}
+            excludeOwnReview
+            emptyMessage={t('No other reviews yet')}
+          />
+        </ReviewsTabPanel>
+      ) : null}
+
+      {previousPhases.map((phase) => (
+        <ReviewsTabPanel key={phase.id} id={`${PHASE_TAB_PREFIX}${phase.id}`}>
+          <PhaseReviews
+            phaseId={phase.id}
+            emptyMessage={t('No reviews were submitted in this phase')}
+          />
+        </ReviewsTabPanel>
+      ))}
     </Tabs>
   );
 }
 
-function OtherReviews() {
+/** Lazily mounted reviews panel with its own error boundary + suspense fallback. */
+function ReviewsTabPanel({
+  id,
+  children,
+}: {
+  id: string;
+  children: ReactNode;
+}) {
   const t = useTranslations();
+
+  return (
+    <TabPanel id={id} className="sm:p-0">
+      <APIErrorBoundary
+        fallbacks={{
+          default: () => (
+            <p className="py-8 text-center text-base text-neutral-gray4">
+              {t('Failed to load reviews')}
+            </p>
+          ),
+        }}
+      >
+        <Suspense fallback={<PhaseReviewsSkeleton />}>{children}</Suspense>
+      </APIErrorBoundary>
+    </TabPanel>
+  );
+}
+
+/**
+ * One phase's submitted reviews for this proposal (average bar, recommendation
+ * groups, drill-in). `excludeOwnReview` hides the viewer's own review — used by
+ * the current phase's "Other reviews" tab; earlier phases show the full record.
+ */
+function PhaseReviews({
+  phaseId,
+  emptyMessage,
+  excludeOwnReview = false,
+}: {
+  phaseId: string;
+  emptyMessage: string;
+  excludeOwnReview?: boolean;
+}) {
   const { assignment, rubricTemplate } = useReviewForm();
   const { user } = useUser();
-  const excludeProfileId = user?.currentProfileId ?? undefined;
+  const excludeProfileId = excludeOwnReview
+    ? (user?.currentProfileId ?? undefined)
+    : undefined;
 
   const [selectedAssignmentId, setSelectedAssignmentId] = useState<
     string | null
@@ -79,19 +150,19 @@ function OtherReviews() {
     trpc.decision.getProposalWithReviewAggregates.useSuspenseQuery({
       processInstanceId: assignment.processInstanceId,
       proposalId: assignment.proposal.id,
-      phaseId: assignment.phaseId,
+      phaseId,
     });
 
-  const otherReviews = excludeProfileId
+  const visibleReviews = excludeProfileId
     ? proposalWithReviews.reviews.filter(
         (review) => review.reviewer.id !== excludeProfileId,
       )
     : proposalWithReviews.reviews;
 
-  if (otherReviews.length === 0) {
+  if (visibleReviews.length === 0) {
     return (
       <p className="py-8 text-center text-base text-neutral-gray4">
-        {t('No other reviews yet')}
+        {emptyMessage}
       </p>
     );
   }
@@ -108,7 +179,7 @@ function OtherReviews() {
   );
 }
 
-function OtherReviewsSkeleton() {
+function PhaseReviewsSkeleton() {
   return (
     <div className="flex flex-col gap-4">
       <Skeleton className="h-14 w-full" />

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1265,6 +1265,8 @@
   "Other reviews": "مراجعات أخرى",
   "No other reviews yet": "لا توجد مراجعات أخرى بعد",
   "Failed to load reviews": "فشل تحميل المراجعات",
+  "Reviews from {phase}": "مراجعات {phase}",
+  "No reviews were submitted in this phase": "لم يتم إرسال أي مراجعات في هذه المرحلة",
   "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} من أصل {total} مراجعين أرسلوا مراجعة لهذا المقترح",
   "View review by {name}": "عرض مراجعة {name}",
   "Meetings": "الاجتماعات",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1327,6 +1327,8 @@
   "Other reviews": "অন্যান্য পর্যালোচনা",
   "No other reviews yet": "এখনও অন্য কোনো পর্যালোচনা নেই",
   "Failed to load reviews": "পর্যালোচনা লোড করতে ব্যর্থ হয়েছে",
+  "Reviews from {phase}": "{phase} থেকে পর্যালোচনা",
+  "No reviews were submitted in this phase": "এই পর্যায়ে কোনো পর্যালোচনা জমা দেওয়া হয়নি",
   "{submitted} out of {total} reviewers submitted a review for this proposal": "{total} জন পর্যালোচকের মধ্যে {submitted} জন এই প্রস্তাবের জন্য একটি পর্যালোচনা জমা দিয়েছেন",
   "View review by {name}": "{name} এর পর্যালোচনা দেখুন",
   "Results are live!": "ফলাফল প্রকাশিত হয়েছে!",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1341,6 +1341,8 @@
   "Other reviews": "Other reviews",
   "No other reviews yet": "No other reviews yet",
   "Failed to load reviews": "Failed to load reviews",
+  "Reviews from {phase}": "Reviews from {phase}",
+  "No reviews were submitted in this phase": "No reviews were submitted in this phase",
   "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} out of {total} reviewers submitted a review for this proposal",
   "View review by {name}": "View review by {name}",
   "Results are live!": "Results are live!",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1326,6 +1326,8 @@
   "Other reviews": "Otras revisiones",
   "No other reviews yet": "Aún no hay otras revisiones",
   "Failed to load reviews": "No se pudieron cargar las revisiones",
+  "Reviews from {phase}": "Revisiones de {phase}",
+  "No reviews were submitted in this phase": "No se enviaron revisiones en esta fase",
   "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} de {total} revisores enviaron una revisión para esta propuesta",
   "View review by {name}": "Ver revisión de {name}",
   "Results are live!": "¡Los resultados están publicados!",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1326,6 +1326,8 @@
   "Other reviews": "Autres évaluations",
   "No other reviews yet": "Aucune autre évaluation pour le moment",
   "Failed to load reviews": "Échec du chargement des évaluations",
+  "Reviews from {phase}": "Évaluations de {phase}",
+  "No reviews were submitted in this phase": "Aucune évaluation n'a été soumise durant cette phase",
   "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} évaluateurs sur {total} ont soumis une révision pour cette proposition",
   "View review by {name}": "Voir la révision de {name}",
   "Results are live!": "Les résultats sont publiés !",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1326,6 +1326,8 @@
   "Other reviews": "Outras avaliações",
   "No other reviews yet": "Ainda não há outras avaliações",
   "Failed to load reviews": "Falha ao carregar as avaliações",
+  "Reviews from {phase}": "Avaliações de {phase}",
+  "No reviews were submitted in this phase": "Nenhuma avaliação foi enviada nesta fase",
   "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} de {total} avaliadores enviaram uma avaliação para esta proposta",
   "View review by {name}": "Ver avaliação de {name}",
   "Results are live!": "Os resultados estão disponíveis!",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1372,6 +1372,8 @@
   "Other reviews": "Dib-u-eegisyo kale",
   "No other reviews yet": "Wali ma jiraan dib-u-eegisyo kale",
   "Failed to load reviews": "Waa lagu guuldareystay soo-dejinta dib-u-eegisyada",
+  "Reviews from {phase}": "Dib-u-eegisyada {phase}",
+  "No reviews were submitted in this phase": "Wax dib-u-eegis ah laguma gudbin marxaladdan",
   "{submitted} out of {total} reviewers submitted a review for this proposal": "{submitted} ka mid ah {total} dib-u-eegayaal ayaa soo gudbiyay dib-u-eegis soo jeedintan",
   "View review by {name}": "Eeg dib-u-eegista {name}",
   "{count, plural, =1 {1 follower} other {# followers}}": "{count, plural, =1 {1 raacaye} other {# raacayaal}}",


### PR DESCRIPTION
PR 7 (final) of the open-reviews stack, on top of #1700. Completes the openReviews semantic on the reviewer screen: a phase's openReviews opens THAT phase's reviews — to peers while the phase is current, and to the process's reviewers in later phases. There is no extra config; the existing per-phase Open reviews toggle is the entire admin surface.

The reviewer review screen now shows one extra tab per earlier open review phase, labeled "Reviews from {phase name}" next to My review (and Other reviews when the current phase itself has open reviews). Each tab lazily loads that phase's aggregates (average score bar, recommendation groups, drill-in to each review) via getProposalWithReviewAggregates with that phaseId, with a per-phase empty state. Unlike Other reviews, historical phase tabs do NOT exclude the viewer's own review — they are a historical record, so if the viewer reviewed in that phase their review shows like anyone else's. The tab strip renders only when at least one tab beyond My review exists; otherwise the plain form is unchanged. All of it stays behind the reviews-v2 flag.

Columbus story: phase 1 feasibility review has openReviews on (staff see each other), phase 2 community impact review has it off (delegates don't see each other) — during phase 2 a delegate sees My review plus a "Reviews from Feasibility Review" tab with all phase-1 reviews, and no Other reviews tab.

Verified in the browser against a seeded two-review-phase instance: with the community phase current, the reviewer gets exactly My review + Reviews from Feasibility Review; the historical tab shows Average Score 6.5/8pts, Yes(1) and Maybe(1) groups including the viewer's own feasibility review. While verifying, found that React Aria only marks the force-mounted My review panel inert (no visual hiding), so it stayed visibly stacked above the selected tab's content; that bug originated in #1698's tabs and is fixed there (data-[inert]:hidden) — this PR inherits the fix.

No new e2e tests by design (integration tests in #1700 own the semantics); the existing open-reviews.spec.ts passes unchanged locally.
