### PR TITLE
feat(decision): remind reviewers when their review phase is ending soon

### DIFF
--- a/services/emails/emails/ReviewPhaseEndingReminderEmail.tsx
+++ b/services/emails/emails/ReviewPhaseEndingReminderEmail.tsx
@@ -1,0 +1,63 @@
+import { Text } from 'react-email';
+
+import { CtaButton } from '../components/CtaButton';
+import EmailTemplate from '../components/EmailTemplate';
+import { Footnote } from '../components/Footnote';
+import { Header } from '../components/Header';
+
+export const ReviewPhaseEndingReminderEmail = ({
+  processTitle,
+  phaseName,
+  remainingCount,
+  daysLeft,
+  reviewsUrl = 'https://common.oneproject.org/',
+}: {
+  processTitle: string;
+  phaseName: string;
+  remainingCount: number;
+  daysLeft: number;
+  reviewsUrl: string;
+}) => {
+  return (
+    <EmailTemplate
+      previewText={`The ${phaseName} phase of ${processTitle} ends in ${formatDaysLeft(daysLeft)} and you still have reviews to complete`}
+    >
+      <Header>Review phase ending soon</Header>
+      <Text className="my-8 text-lg">
+        The <strong>{phaseName}</strong> phase of{' '}
+        <strong>{processTitle}</strong> ends in{' '}
+        <strong>{formatDaysLeft(daysLeft)}</strong>. You still have{' '}
+        <strong>
+          {remainingCount === 1 ? '1 review' : `${remainingCount} reviews`}
+        </strong>{' '}
+        left to complete.
+      </Text>
+
+      <CtaButton href={reviewsUrl}>Complete your reviews</CtaButton>
+
+      <Footnote>
+        You're receiving this because you have review assignments in{' '}
+        {processTitle}.
+      </Footnote>
+    </EmailTemplate>
+  );
+};
+
+function formatDaysLeft(daysLeft: number) {
+  return daysLeft === 1 ? '1 day' : `${daysLeft} days`;
+}
+
+ReviewPhaseEndingReminderEmail.subject = (
+  processTitle: string,
+  daysLeft: number,
+) => `Your reviews in "${processTitle}" are due in ${formatDaysLeft(daysLeft)}`;
+
+ReviewPhaseEndingReminderEmail.PreviewProps = {
+  processTitle: 'Participatory Budgeting 2026',
+  phaseName: 'Review',
+  remainingCount: 4,
+  daysLeft: 3,
+  reviewsUrl: 'https://common.oneproject.org/',
+} satisfies Parameters<typeof ReviewPhaseEndingReminderEmail>[0];
+
+export default ReviewPhaseEndingReminderEmail;

--- a/services/emails/index.tsx
+++ b/services/emails/index.tsx
@@ -145,6 +145,7 @@ export * from './emails/ProposalSubmittedEmail';
 export * from './emails/PhaseTransitionEmail';
 export * from './emails/VoteSubmittedEmail';
 export * from './emails/RevisionResubmittedEmail';
+export * from './emails/ReviewPhaseEndingReminderEmail';
 export * from './emails/RevisionRequestedEmail';
 export * from './emails/DecisionUpdateNotificationEmail';
 export * from './emails/ContentFlaggedEmail';

--- a/services/events/src/types.ts
+++ b/services/events/src/types.ts
@@ -106,6 +106,17 @@ export const Events = {
       processInstanceId: z.string().uuid(),
     }),
   },
+  // Fan-out from the daily reminder cron: one event per pending transition
+  // whose review phase is ending soon. Carries only ids — the consumer
+  // re-reads current DB state before sending.
+  reviewPhaseEndingSoon: {
+    name: 'review/phase-ending-soon' as const,
+    schema: z.object({
+      transitionId: z.string().uuid(),
+      processInstanceId: z.string().uuid(),
+      phaseId: z.string().min(1),
+    }),
+  },
   reviewRevisionResubmitted: {
     name: 'review/revision-resubmitted' as const,
     schema: z.object({

--- a/services/workflows/src/functions/modules/decisions/index.ts
+++ b/services/workflows/src/functions/modules/decisions/index.ts
@@ -1,1 +1,2 @@
 export { processTransitions } from './processTransitions';
+export { sendReviewPhaseEndingReminders } from './sendReviewPhaseEndingReminders';

--- a/services/workflows/src/functions/modules/decisions/sendReviewPhaseEndingReminders.ts
+++ b/services/workflows/src/functions/modules/decisions/sendReviewPhaseEndingReminders.ts
@@ -1,0 +1,116 @@
+import { type DecisionInstanceData, isReviewPhase } from '@op/common';
+import { db } from '@op/db/client';
+import {
+  ProcessStatus,
+  decisionProcessTransitions,
+  processInstances,
+} from '@op/db/schema';
+import { Events, inngest } from '@op/events';
+import { and, eq, gt, isNull, lte } from 'drizzle-orm';
+
+const { reviewPhaseEndingSoon } = Events;
+
+/** Days before a review phase's scheduled end that the reminder goes out. */
+const REMINDER_DAYS_BEFORE_END = 3;
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/**
+ * Finds pending phase transitions whose review phase is ending soon and fans
+ * out a `review/phase-ending-soon` event per transition. The notification
+ * function re-reads state and emails each reviewer with incomplete
+ * assignments.
+ */
+export const sendReviewPhaseEndingReminders = inngest.createFunction(
+  {
+    id: 'decisions-review-phase-ending-reminders',
+    name: 'Send Review Phase Ending Reminders',
+  },
+  // Run every day at midnight, same grain as processTransitions — our tier of
+  // Inngest only supports up to 7 days advance scheduling, so a daily sweep
+  // is the right shape (not per-phase sleepUntil).
+  { cron: '0 0 * * *' },
+  async ({ step }) => {
+    const endingTransitions = await step.run(
+      'find-ending-review-phases',
+      async () => {
+        // One-day-wide bucket (N-1, N] days out. With a daily cron each
+        // transition lands in the bucket exactly once, which is what enforces
+        // the single-reminder-per-transition guarantee — there is no
+        // "reminder sent" ledger, and Inngest idempotency keys only live for
+        // 24h so a wider window would re-send on subsequent days.
+        const now = Date.now();
+        const windowStart = new Date(
+          now + (REMINDER_DAYS_BEFORE_END - 1) * MS_PER_DAY,
+        ).toISOString();
+        const windowEnd = new Date(
+          now + REMINDER_DAYS_BEFORE_END * MS_PER_DAY,
+        ).toISOString();
+
+        const rows = await db
+          .select({
+            id: decisionProcessTransitions.id,
+            processInstanceId: decisionProcessTransitions.processInstanceId,
+            fromStateId: decisionProcessTransitions.fromStateId,
+            currentStateId: processInstances.currentStateId,
+            instanceData: processInstances.instanceData,
+          })
+          .from(decisionProcessTransitions)
+          .innerJoin(
+            processInstances,
+            eq(
+              decisionProcessTransitions.processInstanceId,
+              processInstances.id,
+            ),
+          )
+          .where(
+            and(
+              isNull(decisionProcessTransitions.completedAt),
+              gt(decisionProcessTransitions.scheduledDate, windowStart),
+              lte(decisionProcessTransitions.scheduledDate, windowEnd),
+              eq(processInstances.status, ProcessStatus.PUBLISHED),
+            ),
+          );
+
+        // Only remind for the phase the instance is actually in, and only
+        // when that phase is a review phase.
+        return rows.flatMap((row) => {
+          if (!row.fromStateId || row.fromStateId !== row.currentStateId) {
+            return [];
+          }
+
+          const instanceData = row.instanceData as DecisionInstanceData;
+          const phase = instanceData?.phases?.find(
+            (p) => p.phaseId === row.fromStateId,
+          );
+
+          if (!phase || !isReviewPhase(phase)) {
+            return [];
+          }
+
+          return [
+            {
+              transitionId: row.id,
+              processInstanceId: row.processInstanceId,
+              phaseId: row.fromStateId,
+            },
+          ];
+        });
+      },
+    );
+
+    if (endingTransitions.length === 0) {
+      return { remindersQueued: 0 };
+    }
+
+    await step.sendEvent(
+      'fan-out-reminders',
+      endingTransitions.map((transition) => ({
+        name: reviewPhaseEndingSoon.name,
+        data: transition,
+      })),
+    );
+
+    return { remindersQueued: endingTransitions.length };
+  },
+);

--- a/services/workflows/src/functions/notifications/index.ts
+++ b/services/workflows/src/functions/notifications/index.ts
@@ -4,6 +4,7 @@ export * from './sendProposalSubmittedNotification';
 export * from './sendPhaseTransitionNotification';
 export * from './sendVoteSubmittedNotification';
 export * from './sendRevisionResubmittedNotification';
+export * from './sendReviewPhaseEndingReminder';
 export * from './sendRevisionRequestedNotification';
 export * from './sendDecisionUpdateNotification';
 export * from './sendContentFlaggedNotification';

--- a/services/workflows/src/functions/notifications/sendReviewPhaseEndingReminder.ts
+++ b/services/workflows/src/functions/notifications/sendReviewPhaseEndingReminder.ts
@@ -1,0 +1,211 @@
+import { type DecisionInstanceData, isReviewPhase } from '@op/common';
+import { hasEmail } from '@op/common/client';
+import { OPURLConfig } from '@op/core';
+import { db } from '@op/db/client';
+import {
+  ProcessStatus,
+  ProposalReviewAssignmentStatus,
+  decisionProcessTransitions,
+  processInstances,
+  profiles,
+} from '@op/db/schema';
+import { OPBatchSend, ReviewPhaseEndingReminderEmail } from '@op/emails';
+import { Events, inngest } from '@op/events';
+import { logger } from '@op/logging';
+import { eq } from 'drizzle-orm';
+
+const { reviewPhaseEndingSoon } = Events;
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export const sendReviewPhaseEndingReminder = inngest.createFunction(
+  {
+    id: 'sendReviewPhaseEndingReminder',
+    // The cron's one-day scheduling window is what prevents cross-day
+    // repeats; these keys dedupe retries and double-fired events within a
+    // single sweep.
+    idempotency: 'event.data.transitionId',
+    debounce: {
+      key: 'event.data.transitionId',
+      period: '1m',
+      timeout: '3m',
+    },
+  },
+  { event: reviewPhaseEndingSoon.name },
+  async ({ event, step }) => {
+    const { transitionId } = reviewPhaseEndingSoon.schema.parse(event.data);
+
+    const transitionData = await step.run('get-transition-data', async () => {
+      const rows = await db
+        .select({
+          fromStateId: decisionProcessTransitions.fromStateId,
+          scheduledDate: decisionProcessTransitions.scheduledDate,
+          completedAt: decisionProcessTransitions.completedAt,
+          processInstanceId: processInstances.id,
+          processName: processInstances.name,
+          processStatus: processInstances.status,
+          currentStateId: processInstances.currentStateId,
+          instanceData: processInstances.instanceData,
+          profileSlug: profiles.slug,
+        })
+        .from(decisionProcessTransitions)
+        .innerJoin(
+          processInstances,
+          eq(decisionProcessTransitions.processInstanceId, processInstances.id),
+        )
+        .leftJoin(profiles, eq(processInstances.profileId, profiles.id))
+        .where(eq(decisionProcessTransitions.id, transitionId))
+        .limit(1);
+
+      return rows[0];
+    });
+
+    if (!transitionData) {
+      logger.error('No transition found for id', { transitionId });
+      return;
+    }
+
+    // Re-verify current DB state before sending — the phase may have
+    // advanced, been rescheduled, or the process unpublished since the cron
+    // queued this event.
+    const phaseId = transitionData.fromStateId;
+    if (
+      transitionData.completedAt !== null ||
+      transitionData.processStatus !== ProcessStatus.PUBLISHED ||
+      !phaseId ||
+      transitionData.currentStateId !== phaseId
+    ) {
+      return {
+        message: `Skipped: transition ${transitionId} is no longer pending for the current phase`,
+      };
+    }
+
+    const instanceData = transitionData.instanceData as DecisionInstanceData;
+    const phase = instanceData?.phases?.find((p) => p.phaseId === phaseId);
+
+    if (!phase || !isReviewPhase(phase)) {
+      return {
+        message: `Skipped: phase ${phaseId} is not a review phase`,
+      };
+    }
+
+    const msLeft =
+      new Date(transitionData.scheduledDate).getTime() - Date.now();
+    if (msLeft <= 0) {
+      return {
+        message: `Skipped: transition ${transitionId} is already due`,
+      };
+    }
+    const daysLeft = Math.ceil(msLeft / MS_PER_DAY);
+
+    if (!transitionData.profileSlug) {
+      logger.error('No profile slug found for process instance', {
+        processInstanceId: transitionData.processInstanceId,
+      });
+      return;
+    }
+
+    const assignments = await step.run(
+      'get-incomplete-assignments',
+      async () => {
+        return db.query.proposalReviewAssignments.findMany({
+          where: {
+            processInstanceId: transitionData.processInstanceId,
+            phaseId,
+            status: { ne: ProposalReviewAssignmentStatus.COMPLETED },
+          },
+          with: {
+            reviewer: {
+              with: {
+                profileUsers: {
+                  where: { email: { isNotNull: true } },
+                },
+              },
+            },
+          },
+        });
+      },
+    );
+
+    if (assignments.length === 0) {
+      return {
+        message: `Skipped: no incomplete assignments for transition ${transitionId}`,
+      };
+    }
+
+    // One reminder per reviewer, listing how many reviews they have left.
+    const reviewerReminders = new Map<
+      string,
+      { emails: string[]; remainingCount: number }
+    >();
+
+    for (const assignment of assignments) {
+      const existing = reviewerReminders.get(assignment.reviewerProfileId);
+      if (existing) {
+        existing.remainingCount++;
+      } else {
+        reviewerReminders.set(assignment.reviewerProfileId, {
+          emails: assignment.reviewer.profileUsers
+            .filter(hasEmail)
+            .map(({ email }) => email),
+          remainingCount: 1,
+        });
+      }
+    }
+
+    const processTitle = transitionData.processName;
+    const phaseName = phase.name ?? phaseId;
+    const reviewsUrl = `${OPURLConfig('APP').ENV_URL}/decisions/${transitionData.profileSlug}/reviews`;
+
+    const emails = Array.from(reviewerReminders.values()).flatMap(
+      ({ emails: reviewerEmails, remainingCount }) =>
+        reviewerEmails.map((email) => ({
+          to: email,
+          subject: ReviewPhaseEndingReminderEmail.subject(
+            processTitle,
+            daysLeft,
+          ),
+          component: () =>
+            ReviewPhaseEndingReminderEmail({
+              processTitle,
+              phaseName,
+              remainingCount,
+              daysLeft,
+              reviewsUrl,
+            }),
+        })),
+    );
+
+    if (emails.length === 0) {
+      logger.warn('No reviewer emails found for review phase reminder', {
+        transitionId,
+        processInstanceId: transitionData.processInstanceId,
+      });
+      return;
+    }
+
+    const result = await step.run('send-emails', async () => {
+      try {
+        const { data, errors } = await OPBatchSend(emails);
+
+        if (errors.length > 0) {
+          throw Error(`Email batch failed: ${JSON.stringify(errors)}`);
+        }
+
+        return {
+          sent: data.length,
+        };
+      } catch (error) {
+        logger.error('Failed to send review phase ending reminders', {
+          error,
+          transitionId,
+        });
+        throw error;
+      }
+    });
+
+    return {
+      message: `${result.sent} review phase ending reminder(s) sent`,
+    };
+  },
+);


### PR DESCRIPTION
Reviewers with incomplete assignments got no nudge before a review phase closed. A daily sweep now emails each such reviewer ~3 days before the phase's scheduled end with their remaining review count and a link to their review queue. One reminder per phase ending — the cron's one-day scheduling window enforces this since no reminder ledger exists.