### PR TITLE
feat(decision): multiple choice rubric criterion type

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -8,11 +8,13 @@ import {
 import { NumberField } from '@op/ui/NumberField';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import type { SortableItemControls } from '@op/ui/Sortable';
+import { DragHandle, Sortable } from '@op/ui/Sortable';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
+import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
 import { cn } from '@op/ui/utils';
-import { useRef, useState } from 'react';
-import { LuTrash2 } from 'react-icons/lu';
+import { useEffect, useRef, useState } from 'react';
+import { LuGripVertical, LuPlus, LuTrash2, LuX } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 import type { TranslationKey } from '@/lib/i18n/routing';
@@ -20,6 +22,7 @@ import type { TranslationKey } from '@/lib/i18n/routing';
 import type {
   CriterionView,
   RubricCriterionType,
+  SelectOption,
 } from '@/components/decisions/rubricTemplate';
 
 import {
@@ -48,6 +51,7 @@ interface RubricCriterionCardProps {
     scoreValue: number,
     label: string,
   ) => void;
+  onUpdateOptions?: (criterionId: string, options: SelectOption[]) => void;
   onUpdateRequired: (criterionId: string, required: boolean) => void;
   isNew?: boolean;
   onNewComplete?: (criterionId: string) => void;
@@ -77,6 +81,7 @@ export function RubricCriterionCard({
   onChangeType,
   onUpdateMaxPoints,
   onUpdateScoreLabel,
+  onUpdateOptions,
   onUpdateRequired,
   isNew,
   onNewComplete,
@@ -169,6 +174,18 @@ export function RubricCriterionCard({
                 }
                 onUpdateScoreLabel={(scoreValue, label) =>
                   onUpdateScoreLabel?.(criterion.id, scoreValue, label)
+                }
+              />
+            </>
+          )}
+
+          {criterion.criterionType === 'single_select' && (
+            <>
+              <hr />
+              <SingleSelectCriterionConfig
+                criterion={criterion}
+                onUpdateOptions={(options) =>
+                  onUpdateOptions?.(criterion.id, options)
                 }
               />
             </>
@@ -366,6 +383,192 @@ function ScoredCriterionConfig({
           })}
         </div>
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Single-select criterion config (option list)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sortable row: `id` is the stored option id, `value` its display label.
+ * `description` isn't editable here but is carried through so edits never
+ * strip per-option descriptions authored outside the builder.
+ */
+interface OptionRow {
+  id: string;
+  value: string;
+  description?: string;
+}
+
+/**
+ * Options editor for single-select criteria. Mirrors the proposal template's
+ * FieldConfigDropdown UI: drag to reorder, min-2 removal guard, Enter adds
+ * the next option. Manages its own row state (initialized on mount) and
+ * reports the full option list on every change; row ids are the stored
+ * option ids so relabels/reorders never break saved answers.
+ */
+function SingleSelectCriterionConfig({
+  criterion,
+  onUpdateOptions,
+}: {
+  criterion: CriterionView;
+  onUpdateOptions: (options: SelectOption[]) => void;
+}) {
+  const t = useTranslations();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const shouldFocusNewRef = useRef(false);
+
+  const [options, setOptions] = useState<OptionRow[]>(() =>
+    criterion.options.map((o) => ({
+      id: o.value,
+      value: o.title,
+      ...(o.description !== undefined ? { description: o.description } : {}),
+    })),
+  );
+
+  const updateOptions = (next: OptionRow[]) => {
+    setOptions(next);
+    onUpdateOptions(
+      next.map((row) => ({
+        value: row.id,
+        title: row.value,
+        ...(row.description !== undefined
+          ? { description: row.description }
+          : {}),
+      })),
+    );
+  };
+
+  // Focus the last input when a new option is added
+  useEffect(() => {
+    if (shouldFocusNewRef.current && containerRef.current) {
+      const inputs = containerRef.current.querySelectorAll(
+        'input[type="text"]',
+      ) as NodeListOf<HTMLInputElement>;
+      const lastInput = inputs[inputs.length - 1];
+      lastInput?.focus();
+      shouldFocusNewRef.current = false;
+    }
+  }, [options.length]);
+
+  const renderDragPreview = (items: OptionRow[]) => {
+    const item = items[0];
+    if (!item) {
+      return null;
+    }
+    return (
+      <div className="flex items-center gap-2">
+        <LuGripVertical className="size-4 text-neutral-gray3" />
+        <span className="me-12 grow rounded-lg border border-neutral-gray2 bg-white px-4 py-3 text-neutral-charcoal shadow-lg">
+          {item.value || t('Option')}
+        </span>
+      </div>
+    );
+  };
+
+  const handleAddOption = () => {
+    shouldFocusNewRef.current = true;
+    updateOptions([
+      ...options,
+      { id: crypto.randomUUID().slice(0, 8), value: '' },
+    ]);
+  };
+
+  const handleUpdateOption = (id: string, value: string) => {
+    updateOptions(
+      options.map((opt) => (opt.id === id ? { ...opt, value } : opt)),
+    );
+  };
+
+  const handleRemoveOption = (id: string) => {
+    updateOptions(options.filter((opt) => opt.id !== id));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent, option: OptionRow) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const isLastOption = options[options.length - 1]?.id === option.id;
+      if (isLastOption && option.value.trim()) {
+        handleAddOption();
+      }
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="space-y-2">
+      <h4 className="text-sm text-neutral-charcoal">{t('Options')}</h4>
+
+      <Sortable
+        items={options}
+        onChange={updateOptions}
+        dragTrigger="handle"
+        getItemLabel={(item) => item.value || t('Option')}
+        renderDragPreview={renderDragPreview}
+        className="gap-2"
+        aria-label={t('Options')}
+      >
+        {(option, controls) => {
+          const index = options.findIndex((o) => o.id === option.id);
+          return (
+            <div className="flex items-center gap-2">
+              <DragHandle
+                {...controls.dragHandleProps}
+                aria-label={t('Drag to reorder option')}
+                className="text-neutral-gray3 hover:text-neutral-gray4"
+              />
+              <TextField
+                value={option.value}
+                onChange={(value) => handleUpdateOption(option.id, value)}
+                onKeyDown={(e) => handleKeyDown(e, option)}
+                inputProps={{
+                  placeholder: t('Option {number}', { number: index + 1 }),
+                  className: 'bg-white',
+                }}
+                className="w-full"
+              />
+              <TooltipTrigger isDisabled={options.length > 2}>
+                <Button
+                  color="ghost"
+                  size="small"
+                  aria-label={t('Remove option')}
+                  aria-disabled={options.length <= 2 || undefined}
+                  aria-description={
+                    options.length <= 2
+                      ? t('At least two options are required')
+                      : undefined
+                  }
+                  excludeFromTabOrder={options.length <= 2}
+                  onPress={() => {
+                    if (options.length > 2) {
+                      handleRemoveOption(option.id);
+                    }
+                  }}
+                  className={`p-2 ${
+                    options.length <= 2
+                      ? 'cursor-default text-neutral-gray3 opacity-30'
+                      : 'text-neutral-gray3 hover:text-neutral-charcoal'
+                  }`}
+                >
+                  <LuX className="size-4" />
+                </Button>
+                <Tooltip>{t('At least two options are required')}</Tooltip>
+              </TooltipTrigger>
+            </div>
+          );
+        }}
+      </Sortable>
+
+      <Button
+        color="ghost"
+        size="small"
+        onPress={handleAddOption}
+        className="gap-1 p-0 text-primary-teal hover:text-primary-tealBlack"
+      >
+        <LuPlus className="size-4" />
+        <span>{t('Add option')}</span>
+      </Button>
     </div>
   );
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import type { RubricTemplateSchema } from '@op/common/client';
+import type {
+  RubricTemplateSchema,
+  XFormatPropertySchema,
+} from '@op/common/client';
 import { Button } from '@op/ui/Button';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header2 } from '@op/ui/Header';
@@ -22,6 +25,7 @@ import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/st
 import type {
   CriterionView,
   RubricCriterionType,
+  SelectOption,
 } from '@/components/decisions/rubricTemplate';
 import {
   addCriterion,
@@ -38,6 +42,7 @@ import {
   removeCriterion,
   reorderCriteria,
   setCriterionRequired,
+  setSelectOptions,
   updateCriterionDescription,
   updateCriterionJsonSchema,
   updateCriterionLabel,
@@ -103,6 +108,12 @@ export function RubricEditorContent({
     Map<string, { maximum: number; oneOf: { const: number; title: string }[] }>
   >(new Map());
 
+  // Cache single-select options (the `oneOf` list) so switching type and
+  // back doesn't lose them
+  const singleSelectOptionsCacheRef = useRef<
+    Map<string, XFormatPropertySchema['oneOf']>
+  >(new Map());
+
   const { saveChanges, autosaveStatus } = useProcessBuilderAutosave();
 
   // Derive criterion views from the template
@@ -156,6 +167,7 @@ export function RubricEditorContent({
       return next;
     });
     scoredConfigCacheRef.current.delete(criterionToDelete);
+    singleSelectOptionsCacheRef.current.delete(criterionToDelete);
     setCriterionToDelete(null);
   }, [criterionToDelete]);
 
@@ -206,8 +218,21 @@ export function RubricEditorContent({
           });
         }
 
-        // Change the type (rebuilds schema from scratch)
-        let updated = changeCriterionType(prev, criterionId, newType);
+        // Stash single-select options before switching away from single_select
+        if (getCriterionType(prev, criterionId) === 'single_select') {
+          const schema = getCriterionSchema(prev, criterionId);
+          if (schema?.oneOf) {
+            singleSelectOptionsCacheRef.current.set(criterionId, schema.oneOf);
+          }
+        }
+
+        // Change the type (rebuilds schema from scratch). Fresh single-select
+        // criteria start pre-filled with editable Yes/Maybe/No options.
+        let updated = changeCriterionType(prev, criterionId, newType, [
+          t('Yes'),
+          t('Maybe'),
+          t('No'),
+        ]);
 
         // Restore cached scored config when switching back to scored
         if (newType === 'scored') {
@@ -220,10 +245,20 @@ export function RubricEditorContent({
           }
         }
 
+        // Restore cached options when switching back to single_select
+        if (newType === 'single_select') {
+          const cached = singleSelectOptionsCacheRef.current.get(criterionId);
+          if (cached) {
+            updated = updateCriterionJsonSchema(updated, criterionId, {
+              oneOf: cached,
+            });
+          }
+        }
+
         return updated;
       });
     },
-    [],
+    [t],
   );
 
   const handleUpdateMaxPoints = useCallback(
@@ -240,6 +275,13 @@ export function RubricEditorContent({
       setTemplate((prev) =>
         updateScoreLabel(prev, criterionId, scoreValue, label),
       );
+    },
+    [],
+  );
+
+  const handleUpdateOptions = useCallback(
+    (criterionId: string, options: SelectOption[]) => {
+      setTemplate((prev) => setSelectOptions(prev, criterionId, options));
     },
     [],
   );
@@ -378,6 +420,7 @@ export function RubricEditorContent({
                       onChangeType={handleChangeType}
                       onUpdateMaxPoints={handleUpdateMaxPoints}
                       onUpdateScoreLabel={handleUpdateScoreLabel}
+                      onUpdateOptions={handleUpdateOptions}
                     />
                   );
                 }}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
@@ -98,6 +98,8 @@ function RubricField({ field }: { field: FieldDescriptor }) {
         );
       }
 
+      // Non-scored dropdowns (single-select included) fall through to the
+      // generic pill select placeholder below, with no points badge.
       const badge = isScoredField(schema)
         ? `${schema.maximum} ${t('pts')}`
         : undefined;

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/rubricCriterionRegistry.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/rubricCriterionRegistry.tsx
@@ -25,6 +25,10 @@ export const CRITERION_TYPE_REGISTRY: Record<
     labelKey: 'Yes/No',
     descriptionKey: 'Simple binary assessment',
   },
+  single_select: {
+    labelKey: 'Multiple choice',
+    descriptionKey: 'Reviewers select one option',
+  },
   long_text: {
     labelKey: 'Text response only',
     descriptionKey: 'No score, just written feedback',
@@ -37,5 +41,6 @@ export const CRITERION_TYPE_REGISTRY: Record<
 export const CRITERION_TYPES: RubricCriterionType[] = [
   'scored',
   'yes_no',
+  'single_select',
   'long_text',
 ];

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -338,6 +338,34 @@ function RubricFieldInput({
         );
       }
 
+      if (criterionType === 'single_select') {
+        const options = parseSchemaOptions(field.schema);
+        return (
+          <Select
+            aria-label={field.schema.title}
+            placeholder={t('Select an option')}
+            selectedKey={typeof value === 'string' ? value : null}
+            onSelectionChange={(key) => {
+              onChange(key === null ? null : String(key));
+            }}
+            className="w-full"
+          >
+            {options.map((option) => {
+              const label = option.title || String(option.value);
+              return (
+                <SelectItem
+                  key={String(option.value)}
+                  id={String(option.value)}
+                  textValue={label}
+                >
+                  {label}
+                </SelectItem>
+              );
+            })}
+          </Select>
+        );
+      }
+
       if (criterionType === 'scored') {
         // Highest score first (to match the process builder); each option
         // renders the score with its description below so reviewers can

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -135,6 +135,17 @@ function RubricFieldResult({
       );
     }
 
+    // Single-select options store an opaque id as the value, so show the
+    // option's title instead.
+    if (inferCriterionType(field.schema) === 'single_select') {
+      return (
+        <ResultCard
+          value={selected ? selected.title || String(selected.value) : '—'}
+          description={rationale}
+        />
+      );
+    }
+
     return (
       <ResultCard
         value={selected?.value}

--- a/apps/app/src/components/decisions/rubricTemplate.test.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  RubricCriterionType,
+  RubricTemplateSchema,
+} from './rubricTemplate';
+import {
+  addCriterion,
+  changeCriterionType,
+  createCriterionJsonSchema,
+  createEmptyRubricTemplate,
+  getCriteria,
+  getCriterion,
+  getCriterionOptions,
+  getCriterionType,
+  inferCriterionType,
+  setCriterionRequired,
+  setSelectOptions,
+  updateCriterionDescription,
+} from './rubricTemplate';
+
+const ALL_TYPES: RubricCriterionType[] = [
+  'scored',
+  'yes_no',
+  'single_select',
+  'long_text',
+];
+
+function templateWithCriterion(
+  type: RubricCriterionType,
+  criterionId = 'crit1',
+): RubricTemplateSchema {
+  return addCriterion(createEmptyRubricTemplate(), criterionId, type, 'Label');
+}
+
+describe('createCriterionJsonSchema / inferCriterionType round-trip', () => {
+  it.each(ALL_TYPES)('round-trips %s', (type) => {
+    const schema = createCriterionJsonSchema(type);
+    expect(inferCriterionType(schema)).toBe(type);
+  });
+
+  it('creates a single-select schema seeded with the given option labels', () => {
+    const schema = createCriterionJsonSchema('single_select', [
+      'Yes',
+      'Maybe',
+      'No',
+    ]);
+
+    expect(schema.type).toBe('string');
+    expect(schema['x-format']).toBe('dropdown');
+    expect(schema.oneOf).toHaveLength(3);
+
+    const titles: string[] = [];
+    for (const entry of schema.oneOf ?? []) {
+      if (typeof entry === 'boolean') {
+        throw new Error('expected oneOf entries to be schema objects');
+      }
+      expect(typeof entry.const).toBe('string');
+      expect(entry.const).not.toBe('');
+      titles.push(String(entry.title));
+    }
+    expect(titles).toEqual(['Yes', 'Maybe', 'No']);
+  });
+
+  it('falls back to two blank options when no labels are given', () => {
+    const schema = createCriterionJsonSchema('single_select');
+
+    expect(schema.oneOf).toHaveLength(2);
+    for (const entry of schema.oneOf ?? []) {
+      if (typeof entry === 'boolean') {
+        throw new Error('expected oneOf entries to be schema objects');
+      }
+      expect(entry.title).toBe('');
+    }
+  });
+
+  it('generates distinct option ids per option and per invocation', () => {
+    const first = createCriterionJsonSchema('single_select');
+    const second = createCriterionJsonSchema('single_select');
+
+    const idsOf = (schema: ReturnType<typeof createCriterionJsonSchema>) =>
+      (schema.oneOf ?? []).map((e) =>
+        typeof e === 'boolean' ? undefined : e.const,
+      );
+
+    const allIds = [...idsOf(first), ...idsOf(second)];
+    expect(new Set(allIds).size).toBe(allIds.length);
+  });
+
+  it('does not affect yes_no / scored inference', () => {
+    expect(inferCriterionType(createCriterionJsonSchema('yes_no'))).toBe(
+      'yes_no',
+    );
+    expect(inferCriterionType(createCriterionJsonSchema('scored'))).toBe(
+      'scored',
+    );
+  });
+});
+
+describe('setSelectOptions', () => {
+  it('adds an option', () => {
+    const template = templateWithCriterion('single_select');
+    const before = getCriterionOptions(template, 'crit1');
+
+    const updated = setSelectOptions(template, 'crit1', [
+      ...before,
+      { value: 'opt-new', title: 'New' },
+    ]);
+    const after = getCriterionOptions(updated, 'crit1');
+
+    expect(after).toHaveLength(before.length + 1);
+    expect(after[after.length - 1]).toEqual({ value: 'opt-new', title: 'New' });
+    // Immutability: original template untouched
+    expect(getCriterionOptions(template, 'crit1')).toEqual(before);
+  });
+
+  it('relabels an option without changing its stored value', () => {
+    const template = setSelectOptions(
+      templateWithCriterion('single_select'),
+      'crit1',
+      [
+        { value: 'opt-a', title: 'Parks' },
+        { value: 'opt-b', title: 'Transit' },
+      ],
+    );
+
+    const relabeled = getCriterionOptions(template, 'crit1').map((option) =>
+      option.value === 'opt-a'
+        ? { ...option, title: 'Parks Department' }
+        : option,
+    );
+    const updated = setSelectOptions(template, 'crit1', relabeled);
+
+    expect(getCriterionOptions(updated, 'crit1')).toEqual([
+      { value: 'opt-a', title: 'Parks Department' },
+      { value: 'opt-b', title: 'Transit' },
+    ]);
+  });
+
+  it('removes an option', () => {
+    let template = templateWithCriterion('single_select');
+    template = setSelectOptions(template, 'crit1', [
+      { value: 'opt-a', title: 'A' },
+      { value: 'opt-b', title: 'B' },
+      { value: 'opt-c', title: 'C' },
+    ]);
+
+    const remaining = getCriterionOptions(template, 'crit1').filter(
+      (option) => option.value !== 'opt-a',
+    );
+    const updated = setSelectOptions(template, 'crit1', remaining);
+    const values = getCriterionOptions(updated, 'crit1').map((o) => o.value);
+
+    expect(values).toEqual(['opt-b', 'opt-c']);
+  });
+
+  it('reorders options while preserving stored values', () => {
+    let template = templateWithCriterion('single_select');
+    template = setSelectOptions(template, 'crit1', [
+      { value: 'opt-a', title: 'A' },
+      { value: 'opt-b', title: 'B' },
+      { value: 'opt-c', title: 'C' },
+    ]);
+
+    const reversed = [...getCriterionOptions(template, 'crit1')].reverse();
+    const updated = setSelectOptions(template, 'crit1', reversed);
+
+    expect(getCriterionOptions(updated, 'crit1')).toEqual([
+      { value: 'opt-c', title: 'C' },
+      { value: 'opt-b', title: 'B' },
+      { value: 'opt-a', title: 'A' },
+    ]);
+  });
+
+  it('round-trips per-option descriptions through edits', () => {
+    let template = templateWithCriterion('single_select');
+    template = setSelectOptions(template, 'crit1', [
+      { value: 'yes', title: 'Yes', description: 'Feasible as scoped' },
+      { value: 'maybe', title: 'Maybe', description: 'Needs modification' },
+      { value: 'no', title: 'No', description: 'Not feasible' },
+    ]);
+
+    expect(getCriterionOptions(template, 'crit1')).toEqual([
+      { value: 'yes', title: 'Yes', description: 'Feasible as scoped' },
+      { value: 'maybe', title: 'Maybe', description: 'Needs modification' },
+      { value: 'no', title: 'No', description: 'Not feasible' },
+    ]);
+
+    // Relabel one option the way the editor does (spread + new title):
+    // untouched descriptions must survive.
+    const relabeled = getCriterionOptions(template, 'crit1').map((option) =>
+      option.value === 'yes' ? { ...option, title: 'Definitely' } : option,
+    );
+    const updated = setSelectOptions(template, 'crit1', relabeled);
+
+    expect(getCriterionOptions(updated, 'crit1')).toEqual([
+      { value: 'yes', title: 'Definitely', description: 'Feasible as scoped' },
+      { value: 'maybe', title: 'Maybe', description: 'Needs modification' },
+      { value: 'no', title: 'No', description: 'Not feasible' },
+    ]);
+  });
+
+  it('is a no-op on non-single-select criteria', () => {
+    const scored = templateWithCriterion('scored');
+    expect(
+      setSelectOptions(scored, 'crit1', [{ value: 'opt-a', title: 'A' }]),
+    ).toBe(scored);
+
+    const yesNo = templateWithCriterion('yes_no');
+    expect(
+      setSelectOptions(yesNo, 'crit1', [{ value: 'opt-a', title: 'A' }]),
+    ).toBe(yesNo);
+  });
+});
+
+describe('changeCriterionType', () => {
+  it('preserves label, description, and required when switching to single_select', () => {
+    let template = templateWithCriterion('scored');
+    template = updateCriterionDescription(template, 'crit1', 'Guidance');
+    template = setCriterionRequired(template, 'crit1', true);
+
+    const updated = changeCriterionType(template, 'crit1', 'single_select', [
+      'Yes',
+      'Maybe',
+      'No',
+    ]);
+    const criterion = getCriterion(updated, 'crit1');
+
+    expect(getCriterionType(updated, 'crit1')).toBe('single_select');
+    expect(criterion?.label).toBe('Label');
+    expect(criterion?.description).toBe('Guidance');
+    expect(criterion?.required).toBe(true);
+    expect(criterion?.options.map((o) => o.title)).toEqual([
+      'Yes',
+      'Maybe',
+      'No',
+    ]);
+  });
+
+  it('preserves label, description, and required when switching away from single_select', () => {
+    let template = templateWithCriterion('single_select');
+    template = updateCriterionDescription(template, 'crit1', 'Guidance');
+    template = setCriterionRequired(template, 'crit1', true);
+
+    const updated = changeCriterionType(template, 'crit1', 'long_text');
+    const criterion = getCriterion(updated, 'crit1');
+
+    expect(getCriterionType(updated, 'crit1')).toBe('long_text');
+    expect(criterion?.label).toBe('Label');
+    expect(criterion?.description).toBe('Guidance');
+    expect(criterion?.required).toBe(true);
+    expect(criterion?.options).toEqual([]);
+  });
+});
+
+describe('getCriteria', () => {
+  it('exposes options on single-select criteria and empty arrays elsewhere', () => {
+    let template = createEmptyRubricTemplate();
+    template = addCriterion(template, 'score1', 'scored', 'Score');
+    template = addCriterion(template, 'multi1', 'single_select', 'Department');
+    template = setSelectOptions(
+      template,
+      'multi1',
+      getCriterionOptions(template, 'multi1').map((option, i) =>
+        i === 0 ? { ...option, title: 'Parks' } : option,
+      ),
+    );
+
+    const criteria = getCriteria(template);
+    const scored = criteria.find((c) => c.id === 'score1');
+    const single = criteria.find((c) => c.id === 'multi1');
+
+    expect(scored?.options).toEqual([]);
+    expect(single?.criterionType).toBe('single_select');
+    expect(single?.options).toHaveLength(2);
+    expect(single?.options[0]?.title).toBe('Parks');
+  });
+});

--- a/apps/app/src/components/decisions/rubricTemplate.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.ts
@@ -44,7 +44,24 @@ export type { RubricTemplateSchema };
 // Criterion types
 // ---------------------------------------------------------------------------
 
-export type RubricCriterionType = 'scored' | 'yes_no' | 'long_text';
+export type RubricCriterionType =
+  | 'scored'
+  | 'yes_no'
+  | 'single_select'
+  | 'long_text';
+
+/** A single admin-defined option on a single-select criterion. */
+export interface SelectOption {
+  /** Stable generated id stored as the answer value. */
+  value: string;
+  /** Admin-editable display label. */
+  title: string;
+  /**
+   * Optional per-option explanation (e.g. what "Maybe" means for this
+   * criterion). Carried in the schema but not yet editable in the builder.
+   */
+  description?: string;
+}
 
 /**
  * Flat read-only view of a single rubric criterion, derived from the template.
@@ -61,6 +78,8 @@ export interface CriterionView {
   maxPoints?: number;
   /** Labels for each score level (index 0 = score 1, ascending). Scored criteria only. */
   scoreLabels: string[];
+  /** Admin-defined options. Single-select criteria only (empty for other types). */
+  options: SelectOption[];
 }
 
 // ---------------------------------------------------------------------------
@@ -80,15 +99,39 @@ function getOneOfEntries(schema: XFormatPropertySchema): JSONSchema7[] {
   return schema.oneOf.filter(isSchemaObject);
 }
 
+/**
+ * Extract `oneOf` option entries with string consts and string titles
+ * (the single-select option encoding).
+ */
+function getSelectOptionEntries(schema: XFormatPropertySchema): SelectOption[] {
+  return getOneOfEntries(schema)
+    .filter(
+      (e): e is JSONSchema7 & { const: string; title: string } =>
+        typeof e.const === 'string' && typeof e.title === 'string',
+    )
+    .map((e) => ({
+      value: e.const,
+      title: e.title,
+      ...(typeof e.description === 'string'
+        ? { description: e.description }
+        : {}),
+    }));
+}
+
 // ---------------------------------------------------------------------------
 // Criterion type ↔ JSON Schema mapping
 // ---------------------------------------------------------------------------
 
 /**
  * Create the JSON Schema for a given criterion type.
+ *
+ * `selectOptionLabels` seeds the options of a `single_select` criterion
+ * (one option per label, each with a fresh id); ignored for other types.
+ * Callers with i18n access pass translated labels (e.g. Yes/Maybe/No).
  */
 export function createCriterionJsonSchema(
   type: RubricCriterionType,
+  selectOptionLabels?: string[],
 ): XFormatPropertySchema {
   switch (type) {
     case 'scored': {
@@ -114,6 +157,17 @@ export function createCriterionJsonSchema(
           { const: 'no', title: 'No' },
         ],
       };
+    case 'single_select': {
+      const labels = selectOptionLabels ?? ['', ''];
+      return {
+        type: 'string',
+        'x-format': 'dropdown',
+        oneOf: labels.map((title) => ({
+          const: crypto.randomUUID().slice(0, 8),
+          title,
+        })),
+      };
+    }
     case 'long_text':
       return {
         type: 'string',
@@ -151,6 +205,14 @@ export function inferCriterionType(
         values.includes('no')
       ) {
         return 'yes_no';
+      }
+
+      // Any other string dropdown with options is a single-select
+      // "multiple choice" criterion. Note the overall recommendation field
+      // matches this shape too — callers exclude it by key before relying
+      // on the inferred type.
+      if (values.some((value) => typeof value === 'string')) {
+        return 'single_select';
       }
     }
   }
@@ -233,6 +295,21 @@ export function getCriterionScoreLabels(
     .map((e) => e.title);
 }
 
+/**
+ * Options of a single-select criterion, in stored order.
+ * Empty for other criterion types.
+ */
+export function getCriterionOptions(
+  template: RubricTemplateSchema,
+  criterionId: string,
+): SelectOption[] {
+  const schema = getCriterionSchema(template, criterionId);
+  if (!schema || inferCriterionType(schema) !== 'single_select') {
+    return [];
+  }
+  return getSelectOptionEntries(schema);
+}
+
 // ---------------------------------------------------------------------------
 // Composite readers
 // ---------------------------------------------------------------------------
@@ -254,6 +331,7 @@ export function getCriterion(
     required: isCriterionRequired(template, criterionId),
     maxPoints: getCriterionMaxPoints(template, criterionId),
     scoreLabels: getCriterionScoreLabels(template, criterionId),
+    options: getCriterionOptions(template, criterionId),
   };
 }
 
@@ -285,6 +363,15 @@ export function getCriterionErrors(criterion: CriterionView): TranslationKey[] {
     errors.push('Criterion label is required');
   }
 
+  if (criterion.criterionType === 'single_select') {
+    if (criterion.options.length < 2) {
+      errors.push('At least two options are required');
+    }
+    if (criterion.options.some((option) => !option.title.trim())) {
+      errors.push('Options cannot be empty');
+    }
+  }
+
   return errors;
 }
 
@@ -297,8 +384,12 @@ export function addCriterion(
   criterionId: string,
   type: RubricCriterionType,
   label: string,
+  selectOptionLabels?: string[],
 ): RubricTemplateSchema {
-  const jsonSchema = { ...createCriterionJsonSchema(type), title: label };
+  const jsonSchema = {
+    ...createCriterionJsonSchema(type, selectOptionLabels),
+    title: label,
+  };
   return addProperty(template, criterionId, jsonSchema);
 }
 
@@ -348,10 +439,11 @@ export function changeCriterionType(
   template: RubricTemplateSchema,
   criterionId: string,
   newType: RubricCriterionType,
+  selectOptionLabels?: string[],
 ): RubricTemplateSchema {
   return updateProperty(template, criterionId, (existing) => {
     const newSchema: XFormatPropertySchema = {
-      ...createCriterionJsonSchema(newType),
+      ...createCriterionJsonSchema(newType, selectOptionLabels),
       title: existing.title,
     };
     if (existing.description) {
@@ -425,6 +517,34 @@ export function updateScoreLabel(
     }
     return entry;
   });
+
+  return updateProperty(template, criterionId, (s) => ({ ...s, oneOf }));
+}
+
+/**
+ * Replace the full option list of a single-select criterion — labels, order,
+ * additions, and removals in one call (mirrors the proposal template's
+ * dropdown options editor). Callers pass existing option ids through
+ * unchanged so stored answers keep matching; only relabels/reorders/removals
+ * affect the schema. No-op when the criterion isn't a single-select.
+ */
+export function setSelectOptions(
+  template: RubricTemplateSchema,
+  criterionId: string,
+  options: SelectOption[],
+): RubricTemplateSchema {
+  const schema = getCriterionSchema(template, criterionId);
+  if (!schema || inferCriterionType(schema) !== 'single_select') {
+    return template;
+  }
+
+  const oneOf = options.map((option) => ({
+    const: option.value,
+    title: option.title,
+    ...(option.description !== undefined
+      ? { description: option.description }
+      : {}),
+  }));
 
   return updateProperty(template, criterionId, (s) => ({ ...s, oneOf }));
 }

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1068,6 +1068,7 @@
   "Criterion name": "اسم المعيار",
   "Criterion description is required": "وصف المعيار مطلوب",
   "Criterion label is required": "تسمية المعيار مطلوبة",
+  "Reviewers select one option": "يختار المراجعون خيارًا واحدًا",
   "Drag to reorder criterion": "اسحب لإعادة ترتيب المعيار",
   "e.g., Goal Alignment": "مثل: محاذاة الأهداف",
   "Add a short, clear name for this evaluation criterion": "أضف اسمًا قصيرًا وواضحًا لمعيار التقييم هذا",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1152,6 +1152,7 @@
   "Criterion name": "মানদণ্ডের নাম",
   "Criterion description is required": "মানদণ্ডের বিবরণ আবশ্যক",
   "Criterion label is required": "মানদণ্ডের লেবেল আবশ্যক",
+  "Reviewers select one option": "পর্যালোচকরা একটি বিকল্প নির্বাচন করেন",
   "Drag to reorder criterion": "মানদণ্ড পুনর্বিন্যাস করতে টানুন",
   "e.g., Goal Alignment": "যেমন, লক্ষ্য সারিবদ্ধকরণ",
   "Add a short, clear name for this evaluation criterion": "এই মূল্যায়ন মানদণ্ডের জন্য একটি সংক্ষিপ্ত, স্পষ্ট নাম যোগ করুন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1164,6 +1164,7 @@
   "Criterion name": "Criterion name",
   "Criterion description is required": "Criterion description is required",
   "Criterion label is required": "Criterion label is required",
+  "Reviewers select one option": "Reviewers select one option",
   "Drag to reorder criterion": "Drag to reorder criterion",
   "e.g., Goal Alignment": "e.g., Goal Alignment",
   "Add a short, clear name for this evaluation criterion": "Add a short, clear name for this evaluation criterion",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1151,6 +1151,7 @@
   "Criterion name": "Nombre del criterio",
   "Criterion description is required": "La descripción del criterio es obligatoria",
   "Criterion label is required": "La etiqueta del criterio es obligatoria",
+  "Reviewers select one option": "Los revisores seleccionan una opción",
   "Drag to reorder criterion": "Arrastrar para reordenar criterio",
   "e.g., Goal Alignment": "p. ej., Alineación con objetivos",
   "Add a short, clear name for this evaluation criterion": "Agregue un nombre corto y claro para este criterio de evaluación",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1151,6 +1151,7 @@
   "Criterion name": "Nom du critère",
   "Criterion description is required": "La description du critère est obligatoire",
   "Criterion label is required": "Le libellé du critère est obligatoire",
+  "Reviewers select one option": "Les évaluateurs sélectionnent une option",
   "Drag to reorder criterion": "Glisser pour réordonner le critère",
   "e.g., Goal Alignment": "p. ex., Alignement des objectifs",
   "Add a short, clear name for this evaluation criterion": "Ajoutez un nom court et clair pour ce critère d'évaluation",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1151,6 +1151,7 @@
   "Criterion name": "Nome do critério",
   "Criterion description is required": "A descrição do critério é obrigatória",
   "Criterion label is required": "O rótulo do critério é obrigatório",
+  "Reviewers select one option": "Os revisores selecionam uma opção",
   "Drag to reorder criterion": "Arrastar para reordenar critério",
   "e.g., Goal Alignment": "p. ex., Alinhamento de objetivos",
   "Add a short, clear name for this evaluation criterion": "Adicione um nome curto e claro para este critério de avaliação",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1087,6 +1087,7 @@
   "Criterion name": "Magaca heerka",
   "Criterion description is required": "Sharaxaadda heerka waa loo baahan yahay",
   "Criterion label is required": "Sumadda heerka waa loo baahan yahay",
+  "Reviewers select one option": "Dib-u-eegayaashu waxay doortaan hal doorasho",
   "Drag to reorder criterion": "Jiid si loo kala horreysiyo heerka",
   "e.g., Goal Alignment": "tusaale, Isku-toosinta Hadafka",
   "Add a short, clear name for this evaluation criterion": "Ku dar magac gaaban, cad oo heerka qiimeynta",

--- a/packages/common/src/services/decision/getRubricScoringInfo.test.ts
+++ b/packages/common/src/services/decision/getRubricScoringInfo.test.ts
@@ -172,6 +172,45 @@ describe('getRubricScoringInfo', () => {
     expect(info.summary).toEqual({ dropdown: 1 });
   });
 
+  it('treats single-select criteria as unscored without changing totalPoints', () => {
+    const schema: RubricTemplateSchema = {
+      type: 'object',
+      properties: {
+        innovation: {
+          type: 'integer',
+          title: 'Innovation',
+          'x-format': 'dropdown',
+          minimum: 1,
+          maximum: 5,
+          oneOf: [
+            { const: 1, title: 'Poor' },
+            { const: 5, title: 'Excellent' },
+          ],
+        },
+        department: {
+          type: 'string',
+          title: 'Department',
+          'x-format': 'dropdown',
+          oneOf: [
+            { const: 'a1b2c3d4', title: 'Parks' },
+            { const: 'e5f6a7b8', title: 'Transportation' },
+          ],
+        },
+      },
+    };
+
+    const info = getRubricScoringInfo(schema);
+
+    expect(info.totalPoints).toBe(5);
+    const singleSelect = info.criteria.find((c) => c.key === 'department');
+    expect(singleSelect).toEqual({
+      key: 'department',
+      maxPoints: 0,
+      scored: false,
+    });
+    expect(info.summary).toEqual({ dropdown: 2 });
+  });
+
   it('treats non-integer types as qualitative (0 points)', () => {
     const schema: RubricTemplateSchema = {
       type: 'object',

--- a/services/api/src/routers/decision/reviews/submitReview.test.ts
+++ b/services/api/src/routers/decision/reviews/submitReview.test.ts
@@ -41,6 +41,24 @@ const rubricTemplate: RubricTemplateSchema = {
   required: ['impact'],
 };
 
+const singleSelectRubricTemplate: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': ['department'],
+  properties: {
+    department: {
+      type: 'string',
+      title: 'Department',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 'a1b2c3d4', title: 'Parks' },
+        { const: 'e5f6a7b8', title: 'Transportation' },
+        { const: 'c9d0e1f2', title: 'Public Health' },
+      ],
+    },
+  },
+  required: ['department'],
+};
+
 async function createAuthenticatedCaller(email: string) {
   const { session } = await createIsolatedSession(email);
   return createCaller(await createTestContextWithSession(session));
@@ -112,6 +130,88 @@ describe.concurrent('submitReview', () => {
 
     expect(result.state).toBe(ProposalReviewState.SUBMITTED);
     expect(result.reviewData.rationales).toEqual({});
+  });
+
+  it('accepts a single-select answer with a known option id', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      singleSelectRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.submitReview({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { department: 'a1b2c3d4' },
+        rationales: {},
+      },
+    });
+
+    expect(result.state).toBe(ProposalReviewState.SUBMITTED);
+    expect(result.reviewData.answers).toEqual({ department: 'a1b2c3d4' });
+  });
+
+  it('rejects a single-select answer with an unknown option id', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      singleSelectRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: { department: 'not-an-option' },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+  });
+
+  it('accepts an array answer for a single-select field by coercing to its first element', async ({
+    task,
+    onTestFinished,
+  }) => {
+    // `coerceToSchema` unwraps an array to `value[0]` before validation, so
+    // a single-item array of a known option id passes; the stored answer
+    // keeps its original array shape since only the validation copy is
+    // coerced.
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      singleSelectRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.submitReview({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { department: ['e5f6a7b8'] },
+        rationales: {},
+      },
+    });
+
+    expect(result.state).toBe(ProposalReviewState.SUBMITTED);
+    expect(result.reviewData.answers).toEqual({ department: ['e5f6a7b8'] });
   });
 
   it('rejects invalid rubric submissions', async ({ task, onTestFinished }) => {


### PR DESCRIPTION
Columbus rubrics need questions where reviewers pick one of several admin-defined options (e.g. which department a project falls under, or a described Yes/Maybe/No), which the rubric builder couldn't express with only rating scale, yes/no, and text criteria. New multiple choice criteria start pre-filled with editable Yes/Maybe/No options, and options support per-option descriptions at the schema level (not yet surfaced in the UI).