### PR TITLE
fix(decisions): keep legacy instances off the v2 instance endpoint

### DIFF
--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -7,6 +7,7 @@ import { useUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import {
   type DecisionAccess,
+  type InstanceData,
   type InstancePhaseData,
   ProposalFilter,
   ProposalStatus,
@@ -58,6 +59,14 @@ export interface ProposalsListProps {
   initialFilter?: ProposalFilter;
   /** When set to 'results', all proposals are returned as non-editable */
   phase?: 'results';
+  /**
+   * Legacy (state-based) instance — skips reads only the phase-based v2 schema
+   * can satisfy. `decision.getInstance` validates its output against the v2
+   * encoder, which requires `processSchema.{id,version,phases}` and
+   * `instanceData.phases[].phaseId`; a legacy instance has `states`/`stateId`
+   * instead, so the call fails output validation and 500s the whole screen.
+   */
+  isLegacy?: boolean;
   /** Current phase; capability flags are derived from `rules`. */
   currentPhase?: InstancePhaseData;
   /** When true, new proposals are hidden by default in the current phase. */
@@ -307,19 +316,28 @@ export const ProposalsList = (props: ProposalsListProps) => {
     excludeAssignedForReview,
   ]);
 
-  const renderContent = (data: ProposalsLoaderRenderProps) => (
-    <ProposalsListContent
-      {...props}
-      {...data}
-      queryParams={queryParams}
-      proposalFilter={proposalFilter}
-      setProposalFilter={setProposalFilter}
-      selectedCategory={selectedCategory}
-      setSelectedCategory={setSelectedCategory}
-      sortOrder={sortOrder}
-      setSortOrder={setSortOrder}
-    />
-  );
+  const renderContent = (data: ProposalsLoaderRenderProps) => {
+    const contentProps: ProposalsListContentProps = {
+      ...props,
+      ...data,
+      queryParams,
+      proposalFilter,
+      setProposalFilter,
+      selectedCategory,
+      setSelectedCategory,
+      sortOrder,
+      setSortOrder,
+    };
+
+    // Legacy instances can't be read through the v2 instance endpoint at all,
+    // so they render without a proposal template (and therefore without the
+    // map view — a legacy process never collected a location).
+    return props.isLegacy ? (
+      <ProposalsListContent {...contentProps} />
+    ) : (
+      <ProposalsListContentWithTemplate {...contentProps} />
+    );
+  };
 
   if (phase === 'results') {
     return (
@@ -346,7 +364,27 @@ type ProposalsListContentProps = ProposalsListProps &
     setSelectedCategory: (value: string) => void;
     sortOrder: string;
     setSortOrder: (value: string) => void;
+    /** Absent for legacy instances — see `isLegacy` on {@link ProposalsListProps}. */
+    proposalTemplate?: InstanceData['proposalTemplate'];
   };
+
+/**
+ * Reads the v2 instance solely for its proposal template, which decides whether
+ * the map view is on offer. Kept in its own component so the suspense query is
+ * never mounted for legacy instances.
+ */
+const ProposalsListContentWithTemplate = (props: ProposalsListContentProps) => {
+  const [instance] = trpc.decision.getInstance.useSuspenseQuery({
+    instanceId: props.instanceId,
+  });
+
+  return (
+    <ProposalsListContent
+      {...props}
+      proposalTemplate={instance.instanceData?.proposalTemplate}
+    />
+  );
+};
 
 // fallow-ignore-next-line complexity
 const ProposalsListContent = ({
@@ -373,6 +411,7 @@ const ProposalsListContent = ({
   setSelectedCategory,
   sortOrder,
   setSortOrder,
+  proposalTemplate,
 }: ProposalsListContentProps) => {
   const isInReviewPhase = !!currentPhase && isReviewPhase(currentPhase);
   const isInVotingPhase = !!currentPhase && isVotingPhase(currentPhase);
@@ -380,17 +419,14 @@ const ProposalsListContent = ({
   const { user } = useUser();
 
   const currentProfileId = user?.currentProfile?.id;
-  const [[categoriesData, voteStatus, instance]] = trpc.useSuspenseQueries(
-    (t) => [
-      t.decision.getCategories({
-        processInstanceId: instanceId,
-      }),
-      t.decision.getVotingStatus({
-        processInstanceId: instanceId,
-      }),
-      t.decision.getInstance({ instanceId }),
-    ],
-  );
+  const [[categoriesData, voteStatus]] = trpc.useSuspenseQueries((t) => [
+    t.decision.getCategories({
+      processInstanceId: instanceId,
+    }),
+    t.decision.getVotingStatus({
+      processInstanceId: instanceId,
+    }),
+  ]);
 
   const categories = categoriesData.categories;
 
@@ -405,7 +441,6 @@ const ProposalsListContent = ({
   // the GIS flag is on. The map fits the proposal markers; this default view
   // (`x-map-default`) is the fallback camera for when none have a location.
   const gisMapsEnabled = useFeatureFlag('gis_maps');
-  const proposalTemplate = instance.instanceData?.proposalTemplate;
   const hasLocationField =
     !!gisMapsEnabled && templateCollectsLocation(proposalTemplate);
   const mapView =

--- a/apps/app/src/components/decisions/pages/ResultsPage.tsx
+++ b/apps/app/src/components/decisions/pages/ResultsPage.tsx
@@ -223,6 +223,7 @@ function ResultsPageContent({
                   initialFilter={ProposalFilter.ALL}
                   phase="results"
                   pinOffset={pinOffset}
+                  isLegacy={isLegacy}
                 />
               </Suspense>
             </DecisionResultsTabPanel>

--- a/tests/e2e/tests/proposal-listing.spec.ts
+++ b/tests/e2e/tests/proposal-listing.spec.ts
@@ -1,6 +1,7 @@
 import {
   EntityType,
   ProcessStatus,
+  ProposalStatus,
   decisionProcesses,
   processInstances,
   profileUserToAccessRoles,
@@ -13,6 +14,7 @@ import { createProposal } from '@op/test';
 import { randomUUID } from 'node:crypto';
 
 import { transformFormDataToProcessSchema as cowopSchema } from '../../../apps/app/src/components/Profile/CreateDecisionProcessModal/schemas/cowop';
+import { transformFormDataToProcessSchema as horizonSchema } from '../../../apps/app/src/components/Profile/CreateDecisionProcessModal/schemas/horizon';
 import { expect, test } from '../fixtures/index.js';
 
 /**
@@ -31,6 +33,7 @@ async function createProcessAndInstance({
   processSchema,
   instanceData,
   processName,
+  currentStateId,
 }: {
   org: {
     organizationProfile: { id: string };
@@ -39,6 +42,11 @@ async function createProcessAndInstance({
   processSchema: Record<string, unknown>;
   instanceData: Record<string, unknown>;
   processName: string;
+  /**
+   * Row-level current state. Defaults to the first phase; legacy instances must
+   * pass it explicitly because their phases are keyed by `stateId`.
+   */
+  currentStateId?: string;
 }) {
   const [process] = await db
     .insert(decisionProcesses)
@@ -74,8 +82,10 @@ async function createProcessAndInstance({
       profileId: profile.id,
       instanceData,
       currentStateId:
+        currentStateId ??
         (instanceData as { phases?: { phaseId: string }[] }).phases?.[0]
-          ?.phaseId ?? 'proposalSubmission',
+          ?.phaseId ??
+        'proposalSubmission',
       status: ProcessStatus.PUBLISHED,
       ownerProfileId: org.organizationProfile.id,
     })
@@ -447,5 +457,120 @@ test.describe('Proposal Listing', () => {
         'Training program for regional co-op organizers.',
       ),
     ).toBeVisible();
+  });
+
+  /**
+   * Legacy Horizon Fund–shaped process on the legacy results route: the process
+   * schema is state-based (`states`/`transitions`/`initialState`) and
+   * `instanceData.phases[]` are keyed by `stateId`, so `decision.getInstance`
+   * rejects the instance in output validation — its v2 encoder requires
+   * `processSchema.{id,version,phases}` and `phases[].phaseId`. Nothing on this
+   * screen may call that endpoint, or the whole page 500s.
+   *
+   * Regression guard for the Horizon Fund "All proposals" 500.
+   */
+  test('lists all proposals on the legacy results route for a state-based instance', async ({
+    authenticatedPage,
+    org,
+  }) => {
+    // Real legacy schema: 4 states (submission → review → voting → results),
+    // no `id`/`version`/`phases` envelope.
+    const horizonLegacySchema = horizonSchema({
+      processName: 'Horizon Legacy Results Test',
+      description: 'Legacy state-based process',
+      totalBudget: 100000,
+      budgetCapAmount: 50000,
+      requireBudget: true,
+      categories: ['Energy democracy', 'Housing justice'],
+    });
+
+    // Legacy instanceData: `stateId`/`plannedStartDate` field names and
+    // `currentStateId` inside the JSON blob — what production rows hold.
+    const legacyInstanceData = {
+      budget: 100000,
+      hideBudget: false,
+      currentStateId: 'results',
+      phases: [
+        {
+          stateId: 'submission',
+          plannedStartDate: '2025-09-01',
+          plannedEndDate: '2025-09-30',
+        },
+        {
+          stateId: 'review',
+          plannedStartDate: '2025-10-01',
+          plannedEndDate: '2025-10-15',
+        },
+        {
+          stateId: 'voting',
+          plannedStartDate: '2025-10-16',
+          plannedEndDate: '2025-10-31',
+        },
+        { stateId: 'results', plannedStartDate: '2025-11-01' },
+      ],
+    };
+
+    const { instance } = await createProcessAndInstance({
+      org,
+      processSchema: horizonLegacySchema,
+      instanceData: legacyInstanceData,
+      processName: 'Horizon Legacy Results',
+      currentStateId: 'results',
+    });
+
+    // Submitted, not draft — the results list excludes drafts.
+    await createProposal({
+      processInstanceId: instance.id,
+      submittedByProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      status: ProposalStatus.SUBMITTED,
+      proposalData: {
+        title: 'Community Solar Array',
+        description: '<p>Rooftop solar for the co-op block.</p>',
+        budget: 15000,
+      },
+    });
+
+    await createProposal({
+      processInstanceId: instance.id,
+      submittedByProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      status: ProposalStatus.SUBMITTED,
+      proposalData: {
+        title: 'Tenant Union Support Fund',
+        description: '<p>Organizing support for tenant unions.</p>',
+        budget: 25000,
+      },
+    });
+
+    // The legacy route — /profile/[slug]/decisions/[id] — always renders the
+    // results screen, whose default tab is "Selected Proposals".
+    await authenticatedPage.goto(
+      `/en/profile/${org.organizationProfile.slug}/decisions/${instance.id}`,
+      { waitUntil: 'domcontentloaded' },
+    );
+
+    await authenticatedPage
+      .getByRole('tab', { name: 'All proposals' })
+      .click({ timeout: 30_000 });
+
+    await expect(
+      authenticatedPage.getByRole('link', { name: 'Community Solar Array' }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expect(
+      authenticatedPage.getByRole('link', {
+        name: 'Tenant Union Support Fund',
+      }),
+    ).toBeVisible();
+
+    // The 500 screen this route used to render instead of the list.
+    await expect(
+      authenticatedPage.getByText(
+        "Something went wrong on our end. We're working to fix it.",
+      ),
+    ).not.toBeVisible();
   });
 });


### PR DESCRIPTION
The legacy results route's "All proposals" tab 500'd for state-based instances, leaving participants able to see only the selected proposals. Covered by an e2e test that seeds a legacy Horizon-shaped instance and fails without the fix.