### PR TITLE
docs: trim CLAUDE.md of stale and redundant guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,75 +4,37 @@ This file provides guidance to Claude Code (claude.ai/code) and other AI agents 
 
 ## Development Commands
 
-### Build and Quality Checks
-
-- **Build all**: `pnpm build` (uses Turbo for optimized builds)
-- **Type checking**: `pnpm typecheck` (runs type checking across all workspaces via Turbo) or `pnpm w:app typecheck` (for main app only)
-- **Format checking**: `pnpm format:check` (verifies code formatting - required by CI)
-- **Format changed files only**: `pnpm format:changes` (formats only files changed in git)
-- **Tests**: `pnpm test` (runs integration tests)
+- **Type checking**: `pnpm typecheck` (all workspaces via Turbo) or `pnpm w:app typecheck` (main app only) — run after making changes
+- **Format checking**: `pnpm format:check` (required by CI); `pnpm format:changes` formats only files changed in git
+- **Tests**: `pnpm test` (integration tests)
+- **Workspaces**: use the `pnpm w:<name>` shortcuts defined in the root `package.json` scripts (e.g. `pnpm w:app`, `pnpm w:db`)
+- **Dependencies**: add with `pnpm add <package> --filter <workspace-name>`; `pnpm deps:clean` / `pnpm deps:override` keep versions consistent
 
 ## Architecture Overview
 
-### Applications (`apps/`)
+Monorepo with `apps/`, `packages/`, and `services/` — directory names are self-describing; the non-obvious ones:
 
-- **`apps/app`**: Main Next.js 15 frontend (App Router, React 19, Tailwind, Zustand)
-- **`apps/api`**: tRPC API server with OpenAPI documentation
-
-### Packages (`packages/`)
-
-- **`@op/ui`**: Custom Intent UI / React Aria Components library using Tailwind variants and Storybook
-- **`@op/core`**: Core utilities, configuration, and environment handling
-- **`@op/hooks`**: Reusable React hooks (auth, data fetching)
-- **`@op/common`**: Shared business logic and service layer
-
-### Services (`services/`)
-
-- **`@op/db`**: Drizzle ORM schema, migrations, and database client
-- **`@op/api`**: tRPC routers, procedures, and middleware
-- **`@op/supabase`**: Supabase client configuration (auth, storage)
-- **`@op/emails`**: React Email templates with Tailwind styling
-- **`@op/cache`**: Caching utilities and Redis integration
+- **`apps/app`**: main Next.js frontend (App Router, React 19, Tailwind, Zustand)
+- **`apps/api`**: Next.js server that hosts the tRPC API; the routers, procedures, and middleware live in `services/api` (`@op/api`)
+- **`@op/common`** (`packages/common`): shared business logic and service layer
+- **`@op/db`** (`services/db`): Drizzle ORM schema, migrations, and database client
 
 ## Key Technical Details
 
 ### UI Component System
 
-- UI components are in `@op/ui` and exported via `package.json` exports field
-- **Always prefer using existing @op/ui components over vanilla html versions such as <button> or <h2>**
-- **Always use design tokens** — never use arbitrary Tailwind values (e.g. `text-[14px]`, `bg-[#333]`)
-- Import components like: `import { Button } from "@op/ui/Button"`
-- Colors: use the token-mapped Tailwind classes (e.g. `text-primary-teal`, `bg-neutral-gray1`) — source tokens are in `packages/styles/tokens.css` (`--op-*`) mapped via `shared-styles.css`
-- Text sizes: use the custom type scale (e.g. `text-title-lg`, `text-sm`) defined in `packages/styles/shared-styles.css` — do not use raw Tailwind size utilities that we have not defined a size for.
-- Tailwind configuration is centralized in `@op/styles` package (`packages/styles/shared-styles.css`)
+- **Always prefer existing `@op/ui` components over vanilla html elements such as `<button>` or `<h2>`**
+- **Always use design tokens** — never arbitrary Tailwind values (e.g. `text-[14px]`, `bg-[#333]`):
+  - Colors: token-mapped Tailwind classes (e.g. `text-primary-teal`, `bg-neutral-gray1`) — source tokens in `packages/styles/tokens.css` (`--op-*`) mapped via `shared-styles.css`
+  - Text sizes: the custom type scale (e.g. `text-title-lg`, `text-sm`) defined in `packages/styles/shared-styles.css` — no raw Tailwind size utilities we haven't defined
+- Tailwind configuration is centralized in `@op/styles` (`packages/styles/shared-styles.css`)
 
 ### Database & tRPC
 
-- Database schema managed with Drizzle ORM in `services/db/schema/`
-- tRPC API provides type-safe client-server communication
-- After schema changes: run `pnpm w:db generate` to generate migrations 
+- After schema changes: run `pnpm w:db generate` to generate migrations
 - **NEVER RUN `pnpm w:db migrate`** (migrations are applied by CI/CD, not locally)
 - **Drizzle relations**: define new relations in `services/db/relations.ts` using the v2 `defineRelations` API (the source of truth for `db.query`). The v1 `relations()` blocks in individual `*.sql.ts` files still exist for legacy `db._query` callers but should **not** be added for new tables.
 - **Row types**: derive a table's row type with `typeof <table>.$inferSelect` (e.g. `export type Foo = typeof foos.$inferSelect;`). Prefer this over `InferModel<typeof <table>>`.
-
-### Workspace Commands
-
-Use `pnpm w:<workspace>` shortcuts:
-
-- `pnpm w:app` - apps/app
-- `pnpm w:api` - apps/api
-- `pnpm w:db` - services/db
-- `pnpm w:ui` - packages/ui
-- `pnpm w:emails` - services/emails
-- `pnpm w:supabase` - services/supabase
-- `pnpm w:cache` - services/cache
-
-### Dependency Management
-
-- **Add dependencies**: `pnpm add <package> --filter <workspace-name>`
-- **Clean unused deps**: `pnpm deps:clean`
-- **Enforce version consistency**: `pnpm deps:override`
-
 
 ## AI Assistant Guidelines
 
@@ -81,17 +43,9 @@ Use `pnpm w:<workspace>` shortcuts:
 - **NEVER search outside the current worktree. Do not exit the current working directory.**
 - The working directory is the root of the monorepo; do not traverse to parent directories or other projects
 
-### Code Quality Standards
-
-- Run type checking with `pnpm typecheck` after making changes
-- Follow existing code conventions and patterns in the file being edited
-- Using `any` to fix type errors should always be avoided
-- Avoide type assertions (`as` keyword)
-- Code quality is enforced via **oxfmt** (pnpm format) and **TypeScript** (type checking) only
-
 ### Coding Conventions
 
-- If statements should never be all on one line; always use K&R style for if statements
+- Never use `any` to fix type errors; avoid type assertions (`as` keyword)
 - Always prefer suspense queries over a query with useEffect
 - When using Suspense Queries, always add proper error boundaries
 - **Component file structure**: Types and interfaces at the top, then the main exported component, then private sub-components and helper functions below. The primary export should be easy to find near the top of the file — don't bury it under utilities.
@@ -99,24 +53,21 @@ Use `pnpm w:<workspace>` shortcuts:
 
 ### Internationalization (i18n)
 
-- **Translation files location**: `apps/app/src/lib/i18n/dictionaries/`
-- **Supported languages**: All `.json` files in the dictionaries folder (e.g., `en.json`, `es.json`, `pt.json`, etc.)
+- **Translation files location**: `apps/app/src/lib/i18n/dictionaries/` — every `.json` file there is a supported language; keep them all in sync
 - **Use `useTranslations` hook for client components**: `const t = useTranslations()` then `t('Key string')`
 - **Use `TranslatedText` component** for server components
-
-**CRITICAL: When adding or modifying user-facing strings:**
-
-1. **ALWAYS** wrap strings with `t('...')` - never hardcode user-facing text
-4. **For dynamic values**, use interpolation: `t('Hello {name}', { name: userName })` and `t.rich()` for strings that are broken up with styles/components.
+- **ALWAYS** wrap user-facing strings with `t('...')` — never hardcode user-facing text
+- **For dynamic values**, use interpolation: `t('Hello {name}', { name: userName })` and `t.rich()` for strings that are broken up with styles/components
 
 ### Logging
 
 - **Never log through `console.*`.** All logging must go through our loggers so it always reports to PostHog:
   - **Server** (services, `@op/common`, tRPC procedures, workflows): `import { logger } from '@op/logging'` — emits OpenTelemetry logs that ship to PostHog. Inside a tRPC procedure prefer `ctx.logger` (adds request context).
   - **Client / browser** (`apps/app`, `'use client'` code): `import { logger } from '@op/logging/client'` — reports to PostHog (`captureException` for `error`/`warn`) and also writes to the console.
-- Use `logger.error(message, { error })` for caught errors (pass the caught error under the `error` key), and `logger.warn` / `logger.info` for everything else. Do **not** call `console.log` / `console.error` / `console.warn` directly in app or service code.
+- Use `logger.error(message, { error })` for caught errors (pass the caught error under the `error` key), and `logger.warn` / `logger.info` for everything else.
 
 ## Workflow Notes
 
 - If you need to check interactions in the browser, you can use the Playwright MCP server and open http://localhost:3100 to open the dev server
+- **Never start or kill the dev server on :3100** — it is shared with other agents and managed externally; verify changes statically or in the browser against the already-running server
 - Authorization checks are achieved by our access-zones library. We usually get the profileUser and pass the user's roles to `assertAccess`


### PR DESCRIPTION
Periodic audit of CLAUDE.md: fixes drifted facts (workspace shortcut mappings, removed OpenAPI claim, apps/api vs services/api split), drops rules that are now default agent behavior, dedupes the design-token guidance, and adds the shared :3100 dev-server rule.