### PR TITLE
feat(decision): email proposal authors their selection outcome

### DIFF
--- a/packages/common/src/services/decision/onPhaseAdvanced.ts
+++ b/packages/common/src/services/decision/onPhaseAdvanced.ts
@@ -47,7 +47,24 @@ export async function onPhaseAdvanced(
   if (isLastPhase(input.toPhaseId, input.phases)) {
     // Best-effort: processResults stamps its own failure row; don't abort the post-advance flow.
     try {
-      await processResults({ processInstanceId: input.instanceId });
+      const processResultId = await processResults({
+        processInstanceId: input.instanceId,
+      });
+
+      event
+        .send({
+          name: Events.resultsProcessed.name,
+          data: {
+            processInstanceId: input.instanceId,
+            processResultId,
+          },
+        })
+        .catch((err) => {
+          logger.error('Failed to send results processed event', {
+            instanceId: input.instanceId,
+            error: err,
+          });
+        });
     } catch (error) {
       logger.error('Error processing results for process instance', {
         instanceId: input.instanceId,

--- a/packages/common/src/services/decision/processResults.ts
+++ b/packages/common/src/services/decision/processResults.ts
@@ -20,6 +20,8 @@ import {
  * caller's transaction; otherwise this manages its own and stamps a failure
  * row on uncaught errors. Pass `instance` when the caller already loaded the
  * row (e.g. inside a locking tx) to skip a redundant fetch.
+ *
+ * Returns the id of the `decision_process_results` row it created.
  */
 export async function processResults({
   processInstanceId,
@@ -29,18 +31,17 @@ export async function processResults({
   processInstanceId: string;
   tx?: DbClient;
   instance?: PhaseScopedInstance;
-}): Promise<void> {
+}): Promise<string> {
   if (tx) {
-    await runProcessResults({
+    return runProcessResults({
       tx,
       processInstanceId,
       preloadedInstance: instance,
     });
-    return;
   }
 
   try {
-    await db.transaction(async (newTx) =>
+    return await db.transaction(async (newTx) =>
       runProcessResults({
         tx: newTx,
         processInstanceId,
@@ -79,7 +80,7 @@ async function runProcessResults({
   tx: DbClient;
   processInstanceId: string;
   preloadedInstance?: PhaseScopedInstance;
-}): Promise<void> {
+}): Promise<string> {
   const resolvedInstance =
     preloadedInstance ??
     (await loadPhaseScopedInstance({ db: tx, processInstanceId }));
@@ -93,7 +94,7 @@ async function runProcessResults({
     fetchVoterCount({ db: tx, processInstanceId }),
   ]);
 
-  await writeResultRow({
+  return writeResultRow({
     tx,
     processInstanceId,
     errorMessage: null,
@@ -147,7 +148,7 @@ async function writeResultRow({
   errorMessage: string | null;
   selectedProposalIds: string[];
   voterCount: number;
-}): Promise<void> {
+}): Promise<string> {
   const [row] = await tx
     .insert(decisionProcessResults)
     .values({
@@ -173,4 +174,6 @@ async function writeResultRow({
       })),
     );
   }
+
+  return row.id;
 }

--- a/packages/common/src/services/decision/submitManualSelection.ts
+++ b/packages/common/src/services/decision/submitManualSelection.ts
@@ -98,6 +98,7 @@ export async function submitManualSelection({
   const now = new Date().toISOString();
   const byProfileId = dbUser.profileId;
   let previousPhaseId: string | null = null;
+  let processResultId: string | null = null;
   let reviewAssignmentInput:
     | Parameters<typeof runGenerateReviewAssignments>[0]
     | null = null;
@@ -282,7 +283,7 @@ export async function submitManualSelection({
     // On the final phase, fold results processing into this transaction so
     // the new result row is atomic with the attachment write.
     if (isLastPhase(currentStateId, lockedPhases ?? [])) {
-      await processResults({
+      processResultId = await processResults({
         processInstanceId,
         tx,
         instance: {
@@ -315,6 +316,25 @@ export async function submitManualSelection({
       })
       .catch((err) => {
         logger.error('Failed to send manual selections confirmed event', {
+          processInstanceId,
+          error: err,
+        });
+      });
+  }
+
+  // Sent after commit so consumers reading on the pooled connection can see
+  // the new result row.
+  if (processResultId) {
+    event
+      .send({
+        name: Events.resultsProcessed.name,
+        data: {
+          processInstanceId,
+          processResultId,
+        },
+      })
+      .catch((err) => {
+        logger.error('Failed to send results processed event', {
           processInstanceId,
           error: err,
         });

--- a/services/emails/emails/SelectionDecisionEmail.tsx
+++ b/services/emails/emails/SelectionDecisionEmail.tsx
@@ -1,0 +1,63 @@
+import { Text } from 'react-email';
+
+import { CtaButton } from '../components/CtaButton';
+import EmailTemplate from '../components/EmailTemplate';
+import { Footnote } from '../components/Footnote';
+import { Header } from '../components/Header';
+
+export const SelectionDecisionEmail = ({
+  proposalName,
+  processTitle,
+  selected,
+  proposalUrl = 'https://common.oneproject.org/',
+}: {
+  proposalName: string;
+  processTitle: string;
+  selected: boolean;
+  proposalUrl: string;
+}) => {
+  return (
+    <EmailTemplate
+      previewText={
+        selected
+          ? `"${proposalName}" was selected in ${processTitle}.`
+          : `An update on "${proposalName}" in ${processTitle}.`
+      }
+    >
+      <Header>{selected ? 'Congratulations!' : 'Selection Results'}</Header>
+      {selected ? (
+        <Text className="my-8 text-lg">
+          Your proposal <strong>{proposalName}</strong> was selected in{' '}
+          <strong>{processTitle}</strong>.
+        </Text>
+      ) : (
+        <Text className="my-8 text-lg">
+          Selections have been made in <strong>{processTitle}</strong>, and your
+          proposal <strong>{proposalName}</strong> was not selected this time.
+          Thank you for participating — your contribution helped shape the
+          process.
+        </Text>
+      )}
+
+      <CtaButton href={proposalUrl}>View proposal</CtaButton>
+
+      <Footnote>
+        You're receiving this because you're an author of this proposal.
+      </Footnote>
+    </EmailTemplate>
+  );
+};
+
+SelectionDecisionEmail.subject = (processTitle: string, selected: boolean) =>
+  selected
+    ? `Your proposal was selected in ${processTitle}`
+    : `Selection results for ${processTitle}`;
+
+SelectionDecisionEmail.PreviewProps = {
+  proposalName: 'Community Garden Revamp',
+  processTitle: 'Participatory Budgeting 2026',
+  selected: true,
+  proposalUrl: 'https://common.oneproject.org/',
+} satisfies Parameters<typeof SelectionDecisionEmail>[0];
+
+export default SelectionDecisionEmail;

--- a/services/emails/index.tsx
+++ b/services/emails/index.tsx
@@ -146,6 +146,7 @@ export * from './emails/PhaseTransitionEmail';
 export * from './emails/VoteSubmittedEmail';
 export * from './emails/RevisionResubmittedEmail';
 export * from './emails/RevisionRequestedEmail';
+export * from './emails/SelectionDecisionEmail';
 export * from './emails/DecisionUpdateNotificationEmail';
 export * from './emails/ContentFlaggedEmail';
 

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -99,6 +99,15 @@ export const Events = {
       toPhaseId: z.string().min(1),
     }),
   },
+  // Emitted after processResults writes a successful result row. Carries the
+  // row id so consumers can detect when a newer run has superseded it.
+  resultsProcessed: {
+    name: 'decision/results-processed' as const,
+    schema: z.object({
+      processInstanceId: z.string().uuid(),
+      processResultId: z.string().uuid(),
+    }),
+  },
   voteSubmitted: {
     name: 'vote/submitted' as const,
     schema: z.object({

--- a/services/workflows/src/functions/notifications/index.ts
+++ b/services/workflows/src/functions/notifications/index.ts
@@ -5,6 +5,7 @@ export * from './sendPhaseTransitionNotification';
 export * from './sendVoteSubmittedNotification';
 export * from './sendRevisionResubmittedNotification';
 export * from './sendRevisionRequestedNotification';
+export * from './sendSelectionDecisionNotification';
 export * from './sendDecisionUpdateNotification';
 export * from './sendContentFlaggedNotification';
 export * from './sendPostCommentNotification';

--- a/services/workflows/src/functions/notifications/sendSelectionDecisionNotification.ts
+++ b/services/workflows/src/functions/notifications/sendSelectionDecisionNotification.ts
@@ -1,0 +1,211 @@
+import { resolveManualSelectionStatus } from '@op/common';
+import { hasEmail } from '@op/common/client';
+import { OPURLConfig } from '@op/core';
+import { db } from '@op/db/client';
+import {
+  ProposalStatus,
+  decisionProcessResultSelections,
+  processInstances,
+  profileUsers,
+  profiles,
+  proposals,
+} from '@op/db/schema';
+import { OPBatchSend, SelectionDecisionEmail } from '@op/emails';
+import { Events, inngest } from '@op/events';
+import { logger } from '@op/logging';
+import { and, eq, isNotNull, isNull, ne } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+
+const { resultsProcessed } = Events;
+
+/**
+ * Emails each proposal's authors their selection outcome after results are
+ * processed for a decision process. Selected = proposals attached to the
+ * result row; everyone else with a submitted (non-draft) proposal gets the
+ * not-selected variant.
+ */
+export const sendSelectionDecisionNotification = inngest.createFunction(
+  {
+    id: 'sendSelectionDecisionNotification',
+    debounce: {
+      key: 'event.data.processInstanceId + "-" + event.data.processResultId',
+      period: '1m',
+      timeout: '3m',
+    },
+  },
+  { event: resultsProcessed.name },
+  async ({ event, step }) => {
+    const { processInstanceId, processResultId } =
+      resultsProcessed.schema.parse(event.data);
+
+    const processData = await step.run('get-process-data', async () => {
+      const instance = await db
+        .select({
+          name: processInstances.name,
+          instanceData: processInstances.instanceData,
+          currentStateId: processInstances.currentStateId,
+          profileSlug: profiles.slug,
+        })
+        .from(processInstances)
+        .leftJoin(profiles, eq(processInstances.profileId, profiles.id))
+        .where(eq(processInstances.id, processInstanceId))
+        .limit(1);
+
+      return instance[0];
+    });
+
+    if (!processData) {
+      logger.error('No process instance found for id', { processInstanceId });
+      return;
+    }
+
+    // Hold the email until the inbound transition is settled — when results
+    // were processed on a phase advance that still awaits a manual selection,
+    // authors would otherwise be told an outcome the admin hasn't confirmed.
+    // submitManualSelection re-processes results (a new result row + event)
+    // when the admin confirms.
+    const manualSelectionStatus = await step.run(
+      'check-manual-selection',
+      async () =>
+        resolveManualSelectionStatus({
+          instance: {
+            id: processInstanceId,
+            instanceData: processData.instanceData,
+            currentStateId: processData.currentStateId,
+          },
+        }),
+    );
+
+    if (!manualSelectionStatus.selectionsAreConfirmed) {
+      return {
+        message: `Skipped: selections not yet confirmed for instance ${processInstanceId}`,
+      };
+    }
+
+    // Only ever report the latest run: if results were re-processed after
+    // this event fired, the newer event covers the newer row.
+    const latestResult = await step.run('check-latest-result', async () =>
+      db.query.decisionProcessResults.findFirst({
+        where: { processInstanceId },
+        orderBy: (table, { desc }) => desc(table.executedAt),
+        columns: { id: true, success: true },
+      }),
+    );
+
+    if (!latestResult || latestResult.id !== processResultId) {
+      return {
+        message: `Skipped: result ${processResultId} superseded by a newer run`,
+      };
+    }
+
+    if (!latestResult.success) {
+      return {
+        message: `Skipped: result ${processResultId} was not successful`,
+      };
+    }
+
+    const selectedProposalIds = await step.run(
+      'get-selected-proposal-ids',
+      async () => {
+        const rows = await db
+          .select({ proposalId: decisionProcessResultSelections.proposalId })
+          .from(decisionProcessResultSelections)
+          .where(
+            eq(
+              decisionProcessResultSelections.processResultId,
+              processResultId,
+            ),
+          );
+
+        return rows.map((r) => r.proposalId);
+      },
+    );
+
+    // Every submitted (non-draft) proposal's authors get an outcome email —
+    // collaborators are members of the proposal's own profile.
+    const recipients = await step.run('get-recipients', async () => {
+      const proposalProfile = alias(profiles, 'proposal_profile');
+
+      const rows = await db
+        .select({
+          proposalId: proposals.id,
+          proposalProfileId: proposals.profileId,
+          proposalName: proposalProfile.name,
+          email: profileUsers.email,
+        })
+        .from(proposals)
+        .innerJoin(proposalProfile, eq(proposals.profileId, proposalProfile.id))
+        .innerJoin(
+          profileUsers,
+          eq(profileUsers.profileId, proposals.profileId),
+        )
+        .where(
+          and(
+            eq(proposals.processInstanceId, processInstanceId),
+            ne(proposals.status, ProposalStatus.DRAFT),
+            isNull(proposals.deletedAt),
+            isNull(proposals.moderationDetachedAt),
+            isNotNull(profileUsers.email),
+          ),
+        );
+
+      return rows.filter(hasEmail);
+    });
+
+    if (recipients.length === 0) {
+      logger.warn('No proposal authors found for process instance', {
+        processInstanceId,
+      });
+      return;
+    }
+
+    const selectedSet = new Set(selectedProposalIds);
+    const baseUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${processData.profileSlug}`;
+
+    const result = await step.run('send-emails', async () => {
+      try {
+        const emails = recipients.map(
+          ({ proposalId, proposalProfileId, proposalName, email }) => {
+            const selected = selectedSet.has(proposalId);
+
+            return {
+              to: email,
+              subject: SelectionDecisionEmail.subject(
+                processData.name,
+                selected,
+              ),
+              component: () =>
+                SelectionDecisionEmail({
+                  proposalName,
+                  processTitle: processData.name,
+                  selected,
+                  proposalUrl: `${baseUrl}/proposal/${proposalProfileId}`,
+                }),
+            };
+          },
+        );
+
+        const { data, errors } = await OPBatchSend(emails);
+
+        if (errors.length > 0) {
+          throw Error(`Email batch failed: ${JSON.stringify(errors)}`);
+        }
+
+        return {
+          sent: data.length,
+        };
+      } catch (error) {
+        logger.error('Failed to send selection decision notifications', {
+          error,
+          processInstanceId,
+          processResultId,
+        });
+        throw error;
+      }
+    });
+
+    return {
+      message: `${result.sent} selection decision notification(s) sent`,
+    };
+  },
+);


### PR DESCRIPTION
When selection results are processed for a decision process, each submitted proposal's authors now receive an email with their outcome — selected or not selected. Not-selected authors get softer copy so open decisions can close the loop with everyone. The email waits for manual selections to be confirmed and skips superseded result runs so re-processing doesn't re-spam.