### PR TITLE
feat(decisions): show dropdown options in builder previews

### DIFF
--- a/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeDropdownField.tsx
@@ -1,14 +1,11 @@
 'use client';
 
 import { useCollaborativeFragment } from '@/hooks/useCollaborativeFragment';
-import { Select, SelectItem } from '@op/ui/Select';
-import { useEffect, useRef, type Key } from 'react';
+import { useEffect, useRef } from 'react';
 
-import { useTranslations } from '@/lib/i18n';
+import { DropdownFieldSelect } from '@/components/form/DropdownFieldSelect';
 
 import { useCollaborativeDoc } from './CollaborativeDocContext';
-
-const EMPTY_KEY = '__none__';
 
 interface CollaborativeDropdownFieldProps {
   options: Array<{ value: string; label: string }>;
@@ -37,7 +34,6 @@ export function CollaborativeDropdownField({
   allowEmpty = false,
   required = false,
 }: CollaborativeDropdownFieldProps) {
-  const t = useTranslations();
   const { ydoc } = useCollaborativeDoc();
 
   const [syncedText, setSyncedText] = useCollaborativeFragment(
@@ -64,45 +60,14 @@ export function CollaborativeDropdownField({
     onChangeRef.current?.(selectedValue);
   }, [selectedValue]);
 
-  if (options.length === 0) {
-    return null;
-  }
-
-  const handleSelectionChange = (key: Key | null) => {
-    if (key === null) {
-      setSelectedValue(null);
-      return;
-    }
-    const value = String(key);
-    if (value === EMPTY_KEY) {
-      setSelectedValue(null);
-    } else {
-      setSelectedValue(value);
-    }
-  };
-
   return (
-    <Select
-      variant="pill"
-      size="medium"
-      isRequired={required}
-      placeholder={placeholder ?? t('Select option')}
+    <DropdownFieldSelect
+      options={options}
       selectedKey={selectedValue}
-      onSelectionChange={handleSelectionChange}
-      selectValueClassName="text-primary-teal data-[placeholder]:text-primary-teal"
-      className="w-fit max-w-full"
-      popoverProps={{ className: 'sm:min-w-fit sm:max-w-2xl' }}
-    >
-      {allowEmpty && (
-        <SelectItem className="min-w-fit" key={EMPTY_KEY} id={EMPTY_KEY}>
-          {t('None')}
-        </SelectItem>
-      )}
-      {options.map((opt) => (
-        <SelectItem className="min-w-fit" key={opt.value} id={opt.value}>
-          {opt.label}
-        </SelectItem>
-      ))}
-    </Select>
+      onSelectionChange={setSelectedValue}
+      placeholder={placeholder}
+      allowEmpty={allowEmpty}
+      required={required}
+    />
   );
 }

--- a/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeMultiSelectField.tsx
@@ -2,18 +2,9 @@
 
 import { useCollaborativeFragment } from '@/hooks/useCollaborativeFragment';
 import { parseCategoryFragmentValue } from '@op/common/client';
-import { Button } from '@op/ui/Button';
-import { DialogTrigger } from '@op/ui/Dialog';
-import { ListBox } from '@op/ui/ListBox';
-import { Popover } from '@op/ui/Popover';
-import { Tag, TagGroup } from '@op/ui/TagGroup';
 import { useEffect, useMemo, useRef } from 'react';
-import type { Key } from 'react';
-import { Dialog, ListBoxItem } from 'react-aria-components';
-import type { Selection } from 'react-aria-components';
-import { LuCheck } from 'react-icons/lu';
 
-import { useTranslations } from '@/lib/i18n';
+import { MultiSelectPopoverField } from '@/components/form/MultiSelectPopoverField';
 
 import { useCollaborativeDoc } from './CollaborativeDocContext';
 
@@ -41,7 +32,6 @@ export function CollaborativeMultiSelectField({
   fragmentName,
   placeholder,
 }: CollaborativeMultiSelectFieldProps) {
-  const t = useTranslations();
   const { ydoc } = useCollaborativeDoc();
   const [syncedValue, setSyncedValue] = useCollaborativeFragment(
     ydoc,
@@ -52,11 +42,6 @@ export function CollaborativeMultiSelectField({
   const selectedValues = useMemo(
     () => parseCategoryFragmentValue(syncedValue),
     [syncedValue],
-  );
-  const selectedKeys = useMemo(() => new Set(selectedValues), [selectedValues]);
-  const selectedOptions = useMemo(
-    () => options.filter((option) => selectedValues.includes(option.value)),
-    [options, selectedValues],
   );
 
   const onChangeRef = useRef(onChange);
@@ -76,95 +61,12 @@ export function CollaborativeMultiSelectField({
     onChangeRef.current?.(selectedValues);
   }, [selectedValues]);
 
-  const handleSelectionChange = (keys: Selection) => {
-    if (keys === 'all') {
-      setSyncedValue(JSON.stringify(options.map((o) => o.value)));
-      return;
-    }
-    const nextValues = options
-      .map((option) => option.value)
-      .filter((value) => keys.has(value));
-    setSyncedValue(JSON.stringify(nextValues));
-  };
-
-  const handleTagRemove = (keys: Set<Key>) => {
-    setSyncedValue(
-      JSON.stringify(selectedValues.filter((value) => !keys.has(value))),
-    );
-  };
-
-  const buttonLabel =
-    selectedOptions.length === 0
-      ? (placeholder ?? t('Select option'))
-      : selectedOptions.length === 1
-        ? t('1 category selected')
-        : t('{count} categories selected', { count: selectedOptions.length });
-
-  if (options.length === 0) {
-    return null;
-  }
-
   return (
-    <div className="flex flex-col gap-1.5">
-      <DialogTrigger>
-        <Button
-          variant="pill"
-          color="pill"
-          className="w-fit justify-start text-start pressed:bg-primary-tealWhite pressed:text-primary-teal pressed:!shadow-none"
-        >
-          {buttonLabel}
-        </Button>
-        <Popover
-          placement="bottom start"
-          className="min-w-(--trigger-width) overflow-hidden rounded border bg-white shadow"
-        >
-          <Dialog className="outline-hidden">
-            <ListBox
-              aria-label={placeholder ?? t('Select option')}
-              items={options.map((option) => ({
-                id: option.value,
-                label: option.label,
-              }))}
-              selectionMode="multiple"
-              selectedKeys={selectedKeys}
-              onSelectionChange={handleSelectionChange}
-              className="max-h-60 overflow-auto rounded border-0 p-2 outline-hidden"
-            >
-              {(item) => (
-                <ListBoxItem
-                  id={item.id}
-                  textValue={item.label}
-                  className="group flex cursor-pointer items-center gap-4 rounded px-3 py-2 text-neutral-black outline-hidden select-none data-[focus-visible]:bg-neutral-gray1 data-[hovered]:bg-neutral-gray1"
-                >
-                  <span className="flex h-full flex-1 items-center gap-2 font-normal">
-                    {item.label}
-                  </span>
-                  <span className="flex w-5 items-center">
-                    <LuCheck
-                      aria-hidden
-                      className="size-4 opacity-0 group-selected:opacity-100"
-                    />
-                  </span>
-                </ListBoxItem>
-              )}
-            </ListBox>
-          </Dialog>
-        </Popover>
-      </DialogTrigger>
-      {selectedOptions.length > 0 && (
-        <TagGroup onRemove={handleTagRemove}>
-          {selectedOptions.map((option) => (
-            <Tag
-              key={option.value}
-              id={option.value}
-              textValue={option.label}
-              className="text-base leading-none"
-            >
-              {option.label}
-            </Tag>
-          ))}
-        </TagGroup>
-      )}
-    </div>
+    <MultiSelectPopoverField
+      options={options}
+      selectedValues={selectedValues}
+      onSelectionChange={(values) => setSyncedValue(JSON.stringify(values))}
+      placeholder={placeholder}
+    />
   );
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
@@ -6,13 +6,13 @@ import {
   parseSchemaOptions,
 } from '@op/common/client';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
-import { Select } from '@op/ui/Select';
 import { ToggleButton } from '@op/ui/ToggleButton';
 import { LuPlus } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
 import { FieldHeader } from '../../../forms/FieldHeader';
+import { RubricCriterionSelect } from '../../../forms/RubricCriterionSelect';
 import type { FieldDescriptor } from '../../../forms/types';
 
 /** Yes/no field: `type: "string"` with exactly `"yes"` and `"no"` oneOf entries. */
@@ -43,7 +43,7 @@ function RationalePlaceholder() {
   const t = useTranslations();
 
   return (
-    <div className="flex items-center gap-1 px-2 py-1.5 text-base text-primary-teal">
+    <div className="pointer-events-none flex items-center gap-1 px-2 py-1.5 text-base text-primary-teal select-none">
       <LuPlus className="size-4" />
       {t('Add Note')}
     </div>
@@ -99,10 +99,12 @@ function RubricField({ field }: { field: FieldDescriptor }) {
       }
 
       // Non-scored dropdowns (single-select included) fall through to the
-      // generic pill select placeholder below, with no points badge.
-      const badge = isScoredField(schema)
-        ? `${schema.maximum} ${t('pts')}`
-        : undefined;
+      // generic pill select below, with no points badge.
+      const scored = isScoredField(schema);
+      const badge = scored ? `${schema.maximum} ${t('pts')}` : undefined;
+      const optionsKey = parseSchemaOptions(schema)
+        .map((option) => String(option.value))
+        .join('|');
 
       return (
         <div className="flex flex-col gap-3">
@@ -112,15 +114,15 @@ function RubricField({ field }: { field: FieldDescriptor }) {
             badge={badge}
             className="gap-1"
           />
-          <Select
+          <RubricCriterionSelect
+            key={optionsKey}
+            schema={schema}
+            kind={scored ? 'scored' : 'single_select'}
             variant="pill"
             size="medium"
-            placeholder={t('Select option')}
             selectValueClassName="text-primary-teal data-[placeholder]:text-primary-teal"
             className="w-fit max-w-full"
-          >
-            {[]}
-          </Select>
+          />
         </div>
       );
     }
@@ -149,9 +151,10 @@ function RubricField({ field }: { field: FieldDescriptor }) {
 }
 
 /**
- * Static read-only preview of rubric fields.
- * Shows field labels and placeholder inputs — no interactivity.
- * Rationale placeholder is rendered under every criterion.
+ * Preview of rubric fields for the builder sidebar.
+ * Dropdown, yes/no, and overall-recommendation controls are fully
+ * interactive (uncontrolled, never persisted) so builders can see and try
+ * the options they've configured. The rationale placeholder stays inert.
  */
 export function RubricFormPreviewRenderer({
   fields,
@@ -159,7 +162,7 @@ export function RubricFormPreviewRenderer({
   fields: FieldDescriptor[];
 }) {
   return (
-    <div className="pointer-events-none flex flex-col gap-6">
+    <div className="flex flex-col gap-6">
       {fields.map((field) => (
         <div key={field.key} className="flex flex-col gap-4">
           <RubricField field={field} />

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -10,7 +10,6 @@ import {
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Button } from '@op/ui/Button';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
-import { Select, SelectItem } from '@op/ui/Select';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
 import type { Key } from 'react';
@@ -20,6 +19,7 @@ import { LuCircleAlert, LuPlus } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 
 import { FieldHeader } from '../forms/FieldHeader';
+import { RubricCriterionSelect } from '../forms/RubricCriterionSelect';
 import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
 import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
@@ -351,88 +351,33 @@ function RubricFieldInput({
       }
 
       if (criterionType === 'single_select') {
-        const options = parseSchemaOptions(field.schema);
         return (
-          <Select
-            aria-label={field.schema.title}
-            placeholder={t('Select an option')}
+          <RubricCriterionSelect
+            schema={field.schema}
+            kind="single_select"
             selectedKey={typeof value === 'string' ? value : null}
             onSelectionChange={(key) => {
               onChange(key === null ? null : String(key));
             }}
-            className="w-full"
-          >
-            {options.map((option) => {
-              const label = option.title || String(option.value);
-              return (
-                <SelectItem
-                  key={String(option.value)}
-                  id={String(option.value)}
-                  textValue={label}
-                >
-                  {option.description ? (
-                    <div className="flex flex-col">
-                      <span>{label}</span>
-                      <span className="text-sm text-neutral-gray4">
-                        {option.description}
-                      </span>
-                    </div>
-                  ) : (
-                    label
-                  )}
-                </SelectItem>
-              );
-            })}
-          </Select>
+          />
         );
       }
 
       if (criterionType === 'scored') {
-        // Highest score first (to match the process builder); each option
-        // renders the score with its description below so reviewers can
-        // tell options apart on long scales.
-        const options = [...parseSchemaOptions(field.schema)].sort(
-          (a, b) => Number(b.value) - Number(a.value),
-        );
         const selectedKey =
           typeof value === 'string' || typeof value === 'number'
             ? String(value)
             : null;
 
         return (
-          <Select
-            aria-label={field.schema.title}
-            placeholder={t('Select an option')}
+          <RubricCriterionSelect
+            schema={field.schema}
+            kind="scored"
             selectedKey={selectedKey}
             onSelectionChange={(key) => {
               onChange(parseSelectedValue(key, field.schema));
             }}
-            className="w-full"
-          >
-            {options.map((option) => {
-              const triggerLabel = option.title
-                ? `${option.value} - ${option.title}`
-                : String(option.value);
-              return (
-                <SelectItem
-                  key={String(option.value)}
-                  id={String(option.value)}
-                  textValue={triggerLabel}
-                >
-                  {option.title ? (
-                    <div className="flex flex-col">
-                      <span>{option.value}</span>
-                      <span className="text-sm text-neutral-gray4">
-                        {option.title}
-                      </span>
-                    </div>
-                  ) : (
-                    String(option.value)
-                  )}
-                </SelectItem>
-              );
-            })}
-          </Select>
+          />
         );
       }
 

--- a/apps/app/src/components/decisions/forms/RubricCriterionSelect.tsx
+++ b/apps/app/src/components/decisions/forms/RubricCriterionSelect.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import type { XFormatPropertySchema } from '@op/common/client';
+import { parseSchemaOptions } from '@op/common/client';
+import { Select, SelectItem } from '@op/ui/Select';
+import type { Key } from 'react';
+
+import { useTranslations } from '@/lib/i18n';
+
+/**
+ * Shared select control for a scored or single-select rubric criterion.
+ * Used by the live review form and, uncontrolled, by the builder preview —
+ * keeping both in lockstep so the preview never drifts from what reviewers
+ * actually see.
+ */
+export function RubricCriterionSelect({
+  schema,
+  kind,
+  selectedKey,
+  onSelectionChange,
+  variant,
+  size,
+  className = 'w-full',
+  selectValueClassName,
+  placeholder,
+}: {
+  schema: XFormatPropertySchema;
+  kind: 'scored' | 'single_select';
+  selectedKey?: string | null;
+  onSelectionChange?: (key: Key | null) => void;
+  variant?: 'default' | 'pill';
+  size?: 'small' | 'medium';
+  className?: string;
+  selectValueClassName?: string;
+  placeholder?: string;
+}) {
+  const t = useTranslations();
+
+  const options =
+    kind === 'scored'
+      ? [...parseSchemaOptions(schema)].sort(
+          (a, b) => Number(b.value) - Number(a.value),
+        )
+      : parseSchemaOptions(schema);
+
+  return (
+    <Select
+      aria-label={schema.title}
+      placeholder={placeholder ?? t('Select an option')}
+      selectedKey={selectedKey}
+      onSelectionChange={onSelectionChange}
+      isDisabled={options.length === 0}
+      variant={variant}
+      size={size}
+      selectValueClassName={selectValueClassName}
+      className={className}
+    >
+      {options.map((option) => {
+        if (kind === 'scored') {
+          const triggerLabel = option.title
+            ? `${option.value} - ${option.title}`
+            : String(option.value);
+
+          return (
+            <SelectItem
+              key={String(option.value)}
+              id={String(option.value)}
+              textValue={triggerLabel}
+            >
+              {option.title ? (
+                <div className="flex flex-col">
+                  <span>{option.value}</span>
+                  <span className="text-sm text-neutral-gray4">
+                    {option.title}
+                  </span>
+                </div>
+              ) : (
+                String(option.value)
+              )}
+            </SelectItem>
+          );
+        }
+
+        const label = option.title || String(option.value);
+
+        return (
+          <SelectItem
+            key={String(option.value)}
+            id={String(option.value)}
+            textValue={label}
+          >
+            {option.description ? (
+              <div className="flex flex-col">
+                <span>{label}</span>
+                <span className="text-sm text-neutral-gray4">
+                  {option.description}
+                </span>
+              </div>
+            ) : (
+              label
+            )}
+          </SelectItem>
+        );
+      })}
+    </Select>
+  );
+}

--- a/apps/app/src/components/decisions/proposalEditor/PreviewProposalFields.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/PreviewProposalFields.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+
+import { DropdownFieldSelect } from '@/components/form/DropdownFieldSelect';
+import { MultiSelectPopoverField } from '@/components/form/MultiSelectPopoverField';
+
+import { FieldHeader } from '../forms/FieldHeader';
+
+type Option = { value: string; label: string };
+
+/**
+ * Interactive (uncontrolled, local-only) dropdown for the template builder
+ * preview. Renders the same `DropdownFieldSelect` participants see, reset
+ * whenever the authored option set changes.
+ */
+export function PreviewDropdownField({
+  options,
+  title,
+  description,
+  required,
+  placeholder,
+}: {
+  options: Option[];
+  title?: string;
+  description?: string;
+  required?: boolean;
+  placeholder: string;
+}) {
+  const optionsKey = options.map((opt) => opt.value).join('|');
+  const content = (
+    <DropdownFieldSelect
+      key={optionsKey}
+      options={options}
+      placeholder={placeholder}
+      allowEmpty={!required}
+      required={required}
+    />
+  );
+
+  if (!title && !description) {
+    return content;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <FieldHeader
+        title={title}
+        description={description}
+        required={required}
+      />
+      {content}
+    </div>
+  );
+}
+
+/**
+ * Interactive (local-only) multi-select popover for the template builder
+ * preview. Selection is never persisted or reported to the parent form.
+ */
+export function PreviewMultiSelectField({
+  options,
+  placeholder,
+}: {
+  options: Option[];
+  placeholder: string;
+}) {
+  const optionsKey = options.map((opt) => opt.value).join('|');
+  // Reset the local selection when the authored option set changes, without
+  // needing the caller to key this component instance.
+  const [state, setState] = useState({ optionsKey, values: [] as string[] });
+  if (state.optionsKey !== optionsKey) {
+    setState({ optionsKey, values: [] });
+  }
+
+  return (
+    <div className="min-w-0">
+      <MultiSelectPopoverField
+        options={options}
+        selectedValues={state.values}
+        onSelectionChange={(values) => setState({ optionsKey, values })}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}

--- a/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/ProposalFormRenderer.tsx
@@ -26,6 +26,10 @@ import { FieldHeader } from '../forms/FieldHeader';
 import type { FieldDescriptor } from '../forms/types';
 import { LocationMapView } from '../location/LocationMapView';
 import {
+  PreviewDropdownField,
+  PreviewMultiSelectField,
+} from './PreviewProposalFields';
+import {
   ReadonlyBudgetField,
   ReadonlyDropdownField,
   ReadonlyTextField,
@@ -218,6 +222,27 @@ function renderField(
     const isMultipleSelection = schemaAllowsMultipleSelection(schema);
 
     if (isReadonlyMode) {
+      if (mode === 'preview-template') {
+        // District categories are auto-assigned from the proposal's
+        // location, so they're hidden here too (see the same filter below).
+        const selectableOptions = options.filter(
+          (opt) => !isDistrictCategoryLabel(opt.label),
+        );
+
+        return isMultipleSelection ? (
+          <PreviewMultiSelectField
+            options={selectableOptions}
+            placeholder={t('Select category')}
+          />
+        ) : (
+          <PreviewDropdownField
+            options={selectableOptions}
+            required={field.required}
+            placeholder={t('Select category')}
+          />
+        );
+      }
+
       const selectedValues = getPreviewCategories({
         mode,
         draftValue: draft.category,
@@ -404,6 +429,18 @@ function renderField(
       const options = extractOptions(schema);
 
       if (isReadonlyMode) {
+        if (mode === 'preview-template') {
+          return (
+            <PreviewDropdownField
+              options={options}
+              title={schema.title}
+              description={schema.description}
+              required={field.required}
+              placeholder={t('Select option')}
+            />
+          );
+        }
+
         const selectedValue = getPreviewText({
           mode,
           draftValue: (draft[key] as string | null) ?? null,

--- a/apps/app/src/components/form/DropdownFieldSelect.tsx
+++ b/apps/app/src/components/form/DropdownFieldSelect.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Select, SelectItem } from '@op/ui/Select';
+import type { Key } from 'react';
+
+import { useTranslations } from '@/lib/i18n';
+
+const EMPTY_KEY = '__none__';
+
+export interface DropdownFieldSelectProps {
+  options: Array<{ value: string; label: string }>;
+  /** Omit for an uncontrolled select (e.g. a builder preview). */
+  selectedKey?: string | null;
+  /** Receives `null` for both the "None" item and RAC's own clear action. */
+  onSelectionChange?: (value: string | null) => void;
+  placeholder?: string;
+  /** When true, prepends a "None" option that clears the selection back to null. */
+  allowEmpty?: boolean;
+  /** When true, sets `aria-required` on the select for assistive tech. */
+  required?: boolean;
+}
+
+/**
+ * Presentational pill select for a single dropdown value. Shared by the
+ * collaborative proposal editor and the template builder preview so both
+ * stay visually and behaviorally in sync.
+ */
+export function DropdownFieldSelect({
+  options,
+  selectedKey,
+  onSelectionChange,
+  placeholder,
+  allowEmpty = false,
+  required = false,
+}: DropdownFieldSelectProps) {
+  const t = useTranslations();
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  const handleSelectionChange = (key: Key | null) => {
+    if (key === null) {
+      onSelectionChange?.(null);
+      return;
+    }
+    const value = String(key);
+    onSelectionChange?.(value === EMPTY_KEY ? null : value);
+  };
+
+  return (
+    <Select
+      variant="pill"
+      size="medium"
+      isRequired={required}
+      placeholder={placeholder ?? t('Select option')}
+      selectedKey={selectedKey}
+      onSelectionChange={onSelectionChange && handleSelectionChange}
+      selectValueClassName="text-primary-teal data-[placeholder]:text-primary-teal"
+      className="w-fit max-w-full"
+      popoverProps={{ className: 'sm:min-w-fit sm:max-w-2xl' }}
+    >
+      {allowEmpty && (
+        <SelectItem className="min-w-fit" key={EMPTY_KEY} id={EMPTY_KEY}>
+          {t('None')}
+        </SelectItem>
+      )}
+      {options.map((opt) => (
+        <SelectItem className="min-w-fit" key={opt.value} id={opt.value}>
+          {opt.label}
+        </SelectItem>
+      ))}
+    </Select>
+  );
+}

--- a/apps/app/src/components/form/MultiSelectPopoverField.tsx
+++ b/apps/app/src/components/form/MultiSelectPopoverField.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { Button } from '@op/ui/Button';
+import { DialogTrigger } from '@op/ui/Dialog';
+import { ListBox } from '@op/ui/ListBox';
+import { Popover } from '@op/ui/Popover';
+import { Tag, TagGroup } from '@op/ui/TagGroup';
+import type { Key } from 'react';
+import { Dialog, ListBoxItem } from 'react-aria-components';
+import type { Selection } from 'react-aria-components';
+import { LuCheck } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+export interface MultiSelectPopoverFieldProps {
+  options: Array<{ value: string; label: string }>;
+  selectedValues: string[];
+  onSelectionChange: (values: string[]) => void;
+  placeholder?: string;
+}
+
+/**
+ * Presentational pill-trigger popover for a multi-select value (e.g.
+ * proposal categories). Shared by the collaborative proposal editor and the
+ * template builder preview so both stay visually and behaviorally in sync.
+ */
+export function MultiSelectPopoverField({
+  options,
+  selectedValues,
+  onSelectionChange,
+  placeholder,
+}: MultiSelectPopoverFieldProps) {
+  const t = useTranslations();
+
+  const selectedKeys = new Set(selectedValues);
+  const selectedOptions = options.filter((option) =>
+    selectedValues.includes(option.value),
+  );
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  const handleSelectionChange = (keys: Selection) => {
+    if (keys === 'all') {
+      onSelectionChange(options.map((o) => o.value));
+      return;
+    }
+    onSelectionChange(
+      options.map((option) => option.value).filter((value) => keys.has(value)),
+    );
+  };
+
+  const handleTagRemove = (keys: Set<Key>) => {
+    onSelectionChange(selectedValues.filter((value) => !keys.has(value)));
+  };
+
+  const buttonLabel =
+    selectedOptions.length === 0
+      ? (placeholder ?? t('Select option'))
+      : selectedOptions.length === 1
+        ? t('1 category selected')
+        : t('{count} categories selected', { count: selectedOptions.length });
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <DialogTrigger>
+        <Button
+          variant="pill"
+          color="pill"
+          className="w-fit justify-start text-start pressed:bg-primary-tealWhite pressed:text-primary-teal pressed:!shadow-none"
+        >
+          {buttonLabel}
+        </Button>
+        <Popover
+          placement="bottom start"
+          className="min-w-(--trigger-width) overflow-hidden rounded border bg-white shadow"
+        >
+          <Dialog className="outline-hidden">
+            <ListBox
+              aria-label={placeholder ?? t('Select option')}
+              items={options.map((option) => ({
+                id: option.value,
+                label: option.label,
+              }))}
+              selectionMode="multiple"
+              selectedKeys={selectedKeys}
+              onSelectionChange={handleSelectionChange}
+              className="max-h-60 overflow-auto rounded border-0 p-2 outline-hidden"
+            >
+              {(item) => (
+                <ListBoxItem
+                  id={item.id}
+                  textValue={item.label}
+                  className="group flex cursor-pointer items-center gap-4 rounded px-3 py-2 text-neutral-black outline-hidden select-none data-[focus-visible]:bg-neutral-gray1 data-[hovered]:bg-neutral-gray1"
+                >
+                  <span className="flex h-full flex-1 items-center gap-2 font-normal">
+                    {item.label}
+                  </span>
+                  <span className="flex w-5 items-center">
+                    <LuCheck
+                      aria-hidden
+                      className="size-4 opacity-0 group-selected:opacity-100"
+                    />
+                  </span>
+                </ListBoxItem>
+              )}
+            </ListBox>
+          </Dialog>
+        </Popover>
+      </DialogTrigger>
+      {selectedOptions.length > 0 && (
+        <TagGroup onRemove={handleTagRemove}>
+          {selectedOptions.map((option) => (
+            <Tag
+              key={option.value}
+              id={option.value}
+              textValue={option.label}
+              className="text-base leading-none"
+            >
+              {option.label}
+            </Tag>
+          ))}
+        </TagGroup>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Builders configuring a review rubric or proposal template could not see the dropdown options they had entered — the sidebar preview showed a collapsed, empty select. The previews now use the same interactive controls participants see, with local-only selection that is never persisted.