### PR TITLE
feat(decision): PostHog analytics events for review flows

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -2,6 +2,7 @@
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { parseAbsoluteToLocal, toCalendarDate } from '@internationalized/date';
+import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
 import type { PhaseDefinition, PhaseRules } from '@op/api/encoders';
 import { isReviewPhase, isVotingPhase } from '@op/common/client';
@@ -13,6 +14,7 @@ import { Select, SelectItem } from '@op/ui/Select';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
 import { useQueryState } from 'nuqs';
+import { usePostHog } from 'posthog-js/react';
 import { useRef, useState } from 'react';
 import { LuTrash2 } from 'react-icons/lu';
 
@@ -160,6 +162,16 @@ function PhaseDetailForm({
   // Open reviews opt-in is gated behind a confirmation dialog (enabling it
   // changes reviewer behavior), so turning it ON opens this modal first.
   const [showOpenReviewsModal, setShowOpenReviewsModal] = useState(false);
+
+  const posthog = usePostHog();
+  const trackOpenReviewsToggled = (enabled: boolean) =>
+    posthog.capture(
+      'open_reviews_toggled',
+      getDecisionCommonProperties({
+        decisionInstanceId: instanceId,
+        additionalProps: { phase_id: phaseId, enabled },
+      }),
+    );
 
   // Delete phase
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -429,6 +441,7 @@ function PhaseDetailForm({
                 if (val) {
                   setShowOpenReviewsModal(true);
                 } else {
+                  trackOpenReviewsToggled(false);
                   updateRules({
                     reviews: { ...phase.rules?.reviews, openReviews: false },
                   });
@@ -519,6 +532,7 @@ function PhaseDetailForm({
             color="primary"
             className="w-full sm:w-fit"
             onPress={() => {
+              trackOpenReviewsToggled(true);
               updateRules({
                 reviews: { ...phase.rules?.reviews, openReviews: true },
               });

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import type { RouterOutput } from '@op/api';
 import { trpc } from '@op/api/client';
 import { logger } from '@op/logging/client';
@@ -9,6 +10,7 @@ import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { MultiSelectComboBox } from '@op/ui/MultiSelectComboBox';
 import type { Option } from '@op/ui/MultiSelectComboBox';
 import { toast } from '@op/ui/Toast';
+import { usePostHog } from 'posthog-js/react';
 import { useMemo } from 'react';
 import { LuX } from 'react-icons/lu';
 
@@ -40,6 +42,7 @@ export function CategoryReviewerCard({
 }: CategoryReviewerCardProps) {
   const t = useTranslations();
   const utils = trpc.useUtils();
+  const posthog = usePostHog();
 
   const invalidate = () =>
     utils.decision.listCategoryReviewers.invalidate({ processInstanceId });
@@ -97,6 +100,16 @@ export function CategoryReviewerCard({
     if (!added) {
       return;
     }
+    posthog.capture(
+      'category_reviewer_added',
+      getDecisionCommonProperties({
+        decisionInstanceId: processInstanceId,
+        additionalProps: {
+          category_id: category.id,
+          reviewer_profile_id: added.id,
+        },
+      }),
+    );
     addReviewer.mutate({
       processInstanceId,
       taxonomyTermId: category.id,
@@ -168,13 +181,23 @@ export function CategoryReviewerCard({
                 <IconButton
                   size="small"
                   isDisabled={isRemoving}
-                  onPress={() =>
+                  onPress={() => {
+                    posthog.capture(
+                      'category_reviewer_removed',
+                      getDecisionCommonProperties({
+                        decisionInstanceId: processInstanceId,
+                        additionalProps: {
+                          category_id: category.id,
+                          reviewer_profile_id: reviewer.reviewerProfileId,
+                        },
+                      }),
+                    );
                     removeReviewer.mutate({
                       processInstanceId,
                       taxonomyTermId: category.id,
                       reviewerProfileId: reviewer.reviewerProfileId,
-                    })
-                  }
+                    });
+                  }}
                   aria-label={t('Remove {name}', {
                     name: reviewer.profile.name,
                   })}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
 import type { InstancePhaseData } from '@op/api/encoders';
 import type { ReviewsScope } from '@op/common';
@@ -9,6 +10,7 @@ import { Chip } from '@op/ui/Chip';
 import { Header2, Header3 } from '@op/ui/Header';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { ToggleButton } from '@op/ui/ToggleButton';
+import { usePostHog } from 'posthog-js/react';
 import { useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -30,6 +32,7 @@ export function ReviewSettingsContent({
   decisionProfileId,
 }: SectionProps) {
   const t = useTranslations();
+  const posthog = usePostHog();
   // Gates the by-category scope. When off, the radio stays disabled with a
   // "Coming soon" chip (pre-flag behavior) and the reviewer cards never render.
   const byCategoryEnabled = useFeatureFlag('reviews-v2');
@@ -114,7 +117,20 @@ export function ReviewSettingsContent({
         <Header3 className="font-serif text-title-sm">{t('Scope')}</Header3>
         <RadioGroup
           value={settings.scope}
-          onChange={(value) => updateSettings({ scope: value as ReviewsScope })}
+          onChange={(value) => {
+            posthog.capture(
+              'review_scope_changed',
+              getDecisionCommonProperties({
+                decisionInstanceId: instanceId,
+                additionalProps: {
+                  phase_id: reviewPhase?.phaseId ?? null,
+                  scope: value,
+                  previous_scope: settings.scope,
+                },
+              }),
+            );
+            updateSettings({ scope: value as ReviewsScope });
+          }}
           aria-label={t('Scope')}
           label={t('What should each reviewer be responsible for?')}
           labelClassName="text-sm font-normal text-neutral-gray4"

--- a/apps/app/src/components/decisions/Review/ReviewTabs.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewTabs.tsx
@@ -2,9 +2,11 @@
 
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { useUser } from '@/utils/UserProvider';
+import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
 import { Skeleton } from '@op/ui/Skeleton';
 import { Tab, TabList, TabPanel, Tabs } from '@op/ui/Tabs';
+import { usePostHog } from 'posthog-js/react';
 import { type ReactNode, Suspense, useState } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -47,9 +49,37 @@ export function ReviewTabs({
 }) {
   const t = useTranslations();
   const { assignment } = useReviewForm();
+  const posthog = usePostHog();
 
   return (
-    <Tabs defaultSelectedKey={MY_REVIEW_TAB}>
+    <Tabs
+      defaultSelectedKey={MY_REVIEW_TAB}
+      onSelectionChange={(key) => {
+        // One event covers every tab, split by `tab`: the reviewer's own form,
+        // the current phase's "Other reviews", and the previous-phase
+        // "Reviews from {phase}" tabs.
+        const isPreviousPhase =
+          key !== MY_REVIEW_TAB && key !== OTHER_REVIEWS_TAB;
+        posthog.capture(
+          'review_tab_opened',
+          getDecisionCommonProperties({
+            decisionInstanceId: assignment.processInstanceId,
+            proposalId: assignment.proposal.id,
+            additionalProps: {
+              tab:
+                key === MY_REVIEW_TAB
+                  ? 'my_review'
+                  : key === OTHER_REVIEWS_TAB
+                    ? 'other_reviews'
+                    : 'previous_phase',
+              phase_id: isPreviousPhase
+                ? String(key).slice(PHASE_TAB_PREFIX.length)
+                : assignment.phaseId,
+            },
+          }),
+        );
+      }}
+    >
       <TabList aria-label={t('Review Proposal')}>
         <Tab id={MY_REVIEW_TAB}>{t('My review')}</Tab>
         {showOtherReviews ? (
@@ -138,6 +168,7 @@ function PhaseReviews({
 }) {
   const { assignment, rubricTemplate } = useReviewForm();
   const { user } = useUser();
+  const posthog = usePostHog();
   const excludeProfileId = excludeOwnReview
     ? (user?.currentProfileId ?? undefined)
     : undefined;
@@ -145,6 +176,25 @@ function PhaseReviews({
   const [selectedAssignmentId, setSelectedAssignmentId] = useState<
     string | null
   >(null);
+
+  const handleSelectAssignment = (reviewAssignmentId: string | null) => {
+    // Non-null = drilling into another reviewer's full review; null = back.
+    if (reviewAssignmentId !== null) {
+      posthog.capture(
+        'review_viewed',
+        getDecisionCommonProperties({
+          decisionInstanceId: assignment.processInstanceId,
+          proposalId: assignment.proposal.id,
+          additionalProps: {
+            phase_id: phaseId,
+            phase_kind: phaseId === assignment.phaseId ? 'current' : 'previous',
+            review_assignment_id: reviewAssignmentId,
+          },
+        }),
+      );
+    }
+    setSelectedAssignmentId(reviewAssignmentId);
+  };
 
   const [proposalWithReviews] =
     trpc.decision.getProposalWithReviewAggregates.useSuspenseQuery({
@@ -172,7 +222,7 @@ function PhaseReviews({
       proposalWithReviews={proposalWithReviews}
       rubricTemplate={rubricTemplate}
       selectedAssignmentId={selectedAssignmentId}
-      onSelectAssignment={setSelectedAssignmentId}
+      onSelectAssignment={handleSelectAssignment}
       excludeProfileId={excludeProfileId}
       hideSummaryHeader
     />

--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useTrackPageView } from '@/hooks/useTrackPageView';
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
+import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
 import {
   ProposalReviewAssignmentStatus,
@@ -80,6 +82,18 @@ export function ReviewAssignmentsList({
     !!currentPhase &&
     getPhaseReviewSettings({ phases }, currentPhase.phaseId).scope ===
       'by_category';
+
+  useTrackPageView(
+    'review_queue_viewed',
+    getDecisionCommonProperties({
+      decisionInstanceId: processInstanceId,
+      additionalProps: {
+        scope: isByCategory ? 'by_category' : 'all',
+        phase_id: currentPhase?.phaseId ?? null,
+      },
+    }),
+    [processInstanceId],
+  );
 
   // Show the category tag only when a by-category reviewer's queue spans more
   // than one category (a single-category queue doesn't need the redundant tag).

--- a/packages/analytics/src/utils.ts
+++ b/packages/analytics/src/utils.ts
@@ -390,9 +390,69 @@ export async function trackUserVoted(
 }
 
 /**
+ * Track a reviewer's first draft save on an assignment (PENDING → IN_PROGRESS)
+ */
+export async function trackReviewStarted(
+  userId: string,
+  processId: string,
+  proposalId: string,
+  additionalProps?: Record<string, unknown>,
+): Promise<void> {
+  await trackEventWithContext(
+    userId,
+    'review_started',
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      proposalId,
+      additionalProps,
+    }),
+  );
+}
+
+/**
+ * Track when a reviewer asks the author to revise a proposal
+ */
+export async function trackRevisionRequested(
+  userId: string,
+  processId: string,
+  proposalId: string,
+  additionalProps?: Record<string, unknown>,
+): Promise<void> {
+  await trackEventWithContext(
+    userId,
+    'review_revision_requested',
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      proposalId,
+      additionalProps,
+    }),
+  );
+}
+
+/**
+ * Track when an author resubmits a proposal in response to a revision request
+ */
+export async function trackRevisionResponseSubmitted(
+  userId: string,
+  processId: string,
+  proposalId: string,
+  additionalProps?: Record<string, unknown>,
+): Promise<void> {
+  await trackEventWithContext(
+    userId,
+    'review_revision_submitted',
+    getDecisionCommonProperties({
+      decisionInstanceId: processId,
+      proposalId,
+      additionalProps,
+    }),
+  );
+}
+
+/**
  * Track when a reviewer submits a review for one proposal
  */
-export async function trackProposalReviewed(
+export async function trackReviewSubmitted(
   userId: string,
   processId: string,
   proposalId: string,
@@ -400,7 +460,7 @@ export async function trackProposalReviewed(
 ): Promise<void> {
   await trackEventWithContext(
     userId,
-    'user_reviewed_proposal',
+    'review_submitted',
     getDecisionCommonProperties({
       decisionInstanceId: processId,
       proposalId,
@@ -412,14 +472,14 @@ export async function trackProposalReviewed(
 /**
  * Track when a reviewer finishes their entire review assignment list for a process
  */
-export async function trackReviewListFinished(
+export async function trackReviewQueueCompleted(
   userId: string,
   processId: string,
   additionalProps?: Record<string, any>,
 ): Promise<void> {
   await trackEventWithContext(
     userId,
-    'user_finished_review',
+    'review_queue_completed',
     getDecisionCommonProperties({
       decisionInstanceId: processId,
       additionalProps,

--- a/packages/common/src/services/decision/requestRevision.ts
+++ b/packages/common/src/services/decision/requestRevision.ts
@@ -1,3 +1,4 @@
+import { trackRevisionRequested } from '@op/analytics';
 import { db } from '@op/db/client';
 import {
   ProposalReviewAssignmentStatus,
@@ -7,6 +8,7 @@ import {
   proposalReviewRequests,
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
+import { waitUntil } from '@vercel/functions';
 import { eq } from 'drizzle-orm';
 
 import { CommonError, ValidationError } from '../../utils';
@@ -66,6 +68,18 @@ export async function requestRevision({
 
     return revisionRequest;
   });
+
+  waitUntil(
+    trackRevisionRequested(
+      user.id,
+      context.assignment.processInstanceId,
+      context.assignment.proposalId,
+      {
+        assignment_id: assignmentId,
+        phase_id: context.assignment.phaseId,
+      },
+    ),
+  );
 
   return {
     ...request,

--- a/packages/common/src/services/decision/saveReviewDraft.ts
+++ b/packages/common/src/services/decision/saveReviewDraft.ts
@@ -1,3 +1,4 @@
+import { trackReviewStarted } from '@op/analytics';
 import { db } from '@op/db/client';
 import {
   type ProposalReview,
@@ -7,6 +8,7 @@ import {
   proposalReviews,
 } from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
+import { waitUntil } from '@vercel/functions';
 import { eq, ne } from 'drizzle-orm';
 
 import { ValidationError } from '../../utils';
@@ -86,6 +88,22 @@ export async function saveReviewDraft({
 
     return draft;
   });
+
+  // First draft save flips PENDING → IN_PROGRESS: the "review started" signal.
+  // Later autosaves find a non-PENDING status, so this fires once per assignment.
+  if (context.assignment.status === ProposalReviewAssignmentStatus.PENDING) {
+    waitUntil(
+      trackReviewStarted(
+        user.id,
+        context.assignment.processInstanceId,
+        context.assignment.proposalId,
+        {
+          assignment_id: assignmentId,
+          phase_id: context.assignment.phaseId,
+        },
+      ),
+    );
+  }
 
   return {
     review,

--- a/packages/common/src/services/decision/submitReview.ts
+++ b/packages/common/src/services/decision/submitReview.ts
@@ -1,4 +1,4 @@
-import { trackProposalReviewed, trackReviewListFinished } from '@op/analytics';
+import { trackReviewQueueCompleted, trackReviewSubmitted } from '@op/analytics';
 import { and, db, eq, ne } from '@op/db/client';
 import {
   type ProposalReview,
@@ -12,6 +12,8 @@ import { waitUntil } from '@vercel/functions';
 import { count } from 'drizzle-orm';
 
 import { CommonError, ValidationError } from '../../utils';
+import { getRubricScoringInfo } from './getRubricScoringInfo';
+import { getSubmittedReviewScore } from './listProposalsWithReviewAggregates';
 import { assertReviewAssignmentContext } from './reviewHelpers';
 import { schemaValidator } from './schemaValidator';
 import type { RubricReviewData } from './schemas/reviews';
@@ -86,11 +88,31 @@ export async function submitReview({
 
   const processInstanceId = context.assignment.processInstanceId;
 
+  const scoredCriterionKeys = getRubricScoringInfo(context.rubricTemplate)
+    .criteria.filter((criterion) => criterion.scored)
+    .map((criterion) => criterion.key);
+  const scored = getSubmittedReviewScore(review, scoredCriterionKeys);
+
+  const assignedAtMs = context.assignment.assignedAt
+    ? Date.parse(context.assignment.assignedAt)
+    : Number.NaN;
+  const secondsToComplete = Number.isFinite(assignedAtMs)
+    ? Math.round((Date.parse(submittedAt) - assignedAtMs) / 1000)
+    : null;
+
   waitUntil(
-    trackProposalReviewed(
+    trackReviewSubmitted(
       user.id,
       processInstanceId,
       context.assignment.proposalId,
+      {
+        assignment_id: assignmentId,
+        phase_id: context.assignment.phaseId,
+        recommendation: scored?.overallRecommendation ?? null,
+        score: scored?.score ?? null,
+        revision_requested: context.assignment.requests.length > 0,
+        seconds_to_complete: secondsToComplete,
+      },
     ),
   );
 
@@ -117,9 +139,9 @@ export async function submitReview({
         );
 
       // Default to 1 (not 0) on a missing row so a count failure cannot
-      // falsely trigger review_list_finished.
+      // falsely trigger review_queue_completed.
       if ((remaining?.value ?? 1) === 0) {
-        await trackReviewListFinished(user.id, processInstanceId);
+        await trackReviewQueueCompleted(user.id, processInstanceId);
       }
     })(),
   );

--- a/packages/common/src/services/decision/submitRevisionResponse.ts
+++ b/packages/common/src/services/decision/submitRevisionResponse.ts
@@ -1,3 +1,4 @@
+import { trackRevisionResponseSubmitted } from '@op/analytics';
 import { getTipTapClient, invalidateCachedDocumentFragments } from '@op/collab';
 import { db } from '@op/db/client';
 import {
@@ -197,6 +198,19 @@ export async function submitRevisionResponse({
       }),
     );
   }
+
+  waitUntil(
+    trackRevisionResponseSubmitted(
+      user.id,
+      request.assignment.processInstanceId,
+      proposal.id,
+      {
+        assignment_id: request.assignmentId,
+        phase_id: request.assignment.phaseId,
+        revision_request_id: revisionRequestId,
+      },
+    ),
+  );
 
   return {
     ...updatedRequest,


### PR DESCRIPTION
Instruments the reviewer, author, and builder review flows with PostHog events so we can see how reviews-v2 is actually used: `review_started`, `review_submitted`, `review_queue_completed`, `review_revision_requested`, `review_revision_submitted` server-side, and `review_queue_viewed`, `review_tab_opened`, `review_viewed`, `open_reviews_toggled`, `review_scope_changed`, `category_reviewer_added`, `category_reviewer_removed` client-side. Properties carry ids plus recommendation and numeric score only — no names, emails, or review text — and capture is fire-and-forget, not gated on the reviews-v2 flag.

Renames the pre-existing `user_reviewed_proposal` and `user_finished_review` events to `review_submitted` and `review_queue_completed` for naming consistency, so existing PostHog insights on the old names lose continuity at deploy time.
