### PR TITLE
fix(i18n): translate JoinAccountModal login link

### DIFF
--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1,4 +1,5 @@
 {
+  "Already have an account? <login>Log in</login>": "لديك حساب بالفعل؟ <login>تسجيل الدخول</login>",
   "Post": "منشور",
   "Posts": "منشورات",
   "Closes": "ينتهي",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1,4 +1,5 @@
 {
+  "Already have an account? <login>Log in</login>": "ইতিমধ্যে একটি অ্যাকাউন্ট আছে? <login>লগ ইন করুন</login>",
   "Post": "পোস্ট",
   "Posts": "পোস্টসমূহ",
   "Closes": "বন্ধ হবে",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1,4 +1,5 @@
 {
+  "Already have an account? <login>Log in</login>": "¿Ya tienes una cuenta? <login>Inicia sesión</login>",
   "Posts": "Publicaciones",
   "Closes": "Cierra",
   "Add your personal details": "Agrega tus datos personales",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1,4 +1,5 @@
 {
+  "Already have an account? <login>Log in</login>": "Vous avez déjà un compte ? <login>Connectez-vous</login>",
   "Post": "Publier",
   "Posts": "Publications",
   "Closes": "Ferme",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1,4 +1,5 @@
 {
+  "Already have an account? <login>Log in</login>": "Já tem uma conta? <login>Entrar</login>",
   "Post": "Publicar",
   "Posts": "Publicações",
   "Closes": "Encerra",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1,4 +1,5 @@
 {
+  "Already have an account? <login>Log in</login>": "Horeyba akoon ma leedahay? <login>Soo gal</login>",
   "Post": "Qoraal",
   "Posts": "Qoraallo",
   "Closes": "Xidhitaanka",


### PR DESCRIPTION
The `Already have an account? <login>Log in</login>` rich-text string was only present in `en.json` — all other locales fell back to the raw key, rendering English plus literal `<login>` tags in the Join/Claim-account modal (which ships in prod).

Adds real translations (tag markup preserved) to es/fr/pt/bn/so/ar.

Independent of the @op/sense migration — targets `dev` directly since the modal is live.