### PR TITLE
fix(app): update IconProvider to render legible icons

### DIFF
--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -11,7 +11,6 @@ import Script from 'next/script';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
 import { FileDropGuard } from '../components/FileDropGuard';
-import { IconProvider } from '../components/IconProvider';
 import { OTelBrowserProvider } from '../components/OTelBrowserProvider';
 import { PostHogProvider } from '../components/PostHogProvider';
 import { QueryInvalidationSubscriber } from '../components/QueryInvalidationSubscriber';
@@ -91,9 +90,7 @@ const RootLayout = async ({ children }: { children: React.ReactNode }) => {
           <I18nProvider locale={locale} messages={messages}>
             <OTelBrowserProvider>
               <PostHogProvider>
-                <NuqsAdapter>
-                  <IconProvider>{children}</IconProvider>
-                </NuqsAdapter>
+                <NuqsAdapter>{children}</NuqsAdapter>
               </PostHogProvider>
             </OTelBrowserProvider>
           </I18nProvider>

--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -10,6 +10,8 @@ import { Roboto, Roboto_Serif } from 'next/font/google';
 import Script from 'next/script';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
+import { IconProvider } from '@/components/IconProvider';
+
 import { FileDropGuard } from '../components/FileDropGuard';
 import { OTelBrowserProvider } from '../components/OTelBrowserProvider';
 import { PostHogProvider } from '../components/PostHogProvider';
@@ -90,7 +92,9 @@ const RootLayout = async ({ children }: { children: React.ReactNode }) => {
           <I18nProvider locale={locale} messages={messages}>
             <OTelBrowserProvider>
               <PostHogProvider>
-                <NuqsAdapter>{children}</NuqsAdapter>
+                <NuqsAdapter>
+                  <IconProvider>{children}</IconProvider>
+                </NuqsAdapter>
               </PostHogProvider>
             </OTelBrowserProvider>
           </I18nProvider>

--- a/apps/app/src/components/IconProvider.tsx
+++ b/apps/app/src/components/IconProvider.tsx
@@ -4,9 +4,7 @@ import { IconContext } from 'react-icons';
 
 export const IconProvider = ({ children }: { children: React.ReactNode }) => {
   return (
-    <IconContext.Provider
-      value={{ className: 'stroke-1 [&_*]:[vector-effect:non-scaling-stroke]' }}
-    >
+    <IconContext.Provider value={{ className: 'stroke-[1.5]' }}>
       {children}
     </IconContext.Provider>
   );

--- a/apps/app/src/components/IconProvider.tsx
+++ b/apps/app/src/components/IconProvider.tsx
@@ -4,7 +4,7 @@ import { IconContext } from 'react-icons';
 
 export const IconProvider = ({ children }: { children: React.ReactNode }) => {
   return (
-    <IconContext.Provider value={{ className: 'stroke-[1.5]' }}>
+    <IconContext.Provider value={{ className: 'stroke-[1.75]' }}>
       {children}
     </IconContext.Provider>
   );


### PR DESCRIPTION
Chromium 151 renders icons differently, so icons are rendering with a very thin stroke weight. The `IconProvider`'s `[&_*]:[vector-effect:non-scaling-stroke]` class is the root cause of this. Removing the class from `IconProvider` from the root layout file means that icons' stroke weight will scale when the icon scales, which is a tradeoff for more legible icons and more consistent rendering across browsers. 

This is what the issue looks like with the `[&_*]:[vector-effect:non-scaling-stroke]` class:
<img width="801" height="316" alt="chromium-icon-weights" src="https://github.com/user-attachments/assets/1b9fb467-67d1-4207-9e87-02f82f880dc7" />

And without:
<img width="296" height="167" alt="without the vector-effect" src="https://github.com/user-attachments/assets/088b8a5f-cd0c-4b6d-ab20-8ee7e47f599e" />

