### PR TITLE
fix(admin): resolve proposal titles from the proposal profile

### DIFF
--- a/services/api/src/routers/platform/admin/assignReviews.test.ts
+++ b/services/api/src/routers/platform/admin/assignReviews.test.ts
@@ -1,6 +1,12 @@
 import { createDecisionRole } from '@op/common';
 import { db, eq } from '@op/db/client';
-import { ProcessStatus, ProposalStatus, processInstances } from '@op/db/schema';
+import {
+  ProcessStatus,
+  ProposalStatus,
+  processInstances,
+  profiles,
+  proposals,
+} from '@op/db/schema';
 import { describe, expect, it } from 'vitest';
 
 import { platformAdminRouter } from '.';
@@ -167,6 +173,47 @@ describe.concurrent('platform.admin.assignReviews', () => {
 
     // Dialog candidates come back too.
     expect(listing.proposals.map((p) => p.id)).toContain(proposal.id);
+  });
+
+  it('resolves titles from the proposal profile, not stale proposalData', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const { instanceId, proposal, phaseId, caller, reviewer } =
+      await createSetupWithProposal(task.id, onTestFinished);
+
+    // Edits write the title only to the proposal's profile (updateProposal
+    // strips it from proposalData), so proposalData.title goes stale.
+    const editedTitle = `Edited title ${task.id}`;
+    await db
+      .update(profiles)
+      .set({ name: editedTitle })
+      .where(eq(profiles.id, proposal.profileId));
+    const { title: _stale, ...dataWithoutTitle } =
+      proposal.proposalData as Record<string, unknown>;
+    await db
+      .update(proposals)
+      .set({ proposalData: dataWithoutTitle })
+      .where(eq(proposals.id, proposal.id));
+
+    await caller.assignReviews({
+      instanceId,
+      phaseId,
+      reviewerProfileId: reviewer.profileId,
+      proposalIds: [proposal.id],
+    });
+
+    const listing = await caller.listDecisionReviewAssignments({
+      instanceId,
+      phaseId,
+    });
+
+    expect(listing.reviewers[0]?.assignments[0]?.proposalTitle).toBe(
+      editedTitle,
+    );
+    expect(listing.proposals.find((p) => p.id === proposal.id)?.title).toBe(
+      editedTitle,
+    );
   });
 
   it('never assigns a reviewer their own proposal', async ({

--- a/services/api/src/routers/platform/admin/listDecisionReviewAssignments.ts
+++ b/services/api/src/routers/platform/admin/listDecisionReviewAssignments.ts
@@ -4,7 +4,7 @@ import {
   getProposalIdsForPhase,
 } from '@op/common';
 import { adminDecisionReviewAssignmentsSchema } from '@op/common/client';
-import { db, eq, inArray } from '@op/db/client';
+import { aliasedTable, db, eq, inArray } from '@op/db/client';
 import { profiles, proposals, users } from '@op/db/schema';
 import { z } from 'zod';
 
@@ -71,7 +71,10 @@ export const listDecisionReviewAssignmentsRouter = router({
               reviews: {
                 columns: { state: true, submittedAt: true },
               },
-              proposal: { columns: { id: true, proposalData: true } },
+              proposal: {
+                columns: { id: true, proposalData: true },
+                with: { profile: { columns: { name: true } } },
+              },
             },
             orderBy: { assignedAt: 'asc' },
           }),
@@ -86,12 +89,17 @@ export const listDecisionReviewAssignmentsRouter = router({
           getProposalIdsForPhase({ instance, phaseId: input.phaseId }),
         ]);
 
+      // The proposal's own profile holds the canonical title (profiles.name);
+      // proposalData.title is only kept as a legacy fallback since edits write
+      // the title to the profile, not into proposalData.
+      const proposalProfiles = aliasedTable(profiles, 'proposal_profiles');
       const assignableProposals =
         phaseProposalIds.length > 0
           ? await db
               .select({
                 id: proposals.id,
                 proposalData: proposals.proposalData,
+                profileName: proposalProfiles.name,
                 submittedByProfileId: proposals.submittedByProfileId,
                 authorId: profiles.id,
                 authorName: profiles.name,
@@ -101,6 +109,10 @@ export const listDecisionReviewAssignmentsRouter = router({
               .leftJoin(
                 profiles,
                 eq(proposals.submittedByProfileId, profiles.id),
+              )
+              .leftJoin(
+                proposalProfiles,
+                eq(proposals.profileId, proposalProfiles.id),
               )
               .where(inArray(proposals.id, phaseProposalIds))
           : [];
@@ -159,9 +171,9 @@ export const listDecisionReviewAssignmentsRouter = router({
         reviewer.assignments.push({
           id: assignment.id,
           proposalId: assignment.proposal.id,
-          proposalTitle: titleParsed.success
-            ? (titleParsed.data.title ?? null)
-            : null,
+          proposalTitle:
+            assignment.proposal.profile.name ??
+            (titleParsed.success ? (titleParsed.data.title ?? null) : null),
           status: assignment.status,
           reviewState: review?.state ?? null,
           submittedAt: review?.submittedAt ?? null,
@@ -188,9 +200,9 @@ export const listDecisionReviewAssignmentsRouter = router({
           );
           return {
             id: proposal.id,
-            title: titleParsed.success
-              ? (titleParsed.data.title ?? null)
-              : null,
+            title:
+              proposal.profileName ??
+              (titleParsed.success ? (titleParsed.data.title ?? null) : null),
             submittedByProfileId: proposal.submittedByProfileId,
             author: proposal.authorId
               ? {


### PR DESCRIPTION
The admin review assignments listing showed every edited proposal as "Untitled proposal" because it read the title from proposalData, which goes stale on first edit — the profile name is the canonical title.