### PR TITLE
feat(decision): email reviewers a confirmation when their review is submitted

### DIFF
--- a/services/api/src/routers/decision/reviews/submitReview.ts
+++ b/services/api/src/routers/decision/reviews/submitReview.ts
@@ -3,6 +3,8 @@ import {
   proposalReviewSchema,
   rubricReviewDataSchema,
 } from '@op/common/client';
+import { Events, inngest } from '@op/events';
+import { waitUntil } from '@vercel/functions';
 import { z } from 'zod';
 
 import { networkAuthenticatedProcedure, router } from '../../../trpcFactory';
@@ -29,6 +31,17 @@ export const submitReviewRouter = router({
         Channels.reviewAssignment(input.assignmentId),
         Channels.reviewAssignments(processInstanceId),
       ]);
+
+      // Confirmation email to the reviewer. Emitted only here (first
+      // submission) — updateReview edits must not re-send it.
+      waitUntil(
+        inngest.send({
+          name: Events.reviewSubmitted.name,
+          data: {
+            assignmentId: input.assignmentId,
+          },
+        }),
+      );
 
       return proposalReviewSchema.parse(review);
     }),

--- a/services/emails/emails/ReviewSubmittedEmail.tsx
+++ b/services/emails/emails/ReviewSubmittedEmail.tsx
@@ -1,0 +1,63 @@
+import { Text } from 'react-email';
+
+import { CtaButton } from '../components/CtaButton';
+import EmailTemplate from '../components/EmailTemplate';
+import { Footnote } from '../components/Footnote';
+import { Header } from '../components/Header';
+
+export const ReviewSubmittedEmail = ({
+  proposalName,
+  processTitle,
+  reviewsUrl = 'https://common.oneproject.org/',
+  completedCount,
+  totalCount,
+}: {
+  proposalName: string;
+  processTitle: string;
+  reviewsUrl: string;
+  completedCount?: number;
+  totalCount?: number;
+}) => {
+  const showProgress =
+    typeof completedCount === 'number' &&
+    typeof totalCount === 'number' &&
+    totalCount > 0;
+
+  return (
+    <EmailTemplate
+      previewText={`Your review of "${proposalName}" was recorded`}
+    >
+      <Header>Your review is in!</Header>
+      <Text className="my-8 text-lg">
+        Thank you for reviewing <strong>{proposalName}</strong> in{' '}
+        <strong>{processTitle}</strong>. Your review has been recorded.
+      </Text>
+
+      {showProgress && (
+        <Text className="mb-8 text-lg">
+          You've completed {completedCount} of {totalCount}{' '}
+          {totalCount === 1 ? 'review' : 'reviews'} in this phase.
+        </Text>
+      )}
+
+      <CtaButton href={reviewsUrl}>View your reviews</CtaButton>
+
+      <Footnote>
+        You're receiving this because you submitted a review in this process.
+      </Footnote>
+    </EmailTemplate>
+  );
+};
+
+ReviewSubmittedEmail.subject = (proposalName: string) =>
+  `Your review of "${proposalName}" was recorded`;
+
+ReviewSubmittedEmail.PreviewProps = {
+  proposalName: 'Community Garden Revamp',
+  processTitle: 'Participatory Budgeting 2026',
+  reviewsUrl: 'https://common.oneproject.org/',
+  completedCount: 3,
+  totalCount: 8,
+} satisfies Parameters<typeof ReviewSubmittedEmail>[0];
+
+export default ReviewSubmittedEmail;

--- a/services/emails/index.tsx
+++ b/services/emails/index.tsx
@@ -145,6 +145,7 @@ export * from './emails/ProposalSubmittedEmail';
 export * from './emails/PhaseTransitionEmail';
 export * from './emails/VoteSubmittedEmail';
 export * from './emails/RevisionResubmittedEmail';
+export * from './emails/ReviewSubmittedEmail';
 export * from './emails/RevisionRequestedEmail';
 export * from './emails/DecisionUpdateNotificationEmail';
 export * from './emails/ContentFlaggedEmail';

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -120,6 +120,14 @@ export const Events = {
       revisionRequestId: z.string().uuid(),
     }),
   },
+  // Emitted only on first submission (the submitReview router); edits to an
+  // already-submitted review (updateReview) must not re-send the confirmation.
+  reviewSubmitted: {
+    name: 'review/submitted' as const,
+    schema: z.object({
+      assignmentId: z.string().uuid(),
+    }),
+  },
   decisionUpdatePosted: {
     name: 'decision/update-posted' as const,
     schema: z.object({

--- a/services/workflows/src/functions/notifications/index.ts
+++ b/services/workflows/src/functions/notifications/index.ts
@@ -5,6 +5,7 @@ export * from './sendPhaseTransitionNotification';
 export * from './sendVoteSubmittedNotification';
 export * from './sendRevisionResubmittedNotification';
 export * from './sendRevisionRequestedNotification';
+export * from './sendReviewSubmittedNotification';
 export * from './sendDecisionUpdateNotification';
 export * from './sendContentFlaggedNotification';
 export * from './sendPostCommentNotification';

--- a/services/workflows/src/functions/notifications/sendReviewSubmittedNotification.ts
+++ b/services/workflows/src/functions/notifications/sendReviewSubmittedNotification.ts
@@ -1,0 +1,154 @@
+import { hasEmail } from '@op/common/client';
+import { OPURLConfig } from '@op/core';
+import { and, count, db, eq, sql } from '@op/db/client';
+import {
+  ProposalReviewAssignmentStatus,
+  proposalReviewAssignments,
+} from '@op/db/schema';
+import { OPBatchSend, ReviewSubmittedEmail } from '@op/emails';
+import { Events, inngest } from '@op/events';
+import { logger } from '@op/logging';
+
+const { reviewSubmitted } = Events;
+
+export const sendReviewSubmittedNotification = inngest.createFunction(
+  {
+    id: 'sendReviewSubmittedNotification',
+    debounce: {
+      key: 'event.data.assignmentId',
+      period: '1m',
+      timeout: '3m',
+    },
+  },
+  { event: reviewSubmitted.name },
+  async ({ event, step }) => {
+    const { assignmentId } = reviewSubmitted.schema.parse(event.data);
+
+    const assignment = await step.run('get-assignment-data', async () => {
+      return db.query.proposalReviewAssignments.findFirst({
+        where: { id: assignmentId },
+        with: {
+          proposal: {
+            with: {
+              profile: true,
+            },
+          },
+          processInstance: {
+            with: {
+              profile: true,
+            },
+          },
+          reviewer: {
+            with: {
+              profileUsers: {
+                where: { email: { isNotNull: true } },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    if (!assignment) {
+      logger.error('No assignment data found for assignment', { assignmentId });
+      return;
+    }
+
+    // Verify the review is still submitted before confirming it — the
+    // assignment may have moved on (e.g. back to revision) since the event.
+    if (assignment.status !== ProposalReviewAssignmentStatus.COMPLETED) {
+      logger.info('Assignment is no longer completed', {
+        assignmentId,
+        status: assignment.status,
+      });
+      return;
+    }
+
+    const { proposal, processInstance, reviewer } = assignment;
+    const reviewerEmails = reviewer.profileUsers.filter(hasEmail);
+
+    if (reviewerEmails.length === 0) {
+      logger.warn('No reviewer emails found for reviewer profile', {
+        reviewerProfileId: assignment.reviewerProfileId,
+      });
+      return;
+    }
+
+    const processProfile = processInstance.profile;
+    if (!processProfile) {
+      logger.error('No profile found for process instance', {
+        processInstanceId: processInstance.id,
+      });
+      return;
+    }
+
+    // The reviewer's own phase progress ("N of M reviews done in this phase").
+    const progress = await step.run('get-review-progress', async () => {
+      const [row] = await db
+        .select({
+          total: count(),
+          completed: sql<number>`count(*) filter (where ${eq(
+            proposalReviewAssignments.status,
+            ProposalReviewAssignmentStatus.COMPLETED,
+          )})`.mapWith(Number),
+        })
+        .from(proposalReviewAssignments)
+        .where(
+          and(
+            eq(
+              proposalReviewAssignments.processInstanceId,
+              assignment.processInstanceId,
+            ),
+            eq(proposalReviewAssignments.phaseId, assignment.phaseId),
+            eq(
+              proposalReviewAssignments.reviewerProfileId,
+              assignment.reviewerProfileId,
+            ),
+          ),
+        );
+
+      return row ?? null;
+    });
+
+    const proposalName = proposal.profile.name;
+    const processTitle = processProfile.name;
+    const reviewsUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processProfile.slug}/reviews`;
+
+    const result = await step.run('send-emails', async () => {
+      try {
+        const emails = reviewerEmails.map(({ email }) => ({
+          to: email,
+          subject: ReviewSubmittedEmail.subject(proposalName),
+          component: () =>
+            ReviewSubmittedEmail({
+              proposalName,
+              processTitle,
+              reviewsUrl,
+              completedCount: progress?.completed,
+              totalCount: progress?.total,
+            }),
+        }));
+
+        const { data, errors } = await OPBatchSend(emails);
+
+        if (errors.length > 0) {
+          throw Error(`Email batch failed: ${JSON.stringify(errors)}`);
+        }
+
+        return {
+          sent: data.length,
+        };
+      } catch (error) {
+        logger.error('Failed to send review submitted notifications', {
+          error,
+          assignmentId,
+        });
+        throw error;
+      }
+    });
+
+    return {
+      message: `${result.sent} review submitted notification(s) sent`,
+    };
+  },
+);


### PR DESCRIPTION
Reviewers currently get no acknowledgment after submitting a review — submitReview emitted no event at all. This sends the reviewer a confirmation email on first submission (with their phase progress), and only on first submission: edits via updateReview don't re-send.