### PR TITLE
feat(decision): per-phase rubric templates with instance-level fallback

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewTabs.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewTabs.tsx
@@ -166,7 +166,7 @@ function PhaseReviews({
   emptyMessage: string;
   excludeOwnReview?: boolean;
 }) {
-  const { assignment, rubricTemplate } = useReviewForm();
+  const { assignment } = useReviewForm();
   const { user } = useUser();
   const posthog = usePostHog();
   const excludeProfileId = excludeOwnReview
@@ -220,7 +220,7 @@ function PhaseReviews({
   return (
     <ReviewsPanel
       proposalWithReviews={proposalWithReviews}
-      rubricTemplate={rubricTemplate}
+      rubricTemplate={proposalWithReviews.rubricTemplate}
       selectedAssignmentId={selectedAssignmentId}
       onSelectAssignment={handleSelectAssignment}
       excludeProfileId={excludeProfileId}

--- a/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionList.tsx
+++ b/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionList.tsx
@@ -46,14 +46,13 @@ export function ReviewSelectionList({
   const advancing = useMemo(() => new Set(advancingIds), [advancingIds]);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
-  const [{ items, total }] =
+  const [{ items, total, rubricTemplate }] =
     trpc.decision.listWithReviewAggregates.useSuspenseQuery({
       processInstanceId,
       phaseId: previousPhaseId,
     });
   const utils = trpc.useUtils();
 
-  const rubricTemplate = instance.instanceData?.rubricTemplate ?? null;
   const totalPoints = useMemo(
     () =>
       rubricTemplate ? getRubricScoringInfo(rubricTemplate).totalPoints : 0,

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
@@ -29,19 +29,16 @@ export function ReviewSummaryView({
   phaseId,
 }: ReviewSummaryViewProps) {
   const t = useTranslations();
-  const [[instance, proposalWithReviews, proposal]] = trpc.useSuspenseQueries(
-    (t) => [
-      t.decision.getInstance({ instanceId }),
-      t.decision.getProposalWithReviewAggregates({
-        processInstanceId: instanceId,
-        proposalId,
-        phaseId,
-      }),
-      t.decision.getProposal({ profileId: proposalProfileId }),
-    ],
-  );
+  const [[proposalWithReviews, proposal]] = trpc.useSuspenseQueries((t) => [
+    t.decision.getProposalWithReviewAggregates({
+      processInstanceId: instanceId,
+      proposalId,
+      phaseId,
+    }),
+    t.decision.getProposal({ profileId: proposalProfileId }),
+  ]);
 
-  const rubricTemplate = instance.instanceData?.rubricTemplate ?? null;
+  const rubricTemplate = proposalWithReviews.rubricTemplate;
 
   const [selectedAssignmentId, setSelectedAssignmentId] = useQueryState(
     'assignment',

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -25,6 +25,10 @@ export {
   isPhaseAtOrBefore,
 } from './services/decision/utils/phaseOrder';
 export {
+  getPhaseRubricTemplate,
+  resolvePhaseTemplate,
+} from './services/decision/utils/phaseTemplates';
+export {
   attachmentSchema,
   documentContentSchema,
   proposalAccessSchema,

--- a/packages/common/src/services/decision/duplicateInstance.ts
+++ b/packages/common/src/services/decision/duplicateInstance.ts
@@ -187,6 +187,12 @@ function buildInstanceData(
         copied.rules = phase.rules;
       }
 
+      // Phase-level rubrics travel with the rubric flag, like the
+      // instance-level template below.
+      if (include.reviewRubric && phase.rubricTemplate) {
+        copied.rubricTemplate = phase.rubricTemplate;
+      }
+
       return copied;
     });
   } else if (source.phases.length > 0) {
@@ -195,7 +201,11 @@ function buildInstanceData(
       (phase): PhaseInstanceData => ({
         phaseId: phase.phaseId,
         name: phase.name,
-        // Minimal phase - just identity
+        // Minimal phase - just identity, plus the phase rubric when the
+        // rubric flag asks for it.
+        ...(include.reviewRubric && phase.rubricTemplate
+          ? { rubricTemplate: phase.rubricTemplate }
+          : {}),
       }),
     );
   }

--- a/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
@@ -17,6 +17,7 @@ import {
   type ProposalWithSubmittedReviews,
   proposalWithSubmittedReviewsSchema,
 } from './schemas/reviews';
+import { getPhaseRubricTemplate } from './utils/phaseTemplates';
 
 export const getProposalWithReviewAggregatesInputSchema =
   instanceOptionalPhaseRefSchema.extend({
@@ -46,7 +47,12 @@ export async function getProposalWithReviewAggregates(
   // or before the current one — see `canReadPhaseReviews` for the semantics.
   assertCanReadPhaseReviews(instance, phaseId);
 
-  const rubricTemplate = instance.instanceData.rubricTemplate;
+  // Resolved by the requested phase so each phase's reviews are scored (and
+  // rendered by clients) against that phase's rubric. When an admin omits
+  // `phaseId` (all phases) this falls back to the instance-level rubric —
+  // aggregates blended across phases with different rubrics are inherently
+  // approximate.
+  const rubricTemplate = getPhaseRubricTemplate(instance.instanceData, phaseId);
   const scoredCriterionKeys = rubricTemplate
     ? getRubricScoringInfo(rubricTemplate)
         .criteria.filter((c) => c.scored)
@@ -97,5 +103,6 @@ export async function getProposalWithReviewAggregates(
     aggregates,
     categories: categoriesByProposalId.get(proposal.id) ?? [],
     reviews,
+    rubricTemplate,
   });
 }

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -136,6 +136,9 @@ export * from './utils/phaseSettings';
 // Phase-order navigation
 export * from './utils/phaseOrder';
 
+// Phase-scoped template resolution
+export * from './utils/phaseTemplates';
+
 // Voting management
 export * from './voting';
 

--- a/packages/common/src/services/decision/listProposalsWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/listProposalsWithReviewAggregates.ts
@@ -27,6 +27,8 @@ import {
   type ProposalsWithReviewAggregatesList,
   proposalsWithReviewAggregatesListSchema,
 } from './schemas/reviews';
+import type { RubricTemplateSchema } from './types';
+import { getPhaseRubricTemplate } from './utils/phaseTemplates';
 
 // ── Input schema ───────────────────────────────────────────────────────
 
@@ -74,14 +76,16 @@ export async function listProposalsWithReviewAggregates(
     );
   }
 
-  const rubricTemplate = instance.instanceData.rubricTemplate;
+  const phaseId = input.phaseId ?? instance.currentStateId ?? undefined;
+
+  // Scoring follows the effective phase's rubric (the list is always
+  // phase-scoped: explicit `phaseId`, else the current phase).
+  const rubricTemplate = getPhaseRubricTemplate(instance.instanceData, phaseId);
   const scoredCriterionKeys = rubricTemplate
     ? getRubricScoringInfo(rubricTemplate)
         .criteria.filter((c) => c.scored)
         .map((c) => c.key)
     : [];
-
-  const phaseId = input.phaseId ?? instance.currentStateId ?? undefined;
   const phaseProposalIds = await getProposalIdsForPhase({
     instance,
     phaseId,
@@ -94,6 +98,7 @@ export async function listProposalsWithReviewAggregates(
       processInstanceId,
       phaseId,
       scoredCriterionKeys,
+      rubricTemplate,
     });
   }
 
@@ -104,6 +109,7 @@ export async function listProposalsWithReviewAggregates(
     limit: input.limit,
     cursor: input.cursor,
     scoredCriterionKeys,
+    rubricTemplate,
   });
 }
 
@@ -115,12 +121,14 @@ async function listProposalsFiltered({
   processInstanceId,
   phaseId,
   scoredCriterionKeys,
+  rubricTemplate,
 }: {
   proposalIds: string[];
   phaseProposalIds: string[];
   processInstanceId: string;
   phaseId: string | undefined;
   scoredCriterionKeys: string[];
+  rubricTemplate: RubricTemplateSchema | null;
 }): Promise<ProposalsWithReviewAggregatesList> {
   const phaseProposalIdSet = new Set(phaseProposalIds);
   const filteredProposalIds = proposalIds.filter((id) =>
@@ -128,7 +136,7 @@ async function listProposalsFiltered({
   );
 
   if (filteredProposalIds.length === 0) {
-    return { items: [], total: 0, next: null };
+    return { items: [], total: 0, next: null, rubricTemplate };
   }
 
   const [proposalsFull, categoriesByProposalId] = await Promise.all([
@@ -161,6 +169,7 @@ async function listProposalsFiltered({
     items,
     total: items.length,
     next: null,
+    rubricTemplate,
   });
 }
 
@@ -173,6 +182,7 @@ async function listProposalsPaginated({
   limit,
   cursor,
   scoredCriterionKeys,
+  rubricTemplate,
 }: {
   processInstanceId: string;
   phaseId: string | undefined;
@@ -180,9 +190,10 @@ async function listProposalsPaginated({
   limit: number;
   cursor: string | undefined;
   scoredCriterionKeys: string[];
+  rubricTemplate: RubricTemplateSchema | null;
 }): Promise<ProposalsWithReviewAggregatesList> {
   if (phaseProposalIds.length === 0) {
-    return { items: [], total: 0, next: null };
+    return { items: [], total: 0, next: null, rubricTemplate };
   }
 
   const decodedCursor = cursor
@@ -229,7 +240,7 @@ async function listProposalsPaginated({
   const total = Number(totalRows[0]?.count ?? 0);
 
   if (pageRows.length === 0) {
-    return { items: [], total, next: null };
+    return { items: [], total, next: null, rubricTemplate };
   }
 
   const pageIds = pageRows.map((p) => p.id);
@@ -257,6 +268,7 @@ async function listProposalsPaginated({
     items,
     total,
     next,
+    rubricTemplate,
   });
 }
 

--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -22,6 +22,7 @@ import {
   type ReviewAssignmentSort,
   reviewAssignmentListSchema,
 } from './schemas/reviews';
+import { getPhaseRubricTemplate } from './utils/phaseTemplates';
 
 /**
  * Status priority for the "least reviewed" secondary sort — lower ranks first,
@@ -149,7 +150,6 @@ export async function listReviewAssignments({
     instance.instanceData,
     instance.process.id,
   );
-  const rubricTemplate = instance.instanceData.rubricTemplate ?? null;
 
   const docContentInputs: Array<{
     id: string;
@@ -200,7 +200,11 @@ export async function listReviewAssignments({
           htmlContent,
         },
       },
-      rubricTemplate,
+      // Assignments in this list can span phases, each with its own rubric.
+      rubricTemplate: getPhaseRubricTemplate(
+        instance.instanceData,
+        assignment.phaseId,
+      ),
       review,
       revisionRequest: getActiveRevisionRequest(assignment.requests),
       canEditReview: canEditSubmittedReview({ assignment, instance, review }),

--- a/packages/common/src/services/decision/reviewHelpers.ts
+++ b/packages/common/src/services/decision/reviewHelpers.ts
@@ -16,6 +16,7 @@ import type { DecisionInstanceData } from './schemas/instanceData';
 import { isInstanceCurrentPhase } from './utils/instance';
 import { isPhaseAtOrBefore } from './utils/phaseOrder';
 import { getPhaseReviewSettings } from './utils/phaseSettings';
+import { getPhaseRubricTemplate } from './utils/phaseTemplates';
 
 /** Shared `with` config for review assignment queries. */
 export const reviewAssignmentWithConfig = {
@@ -224,7 +225,12 @@ export async function assertReviewAssignmentContext({
     instance,
     review: assignment.reviews[0] ?? null,
     revisionRequest: getActiveRevisionRequest(assignment.requests),
-    rubricTemplate: instance.instanceData.rubricTemplate ?? null,
+    // Reviews are validated and rendered against the rubric of the phase
+    // their assignment belongs to.
+    rubricTemplate: getPhaseRubricTemplate(
+      instance.instanceData,
+      assignment.phaseId,
+    ),
   };
 }
 

--- a/packages/common/src/services/decision/schemas/instanceData.ts
+++ b/packages/common/src/services/decision/schemas/instanceData.ts
@@ -42,6 +42,8 @@ export interface PhaseInstanceData {
   startDate?: string;
   endDate?: string;
   settings?: Record<string, unknown>;
+  /** Phase-specific rubric; resolve via `getPhaseRubricTemplate`, never directly. */
+  rubricTemplate?: RubricTemplateSchema;
 }
 
 /** Public-facing overview content (headline, short description, rich text body) */
@@ -91,6 +93,8 @@ export interface PhaseOverride {
   startDate?: string;
   endDate?: string;
   settings?: Record<string, unknown>;
+  /** Phase rubric override; `null` clears it, `undefined` leaves it unchanged. */
+  rubricTemplate?: RubricTemplateSchema | null;
 }
 
 /**
@@ -152,6 +156,7 @@ export function createInstanceDataFromTemplate(input: {
           selectionPipeline: phase.selectionPipeline,
         }),
         ...(phase.settings && { settingsSchema: phase.settings }),
+        ...(phase.rubricTemplate && { rubricTemplate: phase.rubricTemplate }),
         ...(override?.startDate && {
           startDate: override.startDate,
         }),

--- a/packages/common/src/services/decision/schemas/reviews.ts
+++ b/packages/common/src/services/decision/schemas/reviews.ts
@@ -196,6 +196,8 @@ export const proposalsWithReviewAggregatesListSchema = z.object({
   items: z.array(proposalWithAggregatesSchema),
   total: z.number().int(),
   next: z.string().nullable(),
+  /** The phase-resolved rubric the items' aggregates were scored against. */
+  rubricTemplate: rubricTemplateSchema.nullable(),
 });
 
 // ── Single proposal with submitted reviews ─────────────────────────────
@@ -212,6 +214,8 @@ export const submittedReviewItemSchema = z.object({
 export const proposalWithSubmittedReviewsSchema =
   proposalWithAggregatesSchema.extend({
     reviews: z.array(submittedReviewItemSchema),
+    /** The phase-resolved rubric the returned reviews were scored against. */
+    rubricTemplate: rubricTemplateSchema.nullable(),
   });
 
 // ── Instance-level review progress (admin overview header) ─────────────

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -55,6 +55,9 @@ export interface PhaseDefinition {
 
   /** Optional per-phase settings form (use `default` in schema properties) */
   settings?: JSONSchema7 & { ui?: UiSchema };
+
+  /** Phase-specific rubric; overrides the schema-level `rubricTemplate`. */
+  rubricTemplate?: RubricTemplateSchema;
 }
 
 /**

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -101,6 +101,13 @@ export const updateDecisionInstance = async ({
     schemaValidator.validateJsonSchema(rubricTemplate);
   }
 
+  // Same validation for phase-level rubric templates (null = clear, skipped)
+  for (const phase of phases ?? []) {
+    if (phase.rubricTemplate != null) {
+      schemaValidator.validateJsonSchema(phase.rubricTemplate);
+    }
+  }
+
   // Build update data
   const updateData: Record<string, unknown> = {};
 
@@ -206,7 +213,7 @@ export const updateDecisionInstance = async ({
 
       updatedInstanceData.phases = phases.map((phase) => {
         const existing = existingPhaseMap.get(phase.phaseId);
-        return {
+        const merged = {
           ...existing,
           phaseId: phase.phaseId,
           ...(phase.name !== undefined && { name: phase.name }),
@@ -221,7 +228,15 @@ export const updateDecisionInstance = async ({
           ...(phase.startDate !== undefined && { startDate: phase.startDate }),
           ...(phase.endDate !== undefined && { endDate: phase.endDate }),
           ...(phase.settings !== undefined && { settings: phase.settings }),
+          ...(phase.rubricTemplate != null && {
+            rubricTemplate: phase.rubricTemplate,
+          }),
         };
+        // `null` clears the phase rubric (falls back to the instance-level template).
+        if (phase.rubricTemplate === null) {
+          delete merged.rubricTemplate;
+        }
+        return merged;
       });
     }
 

--- a/packages/common/src/services/decision/utils/phaseTemplates.test.ts
+++ b/packages/common/src/services/decision/utils/phaseTemplates.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RubricTemplateSchema } from '../types';
+import { getPhaseRubricTemplate } from './phaseTemplates';
+
+const instanceRubric: RubricTemplateSchema = {
+  type: 'object',
+  properties: { impact: { type: 'integer' } },
+};
+
+const phaseRubric: RubricTemplateSchema = {
+  type: 'object',
+  properties: { viability: { type: 'integer' } },
+};
+
+describe('getPhaseRubricTemplate', () => {
+  it('returns the phase rubric when the phase has its own', () => {
+    const instanceData = {
+      rubricTemplate: instanceRubric,
+      phases: [
+        { phaseId: 'feasibility', rubricTemplate: phaseRubric },
+        { phaseId: 'community' },
+      ],
+    };
+
+    expect(getPhaseRubricTemplate(instanceData, 'feasibility')).toBe(
+      phaseRubric,
+    );
+  });
+
+  it('falls back to the instance rubric when the phase has none', () => {
+    const instanceData = {
+      rubricTemplate: instanceRubric,
+      phases: [
+        { phaseId: 'feasibility', rubricTemplate: phaseRubric },
+        { phaseId: 'community' },
+      ],
+    };
+
+    expect(getPhaseRubricTemplate(instanceData, 'community')).toBe(
+      instanceRubric,
+    );
+  });
+
+  it('falls back to the instance rubric for an unknown phase', () => {
+    const instanceData = {
+      rubricTemplate: instanceRubric,
+      phases: [{ phaseId: 'review', rubricTemplate: phaseRubric }],
+    };
+
+    expect(getPhaseRubricTemplate(instanceData, 'nope')).toBe(instanceRubric);
+  });
+
+  it('falls back to the instance rubric when no phase is named (cross-phase reads)', () => {
+    const instanceData = {
+      rubricTemplate: instanceRubric,
+      phases: [{ phaseId: 'review', rubricTemplate: phaseRubric }],
+    };
+
+    expect(getPhaseRubricTemplate(instanceData, undefined)).toBe(
+      instanceRubric,
+    );
+  });
+
+  it('returns null when neither the phase nor the instance has a rubric', () => {
+    expect(
+      getPhaseRubricTemplate({ phases: [{ phaseId: 'review' }] }, 'review'),
+    ).toBeNull();
+    expect(getPhaseRubricTemplate({}, 'review')).toBeNull();
+    expect(getPhaseRubricTemplate({}, undefined)).toBeNull();
+  });
+
+  it('prefers the phase rubric even when the instance also has one set', () => {
+    const instanceData = {
+      rubricTemplate: instanceRubric,
+      phases: [{ phaseId: 'review', rubricTemplate: phaseRubric }],
+    };
+
+    expect(getPhaseRubricTemplate(instanceData, 'review')).toBe(phaseRubric);
+  });
+
+  it('returns the phase rubric when the instance has none', () => {
+    const instanceData = {
+      phases: [{ phaseId: 'review', rubricTemplate: phaseRubric }],
+    };
+
+    expect(getPhaseRubricTemplate(instanceData, 'review')).toBe(phaseRubric);
+  });
+});

--- a/packages/common/src/services/decision/utils/phaseTemplates.ts
+++ b/packages/common/src/services/decision/utils/phaseTemplates.ts
@@ -1,0 +1,58 @@
+/**
+ * Phase-scoped template resolution over `instanceData.phases`: a phase's own
+ * template wins, else the instance-level template, else null. Structural like
+ * `phaseOrder.ts`, so domain instance data and the API-encoder shape both
+ * pass. Client-safe: no server-only imports.
+ */
+import type { RubricTemplateSchema } from '../types';
+
+/**
+ * Phase-first template resolution. An unknown or omitted `phaseId` resolves
+ * to the instance-level template, so cross-phase callers and phases without
+ * their own template share the instance's.
+ *
+ * Shared by design: per-phase `proposalTemplate` is expected to reuse this
+ * with its own selector.
+ */
+export function resolvePhaseTemplate<
+  Template,
+  Phase extends { phaseId: string },
+>(
+  instanceData: { phases?: readonly Phase[] },
+  phaseId: string | undefined,
+  selectPhaseTemplate: (phase: Phase) => Template | undefined,
+  instanceTemplate: Template | undefined,
+): Template | null {
+  if (phaseId != null) {
+    const phase = instanceData.phases?.find((p) => p.phaseId === phaseId);
+    const phaseTemplate = phase ? selectPhaseTemplate(phase) : undefined;
+    if (phaseTemplate !== undefined) {
+      return phaseTemplate;
+    }
+  }
+  return instanceTemplate ?? null;
+}
+
+/**
+ * The rubric template in effect for `phaseId`: the phase's own
+ * `rubricTemplate` when set, else the instance-level one, else null. Every
+ * review read/write path resolves its rubric through here — reviews are
+ * always interpreted against the rubric of the phase they belong to.
+ */
+export function getPhaseRubricTemplate(
+  instanceData: {
+    rubricTemplate?: RubricTemplateSchema;
+    phases?: ReadonlyArray<{
+      phaseId: string;
+      rubricTemplate?: RubricTemplateSchema;
+    }>;
+  },
+  phaseId: string | undefined,
+): RubricTemplateSchema | null {
+  return resolvePhaseTemplate(
+    instanceData,
+    phaseId,
+    (phase) => phase.rubricTemplate,
+    instanceData.rubricTemplate,
+  );
+}

--- a/services/api/src/encoders/decision.ts
+++ b/services/api/src/encoders/decision.ts
@@ -118,6 +118,8 @@ const phaseDefinitionEncoder = z.object({
   rules: phaseRulesEncoder,
   selectionPipeline: selectionPipelineEncoder.optional(),
   settings: jsonSchemaEncoder.optional(),
+  // Phase-specific rubric (overrides the schema-level rubricTemplate)
+  rubricTemplate: rubricTemplateSchema.optional(),
   // Instance-specific dates (merged from instanceData.phases)
   startDate: z.string().optional(),
   endDate: z.string().optional(),
@@ -196,6 +198,9 @@ export const instancePhaseDataEncoder = z.object({
   selectionPipeline: selectionPipelineEncoder.optional(),
   settingsSchema: jsonSchemaEncoder.optional(),
   settings: z.record(z.string(), z.unknown()).optional(),
+  // Phase-specific rubric; resolve via getPhaseRubricTemplate (instance-level
+  // rubricTemplate is the fallback)
+  rubricTemplate: rubricTemplateSchema.optional(),
 });
 
 /**
@@ -524,6 +529,8 @@ export const createInstanceFromTemplateInputSchema = z.object({
 const instancePhaseDataInputEncoder = instancePhaseDataEncoder.extend({
   startDate: z.string().datetime({ offset: true }).optional(),
   endDate: z.string().datetime({ offset: true }).optional(),
+  // `null` clears the phase-level rubric; omitted leaves it unchanged.
+  rubricTemplate: rubricTemplateSchema.nullable().optional(),
 });
 
 export const updateDecisionInstanceInputSchema = z.object({

--- a/services/api/src/routers/decision/instances/duplicateInstance.test.ts
+++ b/services/api/src/routers/decision/instances/duplicateInstance.test.ts
@@ -271,6 +271,104 @@ describe.concurrent('duplicateInstance', () => {
     }
   });
 
+  it('should copy phase-level rubric templates in both include.phases branches when include.reviewRubric is true', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { result: source, caller } = await createSourceInstance(
+      testData,
+      task.id,
+    );
+
+    const phaseRubric = {
+      type: 'object' as const,
+      properties: {
+        viability: { type: 'integer' as const, title: 'Viability' },
+      },
+    };
+    await caller.decision.updateDecisionInstance({
+      instanceId: source.processInstance.id,
+      phases: [{ phaseId: 'submission', rubricTemplate: phaseRubric }],
+    });
+
+    const fullCopy = await caller.decision.duplicateInstance({
+      instanceId: source.processInstance.id,
+      name: 'Phase Rubric Full Copy',
+      include: ALL_INCLUDED,
+    });
+    testData.trackProfileForCleanup(fullCopy.id);
+
+    const fullInstance = await db.query.processInstances.findFirst({
+      where: { id: fullCopy.processInstance.id },
+    });
+    const fullData = fullInstance!.instanceData as DecisionInstanceData;
+    expect(
+      fullData.phases.find((p) => p.phaseId === 'submission')?.rubricTemplate,
+    ).toMatchObject({ properties: { viability: { title: 'Viability' } } });
+
+    // Minimal-phase branch: identity-only phases still carry the rubric.
+    const minimalCopy = await caller.decision.duplicateInstance({
+      instanceId: source.processInstance.id,
+      name: 'Phase Rubric Minimal Copy',
+      include: { ...ALL_INCLUDED, phases: false },
+    });
+    testData.trackProfileForCleanup(minimalCopy.id);
+
+    const minimalInstance = await db.query.processInstances.findFirst({
+      where: { id: minimalCopy.processInstance.id },
+    });
+    const minimalData = minimalInstance!.instanceData as DecisionInstanceData;
+    const minimalPhase = minimalData.phases.find(
+      (p) => p.phaseId === 'submission',
+    );
+    expect(minimalPhase?.rubricTemplate).toMatchObject({
+      properties: { viability: { title: 'Viability' } },
+    });
+    expect(minimalPhase?.rules).toBeUndefined();
+  });
+
+  it('should not copy phase-level rubric templates when include.reviewRubric is false', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { result: source, caller } = await createSourceInstance(
+      testData,
+      task.id,
+    );
+
+    await caller.decision.updateDecisionInstance({
+      instanceId: source.processInstance.id,
+      phases: [
+        {
+          phaseId: 'submission',
+          rubricTemplate: {
+            type: 'object',
+            properties: {
+              viability: { type: 'integer', title: 'Viability' },
+            },
+          },
+        },
+      ],
+    });
+
+    const duplicate = await caller.decision.duplicateInstance({
+      instanceId: source.processInstance.id,
+      name: 'No Phase Rubric Test',
+      include: { ...ALL_INCLUDED, reviewRubric: false },
+    });
+    testData.trackProfileForCleanup(duplicate.id);
+
+    const instance = await db.query.processInstances.findFirst({
+      where: { id: duplicate.processInstance.id },
+    });
+    const instanceData = instance!.instanceData as DecisionInstanceData;
+    for (const phase of instanceData.phases) {
+      expect(phase.rubricTemplate).toBeUndefined();
+    }
+  });
+
   it('should not copy proposalTemplate when include.proposalTemplate is false', async ({
     task,
     onTestFinished,

--- a/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
+++ b/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
@@ -1,0 +1,553 @@
+import { mockCollab } from '@op/collab/testing';
+import type {
+  DecisionSchemaDefinition,
+  RubricTemplateSchema,
+} from '@op/common';
+import { OVERALL_RECOMMENDATION_KEY } from '@op/common/client';
+import { ProposalReviewState } from '@op/db/schema';
+import { db } from '@op/db/test';
+import { createProposalReview, createReviewAssignment } from '@op/test';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestReviewsDataManager } from '../../../test/helpers/TestReviewsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+/**
+ * Per-phase rubric templates: two back-to-back review phases where the
+ * feasibility phase carries its own rubric (phase-level field) while the
+ * community phase falls back to the instance-level rubric. Covers assignment
+ * context resolution, phase-scoped aggregates, submit/edit validation, and
+ * the instance-level fallback.
+ */
+
+const FEASIBILITY_PHASE = 'feasibility';
+const COMMUNITY_PHASE = 'community';
+
+/** Instance-level rubric — what the community (current) phase reviews against. */
+const instanceRubric: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': ['impact', 'feasibility', OVERALL_RECOMMENDATION_KEY],
+  properties: {
+    impact: {
+      type: 'integer',
+      title: 'Impact',
+      minimum: 0,
+      maximum: 10,
+    },
+    feasibility: {
+      type: 'integer',
+      title: 'Feasibility',
+      minimum: 1,
+      maximum: 5,
+    },
+    [OVERALL_RECOMMENDATION_KEY]: {
+      type: 'string',
+      title: 'Recommendation',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 'yes', title: 'Yes' },
+        { const: 'no', title: 'No' },
+      ],
+    },
+  },
+  required: ['impact'],
+};
+
+/** Feasibility phase's own rubric — different criteria, different max score. */
+const feasibilityRubric: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': ['viability'],
+  properties: {
+    viability: {
+      type: 'integer',
+      title: 'Viability',
+      minimum: 1,
+      maximum: 3,
+    },
+  },
+  required: ['viability'],
+};
+
+const twoReviewPhaseSchema = {
+  id: 'phase-rubrics',
+  version: '1.0.0',
+  name: 'Phase Rubrics',
+  description: 'Feasibility review followed by a community impact review.',
+  phases: [
+    {
+      id: 'submission',
+      name: 'Proposal Submission',
+      rules: {
+        proposals: { submit: true },
+        advancement: { method: 'date' as const, endDate: '2026-01-01' },
+      },
+    },
+    {
+      id: FEASIBILITY_PHASE,
+      name: 'Feasibility Review',
+      rules: {
+        reviews: { submit: true, openReviews: true },
+        advancement: { method: 'date' as const, endDate: '2026-01-02' },
+      },
+    },
+    {
+      id: COMMUNITY_PHASE,
+      name: 'Community Impact Review',
+      rules: {
+        reviews: { submit: true },
+        advancement: { method: 'date' as const, endDate: '2026-01-03' },
+      },
+    },
+  ],
+} satisfies DecisionSchemaDefinition;
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+/** getReviewAssignment resolves the proposal's collab doc — stub its content. */
+function seedMockCollab(proposal: { proposalData: unknown }) {
+  const { collaborationDocId } = proposal.proposalData as {
+    collaborationDocId: string;
+  };
+  mockCollab.setDocResponse(collaborationDocId, {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Phase rubric proposal content' }],
+      },
+    ],
+  });
+}
+
+/**
+ * Instance on the community phase: instance-level rubric set, feasibility
+ * phase carrying its own rubric override.
+ */
+async function createTwoRubricContext(testData: TestReviewsDataManager) {
+  const context = await testData.createContext({
+    processSchema: twoReviewPhaseSchema,
+  });
+  const instanceId = context.instance.instance.id;
+  await testData.setRubricTemplate(context, instanceRubric);
+  await testData.setPhaseRubricTemplate(
+    instanceId,
+    FEASIBILITY_PHASE,
+    feasibilityRubric,
+  );
+  await testData.setCurrentPhase(instanceId, COMMUNITY_PHASE);
+  return context;
+}
+
+describe.concurrent('per-phase rubric templates', () => {
+  it('resolves the assignment-phase rubric in the review assignment context', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoRubricContext(testData);
+
+    const feasibilityScenario = await testData.createReviewAssignment({
+      context,
+      title: 'Assignment-phase rubric',
+      phaseId: FEASIBILITY_PHASE,
+    });
+    const communityReviewer =
+      await testData.createInstanceReviewerWithRole(context);
+    const communityAssignment = await createReviewAssignment({
+      processInstanceId: context.instance.instance.id,
+      proposalId: feasibilityScenario.proposal.id,
+      reviewerProfileId: communityReviewer.profileId,
+      phaseId: COMMUNITY_PHASE,
+    });
+    seedMockCollab(feasibilityScenario.proposal);
+
+    const feasibilityCaller = await createAuthenticatedCaller(
+      feasibilityScenario.reviewer.email,
+    );
+    const feasibilityResult =
+      await feasibilityCaller.decision.getReviewAssignment({
+        assignmentId: feasibilityScenario.assignment.id,
+      });
+    expect(feasibilityResult.rubricTemplate).toMatchObject({
+      properties: { viability: { title: 'Viability' } },
+    });
+
+    const communityCaller = await createAuthenticatedCaller(
+      communityReviewer.email,
+    );
+    const communityResult = await communityCaller.decision.getReviewAssignment({
+      assignmentId: communityAssignment.id,
+    });
+    // No phase-level rubric on the community phase → instance-level fallback.
+    expect(communityResult.rubricTemplate).toMatchObject({
+      properties: { impact: { title: 'Impact' } },
+    });
+  });
+
+  it('resolves the rubric per assignment in listReviewAssignments', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoRubricContext(testData);
+
+    // The same reviewer holds one assignment in each phase.
+    const reviewer = await testData.createInstanceReviewerWithRole(context);
+    const feasibilityScenario = await testData.createReviewAssignment({
+      context,
+      reviewer,
+      title: 'Per-assignment rubric',
+      phaseId: FEASIBILITY_PHASE,
+    });
+    const communityAssignment = await createReviewAssignment({
+      processInstanceId: context.instance.instance.id,
+      proposalId: feasibilityScenario.proposal.id,
+      reviewerProfileId: reviewer.profileId,
+      phaseId: COMMUNITY_PHASE,
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+    const { assignments } = await reviewerCaller.decision.listReviewAssignments(
+      {
+        processInstanceId: context.instance.instance.id,
+      },
+    );
+
+    const byId = new Map(assignments.map((a) => [a.assignment.id, a]));
+    expect(
+      byId.get(feasibilityScenario.assignment.id)?.rubricTemplate,
+    ).toMatchObject({ properties: { viability: { title: 'Viability' } } });
+    expect(byId.get(communityAssignment.id)?.rubricTemplate).toMatchObject({
+      properties: { impact: { title: 'Impact' } },
+    });
+  });
+
+  it('returns phase-scoped aggregates scored against that phase’s rubric', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoRubricContext(testData);
+    const instanceId = context.instance.instance.id;
+
+    const feasibilityScenario = await testData.createReviewAssignment({
+      context,
+      title: 'Phase-scoped rubric aggregates',
+      phaseId: FEASIBILITY_PHASE,
+    });
+    await createProposalReview({
+      assignmentId: feasibilityScenario.assignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: { viability: 3 },
+        rationales: {},
+      },
+      submittedAt: new Date().toISOString(),
+    });
+
+    const communityReviewer = await testData.createReviewer(context);
+    const communityAssignment = await createReviewAssignment({
+      processInstanceId: instanceId,
+      proposalId: feasibilityScenario.proposal.id,
+      reviewerProfileId: communityReviewer.profileId,
+      phaseId: COMMUNITY_PHASE,
+    });
+    await createProposalReview({
+      assignmentId: communityAssignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          impact: 7,
+          feasibility: 4,
+          [OVERALL_RECOMMENDATION_KEY]: 'yes',
+        },
+        rationales: {},
+      },
+      submittedAt: new Date().toISOString(),
+    });
+
+    const adminCaller = await createAuthenticatedCaller(
+      context.defaultReviewer.email,
+    );
+
+    // Feasibility phase: its own rubric, score = viability alone.
+    const feasibilityResult =
+      await adminCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: instanceId,
+        proposalId: feasibilityScenario.proposal.id,
+        phaseId: FEASIBILITY_PHASE,
+      });
+    expect(feasibilityResult.rubricTemplate).toMatchObject({
+      properties: { viability: { title: 'Viability' } },
+    });
+    expect(feasibilityResult.aggregates.averageScore).toBe(3);
+    expect(feasibilityResult.reviews).toHaveLength(1);
+    expect(feasibilityResult.reviews[0]!.score).toBe(3);
+
+    // Community phase: instance-level fallback, score = impact + feasibility.
+    const communityResult =
+      await adminCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: instanceId,
+        proposalId: feasibilityScenario.proposal.id,
+        phaseId: COMMUNITY_PHASE,
+      });
+    expect(communityResult.rubricTemplate).toMatchObject({
+      properties: { impact: { title: 'Impact' } },
+    });
+    expect(communityResult.aggregates.averageScore).toBe(11);
+    expect(communityResult.reviews[0]!.overallRecommendation).toBe('yes');
+
+    // Admin omitting phaseId blends phases; the documented behavior is the
+    // instance-level rubric, so the feasibility review scores 0 against it.
+    const blendedResult =
+      await adminCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: instanceId,
+        proposalId: feasibilityScenario.proposal.id,
+      });
+    expect(blendedResult.rubricTemplate).toMatchObject({
+      properties: { impact: { title: 'Impact' } },
+    });
+    expect(blendedResult.aggregates.reviewsSubmittedCount).toBe(2);
+    expect(blendedResult.aggregates.averageScore).toBe(5.5);
+
+    // The list endpoint carries the same phase-resolved rubric, so clients
+    // never resolve one themselves (e.g. shortlist total points).
+    const feasibilityList = await adminCaller.decision.listWithReviewAggregates(
+      {
+        processInstanceId: instanceId,
+        phaseId: FEASIBILITY_PHASE,
+      },
+    );
+    expect(feasibilityList.rubricTemplate).toMatchObject({
+      properties: { viability: { title: 'Viability' } },
+    });
+
+    // Effective phase defaults to the current (community) phase → fallback.
+    const currentPhaseList =
+      await adminCaller.decision.listWithReviewAggregates({
+        processInstanceId: instanceId,
+      });
+    expect(currentPhaseList.rubricTemplate).toMatchObject({
+      properties: { impact: { title: 'Impact' } },
+    });
+  });
+
+  it('validates submissions against the assignment-phase rubric', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoRubricContext(testData);
+
+    const scenario = await testData.createReviewAssignment({
+      context,
+      title: 'Submit against phase rubric',
+      phaseId: FEASIBILITY_PHASE,
+    });
+    const reviewerCaller = await createAuthenticatedCaller(
+      scenario.reviewer.email,
+    );
+
+    // Valid under the instance rubric, but not under the phase's own rubric.
+    await expect(
+      reviewerCaller.decision.submitReview({
+        assignmentId: scenario.assignment.id,
+        reviewData: { answers: { impact: 3 }, rationales: {} },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+
+    const result = await reviewerCaller.decision.submitReview({
+      assignmentId: scenario.assignment.id,
+      reviewData: { answers: { viability: 2 }, rationales: {} },
+    });
+    expect(result.state).toBe(ProposalReviewState.SUBMITTED);
+    expect(result.reviewData.answers).toEqual({ viability: 2 });
+  });
+
+  it('validates edits of a submitted review against the assignment-phase rubric', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoRubricContext(testData);
+    const instanceId = context.instance.instance.id;
+    // Editing is only allowed while the assignment's phase is current.
+    await testData.setCurrentPhase(instanceId, FEASIBILITY_PHASE);
+
+    const scenario = await testData.createReviewAssignment({
+      context,
+      title: 'Edit against phase rubric',
+      phaseId: FEASIBILITY_PHASE,
+    });
+    const reviewerCaller = await createAuthenticatedCaller(
+      scenario.reviewer.email,
+    );
+
+    await reviewerCaller.decision.submitReview({
+      assignmentId: scenario.assignment.id,
+      reviewData: { answers: { viability: 1 }, rationales: {} },
+    });
+
+    await expect(
+      reviewerCaller.decision.updateReview({
+        assignmentId: scenario.assignment.id,
+        reviewData: { answers: { impact: 5 }, rationales: {} },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+
+    const updated = await reviewerCaller.decision.updateReview({
+      assignmentId: scenario.assignment.id,
+      reviewData: { answers: { viability: 3 }, rationales: {} },
+    });
+    expect(updated.reviewData.answers).toEqual({ viability: 3 });
+  });
+
+  it('sets, validates, and clears a phase rubric through updateDecisionInstance', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext({
+      processSchema: twoReviewPhaseSchema,
+    });
+    const instanceId = context.instance.instance.id;
+    await testData.setRubricTemplate(context, instanceRubric);
+
+    const adminCaller = await createAuthenticatedCaller(
+      context.defaultReviewer.email,
+    );
+
+    const currentPhases = async () => {
+      const row = await db.query.processInstances.findFirst({
+        where: { id: instanceId },
+      });
+      const data = row?.instanceData as {
+        phases: Array<{ phaseId: string; rubricTemplate?: unknown }>;
+      };
+      return data.phases;
+    };
+    const phaseIds = (await currentPhases()).map((p) => p.phaseId);
+
+    // An invalid phase rubric (uncompilable regex pattern) is rejected
+    // before anything persists.
+    const uncompilableRubric: RubricTemplateSchema = {
+      type: 'object',
+      properties: { broken: { type: 'string', pattern: '[' } },
+    };
+    await expect(
+      adminCaller.decision.updateDecisionInstance({
+        instanceId,
+        phases: phaseIds.map((phaseId) =>
+          phaseId === FEASIBILITY_PHASE
+            ? { phaseId, rubricTemplate: uncompilableRubric }
+            : { phaseId },
+        ),
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
+
+    // Set the feasibility phase's rubric; other phases stay untouched.
+    await adminCaller.decision.updateDecisionInstance({
+      instanceId,
+      phases: phaseIds.map((phaseId) =>
+        phaseId === FEASIBILITY_PHASE
+          ? { phaseId, rubricTemplate: feasibilityRubric }
+          : { phaseId },
+      ),
+    });
+
+    let phases = await currentPhases();
+    expect(
+      phases.find((p) => p.phaseId === FEASIBILITY_PHASE)?.rubricTemplate,
+    ).toMatchObject({ properties: { viability: { title: 'Viability' } } });
+    expect(
+      phases.find((p) => p.phaseId === COMMUNITY_PHASE)?.rubricTemplate,
+    ).toBeUndefined();
+
+    // An update that doesn't mention rubricTemplate leaves it in place.
+    await adminCaller.decision.updateDecisionInstance({
+      instanceId,
+      phases: phaseIds.map((phaseId) => ({ phaseId, name: `n-${phaseId}` })),
+    });
+    phases = await currentPhases();
+    expect(
+      phases.find((p) => p.phaseId === FEASIBILITY_PHASE)?.rubricTemplate,
+    ).toMatchObject({ properties: { viability: { title: 'Viability' } } });
+
+    // `null` clears the phase rubric — back to the instance-level fallback.
+    await adminCaller.decision.updateDecisionInstance({
+      instanceId,
+      phases: phaseIds.map((phaseId) =>
+        phaseId === FEASIBILITY_PHASE
+          ? { phaseId, rubricTemplate: null }
+          : { phaseId },
+      ),
+    });
+    phases = await currentPhases();
+    expect(
+      phases.find((p) => p.phaseId === FEASIBILITY_PHASE)?.rubricTemplate,
+    ).toBeUndefined();
+  });
+
+  it('uses the instance rubric for every phase when none carries its own', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext({
+      processSchema: twoReviewPhaseSchema,
+    });
+    const instanceId = context.instance.instance.id;
+    await testData.setRubricTemplate(context, instanceRubric);
+    await testData.setCurrentPhase(instanceId, COMMUNITY_PHASE);
+
+    const scenario = await testData.createReviewAssignment({
+      context,
+      title: 'Instance-level fallback parity',
+      phaseId: FEASIBILITY_PHASE,
+    });
+    await createProposalReview({
+      assignmentId: scenario.assignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: { impact: 7, feasibility: 4 },
+        rationales: {},
+      },
+      submittedAt: new Date().toISOString(),
+    });
+
+    seedMockCollab(scenario.proposal);
+    const reviewerCaller = await createAuthenticatedCaller(
+      scenario.reviewer.email,
+    );
+    const assignmentResult = await reviewerCaller.decision.getReviewAssignment({
+      assignmentId: scenario.assignment.id,
+    });
+    expect(assignmentResult.rubricTemplate).toMatchObject({
+      properties: { impact: { title: 'Impact' } },
+    });
+
+    const adminCaller = await createAuthenticatedCaller(
+      context.defaultReviewer.email,
+    );
+    const aggregates =
+      await adminCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: instanceId,
+        proposalId: scenario.proposal.id,
+        phaseId: FEASIBILITY_PHASE,
+      });
+    expect(aggregates.rubricTemplate).toMatchObject({
+      properties: { impact: { title: 'Impact' } },
+    });
+    expect(aggregates.aggregates.averageScore).toBe(11);
+  });
+});

--- a/services/api/src/test/helpers/TestReviewsDataManager.ts
+++ b/services/api/src/test/helpers/TestReviewsDataManager.ts
@@ -313,6 +313,36 @@ export class TestReviewsDataManager {
       .where(eq(processInstances.id, context.instance.instance.id));
   }
 
+  /** Sets a phase-level rubric template (overrides the instance-level one for that phase). */
+  async setPhaseRubricTemplate(
+    instanceId: string,
+    phaseId: string,
+    rubricTemplate: RubricTemplateSchema,
+  ) {
+    const instanceRecord = await db.query.processInstances.findFirst({
+      where: { id: instanceId },
+    });
+    const instanceData =
+      (instanceRecord?.instanceData as {
+        phases?: Array<{ phaseId: string }>;
+      } | null) ?? {};
+    // Mirror the service posture: an unknown phase is a hard error, not a
+    // silent no-op. Throws NotFoundError, exactly like production reads.
+    assertInstancePhase({ instance: { instanceData }, phaseId });
+    const phases = (instanceData.phases ?? []).map((p) =>
+      p.phaseId === phaseId ? { ...p, rubricTemplate } : p,
+    );
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...instanceData,
+          phases,
+        },
+      })
+      .where(eq(processInstances.id, instanceId));
+  }
+
   /** Creates a single review assignment and the minimum related data it needs. */
   async createReviewAssignment(opts: CreateReviewAssignmentOptions = {}) {
     const context = opts.context ?? (await this.createContext());


### PR DESCRIPTION
Columbus runs two back-to-back review phases that each need a different rubric, but an instance carries a single rubricTemplate and reviews are re-scored against it at read time — swapping it at the phase boundary would re-interpret earlier reviews against the wrong criteria. Phases can now carry their own rubricTemplate, falling back to the instance-level one, and every review read/write path resolves the rubric for the phase the review belongs to. Responses that return review scores include the rubric that produced them, so clients never resolve one themselves. With no phase-level rubric set, behavior is unchanged. Backend/API plus read-side rendering only — no builder UI yet.
