### PR TITLE
feat(decision): per-option descriptions on multiple choice rubric criteria

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -391,11 +391,7 @@ function ScoredCriterionConfig({
 // Single-select criterion config (option list)
 // ---------------------------------------------------------------------------
 
-/**
- * Sortable row: `id` is the stored option id, `value` its display label.
- * `description` isn't editable here but is carried through so edits never
- * strip per-option descriptions authored outside the builder.
- */
+/** Sortable row: `id` is the stored option id, `value` its display label. */
 interface OptionRow {
   id: string;
   value: string;
@@ -405,9 +401,10 @@ interface OptionRow {
 /**
  * Options editor for single-select criteria. Mirrors the proposal template's
  * FieldConfigDropdown UI: drag to reorder, min-2 removal guard, Enter adds
- * the next option. Manages its own row state (initialized on mount) and
- * reports the full option list on every change; row ids are the stored
- * option ids so relabels/reorders never break saved answers.
+ * the next option. Each option carries an optional description, revealed via
+ * an "Add a description" link. Manages its own row state (initialized on
+ * mount) and reports the full option list on every change; row ids are the
+ * stored option ids so relabels/reorders never break saved answers.
  */
 function SingleSelectCriterionConfig({
   criterion,
@@ -419,6 +416,7 @@ function SingleSelectCriterionConfig({
   const t = useTranslations();
   const containerRef = useRef<HTMLDivElement>(null);
   const shouldFocusNewRef = useRef(false);
+  const focusDescriptionIdRef = useRef<string | null>(null);
 
   const [options, setOptions] = useState<OptionRow[]>(() =>
     criterion.options.map((o) => ({
@@ -428,13 +426,22 @@ function SingleSelectCriterionConfig({
     })),
   );
 
+  const [openDescriptionIds, setOpenDescriptionIds] = useState<Set<string>>(
+    () =>
+      new Set(
+        criterion.options
+          .filter((o) => o.description !== undefined)
+          .map((o) => o.value),
+      ),
+  );
+
   const updateOptions = (next: OptionRow[]) => {
     setOptions(next);
     onUpdateOptions(
       next.map((row) => ({
         value: row.id,
         title: row.value,
-        ...(row.description !== undefined
+        ...(row.description !== undefined && row.description.trim() !== ''
           ? { description: row.description }
           : {}),
       })),
@@ -482,6 +489,17 @@ function SingleSelectCriterionConfig({
     );
   };
 
+  const handleUpdateOptionDescription = (id: string, description: string) => {
+    updateOptions(
+      options.map((opt) => (opt.id === id ? { ...opt, description } : opt)),
+    );
+  };
+
+  const handleOpenDescription = (id: string) => {
+    focusDescriptionIdRef.current = id;
+    setOpenDescriptionIds((prev) => new Set(prev).add(id));
+  };
+
   const handleRemoveOption = (id: string) => {
     updateOptions(options.filter((opt) => opt.id !== id));
   };
@@ -512,49 +530,78 @@ function SingleSelectCriterionConfig({
         {(option, controls) => {
           const index = options.findIndex((o) => o.id === option.id);
           return (
-            <div className="flex items-center gap-2">
-              <DragHandle
-                {...controls.dragHandleProps}
-                aria-label={t('Drag to reorder option')}
-                className="text-neutral-gray3 hover:text-neutral-gray4"
-              />
-              <TextField
-                value={option.value}
-                onChange={(value) => handleUpdateOption(option.id, value)}
-                onKeyDown={(e) => handleKeyDown(e, option)}
-                inputProps={{
-                  placeholder: t('Option {number}', { number: index + 1 }),
-                  className: 'bg-white',
-                }}
-                className="w-full"
-              />
-              <TooltipTrigger isDisabled={options.length > 2}>
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <DragHandle
+                  {...controls.dragHandleProps}
+                  aria-label={t('Drag to reorder option')}
+                  className="text-neutral-gray3 hover:text-neutral-gray4"
+                />
+                <TextField
+                  value={option.value}
+                  onChange={(value) => handleUpdateOption(option.id, value)}
+                  onKeyDown={(e) => handleKeyDown(e, option)}
+                  inputProps={{
+                    placeholder: t('Option {number}', { number: index + 1 }),
+                    className: 'bg-white',
+                  }}
+                  className="w-full"
+                />
+                <TooltipTrigger isDisabled={options.length > 2}>
+                  <Button
+                    color="ghost"
+                    size="small"
+                    aria-label={t('Remove option')}
+                    aria-disabled={options.length <= 2 || undefined}
+                    aria-description={
+                      options.length <= 2
+                        ? t('At least two options are required')
+                        : undefined
+                    }
+                    excludeFromTabOrder={options.length <= 2}
+                    onPress={() => {
+                      if (options.length > 2) {
+                        handleRemoveOption(option.id);
+                      }
+                    }}
+                    className={`p-2 ${
+                      options.length <= 2
+                        ? 'cursor-default text-neutral-gray3 opacity-30'
+                        : 'text-neutral-gray3 hover:text-neutral-charcoal'
+                    }`}
+                  >
+                    <LuX className="size-4" />
+                  </Button>
+                  <Tooltip>{t('At least two options are required')}</Tooltip>
+                </TooltipTrigger>
+              </div>
+
+              {openDescriptionIds.has(option.id) ? (
+                <TextField
+                  aria-label={t('Description')}
+                  useTextArea
+                  autoFocus={focusDescriptionIdRef.current === option.id}
+                  value={option.description ?? ''}
+                  onChange={(value) =>
+                    handleUpdateOptionDescription(option.id, value)
+                  }
+                  textareaProps={{
+                    placeholder: t('Add a description'),
+                    className: 'min-h-16 resize-none bg-white',
+                  }}
+                  className="ps-8 pe-10"
+                />
+              ) : (
                 <Button
                   color="ghost"
                   size="small"
-                  aria-label={t('Remove option')}
-                  aria-disabled={options.length <= 2 || undefined}
-                  aria-description={
-                    options.length <= 2
-                      ? t('At least two options are required')
-                      : undefined
-                  }
-                  excludeFromTabOrder={options.length <= 2}
-                  onPress={() => {
-                    if (options.length > 2) {
-                      handleRemoveOption(option.id);
-                    }
-                  }}
-                  className={`p-2 ${
-                    options.length <= 2
-                      ? 'cursor-default text-neutral-gray3 opacity-30'
-                      : 'text-neutral-gray3 hover:text-neutral-charcoal'
-                  }`}
+                  onPress={() => handleOpenDescription(option.id)}
+                  className="ms-8 gap-1 self-start p-0 text-primary-teal hover:text-primary-tealBlack"
                 >
-                  <LuX className="size-4" />
+                  <LuPlus className="size-4" />
+                  <span>{t('Add a description')}</span>
                 </Button>
-                <Tooltip>{t('At least two options are required')}</Tooltip>
-              </TooltipTrigger>
+              )}
             </div>
           );
         }}

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -370,7 +370,16 @@ function RubricFieldInput({
                   id={String(option.value)}
                   textValue={label}
                 >
-                  {label}
+                  {option.description ? (
+                    <div className="flex flex-col">
+                      <span>{label}</span>
+                      <span className="text-sm text-neutral-gray4">
+                        {option.description}
+                      </span>
+                    </div>
+                  ) : (
+                    label
+                  )}
                 </SelectItem>
               );
             })}

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -141,7 +141,8 @@ function RubricFieldResult({
       return (
         <ResultCard
           value={selected ? selected.title || String(selected.value) : '—'}
-          description={rationale}
+          description={selected?.description || rationale}
+          rationale={selected?.description ? rationale : undefined}
         />
       );
     }

--- a/packages/common/src/services/decision/proposalDataSchema.test.ts
+++ b/packages/common/src/services/decision/proposalDataSchema.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeLocation,
   normalizeProposalCategories,
   parseProposalData,
+  parseSchemaOptions,
 } from './proposalDataSchema';
 import type { ProposalTemplateSchema } from './types';
 
@@ -33,6 +34,25 @@ describe('proposalDataSchema category normalization', () => {
     });
 
     expect(result.category).toEqual(['Housing', 'Public Transit']);
+  });
+});
+
+describe('parseSchemaOptions', () => {
+  it('passes per-option descriptions through from canonical oneOf entries', () => {
+    const options = parseSchemaOptions({
+      type: 'string',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 'a1', title: 'Yes', description: 'Feasible as scoped' },
+        { const: 'b2', title: 'Maybe' },
+      ],
+    });
+
+    expect(options).toEqual([
+      { value: 'a1', title: 'Yes', description: 'Feasible as scoped' },
+      { value: 'b2', title: 'Maybe' },
+    ]);
+    expect('description' in (options[1] ?? {})).toBe(false);
   });
 });
 

--- a/packages/common/src/services/decision/proposalDataSchema.ts
+++ b/packages/common/src/services/decision/proposalDataSchema.ts
@@ -218,6 +218,8 @@ export function parseProposalData(proposalData: unknown): ProposalData {
 export interface SchemaOption {
   value: string | number;
   title: string;
+  /** Optional per-option explanation (canonical `oneOf` entries only). */
+  description?: string;
 }
 
 /**
@@ -298,7 +300,13 @@ export function parseSchemaOptions(
   if (Array.isArray(schema.oneOf)) {
     return schema.oneOf
       .filter(
-        (entry): entry is { const: string | number; title: string } =>
+        (
+          entry,
+        ): entry is {
+          const: string | number;
+          title: string;
+          description?: string;
+        } =>
           typeof entry === 'object' &&
           entry !== null &&
           'const' in entry &&
@@ -307,7 +315,13 @@ export function parseSchemaOptions(
           'title' in entry &&
           typeof (entry as Record<string, unknown>).title === 'string',
       )
-      .map((entry) => ({ value: entry.const, title: entry.title }));
+      .map((entry) => ({
+        value: entry.const,
+        title: entry.title,
+        ...(typeof entry.description === 'string'
+          ? { description: entry.description }
+          : {}),
+      }));
   }
 
   const itemSchema =


### PR DESCRIPTION
Admins can now explain what each multiple choice option means (e.g. what "Maybe" implies for a criterion), so reviewers score consistently. Descriptions show under each option in the reviewer dropdown and on submitted reviews.