### PR TITLE
docs: add C4 architecture and data-model diagrams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,13 @@ ralph.sh
 tasks/
 .gstack/
 .plans/
+
+# Generated PlantUML output (rendered via `just render`)
+docs/plantuml/**/*.svg
+docs/plantuml/**/*.png
+
+# docs/ pandoc toolchain — venv + pandoc-plantuml-filter's rendered output (via `just docs-html`)
+docs/.venv/
+docs/plantuml-images/
+docs/*.html
+docs/*.svg

--- a/docs/Pipfile
+++ b/docs/Pipfile
@@ -1,0 +1,9 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pandoc-plantuml-filter = "*"
+
+[dev-packages]

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -1,0 +1,36 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "e4bb3382e19c38168e4950fc8dc4df7bc0e0e8490587d8c067d631b227c6a6fd"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "pandoc-plantuml-filter": {
+            "hashes": [
+                "sha256:ad8e00752a14acf2a308914615d5ba394a0cea1c6209078076b8cb4e45c6112d",
+                "sha256:f6a5de219b82bb8e26f44a0f08f2fb32011ba04c0df753b294b7db9308646584"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.1.5"
+        },
+        "pandocfilters": {
+            "hashes": [
+                "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e",
+                "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.5.1"
+        }
+    },
+    "develop": {}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# docs
+
+Architecture documentation for the Common monorepo.
+
+- [`plantuml/`](./plantuml/) — C4 model + entity-relationship diagrams, source of truth for the platform's architecture and data model. See that folder's README for `just lint` / `just render`.
+- `architecture.md` — a rendered write-up that embeds the C4 diagrams above via [pandoc-plantuml-filter](https://pypi.org/project/pandoc-plantuml-filter/), so prose and diagrams ship as one document instead of drifting apart.
+- `data-model.md` — same idea, for the entity-relationship diagrams.
+
+## Rendering markdown docs
+
+Markdown files in this folder can embed a diagram with a fenced code block that
+`!include`s one of the `.puml` sources in `plantuml/` (paths are relative to
+`docs/plantuml-images/`, the filter's scratch directory, hence the `../`):
+
+````markdown
+```{.plantuml plantuml-filename=my-diagram.svg}
+!include ../plantuml/context.puml
+```
+````
+
+Setup (once): `just docs-setup` — creates a `docs/.venv` (via `pipenv`) with `pandoc`'s
+PlantUML filter installed. Requires `pandoc` and `plantuml` on `$PATH` (both already
+required by [`plantuml/`](./plantuml/)).
+
+- Render a single doc to HTML: `just docs-html` (defaults to `architecture.md`), or `just docs-html data-model.md` for another file
+- Render `architecture.md` + `data-model.md` together as one document: `just docs-book` → `docs/system-design.html`
+- Remove generated HTML/SVG output: `just docs-clean`
+
+`docs/.venv`, `docs/plantuml-images/`, and the rendered `.html`/`.svg` output are all
+git-ignored — only the Pipfile, its lockfile, and the markdown/`.puml` sources are checked in.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,29 @@
+---
+title: Common Platform — Architecture
+plantuml-format: svg
+---
+
+# Architecture
+
+C4 model diagrams for the Common Platform. Each diagram below is rendered
+from its source of truth in [`docs/plantuml/`](./plantuml/), included
+directly so this document never drifts from the diagrams used by
+`just lint` / `just render`.
+
+## System Context
+
+```{.plantuml plantuml-filename=architecture-context.svg}
+!include ../plantuml/context.puml
+```
+
+## Containers
+
+```{.plantuml plantuml-filename=architecture-container.svg}
+!include ../plantuml/container.puml
+```
+
+## API Host Components
+
+```{.plantuml plantuml-filename=architecture-api-components.svg}
+!include ../plantuml/api-components.puml
+```

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,26 @@
+---
+title: Common Platform — Data Model
+plantuml-format: svg
+---
+
+# Data Model
+
+Entity-relationship diagrams (using PlantUML's [IE / crow's-foot notation](https://plantuml.com/ie-diagram))
+for the core product tables, sourced directly from `services/db/schema/tables/*.sql.ts`
+and the v2 relations in `services/db/relations.ts`. Rendered from
+[`docs/plantuml/`](./plantuml/) so this document can't drift from what `just lint` checks.
+
+These diagrams intentionally cover the core product domain, not the full schema — see
+[`plantuml/README.md`](./plantuml/README.md) for what's out of scope and why.
+
+## Identity & Access
+
+```{.plantuml plantuml-filename=data-model-identity.svg}
+!include ../plantuml/data-model-identity.puml
+```
+
+## Decision Process Domain
+
+```{.plantuml plantuml-filename=data-model-decisions.svg}
+!include ../plantuml/data-model-decisions.puml
+```

--- a/docs/plantuml/README.md
+++ b/docs/plantuml/README.md
@@ -1,0 +1,24 @@
+# Architecture diagrams
+
+[C4 model](https://c4model.com/) diagrams for the Common Platform, written in [PlantUML](https://plantuml.com/) using its bundled C4-PlantUML stdlib (`!include <C4/C4_*>` — no network access needed to lint or render).
+
+- `context.puml` — C4 level 1: the platform, its users, and the external systems it talks to.
+- `container.puml` — C4 level 2: the deployable containers inside the platform (`apps/app`, `apps/api`) and the infrastructure they depend on.
+- `api-components.puml` — C4 level 3: the packages/services composing the API Host container.
+
+Data model ([IE / entity-relationship notation](https://plantuml.com/ie-diagram)), sourced from `services/db/schema/tables/*.sql.ts` and `services/db/relations.ts`:
+
+- `data-model-identity.puml` — auth users, app users, profiles, organizations, and access roles.
+- `data-model-decisions.puml` — the decision process domain: processes, instances, proposals, reviews, category-scoped reviewers, votes, and results.
+
+These two intentionally cover the core product tables, not the full ~30-table schema — state-machine bookkeeping (`processTransitions`, `decisionTransitionProposals`), geo-boundaries, moderation, storage, and taxonomy/location tables are left for a future diagram if/when they need documenting.
+
+## Working with these diagrams
+
+- Lint (syntax-check, no images produced): `just lint`
+- Render all diagrams to SVG next to their source: `just render`
+- Remove generated SVG output: `just clean`
+
+Diagrams should stay grounded in what's verifiably true of the codebase (real package names, real deployables per `docker-compose.dev.yml` / each workspace's `package.json`) — check the code before adding a new box, don't infer architecture from naming alone.
+
+To embed these diagrams inline in a prose document instead of viewing them standalone, see [`../README.md`](../README.md) (`../architecture.md` for an example).

--- a/docs/plantuml/api-components.puml
+++ b/docs/plantuml/api-components.puml
@@ -1,0 +1,44 @@
+@startuml api-components
+!include <C4/C4_Component>
+
+title Component Diagram — API Host (apps/api)
+
+Container_Boundary(api, "API Host") {
+  Component(routers, "tRPC Routers & Procedures", "@op/api (services/api)", "Defines routers, procedures, and middleware; enforces access control via assertAccess")
+  Component(common, "Shared Business Logic", "@op/common (packages/common)", "Core domain services used by routers: decisions, proposals, reviews, organizations")
+  Component(db, "Database Client", "@op/db (services/db)", "Drizzle ORM schema, relations, and typed Postgres client")
+  Component(ai, "AI Agent Layer", "@op/ai (packages/ai)", "Mastra-based agents for AI-assisted features")
+  Component(cacheLib, "Cache Client", "@op/cache (services/cache)", "Redis-backed caching")
+  Component(realtime, "Realtime", "@op/realtime (services/realtime)", "Live update / subscription support")
+  Component(collab, "Collaboration", "@op/collab (services/collab)", "Real-time collaborative editing support")
+  Component(events, "Events", "@op/events (services/events)", "Internal event/pubsub definitions")
+  Component(translation, "Translation", "@op/translation (services/translation)", "Content translation/i18n support")
+  Component(emailsLib, "Email Templates", "@op/emails (services/emails)", "React Email templates rendered for outbound mail")
+  Component(workflows, "Workflow Functions", "@op/workflows (services/workflows)", "Inngest function definitions for background jobs")
+}
+
+ContainerDb_Ext(postgres, "Postgres", "Supabase-managed PostgreSQL")
+ContainerDb_Ext(redis, "Redis", "Cache store")
+System_Ext(resend, "Resend", "Transactional email")
+System_Ext(anthropic, "Anthropic Claude", "LLM provider")
+System_Ext(inngest, "Inngest", "Workflow orchestration")
+System_Ext(posthog, "PostHog", "Logs & analytics")
+
+Rel(routers, common, "Delegates business logic to")
+Rel(common, db, "Reads/writes via")
+Rel(common, ai, "Invokes for AI features")
+Rel(routers, cacheLib, "Reads/writes cache via")
+Rel(routers, realtime, "Publishes updates via")
+Rel(routers, collab, "Coordinates sessions via")
+Rel(common, events, "Emits/consumes events via")
+Rel(common, translation, "Translates content via")
+Rel(common, emailsLib, "Renders email via")
+Rel(emailsLib, resend, "Delivered through", "SMTP")
+Rel(db, postgres, "Queries", "SQL")
+Rel(cacheLib, redis, "Reads/writes", "Redis protocol")
+Rel(ai, anthropic, "Requests completions", "HTTPS")
+Rel(workflows, inngest, "Registered with / invoked by", "HTTPS")
+Rel(routers, posthog, "Logs via ctx.logger")
+
+SHOW_LEGEND()
+@enduml

--- a/docs/plantuml/container.puml
+++ b/docs/plantuml/container.puml
@@ -1,0 +1,41 @@
+@startuml container
+!include <C4/C4_Container>
+
+title Container Diagram — Common Platform
+
+Person(member, "Member", "Submits proposals, votes")
+Person(reviewer, "Reviewer", "Scores proposals against rubrics")
+Person(admin, "Admin", "Configures decision processes")
+
+System_Boundary(platform, "Common Platform") {
+  Container(app, "Web App", "Next.js (App Router), React 19, Tailwind, Zustand", "Renders the UI; calls the tRPC API over HTTPS")
+  Container(api, "API Host", "Next.js, tRPC, OpenAPI", "Hosts tRPC routers/procedures (@op/api) and the OpenAPI spec; runs Inngest workflow functions (@op/workflows)")
+}
+
+ContainerDb_Ext(postgres, "Postgres", "Supabase-managed PostgreSQL", "Application data, accessed via Drizzle ORM (@op/db)")
+System_Ext(supabaseAuth, "Supabase Auth", "Authentication & session management")
+System_Ext(supabaseStorage, "Supabase Storage", "File & media storage")
+ContainerDb_Ext(redis, "Redis", "Cache store (@op/cache)")
+System_Ext(posthog, "PostHog", "Analytics + log sink")
+System_Ext(resend, "Resend", "Transactional email (@op/emails)")
+System_Ext(inngest, "Inngest", "Background workflow orchestration")
+System_Ext(anthropic, "Anthropic Claude", "LLM provider for AI features (@op/ai)")
+
+Rel(member, app, "Uses", "HTTPS")
+Rel(reviewer, app, "Uses", "HTTPS")
+Rel(admin, app, "Uses", "HTTPS")
+
+Rel(app, api, "Calls", "tRPC / HTTPS")
+Rel(app, supabaseAuth, "Authenticates", "HTTPS")
+
+Rel(api, postgres, "Reads/writes", "SQL / Drizzle")
+Rel(api, supabaseAuth, "Verifies sessions", "HTTPS")
+Rel(api, supabaseStorage, "Stores/retrieves files", "HTTPS")
+Rel(api, redis, "Reads/writes cache", "Redis protocol")
+Rel(api, posthog, "Sends logs & events", "HTTPS")
+Rel(api, resend, "Sends email", "SMTP")
+Rel(api, inngest, "Triggers/receives workflow calls", "HTTPS")
+Rel(api, anthropic, "Requests completions", "HTTPS")
+
+SHOW_LEGEND()
+@enduml

--- a/docs/plantuml/context.puml
+++ b/docs/plantuml/context.puml
@@ -1,0 +1,29 @@
+@startuml context
+!include <C4/C4_Context>
+
+title System Context — Common Platform
+
+Person(member, "Member", "An organization member who submits proposals and votes")
+Person(reviewer, "Reviewer", "Assigned to score proposals against a rubric during a review phase")
+Person(admin, "Admin", "Configures decision processes, phases, and access for an organization")
+
+System(platform, "Common Platform", "Lets organizations run structured decision-making processes: proposals, reviews, and voting")
+
+System_Ext(supabase, "Supabase", "Postgres database, authentication, and file storage")
+System_Ext(posthog, "PostHog", "Product analytics and centralized log ingestion")
+System_Ext(resend, "Resend", "Transactional email delivery (SMTP)")
+System_Ext(inngest, "Inngest", "Background workflow orchestration")
+System_Ext(anthropic, "Anthropic Claude", "LLM used for AI-assisted features")
+
+Rel(member, platform, "Submits proposals, votes", "HTTPS")
+Rel(reviewer, platform, "Scores proposals against rubrics", "HTTPS")
+Rel(admin, platform, "Configures decision processes", "HTTPS")
+
+Rel(platform, supabase, "Reads/writes data, authenticates users, stores files", "Postgres / HTTPS")
+Rel(platform, posthog, "Sends analytics events and logs", "HTTPS")
+Rel(platform, resend, "Sends transactional email", "SMTP")
+Rel(platform, inngest, "Schedules & runs background workflows", "HTTPS")
+Rel(platform, anthropic, "Requests AI-generated content", "HTTPS")
+
+SHOW_LEGEND()
+@enduml

--- a/docs/plantuml/data-model-decisions.puml
+++ b/docs/plantuml/data-model-decisions.puml
@@ -1,0 +1,174 @@
+@startuml data-model-decisions
+hide circle
+skinparam linetype ortho
+
+title Data Model — Decision Process Domain
+
+entity "Profile" as profile <<external>> {
+  *id : uuid <<generated>>
+  --
+  name : text
+}
+
+entity "TaxonomyTerm" as taxonomy_term <<external>> {
+  *id : uuid <<generated>>
+  --
+  name : text
+}
+
+entity "DecisionProcess" as decision_process {
+  *id : uuid <<generated>>
+  --
+  createdByProfileId : uuid <<FK>>
+  --
+  name : text
+  processSchema : jsonb
+}
+
+entity "ProcessInstance" as process_instance {
+  *id : uuid <<generated>>
+  --
+  processId : uuid <<FK>>
+  ownerProfileId : uuid <<FK>>
+  stewardProfileId : uuid <<FK, nullable>>
+  profileId : uuid <<FK, nullable>>
+  --
+  name : text
+  status : enum
+  instanceData : jsonb
+}
+
+entity "Proposal" as proposal {
+  *id : uuid <<generated>>
+  --
+  processInstanceId : uuid <<FK>>
+  submittedByProfileId : uuid <<FK>>
+  profileId : uuid <<FK>>
+  lastEditedByProfileId : uuid <<FK, nullable>>
+  --
+  status : enum
+  visibility : enum
+  proposalData : jsonb
+}
+
+entity "ProposalHistory" as proposal_history {
+  *historyId : uuid <<generated>>
+  --
+  id : uuid <<logical link to Proposal.id, unenforced>>
+  processInstanceId : uuid <<FK>>
+  --
+  status : enum
+  validDuring : tstzrange
+}
+
+entity "ProposalReviewAssignment" as review_assignment {
+  *id : uuid <<generated>>
+  --
+  processInstanceId : uuid <<FK>>
+  proposalId : uuid <<FK>>
+  reviewerProfileId : uuid <<FK>>
+  --
+  phaseId : text
+  status : enum
+}
+
+entity "ProposalReview" as review {
+  *id : uuid <<generated>>
+  --
+  assignmentId : uuid <<FK, unique>>
+  --
+  state : enum
+  reviewData : jsonb
+  overallComment : text
+}
+
+entity "ProposalReviewRequest" as review_request {
+  *id : uuid <<generated>>
+  --
+  assignmentId : uuid <<FK>>
+  --
+  state : enum
+  requestComment : text
+  responseComment : text
+}
+
+entity "CategoryReviewer" as category_reviewer {
+  *id : uuid <<generated>>
+  --
+  processInstanceId : uuid <<FK>>
+  taxonomyTermId : uuid <<FK>>
+  reviewerProfileId : uuid <<FK>>
+  --
+  phaseId : text <<nullable>>
+}
+
+entity "DecisionsVoteSubmission" as vote_submission {
+  *id : uuid <<generated>>
+  --
+  processInstanceId : uuid <<FK>>
+  submittedByProfileId : uuid <<FK>>
+  --
+  voteData : jsonb
+  signature : text
+}
+
+entity "DecisionProcessResult" as process_result {
+  *id : uuid <<generated>>
+  --
+  processInstanceId : uuid <<FK>>
+  --
+  success : boolean
+  selectedCount : integer
+  voterCount : integer
+}
+
+entity "DecisionProcessResultSelection" as result_selection {
+  *id : uuid <<generated>>
+  --
+  processResultId : uuid <<FK>>
+  proposalId : uuid <<FK>>
+  --
+  selectionRank : integer
+  allocated : numeric
+}
+
+decision_process ||--o{ process_instance : "defines"
+profile ||--o{ process_instance : "owns"
+
+process_instance ||--o{ proposal : "collects"
+profile ||--o{ proposal : "submits"
+profile ||--o{ proposal : "is subject of"
+
+proposal ||--o{ proposal_history : "versioned as"
+
+proposal ||--o{ review_assignment : "assigned for review"
+profile ||--o{ review_assignment : "reviews as"
+review_assignment ||--o| review : "produces"
+review_assignment ||--o{ review_request : "revision requested via"
+
+process_instance ||--o{ category_reviewer : "scopes"
+taxonomy_term ||--o{ category_reviewer : "covered by"
+profile ||--o{ category_reviewer : "reviews category as"
+
+' proposalCategories is a pure join table (proposalId + taxonomyTermId,
+' no attributes of its own), collapsed into a direct M:N line.
+proposal }o--o{ taxonomy_term : "categorized as"
+
+process_instance ||--o{ vote_submission : "collects"
+profile ||--o{ vote_submission : "casts"
+
+' decisionsVoteProposals is a pure join table (voteSubmissionId + proposalId),
+' collapsed into a direct M:N line.
+vote_submission }o--o{ proposal : "selects"
+
+process_instance ||--o{ process_result : "produces"
+process_result ||--o{ result_selection : "selects"
+proposal ||--o{ result_selection : "selected as"
+
+note bottom of proposal
+  DecisionBoundaries (geo-boundary definitions, scoped to Profile),
+  decisionTransitionProposals, and processTransitions (state-machine
+  bookkeeping) are omitted from this diagram to keep the core
+  propose/review/vote flow legible.
+end note
+@enduml

--- a/docs/plantuml/data-model-identity.puml
+++ b/docs/plantuml/data-model-identity.puml
@@ -1,0 +1,102 @@
+@startuml data-model-identity
+hide circle
+skinparam linetype ortho
+
+title Data Model — Identity & Access
+
+entity "AuthUser" as auth_user <<external>> {
+  *id : uuid <<generated>>
+  --
+  email : text
+  phone : text <<unique>>
+  isAnonymous : boolean
+}
+
+entity "User" as app_user {
+  *id : uuid <<generated>>
+  --
+  authUserId : uuid <<FK>>
+  profileId : uuid <<FK, nullable>>
+  currentProfileId : uuid <<FK, nullable>>
+  lastOrgId : uuid <<FK, nullable>>
+  --
+  email : text <<unique>>
+  username : text
+  name : text
+}
+
+entity "Profile" as profile {
+  *id : uuid <<generated>>
+  --
+  type : entity_type
+  name : text
+  slug : text <<unique>>
+  bio : text
+}
+
+entity "Organization" as organization {
+  *id : uuid <<generated>>
+  --
+  profileId : uuid <<FK>>
+  --
+  orgType : enum
+  isVerified : boolean
+  isOfferingFunds : boolean
+}
+
+entity "ProfileUser" as profile_user {
+  *id : uuid <<generated>>
+  --
+  authUserId : uuid <<FK>>
+  profileId : uuid <<FK>>
+  --
+  isOwner : boolean
+  name : text
+  email : text
+}
+
+entity "OrganizationUser" as org_user {
+  *id : uuid <<generated>>
+  --
+  authUserId : uuid <<FK>>
+  organizationId : uuid <<FK>>
+  --
+  name : text
+  email : text
+}
+
+entity "AccessRole" as access_role {
+  *id : uuid <<generated>>
+  --
+  profileId : uuid <<FK, nullable>>
+  --
+  name : text
+  description : text
+}
+
+auth_user ||--o{ app_user : "has app record"
+auth_user ||--o{ profile_user : "is member via"
+auth_user ||--o{ org_user : "is member via"
+
+' No unique constraint was found on organizations.profileId in the schema,
+' so this is modeled as one-to-many even though in practice each profile
+' currently has at most one organization row.
+profile ||--o{ organization : "extended by"
+
+profile ||--o{ profile_user : "has member"
+organization ||--o{ org_user : "has member"
+
+' NULL profileId means a global (deployment-wide) role.
+profile |o--o{ access_role : "scopes"
+
+' Pure join tables (profileUser_to_access_roles / organizationUser_to_access_roles)
+' carry no attributes of their own, so they're collapsed into direct M:N lines.
+profile_user }o--o{ access_role : "granted"
+org_user }o--o{ access_role : "granted"
+
+note bottom of app_user
+  users.avatarImageId, profiles.avatarImageId/headerImageId,
+  and users.lastOrgId/currentProfileId are omitted from this
+  diagram (secondary pointer FKs, not core structural relationships).
+end note
+@enduml

--- a/justfile
+++ b/justfile
@@ -1,0 +1,41 @@
+plantuml_dir := "docs/plantuml"
+docs_dir := "docs"
+docs_pipfile := "docs/Pipfile"
+tmpdir := env_var_or_default("TMPDIR", "/tmp")
+
+# List available recipes
+default:
+    @just --list
+
+# Validate PlantUML diagram syntax without generating images
+lint:
+    plantuml --check-syntax --stop-on-error "{{plantuml_dir}}/**/*.puml"
+
+# Render all diagrams to SVG next to their sources (for local review)
+render:
+    JAVA_TOOL_OPTIONS="-Djava.io.tmpdir={{tmpdir}}" plantuml -tsvg "{{plantuml_dir}}/**/*.puml"
+
+# Remove generated PlantUML SVG output
+clean:
+    find {{plantuml_dir}} -name "*.svg" -delete
+
+# Install the pandoc/pandoc-plantuml toolchain used to render docs/*.md
+docs-setup:
+    PIPENV_PIPFILE={{docs_pipfile}} pipenv install
+
+# Render a markdown file (with embedded ```plantuml fences) to standalone HTML.
+# `file` is relative to docs/ — fenced blocks include diagrams via `!include ../plantuml/*.puml`,
+# resolved relative to docs/plantuml-images/ (where the filter writes its temp .uml files), so
+# pandoc must run with docs/ as its working directory.
+docs-html file="architecture.md":
+    cd {{docs_dir}} && PIPENV_PIPFILE=Pipfile JAVA_TOOL_OPTIONS="-Djava.io.tmpdir={{tmpdir}}" pipenv run pandoc {{file}} -o {{without_extension(file)}}.html --filter pandoc-plantuml --standalone
+
+# Render architecture.md + data-model.md together into one standalone HTML document
+docs-book:
+    cd {{docs_dir}} && PIPENV_PIPFILE=Pipfile JAVA_TOOL_OPTIONS="-Djava.io.tmpdir={{tmpdir}}" pipenv run pandoc architecture.md data-model.md -o system-design.html --filter pandoc-plantuml --standalone --toc --metadata title="Common Platform — System Design"
+
+# Remove generated docs HTML/SVG output (leaves .md sources and the venv alone)
+docs-clean:
+    find {{docs_dir}} -maxdepth 1 -name "*.html" -delete
+    find {{docs_dir}} -maxdepth 1 -name "*.svg" -type l -delete
+    rm -rf {{docs_dir}}/plantuml-images


### PR DESCRIPTION
## LLM Usage 🤖 

- claude sonnet 5 with claude-code

## Commits 📚 

### docs: add C4 architecture and data-model diagrams

The README/CONTRIBUTING package lists have drifted badly — they describe a handful of workspaces from an earlier, much smaller version of this monorepo, and CLAUDE.md documents only 4 of the ~20 packages/services that exist today. Anyone ramping up on this codebase, human or agent, currently has to reconstruct the system's topology and its ~30-table decision-making schema from source every time, which is slow and easy to get wrong — especially as the review/voting domain keeps adding complexity (phase-scoped rubrics, category-scoped reviewer assignment).

Diagrams are written as lint-checkable PlantUML rather than static images specifically so they don't quietly rot the way an ad-hoc wiki page would — `just lint` can catch a diagram that no longer parses, and CI can run the same check. Scoped intentionally to the core system view and the core decision-domain tables rather than the full schema, so what's here stays legible and is something the team will actually keep current going forward.


## Risk Justification 🔥 🚒 

- no risk. Only documentation. 

