### PR TITLE
feat(reviews): email the requesting reviewer a confirmation when they request a revision

### DIFF
--- a/services/emails/emails/RevisionRequestedConfirmationEmail.tsx
+++ b/services/emails/emails/RevisionRequestedConfirmationEmail.tsx
@@ -1,0 +1,44 @@
+import { Text } from 'react-email';
+
+import { CtaButton } from '../components/CtaButton';
+import EmailTemplate from '../components/EmailTemplate';
+import { Footnote } from '../components/Footnote';
+import { Header } from '../components/Header';
+
+export const RevisionRequestedConfirmationEmail = ({
+  proposalName,
+  processTitle,
+  reviewUrl = 'https://common.oneproject.org/',
+}: {
+  proposalName: string;
+  processTitle: string;
+  reviewUrl: string;
+}) => {
+  return (
+    <EmailTemplate previewText={`You requested changes to "${proposalName}"`}>
+      <Header>Revision Requested</Header>
+      <Text className="my-8 text-lg">
+        You requested changes to <strong>{proposalName}</strong> in{' '}
+        <strong>{processTitle}</strong>. The author has been notified, and
+        you'll receive another email when they resubmit their revision.
+      </Text>
+
+      <CtaButton href={reviewUrl}>View your review</CtaButton>
+
+      <Footnote>
+        You're receiving this because you requested changes to this proposal.
+      </Footnote>
+    </EmailTemplate>
+  );
+};
+
+RevisionRequestedConfirmationEmail.subject = (proposalName: string) =>
+  `You requested changes to "${proposalName}"`;
+
+RevisionRequestedConfirmationEmail.PreviewProps = {
+  proposalName: 'Community Garden Revamp',
+  processTitle: 'Participatory Budgeting 2026',
+  reviewUrl: 'https://common.oneproject.org/',
+} satisfies Parameters<typeof RevisionRequestedConfirmationEmail>[0];
+
+export default RevisionRequestedConfirmationEmail;

--- a/services/emails/index.tsx
+++ b/services/emails/index.tsx
@@ -146,6 +146,7 @@ export * from './emails/PhaseTransitionEmail';
 export * from './emails/VoteSubmittedEmail';
 export * from './emails/RevisionResubmittedEmail';
 export * from './emails/RevisionRequestedEmail';
+export * from './emails/RevisionRequestedConfirmationEmail';
 export * from './emails/DecisionUpdateNotificationEmail';
 export * from './emails/ContentFlaggedEmail';
 

--- a/services/workflows/src/functions/notifications/index.ts
+++ b/services/workflows/src/functions/notifications/index.ts
@@ -5,6 +5,7 @@ export * from './sendPhaseTransitionNotification';
 export * from './sendVoteSubmittedNotification';
 export * from './sendRevisionResubmittedNotification';
 export * from './sendRevisionRequestedNotification';
+export * from './sendRevisionRequestedConfirmation';
 export * from './sendDecisionUpdateNotification';
 export * from './sendContentFlaggedNotification';
 export * from './sendPostCommentNotification';

--- a/services/workflows/src/functions/notifications/sendRevisionRequestedConfirmation.ts
+++ b/services/workflows/src/functions/notifications/sendRevisionRequestedConfirmation.ts
@@ -1,0 +1,145 @@
+import { hasEmail } from '@op/common/client';
+import { OPURLConfig } from '@op/core';
+import { db } from '@op/db/client';
+import {
+  ProposalReviewAssignmentStatus,
+  ProposalReviewRequestState,
+} from '@op/db/schema';
+import { OPBatchSend, RevisionRequestedConfirmationEmail } from '@op/emails';
+import { Events, inngest } from '@op/events';
+import { logger } from '@op/logging';
+
+const { reviewRevisionRequested } = Events;
+
+export const sendRevisionRequestedConfirmation = inngest.createFunction(
+  {
+    id: 'sendRevisionRequestedConfirmation',
+    debounce: {
+      key: 'event.data.revisionRequestId',
+      period: '1m',
+      timeout: '3m',
+    },
+  },
+  { event: reviewRevisionRequested.name },
+  async ({ event, step }) => {
+    const { assignmentId, revisionRequestId } =
+      reviewRevisionRequested.schema.parse(event.data);
+
+    const assignment = await step.run('get-assignment-data', async () => {
+      return db.query.proposalReviewAssignments.findFirst({
+        where: { id: assignmentId },
+        with: {
+          proposal: {
+            with: {
+              profile: true,
+            },
+          },
+          processInstance: {
+            with: {
+              profile: true,
+            },
+          },
+          reviewer: {
+            with: {
+              profileUsers: {
+                where: { email: { isNotNull: true } },
+              },
+            },
+          },
+          requests: true,
+        },
+      });
+    });
+
+    if (!assignment) {
+      logger.error('No assignment data found for assignment', { assignmentId });
+      return;
+    }
+
+    // Verify the revision request is still active before sending
+    const revisionRequest = assignment.requests.find(
+      (r) => r.id === revisionRequestId,
+    );
+
+    if (!revisionRequest) {
+      logger.warn('Revision request not found', { revisionRequestId });
+      return;
+    }
+
+    if (revisionRequest.state !== ProposalReviewRequestState.REQUESTED) {
+      logger.info('Revision request is no longer active', {
+        revisionRequestId,
+        state: revisionRequest.state,
+      });
+      return;
+    }
+
+    if (
+      assignment.status !==
+      ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION
+    ) {
+      logger.info('Assignment is no longer awaiting revision', {
+        assignmentId,
+        status: assignment.status,
+      });
+      return;
+    }
+
+    const { proposal, processInstance, reviewer } = assignment;
+    const reviewerEmails = reviewer.profileUsers.filter(hasEmail);
+
+    if (reviewerEmails.length === 0) {
+      logger.warn('No reviewer emails found for reviewer profile', {
+        reviewerProfileId: assignment.reviewerProfileId,
+      });
+      return;
+    }
+
+    const processProfile = processInstance.profile;
+    if (!processProfile) {
+      logger.error('No profile found for process instance', {
+        processInstanceId: processInstance.id,
+      });
+      return;
+    }
+
+    const proposalName = proposal.profile.name;
+    const processTitle = processProfile.name;
+    const reviewUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processProfile.slug}/reviews/${assignmentId}`;
+
+    const result = await step.run('send-emails', async () => {
+      try {
+        const emails = reviewerEmails.map(({ email }) => ({
+          to: email,
+          subject: RevisionRequestedConfirmationEmail.subject(proposalName),
+          component: () =>
+            RevisionRequestedConfirmationEmail({
+              proposalName,
+              processTitle,
+              reviewUrl,
+            }),
+        }));
+
+        const { data, errors } = await OPBatchSend(emails);
+
+        if (errors.length > 0) {
+          throw Error(`Email batch failed: ${JSON.stringify(errors)}`);
+        }
+
+        return {
+          sent: data.length,
+        };
+      } catch (error) {
+        logger.error('Failed to send revision requested confirmations', {
+          error,
+          assignmentId,
+        });
+        throw error;
+      }
+    });
+
+    return {
+      message: `${result.sent} revision requested confirmation(s) sent`,
+    };
+  },
+);


### PR DESCRIPTION
Rides the existing reviewRevisionRequested event to send the requesting reviewer a confirmation that their revision request went out, symmetric with the author-side RevisionRequestedEmail. Possible follow-up: also notify co-reviewers assigned to the same proposal, since the content they're reviewing will change.