### PR TITLE
refactor(decision): adopt phaseOrder utils at ad-hoc phase-index sites

### DIFF
--- a/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
+++ b/apps/app/src/components/decisions/DecisionPhaseTimeline.tsx
@@ -48,6 +48,8 @@ export function DecisionPhaseTimeline({
   const phaseName = (phase: ProcessPhase) =>
     translatedPhaseNames?.get(phase.id) ?? phase.name;
 
+  // phaseOrder: intentionally ad-hoc — legacy ProcessPhase is keyed by `id`,
+  // not `phaseId`, so the shared utils' input type doesn't fit.
   const currentIndex = phases.findIndex((p) => p.id === currentPhaseId);
   const currentPhase = currentIndex >= 0 ? phases[currentIndex] : undefined;
   const nextPhase = currentIndex >= 0 ? phases[currentIndex + 1] : undefined;

--- a/apps/app/src/components/decisions/DecisionProcessStepper.tsx
+++ b/apps/app/src/components/decisions/DecisionProcessStepper.tsx
@@ -41,6 +41,8 @@ export function DecisionProcessStepper({
     currentPhaseAdvancement,
     currentPhaseEndDate,
   } = useMemo(() => {
+    // phaseOrder: intentionally ad-hoc — legacy ProcessPhase is keyed by `id`,
+    // not `phaseId`, so the shared utils' input type doesn't fit.
     const idx = phases.findIndex((p) => p.id === currentStateId);
     const currentPhase = idx >= 0 ? phases[idx] : undefined;
     const nextPhase = idx >= 0 ? phases[idx + 1] : undefined;

--- a/apps/app/src/components/decisions/DecisionStateRouter.tsx
+++ b/apps/app/src/components/decisions/DecisionStateRouter.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { isLastPhase, isReviewPhase, isVotingPhase } from '@op/common/client';
+import {
+  getPreviousPhase,
+  isLastPhase,
+  isReviewPhase,
+  isVotingPhase,
+} from '@op/common/client';
 import { notFound } from 'next/navigation';
 
 import { FinalPhaseManualSelectionPage } from './pages/FinalPhaseManualSelectionPage';
@@ -54,8 +59,7 @@ function DecisionStateRouterNew({
     // When the *previous* phase was a review phase, an admin can advance
     // proposals using rich review aggregates — that's the ReviewSelection view.
     // Everyone else falls back to the generic manual-selection prompt.
-    const currentIdx = phases.findIndex((p) => p.phaseId === currentStateId);
-    const previousPhase = currentIdx > 0 ? phases[currentIdx - 1] : null;
+    const previousPhase = getPreviousPhase({ phases }, currentStateId);
     const previousWasReview = !!previousPhase && isReviewPhase(previousPhase);
 
     if (previousWasReview && previousPhase && isAdmin) {

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
@@ -113,6 +113,8 @@ function resolveReviewPhaseId(instance: {
   } | null;
 }): string | undefined {
   const phases = instance.instanceData?.phases ?? [];
+  // phaseOrder: intentionally ad-hoc — an unknown current phase falls back to
+  // scanning from the LAST phase, unlike the utils' fail-closed -1/empty.
   const currentIdx = phases.findIndex(
     (p) => p.phaseId === instance.currentStateId,
   );

--- a/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
+++ b/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
@@ -2,7 +2,7 @@
 
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { trpc } from '@op/api/client';
-import { isLastPhase } from '@op/common/client';
+import { getNextPhase, getPhaseIndex, isLastPhase } from '@op/common/client';
 import { EmptyState } from '@op/ui/EmptyState';
 import { Header3 } from '@op/ui/Header';
 import { Suspense } from 'react';
@@ -46,13 +46,10 @@ export function StandardDecisionPage({
 
   const phases = instance.instanceData?.phases ?? [];
   const currentPhaseId = instance.currentStateId;
-  const currentPhaseIndex = phases.findIndex(
-    (phase) => phase.phaseId === currentPhaseId,
-  );
+  const currentPhaseIndex = getPhaseIndex({ phases }, currentPhaseId);
   const currentPhase =
     currentPhaseIndex >= 0 ? phases[currentPhaseIndex] : undefined;
-  const nextPhase =
-    currentPhaseIndex >= 0 ? phases[currentPhaseIndex + 1] : undefined;
+  const nextPhase = getNextPhase({ phases }, currentPhaseId);
   const allowProposals = currentPhase?.rules?.proposals?.submit === true;
   const proposalsHidden =
     currentPhase?.rules?.proposals?.defaults?.hidden === true;

--- a/apps/app/src/components/decisions/pages/VotingPage.tsx
+++ b/apps/app/src/components/decisions/pages/VotingPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { trpc } from '@op/api/client';
-import { type InstancePhaseData } from '@op/api/encoders';
+import { getNextPhase, getPhaseIndex } from '@op/common/client';
 import { useLocale } from 'next-intl';
 import { Suspense } from 'react';
 
@@ -41,17 +41,10 @@ export function VotingPage({
 
   const phases = instance.instanceData?.phases ?? [];
   const currentPhaseId = instance.currentStateId;
-  const currentPhaseIndex = phases.findIndex(
-    (p) => p.phaseId === currentPhaseId,
-  );
+  const currentPhaseIndex = getPhaseIndex({ phases }, currentPhaseId);
   const currentPhase =
-    currentPhaseIndex >= 0
-      ? (phases[currentPhaseIndex] as InstancePhaseData)
-      : undefined;
-  const nextPhase =
-    currentPhaseIndex >= 0
-      ? (phases[currentPhaseIndex + 1] as InstancePhaseData | undefined)
-      : undefined;
+    currentPhaseIndex >= 0 ? phases[currentPhaseIndex] : undefined;
+  const nextPhase = getNextPhase({ phases }, currentPhaseId);
 
   const hasVoted = voteStatus.hasVoted;
 

--- a/apps/app/src/components/decisions/utils/processSteps.ts
+++ b/apps/app/src/components/decisions/utils/processSteps.ts
@@ -1,3 +1,5 @@
+import { getPhaseIndex } from '@op/common/client';
+
 export interface NextStep {
   id: string;
   name: string;
@@ -19,9 +21,7 @@ export function getNextSteps(
   currentStateId: string | null,
 ): NextStep[] {
   // Find current phase index
-  const currentPhaseIndex = phases.findIndex(
-    (phase) => phase.phaseId === currentStateId,
-  );
+  const currentPhaseIndex = getPhaseIndex({ phases }, currentStateId);
 
   if (currentPhaseIndex === -1) {
     return [];

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -20,7 +20,9 @@ export {
   type ReviewSettings,
 } from './services/decision/utils/phaseSettings';
 export {
+  getNextPhase,
   getPhaseIndex,
+  getPreviousPhase,
   getPreviousPhases,
   isPhaseAtOrBefore,
 } from './services/decision/utils/phaseOrder';

--- a/packages/common/src/services/decision/buildExpectedTransitions.ts
+++ b/packages/common/src/services/decision/buildExpectedTransitions.ts
@@ -28,6 +28,8 @@ export function buildExpectedTransitions(
   const transitions: ScheduledTransition[] = [];
 
   phases.forEach((currentPhase, index) => {
+    // phaseOrder: intentionally ad-hoc — pairs every consecutive phase while
+    // iterating, not an id lookup, so getNextPhase would just re-scan per phase.
     const nextPhase = phases[index + 1];
     // Skip last phase (no next phase to transition to)
     if (!nextPhase) {

--- a/packages/common/src/services/decision/listSelectionCandidates.ts
+++ b/packages/common/src/services/decision/listSelectionCandidates.ts
@@ -10,6 +10,7 @@ import { isLegacyInstanceData } from './isLegacyInstance';
 import { listProposals } from './listProposals';
 import type { DecisionInstanceData } from './schemas/instanceData';
 import type { Proposal } from './schemas/proposal';
+import { getPreviousPhase } from './utils/phaseOrder';
 
 export interface SelectionCandidates {
   proposals: Proposal[];
@@ -127,10 +128,5 @@ function resolvePreviousPhaseId(instance: {
     return undefined;
   }
 
-  const currentIndex = phases.findIndex((p) => p.phaseId === currentStateId);
-  if (currentIndex <= 0) {
-    return undefined;
-  }
-
-  return phases[currentIndex - 1]?.phaseId;
+  return getPreviousPhase({ phases }, currentStateId)?.phaseId;
 }

--- a/packages/common/src/services/decision/resolveManualSelectionStatus.ts
+++ b/packages/common/src/services/decision/resolveManualSelectionStatus.ts
@@ -4,6 +4,7 @@ import type { DbClient } from '@op/db/client';
 import { isLegacyInstanceData } from './isLegacyInstance';
 import type { DecisionInstanceData } from './schemas/instanceData';
 import type { TransitionData } from './schemas/transitionData';
+import { getPreviousPhase } from './utils/phaseOrder';
 
 export type InstanceForStatusResolution = {
   id: string;
@@ -45,14 +46,7 @@ export async function resolveManualSelectionStatus({
     return { selectionsAreConfirmed: true };
   }
 
-  const currentPhaseIndex = phases.findIndex(
-    (p) => p.phaseId === currentStateId,
-  );
-  if (currentPhaseIndex <= 0) {
-    return { selectionsAreConfirmed: true };
-  }
-
-  const previousPhase = phases[currentPhaseIndex - 1];
+  const previousPhase = getPreviousPhase({ phases }, currentStateId);
   if (!previousPhase) {
     return { selectionsAreConfirmed: true };
   }

--- a/packages/common/src/services/decision/submitManualSelection.ts
+++ b/packages/common/src/services/decision/submitManualSelection.ts
@@ -28,6 +28,7 @@ import type {
   ManualSelectionAudit,
   TransitionData,
 } from './schemas/transitionData';
+import { getPhaseIndex, getPreviousPhase } from './utils/phaseOrder';
 import { isReviewPhase } from './utils/phaseSettings';
 
 export interface SubmitManualSelectionInput {
@@ -135,12 +136,14 @@ export async function submitManualSelection({
     const lockedData =
       lockedInstance.instanceData as DecisionInstanceData | null;
     const lockedPhases = lockedData?.phases;
-    const lockedPhaseIndex =
-      lockedPhases?.findIndex((p) => p.phaseId === currentStateId) ?? -1;
-    const lockedPreviousPhase =
-      lockedPhases && lockedPhaseIndex > 0
-        ? lockedPhases[lockedPhaseIndex - 1]
-        : undefined;
+    const lockedPhaseIndex = getPhaseIndex(
+      { phases: lockedPhases },
+      currentStateId,
+    );
+    const lockedPreviousPhase = getPreviousPhase(
+      { phases: lockedPhases },
+      currentStateId,
+    );
     if (!lockedPreviousPhase) {
       throw new ValidationError(
         'Manual selection is not available for this instance',

--- a/packages/common/src/services/decision/triggerPhaseAdvancement.ts
+++ b/packages/common/src/services/decision/triggerPhaseAdvancement.ts
@@ -14,6 +14,7 @@ import { assertProfileAccess, assertUserByAuthId } from '../assert';
 import { advancePhase } from './advancePhase';
 import { onPhaseAdvanced } from './onPhaseAdvanced';
 import type { DecisionInstanceData } from './schemas/instanceData';
+import { getNextPhase, getPhaseIndex } from './utils/phaseOrder';
 
 export interface TriggerPhaseAdvancementInput {
   instanceId: string;
@@ -92,17 +93,17 @@ export async function triggerPhaseAdvancement({
     );
   }
 
-  const currentPhaseIndex = phases.findIndex((p) => p.phaseId === fromPhaseId);
-
-  if (currentPhaseIndex === -1) {
+  if (getPhaseIndex(instanceData, fromPhaseId) === -1) {
     throw new CommonError('Current phase not found in instance phases');
   }
 
-  if (currentPhaseIndex === phases.length - 1) {
+  const nextPhase = getNextPhase(instanceData, fromPhaseId);
+
+  if (!nextPhase) {
     throw new ValidationError('Already on final phase');
   }
 
-  const toPhaseId = phases[currentPhaseIndex + 1]!.phaseId;
+  const toPhaseId = nextPhase.phaseId;
 
   const advanceResult = await db.transaction(async (tx) => {
     const result = await advancePhase({

--- a/packages/common/src/services/decision/utils/phaseOrder.test.ts
+++ b/packages/common/src/services/decision/utils/phaseOrder.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  getNextPhase,
   getPhaseIndex,
+  getPreviousPhase,
   getPreviousPhases,
   isPhaseAtOrBefore,
 } from './phaseOrder';
@@ -28,6 +30,59 @@ describe('getPhaseIndex', () => {
   it('returns -1 when the instance has no phases', () => {
     expect(getPhaseIndex({ phases: [] }, 'submission')).toBe(-1);
     expect(getPhaseIndex({}, 'submission')).toBe(-1);
+  });
+
+  it('returns -1 for a nullish phase id', () => {
+    expect(getPhaseIndex(instanceData, null)).toBe(-1);
+    expect(getPhaseIndex(instanceData, undefined)).toBe(-1);
+  });
+});
+
+describe('getNextPhase', () => {
+  it('returns the phase immediately after the given phase', () => {
+    expect(getNextPhase(instanceData, 'submission')).toEqual({
+      phaseId: 'feasibility',
+    });
+    expect(getNextPhase(instanceData, 'community')).toEqual({
+      phaseId: 'results',
+    });
+  });
+
+  it('returns undefined for the final phase', () => {
+    expect(getNextPhase(instanceData, 'results')).toBeUndefined();
+  });
+
+  it('returns undefined for a phase not configured on the instance', () => {
+    expect(getNextPhase(instanceData, 'missing')).toBeUndefined();
+  });
+
+  it('returns undefined for a nullish phase id or missing phases', () => {
+    expect(getNextPhase(instanceData, null)).toBeUndefined();
+    expect(getNextPhase({}, 'submission')).toBeUndefined();
+  });
+});
+
+describe('getPreviousPhase', () => {
+  it('returns the phase immediately before the given phase', () => {
+    expect(getPreviousPhase(instanceData, 'feasibility')).toEqual({
+      phaseId: 'submission',
+    });
+    expect(getPreviousPhase(instanceData, 'results')).toEqual({
+      phaseId: 'community',
+    });
+  });
+
+  it('returns undefined for the first phase', () => {
+    expect(getPreviousPhase(instanceData, 'submission')).toBeUndefined();
+  });
+
+  it('returns undefined for a phase not configured on the instance', () => {
+    expect(getPreviousPhase(instanceData, 'missing')).toBeUndefined();
+  });
+
+  it('returns undefined for a nullish phase id or missing phases', () => {
+    expect(getPreviousPhase(instanceData, null)).toBeUndefined();
+    expect(getPreviousPhase({}, 'feasibility')).toBeUndefined();
   });
 });
 

--- a/packages/common/src/services/decision/utils/phaseOrder.ts
+++ b/packages/common/src/services/decision/utils/phaseOrder.ts
@@ -9,10 +9,14 @@ interface PhaseOrderInstanceData<Phase extends { phaseId: string }> {
   phases?: readonly Phase[];
 }
 
-/** Index of `phaseId` in the instance's phase ordering; `-1` when absent. */
+/**
+ * Index of `phaseId` in the instance's phase ordering; `-1` when absent.
+ * Accepts a nullish id (e.g. an instance's unset `currentStateId`) — it never
+ * matches, so lookups fail closed with `-1`.
+ */
 export function getPhaseIndex(
   instanceData: PhaseOrderInstanceData<{ phaseId: string }>,
-  phaseId: string,
+  phaseId: string | null | undefined,
 ): number {
   return (instanceData.phases ?? []).findIndex((p) => p.phaseId === phaseId);
 }
@@ -30,6 +34,36 @@ export function isPhaseAtOrBefore(
   const target = getPhaseIndex(instanceData, phaseId);
   const reference = getPhaseIndex(instanceData, referencePhaseId);
   return target !== -1 && reference !== -1 && target <= reference;
+}
+
+/**
+ * The phase immediately after `phaseId` in the ordering; `undefined` when
+ * `phaseId` is the final phase or is not configured on the instance.
+ */
+export function getNextPhase<Phase extends { phaseId: string }>(
+  instanceData: PhaseOrderInstanceData<Phase>,
+  phaseId: string | null | undefined,
+): Phase | undefined {
+  const index = getPhaseIndex(instanceData, phaseId);
+  if (index === -1) {
+    return undefined;
+  }
+  return (instanceData.phases ?? [])[index + 1];
+}
+
+/**
+ * The phase immediately before `phaseId` in the ordering; `undefined` when
+ * `phaseId` is the first phase or is not configured on the instance.
+ */
+export function getPreviousPhase<Phase extends { phaseId: string }>(
+  instanceData: PhaseOrderInstanceData<Phase>,
+  phaseId: string | null | undefined,
+): Phase | undefined {
+  const index = getPhaseIndex(instanceData, phaseId);
+  if (index <= 0) {
+    return undefined;
+  }
+  return (instanceData.phases ?? [])[index - 1];
 }
 
 /**


### PR DESCRIPTION
Behavior-preserving adoption of the shared phaseOrder utils (from #1700) at the ad-hoc phase-index sites that predate them. Adds getNextPhase / getPreviousPhase (each with 3+ callers) and widens the lookup id param to string | null | undefined so callers with a nullable currentStateId keep their exact findIndex semantics (nullish never matches, -1).

Migrated:
- packages/common resolveManualSelectionStatus.ts — findIndex + [idx-1] → getPreviousPhase
- packages/common triggerPhaseAdvancement.ts — findIndex + [idx+1]! → getPhaseIndex + getNextPhase (same two error paths)
- packages/common submitManualSelection.ts — lockedPhases findIndex + [idx-1] → getPhaseIndex + getPreviousPhase (index still needed later for the current phase)
- packages/common listSelectionCandidates.ts (resolvePreviousPhaseId) — findIndex + [idx-1] → getPreviousPhase
- apps/app DecisionStateRouter.tsx — findIndex + [idx-1] → getPreviousPhase
- apps/app pages/StandardDecisionPage.tsx — findIndex + [idx+1] → getPhaseIndex + getNextPhase
- apps/app pages/VotingPage.tsx — same, and drops the now-redundant `as InstancePhaseData` casts
- apps/app utils/processSteps.ts (getNextSteps) — findIndex → getPhaseIndex (slice-after-current kept)

Skipped (with // phaseOrder: intentionally ad-hoc comments where the site could tempt a future migration):
- packages/common buildExpectedTransitions.ts — pairs consecutive phases while iterating, not an id lookup
- packages/common schemas/instanceData.ts isLastPhase — already a shared helper; compares identity against the last element, not an index lookup
- packages/common createInstanceFromTemplate.ts / instanceData.ts — plain first-phase access (phases[0])
- apps/app DecisionProcessStepper.tsx, DecisionPhaseTimeline.tsx — legacy ProcessPhase shape is keyed by `id`, not `phaseId`; util input type doesn't fit (no casts forced)
- apps/app ReviewSummary/ReviewSummaryLayout.tsx — unknown current phase deliberately falls back to scanning from the last phase, unlike the utils' fail-closed semantics
- apps/app ProcessBuilder PhaseDetailPage.tsx / useProcessBuilderStore.ts — builder template phases keyed by `id`; identity lookup / display numbering, not ordering
- apps/app ProcessBuilder useProcessNavigation.ts — section navigation, not phases

Tests: phaseOrder.test.ts extended for getNextPhase, getPreviousPhase, and the nullish-id contract (21 unit tests pass); full packages/common suite 433/433; services/api integration tests for advancePhase, submitManualSelection, listSelectionCandidates, buildExpectedTransitions, getInstance, transitionFromPhase 68/68. pnpm typecheck and pnpm format:check clean. No existing test was modified.