### PR TITLE
fix(decision): graceful forbidden page for unauthenticated review screen instead of 500

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/reviews/[reviewId]/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/reviews/[reviewId]/page.tsx
@@ -1,6 +1,8 @@
 import { createClient } from '@op/api/serverClient';
+import { CommonError } from '@op/common';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
+import { forbidden, notFound } from 'next/navigation';
 
 import { ReviewLayout } from '@/components/decisions/Review/ReviewLayout';
 
@@ -33,7 +35,18 @@ export async function generateMetadata({
     return {
       title: decisionName ? `${reviewLabel} | ${decisionName}` : reviewLabel,
     };
-  } catch {
+  } catch (error) {
+    // Auth failures become the same interrupts ReviewLayout uses; anything
+    // else falls through to empty metadata and lets the page render decide.
+    const cause = error instanceof Error ? error.cause : null;
+    if (cause instanceof CommonError) {
+      if (cause.statusCode === 401 || cause.statusCode === 403) {
+        forbidden();
+      }
+      if (cause.statusCode === 404) {
+        notFound();
+      }
+    }
     return {};
   }
 }

--- a/apps/app/src/components/decisions/Review/ReviewLayout.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayout.tsx
@@ -71,7 +71,10 @@ export async function ReviewLayout({
         : error instanceof Error
           ? error.cause
           : null;
-    if (cause instanceof CommonError && cause.statusCode === 403) {
+    if (
+      cause instanceof CommonError &&
+      (cause.statusCode === 401 || cause.statusCode === 403)
+    ) {
       forbidden();
     }
     if (cause instanceof CommonError && cause.statusCode === 404) {


### PR DESCRIPTION
A logged-out hit of a review screen URL (/decisions/[slug]/reviews/[reviewId]) surfaced an unhandled SSR error: the network-tier gate rejects a sessionless caller with AccessTierError carrying status 401, and ReviewLayout's catch only translated 403/404 into navigation interrupts, so the 401 was rethrown as a server error. Which stack appeared (AccessTierError vs UnauthorizedError) depended on which of the two parallel fetches rejected first, hence the intermittent-looking repros.

Chosen posture: forbidden(), not notFound() and not a login redirect. This matches the repo's existing conventions for exactly this situation — handleServerError translates 401/403 to forbidden(), the (main) layout gates non-members via forbidden(), and this route's own catch already sent 403s there, so a signed-in user without access and an anonymous visitor now land on the same page. There is no resource-existence leak to justify the not-found posture here: the tier gate rejects anonymous callers before any lookup, so a real and a bogus review id return the identical response.

Before: anonymous request renders the error boundary / 500 with an AccessTierError digest. After: anonymous request renders the existing decisions forbidden page ("You don't have access to this page" with a link home); genuine server errors still rethrow and 500. generateMetadata now translates the same auth causes into the same interrupts instead of only swallowing them, so neither render path can surface them as a 500. Logged-in behavior is unchanged (authz untouched; presentation only).

Verified locally against seeded open-reviews data: pre-fix anonymous GET streams the error boundary with an AccessTierError digest; post-fix (dev and a production build) it renders the forbidden page with no error digest and no unhandled error in the server log (only the expected tRPC 401 rejection). Logged-in via Mailpit code login still gets the full review screen with the My review / Reviews from [phase] tabs and the metadata title. Note on wire status: like every existing forbidden()/notFound() route in this app, the response streams a 200 shell and delivers the 403 interrupt in the RSC payload (verified the long-standing not-found routes behave identically in the production build), so curl shows 200 while the rendered result is the forbidden page. pnpm typecheck and pnpm format:check pass. The sibling ReviewSummaryLayout has the same 401 gap on the proposal reviews route; left untouched to keep this change tight.