### PR TITLE
fix(decisions): paginate invite modal members server-side per role

### DIFF
--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -18,7 +18,6 @@ import { Skeleton } from '@op/ui/Skeleton';
 import { toast } from '@op/ui/Toast';
 import Image from 'next/image';
 import {
-  Key,
   type ReactNode,
   Suspense,
   useEffect,
@@ -113,8 +112,7 @@ function ProfileInviteModalContent({
   const utils = trpc.useUtils();
   const [selectedItemsByRole, setSelectedItemsByRole] =
     useState<SelectedItemsByRole>({});
-  const [selectedRoleId, setSelectedRoleId] = useState<string>('');
-  const [selectedRoleName, setSelectedRoleName] = useState<string>('');
+  const [requestedRoleId, setRequestedRoleId] = useState<string>();
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery] = useDebounce(searchQuery, 200);
   const [isSubmitting, startSendTransition] = useTransition();
@@ -126,21 +124,17 @@ function ProfileInviteModalContent({
     width: 0,
   });
 
-  // Fetch roles with decisions zone permissions to identify admin roles
-  const { data: rolesWithPerms } = trpc.profile.listRoles.useQuery(
-    { profileId, zoneName: 'decisions' },
-    { enabled: isDraft },
-  );
-  const adminRoleIds = useMemo(() => {
-    if (!rolesWithPerms) {
-      return new Set<string>();
-    }
-    return new Set(
-      rolesWithPerms.items.filter((r) => r.permissions?.admin).map((r) => r.id),
-    );
-  }, [rolesWithPerms]);
-
-  const showDraftBanner = isDraft && !adminRoleIds.has(selectedRoleId);
+  const [{ items: roles }] = trpc.profile.listRoles.useSuspenseQuery({
+    profileId,
+    zoneName: 'decisions',
+    limit: 100,
+  });
+  const selectedRole =
+    roles.find((role) => role.id === requestedRoleId) ?? roles[0];
+  const selectedRoleId = selectedRole?.id ?? '';
+  const selectedRoleName = selectedRole?.name ?? '';
+  const showDraftBanner =
+    isDraft && !!selectedRole && !selectedRole.permissions?.admin;
 
   // Fetch existing pending invites
   const [serverInvites] = trpc.profile.listProfileInvites.useSuspenseQuery({
@@ -187,6 +181,20 @@ function ProfileInviteModalContent({
   const allSelectedItems = useMemo(
     () => Object.values(selectedItemsByRole).flat(),
     [selectedItemsByRole],
+  );
+
+  // Member emails cover the loaded pages for the selected role; the invite
+  // service remains authoritative for members on other roles or pages.
+  const takenEmails = useMemo(
+    () =>
+      new Set([
+        ...allSelectedItems.map((item) => item.email.toLowerCase()),
+        ...optimisticUsers
+          .filter(hasEmail)
+          .map((user) => user.email.toLowerCase()),
+        ...optimisticInvites.map((invite) => invite.email.toLowerCase()),
+      ]),
+    [allSelectedItems, optimisticUsers, optimisticInvites],
   );
 
   // Filter server invites by current role
@@ -238,44 +246,24 @@ function ProfileInviteModalContent({
       .sort((a, b) => b.rank - a.rank);
   }, [searchResults]);
 
-  // Filter out already selected, already invited, and existing members.
-  // Note: member exclusion only sees the pages loaded so far for the selected
-  // role; the server (inviteUsersToProfile) dedupes authoritatively.
+  // Filter out already selected, already invited, and loaded members.
   const filteredResults = useMemo(() => {
     const selectedIds = new Set(allSelectedItems.map((item) => item.profileId));
-    const selectedEmails = new Set(
-      allSelectedItems.map((item) => item.email.toLowerCase()),
-    );
-    const existingUserEmails = new Set(
-      optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
-    );
-    const invitedEmails = new Set(
-      optimisticInvites.map((i) => i.email.toLowerCase()),
-    );
     return flattenedResults.filter(
       (result) =>
         !selectedIds.has(result.id) &&
         (!result.user?.email ||
-          (!selectedEmails.has(result.user.email.toLowerCase()) &&
-            !existingUserEmails.has(result.user.email.toLowerCase()) &&
-            !invitedEmails.has(result.user.email.toLowerCase()))),
+          !takenEmails.has(result.user.email.toLowerCase())),
     );
-  }, [flattenedResults, allSelectedItems, optimisticUsers, optimisticInvites]);
+  }, [flattenedResults, allSelectedItems, takenEmails]);
 
-  // Check if query is a valid email that hasn't been selected yet (across all
-  // roles; checks loaded members only — the server dedupes authoritatively)
+  // Check if query is a valid email that hasn't been selected yet.
   const canAddEmail = useMemo(() => {
     if (!isValidEmail(debouncedQuery)) {
       return false;
     }
-    const lowerQuery = debouncedQuery.toLowerCase();
-    const takenEmails = new Set([
-      ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
-      ...optimisticInvites.map((i) => i.email.toLowerCase()),
-    ]);
-    return !takenEmails.has(lowerQuery);
-  }, [debouncedQuery, allSelectedItems, optimisticUsers, optimisticInvites]);
+    return !takenEmails.has(debouncedQuery.toLowerCase());
+  }, [debouncedQuery, takenEmails]);
 
   // Mutations
   const inviteMutation = trpc.profile.invite.useMutation();
@@ -285,19 +273,21 @@ function ProfileInviteModalContent({
   // Calculate total people count across all roles (staged only)
   const totalPeople = allSelectedItems.length;
 
-  // Calculate counts by role for the tab badges (staged + server invites).
-  // The existing-member portion of each badge comes from the server via
-  // listRoles' memberCount and is added inside RoleSelector.
+  // Merge authoritative member counts with staged items and pending invites so
+  // each badge has one final count.
   const countsByRole = useMemo(() => {
-    const counts: Record<string, number> = {};
+    const counts: Record<string, number> = Object.fromEntries(
+      roles.map((role) => [role.id, role.memberCount ?? 0]),
+    );
     for (const [roleId, items] of Object.entries(selectedItemsByRole)) {
-      counts[roleId] = items.length;
+      counts[roleId] = (counts[roleId] ?? 0) + items.length;
     }
     for (const invite of optimisticInvites) {
       counts[invite.accessRoleId] = (counts[invite.accessRoleId] ?? 0) + 1;
     }
+
     return counts;
-  }, [selectedItemsByRole, optimisticInvites]);
+  }, [roles, selectedItemsByRole, optimisticInvites]);
 
   const handleSelectItem = (result: (typeof flattenedResults)[0]) => {
     if (!result.user?.email || !selectedRoleId) {
@@ -358,16 +348,49 @@ function ProfileInviteModalContent({
     });
   };
 
-  const handleRemoveUser = (profileUserId: string) => {
+  const handleRemoveUser = ({
+    id,
+    roles: memberRoles,
+  }: {
+    id: string;
+    roles: Array<{ id: string }>;
+  }) => {
     startOptimisticTransition(async () => {
-      dispatchRemoveUser(profileUserId);
+      dispatchRemoveUser(id);
+      const removedRoleIds = new Set(memberRoles.map((role) => role.id));
+      const rolesQueryInput = {
+        profileId,
+        zoneName: 'decisions',
+        limit: 100,
+      };
+      const updateMemberCounts = (delta: number) =>
+        utils.profile.listRoles.setData(rolesQueryInput, (rolesData) =>
+          rolesData
+            ? {
+                ...rolesData,
+                items: rolesData.items.map((role) =>
+                  removedRoleIds.has(role.id)
+                    ? {
+                        ...role,
+                        memberCount: Math.max(
+                          0,
+                          (role.memberCount ?? 0) + delta,
+                        ),
+                      }
+                    : role,
+                ),
+              }
+            : rolesData,
+        );
+      updateMemberCounts(-1);
       try {
-        await removeUserMutation.mutateAsync({ profileUserId });
+        await removeUserMutation.mutateAsync({ profileUserId: id });
       } catch {
+        updateMemberCounts(1);
         toast.error({ message: t('Failed to remove user') });
       }
       // Partial input matching also invalidates the per-role infinite queries;
-      // listRoles refreshes the member counts behind the tab badges.
+      // listRoles refreshes or restores the optimistic member counts.
       await Promise.all([
         utils.profile.listUsers.invalidate({ profileId }),
         utils.profile.listRoles.invalidate({ profileId }),
@@ -440,13 +463,7 @@ function ProfileInviteModalContent({
       return;
     }
 
-    // Loaded members only — the server dedupes authoritatively
-    const existingEmails = new Set([
-      ...allSelectedItems.map((item) => item.email.toLowerCase()),
-      ...optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
-      ...optimisticInvites.map((i) => i.email.toLowerCase()),
-    ]);
-    const emails = parseEmailPaste(pastedText, existingEmails);
+    const emails = parseEmailPaste(pastedText, takenEmails);
     if (!emails) {
       return;
     }
@@ -468,10 +485,6 @@ function ProfileInviteModalContent({
     setSearchQuery('');
   };
 
-  const handleTabChange = (key: Key) => {
-    setSelectedRoleId(String(key));
-  };
-
   const hasNoItems =
     !isMembersPending &&
     currentRoleItems.length === 0 &&
@@ -483,15 +496,10 @@ function ProfileInviteModalContent({
       <ModalBody className="space-y-6">
         {/* Role Tabs */}
         <RoleSelector
-          profileId={profileId}
+          roles={roles}
           selectedRoleId={selectedRoleId}
-          onSelectionChange={handleTabChange}
+          onSelectionChange={setRequestedRoleId}
           countsByRole={countsByRole}
-          onRolesLoaded={(roleId, roleName) => {
-            setSelectedRoleId(roleId);
-            setSelectedRoleName(roleName);
-          }}
-          onRoleNameChange={setSelectedRoleName}
         />
 
         {showDraftBanner && (
@@ -677,7 +685,7 @@ function ProfileInviteModalContent({
                   ) : undefined
                 }
                 onRemove={
-                  !user.isOwner ? () => handleRemoveUser(user.id) : undefined
+                  !user.isOwner ? () => handleRemoveUser(user) : undefined
                 }
                 removeLabel={t('Remove {name}', {
                   name: user.name ?? user.email,

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -389,10 +389,33 @@ function ProfileInviteModalContent({
           return;
         }
 
-        await inviteMutation.mutateAsync({
+        const result = await inviteMutation.mutateAsync({
           invitations,
           profileId,
         });
+
+        if (result.details.failed.length > 0) {
+          const successfulEmails = new Set(result.details.successful);
+          setSelectedItemsByRole((selectedItems) =>
+            Object.fromEntries(
+              Object.entries(selectedItems).map(([roleId, items]) => [
+                roleId,
+                items.filter(
+                  (item) => !successfulEmails.has(item.email.toLowerCase()),
+                ),
+              ]),
+            ),
+          );
+          setSearchQuery('');
+          toast.error({ message: t('Failed to send invite') });
+
+          if (result.details.successful.length > 0) {
+            utils.profile.listUsers.invalidate({ profileId });
+            utils.profile.listProfileInvites.invalidate({ profileId });
+            utils.profile.listRoles.invalidate({ profileId });
+          }
+          return;
+        }
 
         toast.success({ message: t('Invite sent successfully') });
         setSelectedItemsByRole({});

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -4,7 +4,7 @@ import { getPublicUrl } from '@/utils';
 import { trpc } from '@op/api/client';
 import { EntityType } from '@op/api/encoders';
 import { hasEmail } from '@op/common/client';
-import { useDebounce } from '@op/hooks';
+import { useDebounce, useInfiniteScroll } from '@op/hooks';
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Avatar } from '@op/ui/Avatar';
 import { Button } from '@op/ui/Button';
@@ -14,6 +14,7 @@ import { LoadingSpinner } from '@op/ui/LoadingSpinner';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@op/ui/Modal';
 import { ProfileItem } from '@op/ui/ProfileItem';
 import { SearchField } from '@op/ui/SearchField';
+import { Skeleton } from '@op/ui/Skeleton';
 import { toast } from '@op/ui/Toast';
 import Image from 'next/image';
 import {
@@ -141,11 +142,32 @@ function ProfileInviteModalContent({
 
   const showDraftBanner = isDraft && !adminRoleIds.has(selectedRoleId);
 
-  // Fetch existing pending invites and members
+  // Fetch existing pending invites
   const [serverInvites] = trpc.profile.listProfileInvites.useSuspenseQuery({
     profileId,
   });
-  const [usersData] = trpc.profile.listUsers.useSuspenseQuery({ profileId });
+
+  // Members for the selected role, paginated server-side. React Query caches
+  // per input key, so each role tab paginates independently and switching
+  // tabs preserves already-loaded pages.
+  const {
+    data: usersData,
+    isPending: isMembersPending,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = trpc.profile.listUsers.useInfiniteQuery(
+    { profileId, roleId: selectedRoleId, limit: 25 },
+    {
+      getNextPageParam: (lastPage) => lastPage.next,
+      enabled: !!selectedRoleId,
+    },
+  );
+
+  const loadedMembers = useMemo(
+    () => usersData?.pages.flatMap((page) => page.items) ?? [],
+    [usersData],
+  );
 
   const [optimisticInvites, dispatchRemoveInvite] = useOptimistic(
     serverInvites,
@@ -153,7 +175,7 @@ function ProfileInviteModalContent({
   );
 
   const [optimisticUsers, dispatchRemoveUser] = useOptimistic(
-    usersData.items,
+    loadedMembers,
     (state, profileUserId: string) =>
       state.filter((u) => u.id !== profileUserId),
   );
@@ -173,13 +195,12 @@ function ProfileInviteModalContent({
     [optimisticInvites, selectedRoleId],
   );
 
-  // Filter members by current role
-  const currentRoleMembers = useMemo(
-    () =>
-      optimisticUsers.filter((u) =>
-        u.roles.some((r) => r.id === selectedRoleId),
-      ),
-    [optimisticUsers, selectedRoleId],
+  // Members are already filtered to the selected role by the server query
+  const currentRoleMembers = optimisticUsers;
+
+  const { ref: scrollTriggerRef, shouldShowTrigger } = useInfiniteScroll(
+    fetchNextPage,
+    { hasNextPage, isFetchingNextPage },
   );
 
   // Update dropdown position when search query changes
@@ -217,7 +238,9 @@ function ProfileInviteModalContent({
       .sort((a, b) => b.rank - a.rank);
   }, [searchResults]);
 
-  // Filter out already selected, already invited, and existing members
+  // Filter out already selected, already invited, and existing members.
+  // Note: member exclusion only sees the pages loaded so far for the selected
+  // role; the server (inviteUsersToProfile) dedupes authoritatively.
   const filteredResults = useMemo(() => {
     const selectedIds = new Set(allSelectedItems.map((item) => item.profileId));
     const selectedEmails = new Set(
@@ -239,7 +262,8 @@ function ProfileInviteModalContent({
     );
   }, [flattenedResults, allSelectedItems, optimisticUsers, optimisticInvites]);
 
-  // Check if query is a valid email that hasn't been selected yet (across all roles)
+  // Check if query is a valid email that hasn't been selected yet (across all
+  // roles; checks loaded members only — the server dedupes authoritatively)
   const canAddEmail = useMemo(() => {
     if (!isValidEmail(debouncedQuery)) {
       return false;
@@ -261,7 +285,9 @@ function ProfileInviteModalContent({
   // Calculate total people count across all roles (staged only)
   const totalPeople = allSelectedItems.length;
 
-  // Calculate counts by role for the tab badges (staged + server invites + members)
+  // Calculate counts by role for the tab badges (staged + server invites).
+  // The existing-member portion of each badge comes from the server via
+  // listRoles' memberCount and is added inside RoleSelector.
   const countsByRole = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const [roleId, items] of Object.entries(selectedItemsByRole)) {
@@ -270,13 +296,8 @@ function ProfileInviteModalContent({
     for (const invite of optimisticInvites) {
       counts[invite.accessRoleId] = (counts[invite.accessRoleId] ?? 0) + 1;
     }
-    for (const user of optimisticUsers) {
-      for (const role of user.roles) {
-        counts[role.id] = (counts[role.id] ?? 0) + 1;
-      }
-    }
     return counts;
-  }, [selectedItemsByRole, optimisticInvites, optimisticUsers]);
+  }, [selectedItemsByRole, optimisticInvites]);
 
   const handleSelectItem = (result: (typeof flattenedResults)[0]) => {
     if (!result.user?.email || !selectedRoleId) {
@@ -345,7 +366,12 @@ function ProfileInviteModalContent({
       } catch {
         toast.error({ message: t('Failed to remove user') });
       }
-      await utils.profile.listUsers.invalidate({ profileId });
+      // Partial input matching also invalidates the per-role infinite queries;
+      // listRoles refreshes the member counts behind the tab badges.
+      await Promise.all([
+        utils.profile.listUsers.invalidate({ profileId }),
+        utils.profile.listRoles.invalidate({ profileId }),
+      ]);
     });
   };
 
@@ -373,9 +399,10 @@ function ProfileInviteModalContent({
         setSearchQuery('');
         onOpenChange(false);
 
-        // Invalidate both lists
+        // Invalidate the lists and the per-role member counts (tab badges)
         utils.profile.listUsers.invalidate({ profileId });
         utils.profile.listProfileInvites.invalidate({ profileId });
+        utils.profile.listRoles.invalidate({ profileId });
       } catch (error) {
         const message =
           error instanceof Error ? error.message : t('Failed to send invite');
@@ -390,6 +417,7 @@ function ProfileInviteModalContent({
       return;
     }
 
+    // Loaded members only — the server dedupes authoritatively
     const existingEmails = new Set([
       ...allSelectedItems.map((item) => item.email.toLowerCase()),
       ...optimisticUsers.filter(hasEmail).map((u) => u.email.toLowerCase()),
@@ -422,6 +450,7 @@ function ProfileInviteModalContent({
   };
 
   const hasNoItems =
+    !isMembersPending &&
     currentRoleItems.length === 0 &&
     currentRoleInvites.length === 0 &&
     currentRoleMembers.length === 0;
@@ -556,7 +585,7 @@ function ProfileInviteModalContent({
             </span>
           )}
 
-          <div className="flex flex-col gap-2">
+          <div className="flex max-h-80 flex-col gap-2 overflow-y-auto">
             {/* Staged items (not yet sent) */}
             {currentRoleItems.map((item) => (
               <PersonRow
@@ -605,7 +634,9 @@ function ProfileInviteModalContent({
               );
             })}
 
-            {/* Existing members */}
+            {/* Existing members (loading skeletons while the first page of
+                the selected role is pending) */}
+            {isMembersPending && <MemberRowsSkeleton />}
             {currentRoleMembers.map((user) => (
               <PersonRow
                 key={user.id}
@@ -630,6 +661,17 @@ function ProfileInviteModalContent({
                 })}
               />
             ))}
+
+            {/* Infinite-scroll trigger: loads more members as the user
+                scrolls inside the bounded list container */}
+            {shouldShowTrigger && (
+              <div
+                ref={scrollTriggerRef}
+                className="flex shrink-0 justify-center py-2"
+              >
+                {isFetchingNextPage && <LoadingSpinner className="size-4" />}
+              </div>
+            )}
 
             {/* Empty state */}
             {hasNoItems && selectedRoleName ? (
@@ -660,6 +702,16 @@ function ProfileInviteModalContent({
           {isSubmitting ? t('Adding...') : t('Add')}
         </Button>
       </ModalFooter>
+    </>
+  );
+}
+
+function MemberRowsSkeleton() {
+  return (
+    <>
+      {[0, 1, 2].map((row) => (
+        <Skeleton key={row} className="h-14 w-full shrink-0 rounded-lg" />
+      ))}
     </>
   );
 }

--- a/apps/app/src/components/decisions/RoleSelector.tsx
+++ b/apps/app/src/components/decisions/RoleSelector.tsx
@@ -27,7 +27,6 @@ export const RoleSelector = ({
   const t = useTranslations();
   const [rolesData] = trpc.profile.listRoles.useSuspenseQuery({
     profileId,
-    includeMemberCounts: true,
   });
 
   const roles = useMemo(() => {

--- a/apps/app/src/components/decisions/RoleSelector.tsx
+++ b/apps/app/src/components/decisions/RoleSelector.tsx
@@ -18,12 +18,17 @@ export const RoleSelector = ({
   profileId: string;
   selectedRoleId: string;
   onSelectionChange: (key: Key) => void;
+  /** Client-side badge counts per role (staged items + pending invites);
+   * existing members are counted server-side via listRoles' memberCount. */
   countsByRole: Record<string, number>;
   onRolesLoaded: (roleId: string, roleName: string) => void;
   onRoleNameChange: (roleName: string) => void;
 }) => {
   const t = useTranslations();
-  const [rolesData] = trpc.profile.listRoles.useSuspenseQuery({ profileId });
+  const [rolesData] = trpc.profile.listRoles.useSuspenseQuery({
+    profileId,
+    includeMemberCounts: true,
+  });
 
   const roles = useMemo(() => {
     return rolesData.items ?? [];
@@ -54,7 +59,7 @@ export const RoleSelector = ({
     >
       <TabList aria-label={t('Select a role')}>
         {roles.map((role) => {
-          const count = countsByRole[role.id] ?? 0;
+          const count = (countsByRole[role.id] ?? 0) + (role.memberCount ?? 0);
           return (
             <Tab key={role.id} id={role.id}>
               <span className="flex items-center gap-1">

--- a/apps/app/src/components/decisions/RoleSelector.tsx
+++ b/apps/app/src/components/decisions/RoleSelector.tsx
@@ -1,64 +1,34 @@
 'use client';
 
-import { trpc } from '@op/api/client';
 import { Skeleton } from '@op/ui/Skeleton';
 import { Tab, TabList, Tabs } from '@op/ui/Tabs';
-import { Key, useEffect, useMemo, useRef } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
+interface RoleSelectorProps {
+  roles: Array<{ id: string; name: string }>;
+  selectedRoleId: string;
+  onSelectionChange: (roleId: string) => void;
+  countsByRole: Record<string, number>;
+}
+
+/** Displays role tabs and their participant counts. */
 export const RoleSelector = ({
-  profileId,
+  roles,
   selectedRoleId,
   onSelectionChange,
   countsByRole,
-  onRolesLoaded,
-  onRoleNameChange,
-}: {
-  profileId: string;
-  selectedRoleId: string;
-  onSelectionChange: (key: Key) => void;
-  /** Client-side badge counts per role (staged items + pending invites);
-   * existing members are counted server-side via listRoles' memberCount. */
-  countsByRole: Record<string, number>;
-  onRolesLoaded: (roleId: string, roleName: string) => void;
-  onRoleNameChange: (roleName: string) => void;
-}) => {
+}: RoleSelectorProps) => {
   const t = useTranslations();
-  const [rolesData] = trpc.profile.listRoles.useSuspenseQuery({
-    profileId,
-  });
-
-  const roles = useMemo(() => {
-    return rolesData.items ?? [];
-  }, [rolesData]);
-
-  // Set default role on mount if none selected
-  const hasInitialized = useRef(false);
-  const firstRole = roles[0];
-  useEffect(() => {
-    if (!hasInitialized.current && firstRole && !selectedRoleId) {
-      hasInitialized.current = true;
-      onRolesLoaded(firstRole.id, firstRole.name);
-    }
-  }, [firstRole, selectedRoleId, onRolesLoaded]);
-
-  const handleSelectionChange = (key: Key) => {
-    const role = roles.find((r) => r.id === key);
-    if (role) {
-      onRoleNameChange(role.name);
-    }
-    onSelectionChange(key);
-  };
 
   return (
     <Tabs
       selectedKey={selectedRoleId}
-      onSelectionChange={handleSelectionChange}
+      onSelectionChange={(key) => onSelectionChange(String(key))}
     >
       <TabList aria-label={t('Select a role')}>
         {roles.map((role) => {
-          const count = (countsByRole[role.id] ?? 0) + (role.memberCount ?? 0);
+          const count = countsByRole[role.id] ?? 0;
           return (
             <Tab key={role.id} id={role.id}>
               <span className="flex items-center gap-1">

--- a/packages/common/src/services/access/getRoles.ts
+++ b/packages/common/src/services/access/getRoles.ts
@@ -72,7 +72,7 @@ type RoleCursor = { value: string; id: string };
  *   and named in EXPOSABLE_GLOBAL_ROLE_NAMES)
  * - If zoneName is provided: includes permission for that zone
  * - If profileId is present: each role gains a memberCount — the number of
- *   profile members holding that role
+ *   profile members holding that role, computed in the paginated role query
  */
 export const getRoles = async (params?: {
   profileId?: string;
@@ -121,48 +121,16 @@ export const getRoles = async (params?: {
       : profileCondition;
   };
 
-  /**
-   * Attaches memberCount to each role via one grouped query over the
-   * profileUser -> access role junction, scoped to the profile's members and
-   * excluding the global sentinel users (mirroring listProfileUsers).
-   * Only runs when profileId is present.
-   */
-  const attachMemberCounts = async (items: Role[]): Promise<Role[]> => {
-    if (!profileId || items.length === 0) {
-      return items;
-    }
-
-    const countRows = await db
-      .select({
-        accessRoleId: profileUserToAccessRoles.accessRoleId,
-        memberCount: sql<number>`count(*)::int`,
-      })
-      .from(profileUserToAccessRoles)
-      .innerJoin(
-        profileUsers,
-        eq(profileUsers.id, profileUserToAccessRoles.profileUserId),
-      )
-      .where(
-        and(
-          inArray(
-            profileUserToAccessRoles.accessRoleId,
-            items.map((item) => item.id),
-          ),
-          eq(profileUsers.profileId, profileId),
-          excludeGlobalUsers(profileUsers.authUserId),
-        ),
-      )
-      .groupBy(profileUserToAccessRoles.accessRoleId);
-
-    const countsByRoleId = new Map(
-      countRows.map((row) => [row.accessRoleId, row.memberCount]),
-    );
-
-    return items.map((item) => ({
-      ...item,
-      memberCount: countsByRoleId.get(item.id) ?? 0,
-    }));
-  };
+  // The role junction's accessRoleId index bounds the correlated lookup.
+  const memberCountExpr = (accessRoleCols: typeof accessRoles) => sql<number>`(
+    SELECT COUNT(*)::int
+    FROM ${profileUserToAccessRoles}
+    INNER JOIN ${profileUsers}
+      ON ${profileUsers.id} = ${profileUserToAccessRoles.profileUserId}
+    WHERE ${profileUserToAccessRoles.accessRoleId} = ${accessRoleCols.id}
+      AND ${profileUsers.profileId} = ${profileId}
+      AND ${excludeGlobalUsers(profileUsers.authUserId)}
+  )`;
 
   // Use join-based query when zoneName is provided for DB-level filtering
   if (zoneName) {
@@ -172,6 +140,7 @@ export const getRoles = async (params?: {
         name: accessRoles.name,
         description: accessRoles.description,
         permission: accessRolePermissionsOnAccessZones.permission,
+        ...(profileId && { memberCount: memberCountExpr(accessRoles) }),
       })
       .from(accessRoles)
       .leftJoin(
@@ -206,6 +175,7 @@ export const getRoles = async (params?: {
       name: row.name,
       description: row.description,
       permissions: fromBitField(row.permission ?? 0),
+      ...(profileId && { memberCount: row.memberCount ?? 0 }),
     }));
 
     const lastItem = resultItems[resultItems.length - 1];
@@ -214,7 +184,7 @@ export const getRoles = async (params?: {
         ? encodeCursor<RoleCursor>({ value: lastItem.name, id: lastItem.id })
         : null;
 
-    return { items: await attachMemberCounts(items), next: nextCursor };
+    return { items, next: nextCursor };
   }
 
   // Simple query without permissions when no zoneName
@@ -226,6 +196,10 @@ export const getRoles = async (params?: {
       dir === 'desc'
         ? { name: 'desc', id: 'desc' }
         : { name: 'asc', id: 'asc' },
+    extras: {
+      memberCount: (table, { sql: sqlOp }) =>
+        sqlOp<number>`${memberCountExpr(table)}`.as('member_count'),
+    },
     limit: limit + 1,
   });
 
@@ -238,6 +212,7 @@ export const getRoles = async (params?: {
     id: role.id,
     name: role.name,
     description: role.description,
+    ...(profileId && { memberCount: role.memberCount ?? 0 }),
   }));
 
   // Build next cursor from last item
@@ -248,7 +223,7 @@ export const getRoles = async (params?: {
       : null;
 
   return {
-    items: await attachMemberCounts(items),
+    items,
     next: nextCursor,
   };
 };

--- a/packages/common/src/services/access/getRoles.ts
+++ b/packages/common/src/services/access/getRoles.ts
@@ -71,13 +71,12 @@ type RoleCursor = { value: string; id: string };
  * - If no profileId: returns only exposable global roles (profileId IS NULL
  *   and named in EXPOSABLE_GLOBAL_ROLE_NAMES)
  * - If zoneName is provided: includes permission for that zone
- * - If includeMemberCounts is set (and profileId is present): each role gains
- *   a memberCount — the number of profile members holding that role
+ * - If profileId is present: each role gains a memberCount — the number of
+ *   profile members holding that role
  */
 export const getRoles = async (params?: {
   profileId?: string;
   zoneName?: string;
-  includeMemberCounts?: boolean;
   cursor?: string | null;
   limit?: number;
   dir?: SortDir;
@@ -85,7 +84,6 @@ export const getRoles = async (params?: {
   const {
     profileId = null,
     zoneName,
-    includeMemberCounts,
     cursor,
     limit = 25,
     dir = 'asc',
@@ -127,10 +125,10 @@ export const getRoles = async (params?: {
    * Attaches memberCount to each role via one grouped query over the
    * profileUser -> access role junction, scoped to the profile's members and
    * excluding the global sentinel users (mirroring listProfileUsers).
-   * Only runs when opted in via includeMemberCounts and profileId is present.
+   * Only runs when profileId is present.
    */
   const attachMemberCounts = async (items: Role[]): Promise<Role[]> => {
-    if (!includeMemberCounts || !profileId || items.length === 0) {
+    if (!profileId || items.length === 0) {
       return items;
     }
 

--- a/packages/common/src/services/access/getRoles.ts
+++ b/packages/common/src/services/access/getRoles.ts
@@ -11,11 +11,14 @@ import {
   isNull,
   lt,
   or,
+  sql,
 } from '@op/db/client';
 import {
   accessRolePermissionsOnAccessZones,
   accessRoles,
   accessZones,
+  profileUserToAccessRoles,
+  profileUsers,
 } from '@op/db/schema';
 import { type Permission, fromBitField } from 'access-zones';
 
@@ -24,6 +27,7 @@ import {
   type SortDir,
   decodeCursor,
   encodeCursor,
+  excludeGlobalUsers,
 } from '../../utils/db';
 
 interface Role {
@@ -31,6 +35,7 @@ interface Role {
   name: string;
   description: string | null;
   permissions?: Permission;
+  memberCount?: number;
 }
 
 /**
@@ -66,10 +71,13 @@ type RoleCursor = { value: string; id: string };
  * - If no profileId: returns only exposable global roles (profileId IS NULL
  *   and named in EXPOSABLE_GLOBAL_ROLE_NAMES)
  * - If zoneName is provided: includes permission for that zone
+ * - If includeMemberCounts is set (and profileId is present): each role gains
+ *   a memberCount — the number of profile members holding that role
  */
 export const getRoles = async (params?: {
   profileId?: string;
   zoneName?: string;
+  includeMemberCounts?: boolean;
   cursor?: string | null;
   limit?: number;
   dir?: SortDir;
@@ -77,6 +85,7 @@ export const getRoles = async (params?: {
   const {
     profileId = null,
     zoneName,
+    includeMemberCounts,
     cursor,
     limit = 25,
     dir = 'asc',
@@ -112,6 +121,49 @@ export const getRoles = async (params?: {
     return cursorCondition
       ? and(profileCondition, cursorCondition)!
       : profileCondition;
+  };
+
+  /**
+   * Attaches memberCount to each role via one grouped query over the
+   * profileUser -> access role junction, scoped to the profile's members and
+   * excluding the global sentinel users (mirroring listProfileUsers).
+   * Only runs when opted in via includeMemberCounts and profileId is present.
+   */
+  const attachMemberCounts = async (items: Role[]): Promise<Role[]> => {
+    if (!includeMemberCounts || !profileId || items.length === 0) {
+      return items;
+    }
+
+    const countRows = await db
+      .select({
+        accessRoleId: profileUserToAccessRoles.accessRoleId,
+        memberCount: sql<number>`count(*)::int`,
+      })
+      .from(profileUserToAccessRoles)
+      .innerJoin(
+        profileUsers,
+        eq(profileUsers.id, profileUserToAccessRoles.profileUserId),
+      )
+      .where(
+        and(
+          inArray(
+            profileUserToAccessRoles.accessRoleId,
+            items.map((item) => item.id),
+          ),
+          eq(profileUsers.profileId, profileId),
+          excludeGlobalUsers(profileUsers.authUserId),
+        ),
+      )
+      .groupBy(profileUserToAccessRoles.accessRoleId);
+
+    const countsByRoleId = new Map(
+      countRows.map((row) => [row.accessRoleId, row.memberCount]),
+    );
+
+    return items.map((item) => ({
+      ...item,
+      memberCount: countsByRoleId.get(item.id) ?? 0,
+    }));
   };
 
   // Use join-based query when zoneName is provided for DB-level filtering
@@ -164,7 +216,7 @@ export const getRoles = async (params?: {
         ? encodeCursor<RoleCursor>({ value: lastItem.name, id: lastItem.id })
         : null;
 
-    return { items, next: nextCursor };
+    return { items: await attachMemberCounts(items), next: nextCursor };
   }
 
   // Simple query without permissions when no zoneName
@@ -198,7 +250,7 @@ export const getRoles = async (params?: {
       : null;
 
   return {
-    items,
+    items: await attachMemberCounts(items),
     next: nextCursor,
   };
 };

--- a/packages/common/src/services/profile/listProfileUsers.ts
+++ b/packages/common/src/services/profile/listProfileUsers.ts
@@ -40,6 +40,7 @@ export const listProfileUsers = async ({
   orderBy = 'name',
   dir = 'asc',
   query,
+  roleId,
   cursor,
   limit = 25,
 }: {
@@ -48,6 +49,7 @@ export const listProfileUsers = async ({
   orderBy?: ProfileUserOrderBy;
   dir?: SortDir;
   query?: string;
+  roleId?: string;
   cursor?: string | null;
   limit?: number;
 }): Promise<PaginatedResult<ProfileUserWithRelations>> => {
@@ -125,14 +127,28 @@ export const listProfileUsers = async ({
 
   const cursorCondition = buildCursorCondition();
 
+  // Optional role filter: only members holding the given role via the
+  // profileUser -> access role junction. Purely additive so it composes with
+  // the search and cursor conditions without touching the keyset logic.
+  const roleFilter = roleId
+    ? sql`${profileUsers.id} IN (
+        SELECT pur.profile_user_id
+        FROM "profileUser_to_access_roles" pur
+        WHERE pur.access_role_id = ${roleId}
+      )`
+    : undefined;
+
   // Combine all conditions
   const baseCondition = and(
     eq(profileUsers.profileId, profileId),
     excludeGlobalUsers(profileUsers.authUserId),
   );
-  const conditions = [baseCondition, searchFilter, cursorCondition].filter(
-    Boolean,
-  );
+  const conditions = [
+    baseCondition,
+    searchFilter,
+    roleFilter,
+    cursorCondition,
+  ].filter(Boolean);
   const whereClause =
     conditions.length > 1 ? and(...conditions) : baseCondition;
 

--- a/packages/common/src/services/profile/listProfileUsers.ts
+++ b/packages/common/src/services/profile/listProfileUsers.ts
@@ -1,5 +1,10 @@
-import { and, db, eq, gt, lt, or, sql } from '@op/db/client';
-import { profileUsers, profiles, users } from '@op/db/schema';
+import { and, db, eq, gt, inArray, lt, or, sql } from '@op/db/client';
+import {
+  profileUserToAccessRoles,
+  profileUsers,
+  profiles,
+  users,
+} from '@op/db/schema';
 import type { User } from '@op/supabase/lib';
 
 import {
@@ -131,11 +136,13 @@ export const listProfileUsers = async ({
   // profileUser -> access role junction. Purely additive so it composes with
   // the search and cursor conditions without touching the keyset logic.
   const roleFilter = roleId
-    ? sql`${profileUsers.id} IN (
-        SELECT pur.profile_user_id
-        FROM "profileUser_to_access_roles" pur
-        WHERE pur.access_role_id = ${roleId}
-      )`
+    ? inArray(
+        profileUsers.id,
+        db
+          .select({ profileUserId: profileUserToAccessRoles.profileUserId })
+          .from(profileUserToAccessRoles)
+          .where(eq(profileUserToAccessRoles.accessRoleId, roleId)),
+      )
     : undefined;
 
   // Combine all conditions

--- a/services/api/src/encoders/roles.ts
+++ b/services/api/src/encoders/roles.ts
@@ -12,7 +12,7 @@ export const roleEncoder = createSelectSchema(accessRoles)
   })
   .extend({
     permissions: permissionsSchema.optional(),
-    // Present only when the caller opts in via includeMemberCounts
+    // Present for profile-scoped role listings.
     memberCount: z.number().optional(),
   });
 

--- a/services/api/src/encoders/roles.ts
+++ b/services/api/src/encoders/roles.ts
@@ -12,6 +12,8 @@ export const roleEncoder = createSelectSchema(accessRoles)
   })
   .extend({
     permissions: permissionsSchema.optional(),
+    // Present only when the caller opts in via includeMemberCounts
+    memberCount: z.number().optional(),
   });
 
 export type Role = z.infer<typeof roleEncoder>;

--- a/services/api/src/routers/profile/listRoles.test.ts
+++ b/services/api/src/routers/profile/listRoles.test.ts
@@ -1,8 +1,14 @@
+import { GLOBAL_USER_PUBLIC } from '@op/core';
 import { db } from '@op/db/client';
-import { accessRolePermissionsOnAccessZones, accessRoles } from '@op/db/schema';
+import {
+  accessRolePermissionsOnAccessZones,
+  accessRoles,
+  profileUserToAccessRoles,
+  profileUsers,
+} from '@op/db/schema';
 import { ROLES, ZONES } from '@op/db/seedData/accessControl';
 import { toBitField } from 'access-zones';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 import profileRouter from '.';
@@ -436,6 +442,155 @@ describe.concurrent('profile.listRoles', () => {
     expect(result.items.length).toBe(2);
     // Should return null cursor since there are no more results
     expect(result.next).toBeNull();
+  });
+
+  describe('includeMemberCounts', () => {
+    it('should include per-role member counts when includeMemberCounts is set', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+      const { profile, adminUser, memberUsers } = await testData.createProfile({
+        users: { admin: 1, member: 2 },
+      });
+
+      // Two custom roles: one held by both members, one held by nobody
+      const [heldRole, emptyRole] = await db
+        .insert(accessRoles)
+        .values([
+          { name: `Held Role ${task.id}`, profileId: profile.id },
+          { name: `Vacant Role ${task.id}`, profileId: profile.id },
+        ])
+        .returning();
+
+      if (!heldRole || !emptyRole) {
+        throw new Error('Failed to create test roles');
+      }
+
+      onTestFinished(async () => {
+        await db
+          .delete(accessRoles)
+          .where(inArray(accessRoles.id, [heldRole.id, emptyRole.id]));
+      });
+
+      await db.insert(profileUserToAccessRoles).values(
+        memberUsers.map((member) => ({
+          profileUserId: member.profileUserId,
+          accessRoleId: heldRole.id,
+        })),
+      );
+
+      const { session } = await createIsolatedSession(adminUser.email);
+      const caller = createCaller(await createTestContextWithSession(session));
+
+      // Simple branch (no zoneName)
+      const result = await caller.listRoles({
+        profileId: profile.id,
+        includeMemberCounts: true,
+        limit: 100,
+      });
+
+      expect(result.items.find((r) => r.id === heldRole.id)?.memberCount).toBe(
+        2,
+      );
+      expect(result.items.find((r) => r.id === emptyRole.id)?.memberCount).toBe(
+        0,
+      );
+
+      // Join branch (with zoneName) also attaches counts
+      const zoneResult = await caller.listRoles({
+        profileId: profile.id,
+        zoneName: ZONES.PROFILE.name,
+        includeMemberCounts: true,
+        limit: 100,
+      });
+
+      expect(
+        zoneResult.items.find((r) => r.id === heldRole.id)?.memberCount,
+      ).toBe(2);
+      expect(
+        zoneResult.items.find((r) => r.id === emptyRole.id)?.memberCount,
+      ).toBe(0);
+
+      // Counts are opt-in: absent without the flag
+      const withoutFlag = await caller.listRoles({
+        profileId: profile.id,
+        limit: 100,
+      });
+      expect(
+        withoutFlag.items.find((r) => r.id === heldRole.id)?.memberCount,
+      ).toBeUndefined();
+    });
+
+    it('should exclude global sentinel users from member counts', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+      const { profile, adminUser, memberUsers } = await testData.createProfile({
+        users: { admin: 1, member: 1 },
+      });
+
+      const member = memberUsers[0];
+      if (!member) {
+        throw new Error('Expected member user to be defined');
+      }
+
+      const [customRole] = await db
+        .insert(accessRoles)
+        .values({ name: `Counted Role ${task.id}`, profileId: profile.id })
+        .returning();
+
+      if (!customRole) {
+        throw new Error('Failed to create custom role');
+      }
+
+      // The real member holds the role...
+      await db.insert(profileUserToAccessRoles).values({
+        profileUserId: member.profileUserId,
+        accessRoleId: customRole.id,
+      });
+
+      // ...and so does a profile_users row anchored on the GLOBAL_USER_PUBLIC
+      // sentinel (the public-access grant). It must not inflate the count.
+      const [sentinelRow] = await db
+        .insert(profileUsers)
+        .values({
+          authUserId: GLOBAL_USER_PUBLIC,
+          profileId: profile.id,
+        })
+        .returning();
+
+      if (!sentinelRow) {
+        throw new Error('Failed to create sentinel profile user');
+      }
+
+      await db.insert(profileUserToAccessRoles).values({
+        profileUserId: sentinelRow.id,
+        accessRoleId: customRole.id,
+      });
+
+      onTestFinished(async () => {
+        await db
+          .delete(profileUsers)
+          .where(eq(profileUsers.id, sentinelRow.id));
+        await db.delete(accessRoles).where(eq(accessRoles.id, customRole.id));
+      });
+
+      const { session } = await createIsolatedSession(adminUser.email);
+      const caller = createCaller(await createTestContextWithSession(session));
+
+      const result = await caller.listRoles({
+        profileId: profile.id,
+        includeMemberCounts: true,
+        limit: 100,
+      });
+
+      // Only the real member is counted; the sentinel is excluded.
+      expect(
+        result.items.find((r) => r.id === customRole.id)?.memberCount,
+      ).toBe(1);
+    });
   });
 });
 

--- a/services/api/src/routers/profile/listRoles.test.ts
+++ b/services/api/src/routers/profile/listRoles.test.ts
@@ -48,6 +48,9 @@ describe.concurrent('profile.listRoles', () => {
     const memberRole = result.items.find((r) => r.id === ROLES.MEMBER.id);
     expect(adminRole).toBeDefined();
     expect(memberRole).toBeDefined();
+    expect(result.items.every((role) => role.memberCount === undefined)).toBe(
+      true,
+    );
   });
 
   it('should not expose non-exposable global roles (e.g. system roles like Public)', async ({

--- a/services/api/src/routers/profile/listRoles.test.ts
+++ b/services/api/src/routers/profile/listRoles.test.ts
@@ -444,8 +444,8 @@ describe.concurrent('profile.listRoles', () => {
     expect(result.next).toBeNull();
   });
 
-  describe('includeMemberCounts', () => {
-    it('should include per-role member counts when includeMemberCounts is set', async ({
+  describe('member counts', () => {
+    it('should include per-role member counts by default', async ({
       task,
       onTestFinished,
     }) => {
@@ -486,7 +486,6 @@ describe.concurrent('profile.listRoles', () => {
       // Simple branch (no zoneName)
       const result = await caller.listRoles({
         profileId: profile.id,
-        includeMemberCounts: true,
         limit: 100,
       });
 
@@ -501,7 +500,6 @@ describe.concurrent('profile.listRoles', () => {
       const zoneResult = await caller.listRoles({
         profileId: profile.id,
         zoneName: ZONES.PROFILE.name,
-        includeMemberCounts: true,
         limit: 100,
       });
 
@@ -511,15 +509,6 @@ describe.concurrent('profile.listRoles', () => {
       expect(
         zoneResult.items.find((r) => r.id === emptyRole.id)?.memberCount,
       ).toBe(0);
-
-      // Counts are opt-in: absent without the flag
-      const withoutFlag = await caller.listRoles({
-        profileId: profile.id,
-        limit: 100,
-      });
-      expect(
-        withoutFlag.items.find((r) => r.id === heldRole.id)?.memberCount,
-      ).toBeUndefined();
     });
 
     it('should exclude global sentinel users from member counts', async ({
@@ -582,7 +571,6 @@ describe.concurrent('profile.listRoles', () => {
 
       const result = await caller.listRoles({
         profileId: profile.id,
-        includeMemberCounts: true,
         limit: 100,
       });
 

--- a/services/api/src/routers/profile/listRoles.ts
+++ b/services/api/src/routers/profile/listRoles.ts
@@ -15,6 +15,7 @@ const inputSchema = z
   .object({
     profileId: z.string().uuid().optional(),
     zoneName: z.string().optional(),
+    includeMemberCounts: z.boolean().optional(),
   })
   .merge(paginationSchema)
   .merge(roleSortableSchema);
@@ -24,11 +25,13 @@ export const listRolesRouter = router({
     .input(inputSchema)
     .output(createPaginatedOutput(roleEncoder))
     .query(async ({ input }) => {
-      const { profileId, zoneName, cursor, limit, dir } = input;
+      const { profileId, zoneName, includeMemberCounts, cursor, limit, dir } =
+        input;
 
       return getRoles({
         profileId,
         zoneName,
+        includeMemberCounts,
         cursor,
         limit,
         dir,

--- a/services/api/src/routers/profile/listRoles.ts
+++ b/services/api/src/routers/profile/listRoles.ts
@@ -15,7 +15,6 @@ const inputSchema = z
   .object({
     profileId: z.string().uuid().optional(),
     zoneName: z.string().optional(),
-    includeMemberCounts: z.boolean().optional(),
   })
   .merge(paginationSchema)
   .merge(roleSortableSchema);
@@ -25,13 +24,11 @@ export const listRolesRouter = router({
     .input(inputSchema)
     .output(createPaginatedOutput(roleEncoder))
     .query(async ({ input }) => {
-      const { profileId, zoneName, includeMemberCounts, cursor, limit, dir } =
-        input;
+      const { profileId, zoneName, cursor, limit, dir } = input;
 
       return getRoles({
         profileId,
         zoneName,
-        includeMemberCounts,
         cursor,
         limit,
         dir,

--- a/services/api/src/routers/profile/users/listUsers.test.ts
+++ b/services/api/src/routers/profile/users/listUsers.test.ts
@@ -1,6 +1,6 @@
 import { GLOBAL_USER_PUBLIC } from '@op/core';
 import { db, eq } from '@op/db/client';
-import { profileUsers } from '@op/db/schema';
+import { accessRoles, profileUsers } from '@op/db/schema';
 import { ROLES } from '@op/db/seedData/accessControl';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -689,6 +689,134 @@ describe.concurrent('profile.users.listUsers', () => {
       // Admin should be first (A < M alphabetically)
       expect(allEmails[0]).toBe(adminUser.email);
     });
+  });
+
+  describe('roleId filter', () => {
+    it('should return only members holding the given role', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+      const { profile, adminUser, memberUsers } = await testData.createProfile({
+        users: { admin: 1, member: 2 },
+      });
+
+      const { session } = await createIsolatedSession(adminUser.email);
+      const caller = createCaller(await createTestContextWithSession(session));
+
+      const membersResult = await caller.listUsers({
+        profileId: profile.id,
+        roleId: ROLES.MEMBER.id,
+      });
+
+      expect(membersResult.items).toHaveLength(2);
+      const memberEmails = membersResult.items.map((u) => u.email);
+      expect(memberEmails).toContain(memberUsers[0]?.email);
+      expect(memberEmails).toContain(memberUsers[1]?.email);
+      expect(memberEmails).not.toContain(adminUser.email);
+
+      const adminsResult = await caller.listUsers({
+        profileId: profile.id,
+        roleId: ROLES.ADMIN.id,
+      });
+
+      expect(adminsResult.items).toHaveLength(1);
+      expect(adminsResult.items[0]?.email).toBe(adminUser.email);
+    });
+
+    it('should return empty results for a role no member holds', async ({
+      task,
+      onTestFinished,
+    }) => {
+      const testData = new TestProfileUserDataManager(task.id, onTestFinished);
+      const { profile, adminUser } = await testData.createProfile({
+        users: { admin: 1, member: 1 },
+      });
+
+      // A custom role for this profile that nobody holds
+      const [customRole] = await db
+        .insert(accessRoles)
+        .values({
+          name: `Unassigned Role ${task.id}`,
+          profileId: profile.id,
+        })
+        .returning();
+
+      if (!customRole) {
+        throw new Error('Failed to create custom role');
+      }
+
+      onTestFinished(async () => {
+        await db.delete(accessRoles).where(eq(accessRoles.id, customRole.id));
+      });
+
+      const { session } = await createIsolatedSession(adminUser.email);
+      const caller = createCaller(await createTestContextWithSession(session));
+
+      const result = await caller.listUsers({
+        profileId: profile.id,
+        roleId: customRole.id,
+      });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.next).toBeNull();
+    });
+
+    it(
+      'should paginate with roleId across multiple pages without duplicates or gaps',
+      { timeout: 120_000 },
+      async ({ task, onTestFinished }) => {
+        const testData = new TestProfileUserDataManager(
+          task.id,
+          onTestFinished,
+        );
+        const { profile, adminUser, memberUsers } =
+          await testData.createProfile({
+            users: { admin: 1, member: 28 },
+          });
+
+        const { session } = await createIsolatedSession(adminUser.email);
+        const caller = createCaller(
+          await createTestContextWithSession(session),
+        );
+
+        // Collect all member emails across pages
+        const allEmails: string[] = [];
+        let cursor: string | null | undefined;
+        let pageCount = 0;
+
+        do {
+          const page = await caller.listUsers({
+            profileId: profile.id,
+            roleId: ROLES.MEMBER.id,
+            limit: 25,
+            cursor: cursor ?? undefined,
+            orderBy: 'email',
+            dir: 'asc',
+          });
+
+          allEmails.push(...page.items.map((u) => u.email!));
+          cursor = page.next;
+          pageCount++;
+
+          // Safety check to prevent infinite loops
+          if (pageCount > 10) {
+            throw new Error('Too many pages - possible infinite loop');
+          }
+        } while (cursor);
+
+        // All 28 members returned exactly once; the admin is filtered out
+        expect(allEmails).toHaveLength(28);
+        expect(new Set(allEmails).size).toBe(28);
+        expect(allEmails).not.toContain(adminUser.email);
+        memberUsers.forEach((m) => {
+          expect(allEmails).toContain(m.email);
+        });
+
+        // 28 members with limit 25 -> exactly 2 pages
+        expect(pageCount).toBe(2);
+      },
+    );
   });
 });
 

--- a/services/api/src/routers/profile/users/listUsers.ts
+++ b/services/api/src/routers/profile/users/listUsers.ts
@@ -14,6 +14,7 @@ export const listUsersRouter = router({
         .object({
           profileId: z.uuid(),
           query: z.string().min(2).optional(),
+          roleId: z.uuid().optional(),
           cursor: z.string().nullish(),
           limit: z.number().min(1).max(100).optional(),
         })
@@ -27,7 +28,7 @@ export const listUsersRouter = router({
     )
     .query(async ({ ctx, input }) => {
       const { user } = ctx;
-      const { profileId, orderBy, dir, query, cursor, limit } = input;
+      const { profileId, orderBy, dir, query, roleId, cursor, limit } = input;
 
       return listProfileUsers({
         profileId,
@@ -35,6 +36,7 @@ export const listUsersRouter = router({
         orderBy,
         dir,
         query,
+        roleId,
         cursor,
         limit,
       });


### PR DESCRIPTION
Asana: https://app.asana.com/1/1108348036672214/project/1211387328265612/task/1217093803809976

## Problem

The invite modal fetched only the **first page** of `profile.listUsers` (limit 25) and filtered members by role client-side — so for large processes (251-member stress test) the per-role "People with access" lists and tab badge counts were silently wrong, and loading all members client-side doesn't scale.

## Fix

Server-side per-role pagination:

- **`listProfileUsers`** gains an optional `roleId` filter — a purely additive `IN`-subquery over `profileUser_to_access_roles`. **No cursor/keyset/orderBy code touched**, so this composes cleanly with #1657's cursor rewrite (whichever lands second rebases trivially).
- **`profile.listUsers`** router accepts `roleId`.
- **`getRoles` / `profile.listRoles`** gain opt-in `includeMemberCounts` — one grouped count query per call (junction ⋈ profileUsers, `excludeGlobalUsers` applied, matching `listProfileUsers` semantics) so tab badges no longer require loading all members.
- **`ProfileInviteModal`**: per-role `useInfiniteQuery` (React Query caches per input key → each role tab paginates independently, switching tabs preserves loaded pages), bounded scrollable list with `useInfiniteScroll` trigger, skeleton rows while the first page loads. Badge = server `memberCount` + staged + pending invites.
- Client-side duplicate-exclusion (search dropdown, paste, add-email) now only sees loaded pages — acceptable since `inviteUsersToProfile` dedupes authoritatively server-side.

## Tests

- `users/listUsers.test.ts`: roleId filtering, empty for unheld role, 28-member cursor pagination across 2 pages (no dupes/gaps).
- `listRoles.test.ts`: memberCount correctness in both query branches, absent without the flag, global-user sentinel excluded.

44/44 pass locally; `pnpm typecheck` + `pnpm format:check` clean.

## Out of scope

- `listProfileInvites` remains unpaginated (invite volume is small).
- `ProfileUsersAccess` (Manage Participants table) unchanged.