### PR TITLE
refactor(sense): migrate info/static pages and match decision list rows to Figma

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/ForbiddenContent.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/ForbiddenContent.tsx
@@ -115,7 +115,8 @@ const ForbiddenWithInviteCheck = () => {
             </Button>
             <Button
               variant="link"
-              className="h-auto p-0 text-sm font-normal text-primary-teal underline hover:text-primary-teal/80"
+              size="inline"
+              className="text-sm font-normal text-primary-teal underline hover:text-primary-teal/80"
               onClick={() =>
                 declineInvite.mutate({ inviteId: matchingInvite.id })
               }

--- a/apps/app/src/app/info/columbus-addendum/page.tsx
+++ b/apps/app/src/app/info/columbus-addendum/page.tsx
@@ -7,7 +7,7 @@ import { FormHeader } from '@/components/form/FormHeader';
 const ColumbusAddendumPage = () => {
   const t = useTranslations();
   return (
-    <FormContainer className="max-w-[32rem]">
+    <FormContainer className="max-w-lg">
       <FormHeader text={t('Columbus Addendum')}></FormHeader>
       <ColumbusAddendumContent />
     </FormContainer>

--- a/apps/app/src/app/info/community-commitments/page.tsx
+++ b/apps/app/src/app/info/community-commitments/page.tsx
@@ -7,7 +7,7 @@ import { FormHeader } from '@/components/form/FormHeader';
 const CommunityCommitmentsPage = () => {
   const t = useTranslations();
   return (
-    <FormContainer className="max-w-[32rem]">
+    <FormContainer className="max-w-lg">
       <FormHeader text={t('Community Commitments')}></FormHeader>
       <CommunityCommitmentsContent />
     </FormContainer>

--- a/apps/app/src/app/info/privacy/page.tsx
+++ b/apps/app/src/app/info/privacy/page.tsx
@@ -7,7 +7,7 @@ import { FormHeader } from '@/components/form/FormHeader';
 const PrivacyPage = () => {
   const t = useTranslations();
   return (
-    <FormContainer className="max-w-[100vw] px-4 sm:max-w-[32rem]">
+    <FormContainer className="max-w-[100vw] px-4 sm:max-w-lg">
       <FormHeader text={t('Privacy Policy')}></FormHeader>
       <PrivacyPolicyContent />
     </FormContainer>

--- a/apps/app/src/app/info/tos/page.tsx
+++ b/apps/app/src/app/info/tos/page.tsx
@@ -7,7 +7,7 @@ import { FormHeader } from '@/components/form/FormHeader';
 const ToSPage = () => {
   const t = useTranslations();
   return (
-    <FormContainer className="max-w-[32rem]">
+    <FormContainer className="max-w-lg">
       <FormHeader text={t('Terms of Service')}></FormHeader>
       <ToSContent />
     </FormContainer>

--- a/apps/app/src/components/ButtonLink/index.tsx
+++ b/apps/app/src/components/ButtonLink/index.tsx
@@ -3,7 +3,10 @@ import type { ComponentProps } from 'react';
 
 import { Link } from '@/lib/i18n';
 
-type ButtonLinkProps = Omit<ComponentProps<typeof Button>, 'render'> & {
+type ButtonLinkProps = Omit<
+  ComponentProps<typeof Button>,
+  'render' | 'nativeButton' | 'role'
+> & {
   href: ComponentProps<typeof Link>['href'];
 } & Pick<ComponentProps<typeof Link>, 'target' | 'rel' | 'download'>;
 
@@ -12,6 +15,12 @@ type ButtonLinkProps = Omit<ComponentProps<typeof Button>, 'render'> & {
  * anchor (replaces `@op/ui`'s `ButtonLink`). Inherits every `Button` prop
  * (`variant`, `size`, `loading`, …); `href` plus the anchor props `target`,
  * `rel`, and `download` are forwarded to the i18n `Link`.
+ *
+ * This navigates, so it stays a link: `nativeButton={false}` tells base-ui the
+ * rendered element isn't a `<button>` (it was warning, and putting an invalid
+ * `type="button"` on the anchor), and `role={undefined}` drops the `role="button"`
+ * base-ui swaps in — which would announce it as a button and take it out of the
+ * screen reader's links list.
  */
 export const ButtonLink = ({
   href,
@@ -22,6 +31,8 @@ export const ButtonLink = ({
 }: ButtonLinkProps) => {
   return (
     <Button
+      nativeButton={false}
+      role={undefined}
       render={
         <Link href={href} target={target} rel={rel} download={download} />
       }

--- a/apps/app/src/components/ColumbusAddendumContent/index.tsx
+++ b/apps/app/src/components/ColumbusAddendumContent/index.tsx
@@ -1,4 +1,4 @@
-import { Header3 } from '@op/ui/Header';
+import { Header3 } from '@op/sense/Header';
 
 import { FormalSection } from '../FormalSection';
 

--- a/apps/app/src/components/ColumbusAddendumContent/index.tsx
+++ b/apps/app/src/components/ColumbusAddendumContent/index.tsx
@@ -4,7 +4,7 @@ import { FormalSection } from '../FormalSection';
 
 export const ColumbusAddendumContent = () => {
   return (
-    <div className="relative flex w-full flex-col gap-8 sm:pb-20">
+    <div dir="auto" className="relative flex w-full flex-col gap-8 sm:pb-20">
       <FormalSection>
         <Header3>One Project Special Privacy Standards</Header3>
         <p className="mb-4">

--- a/apps/app/src/components/ColumbusAddendumContent/index.tsx
+++ b/apps/app/src/components/ColumbusAddendumContent/index.tsx
@@ -6,9 +6,7 @@ export const ColumbusAddendumContent = () => {
   return (
     <div className="relative flex w-full flex-col gap-8 sm:pb-20">
       <FormalSection>
-        <Header3 className="font-serif">
-          One Project Special Privacy Standards
-        </Header3>
+        <Header3>One Project Special Privacy Standards</Header3>
         <p className="mb-4">
           City of Columbus Participatory Budgeting Project, 2026
         </p>
@@ -39,7 +37,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">What Information We Collect</Header3>
+        <Header3>What Information We Collect</Header3>
         <p className="mb-4">
           In addition to the information discussed in the Notice, we
           specifically collect the following information when you use the
@@ -48,7 +46,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Information You Give Us</Header3>
+        <Header3>Information You Give Us</Header3>
         <p className="mb-4">
           We collect the following information that you provide us directly:
         </p>
@@ -76,9 +74,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          Automatically Collected Information
-        </Header3>
+        <Header3>Automatically Collected Information</Header3>
         <p className="mb-4">We also collect the following information:</p>
         <ul className="mb-4 list-disc ps-6">
           <li className="mb-2">
@@ -115,9 +111,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          How We Use the Information That We Collect
-        </Header3>
+        <Header3>How We Use the Information That We Collect</Header3>
         <p className="mb-4">
           Our reasons for processing the data are listed in our{' '}
           <a href="/info/privacy" className="text-primary-teal underline">
@@ -129,12 +123,12 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Information That We Share</Header3>
+        <Header3>Information That We Share</Header3>
         <p className="mb-4">We share your information in the following ways:</p>
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Public Content</Header3>
+        <Header3>Public Content</Header3>
         <p className="mb-4">
           Some content, such as project proposals and comments, is designed to
           be shared publicly or with other users of the Instance or Services. We
@@ -143,7 +137,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Instance Administrators</Header3>
+        <Header3>Instance Administrators</Header3>
         <p className="mb-4">
           One Project works with local representatives of the community where
           the Instance is focused. This may include representatives of the
@@ -173,9 +167,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          One Project and Its Contractors
-        </Header3>
+        <Header3>One Project and Its Contractors</Header3>
         <p className="mb-4">
           Members of the One Project team, and any independent contractors that
           they work with, may have access to your information as it is
@@ -184,7 +176,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Third-Party Service Providers</Header3>
+        <Header3>Third-Party Service Providers</Header3>
         <p className="mb-4">
           One Project may work with third-party service providers in order to
           operate the Instance and the Services, and for the other reasons for
@@ -232,7 +224,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Business Transfer</Header3>
+        <Header3>Business Transfer</Header3>
         <p className="mb-4">
           If One Project is acquired by another company, goes into dissolution,
           or otherwise transfers ownership or assets, it may sell or transfer
@@ -242,7 +234,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Legal Compliance</Header3>
+        <Header3>Legal Compliance</Header3>
         <p className="mb-4">
           One Project may share information if we believe, in our sole
           discretion, that such disclosure is necessary in order to comply with
@@ -261,7 +253,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Non-Identifiable Data</Header3>
+        <Header3>Non-Identifiable Data</Header3>
         <p className="mb-4">
           We may share data that cannot be used to identify a specific person or
           that cannot be linked or associated with a specific individual for any
@@ -276,9 +268,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          Management and Deletion of Information
-        </Header3>
+        <Header3>Management and Deletion of Information</Header3>
         <p className="mb-4">
           Please see our{' '}
           <a
@@ -294,7 +284,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Children Under 13 Years of Age</Header3>
+        <Header3>Children Under 13 Years of Age</Header3>
         <p className="mb-4">
           Children under the age of 13 are not permitted to use, access or
           register for use of the Instance or Services in any way. We do not
@@ -306,7 +296,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Changes to This Policy</Header3>
+        <Header3>Changes to This Policy</Header3>
         <p className="mb-4">
           We may update these Special Standards from time to time at our sole
           discretion. If we do, we’ll let you know by posting the updated
@@ -316,7 +306,7 @@ export const ColumbusAddendumContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Contact Us</Header3>
+        <Header3>Contact Us</Header3>
         <p className="mb-4">
           If you have any questions about these Special Standards, the Instance,
           or the Services more generally, please contact{' '}

--- a/apps/app/src/components/CommunityCommitmentsContent/index.tsx
+++ b/apps/app/src/components/CommunityCommitmentsContent/index.tsx
@@ -1,4 +1,4 @@
-import { Header3 } from '@op/ui/Header';
+import { Header3 } from '@op/sense/Header';
 
 import { FormalSection } from '../FormalSection';
 

--- a/apps/app/src/components/CommunityCommitmentsContent/index.tsx
+++ b/apps/app/src/components/CommunityCommitmentsContent/index.tsx
@@ -4,7 +4,7 @@ import { FormalSection } from '../FormalSection';
 
 export const CommunityCommitmentsContent = () => {
   return (
-    <div className="relative flex w-full flex-col gap-8 sm:pb-20">
+    <div dir="auto" className="relative flex w-full flex-col gap-8 sm:pb-20">
       <FormalSection>
         <Header3>Common Community Commitments</Header3>
         <p className="mb-4">

--- a/apps/app/src/components/CommunityCommitmentsContent/index.tsx
+++ b/apps/app/src/components/CommunityCommitmentsContent/index.tsx
@@ -6,7 +6,7 @@ export const CommunityCommitmentsContent = () => {
   return (
     <div className="relative flex w-full flex-col gap-8 sm:pb-20">
       <FormalSection>
-        <Header3 className="font-serif">Common Community Commitments</Header3>
+        <Header3>Common Community Commitments</Header3>
         <p className="mb-4">
           Common is a technical platform that makes it easy for organizations,
           funders, and municipalities to democratically allocate resources—
@@ -117,9 +117,7 @@ export const CommunityCommitmentsContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          How Common Supports These Commitments
-        </Header3>
+        <Header3>How Common Supports These Commitments</Header3>
         <p className="mb-4">
           We are building Common to be a place where participatory processes are
           genuinely transparent and accountable. In partnership with process
@@ -134,9 +132,7 @@ export const CommunityCommitmentsContent = () => {
 
       <div id="prohibited-content">
         <FormalSection>
-          <Header3 className="font-serif">
-            What We Don’t Allow on Common
-          </Header3>
+          <Header3>What We Don’t Allow on Common</Header3>
           <p className="mb-4">
             Common is a space for democratic and participatory processes. To
             keep it that way, we need to be clear about what’s not welcome here.
@@ -165,7 +161,7 @@ export const CommunityCommitmentsContent = () => {
       </div>
 
       <FormalSection>
-        <Header3 className="font-serif">Prohibited Content:</Header3>
+        <Header3>Prohibited Content:</Header3>
         <ul className="mb-4 list-disc ps-6">
           <li className="mb-2">
             <strong>Abuse.</strong> This includes personal attacks, harassment,
@@ -253,7 +249,7 @@ export const CommunityCommitmentsContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Prohibited Account Conduct:</Header3>
+        <Header3>Prohibited Account Conduct:</Header3>
         <p className="mb-4">
           The following behaviors are not allowed. Common may take action
           against accounts that engage in these behaviors, regardless of the
@@ -304,9 +300,7 @@ export const CommunityCommitmentsContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          Prohibited Participatory Processes Conduct:
-        </Header3>
+        <Header3>Prohibited Participatory Processes Conduct:</Header3>
         <p className="mb-4">
           Common is built for democratic participation. The following behaviors
           are not allowed because they undermine the legitimacy of
@@ -379,7 +373,7 @@ export const CommunityCommitmentsContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Reporting Content</Header3>
+        <Header3>Reporting Content</Header3>
         <p className="mb-4">
           If Common users see something on Common that doesn't look right —
           whether it's a comment, a proposal, an account, or a participatory
@@ -395,7 +389,7 @@ export const CommunityCommitmentsContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">How We Enforce Our Rules</Header3>
+        <Header3>How We Enforce Our Rules</Header3>
         <p className="mb-4">
           Common uses a combination of automated and human moderation. Our
           third-party content moderation vendor proactively flags content and

--- a/apps/app/src/components/DiscussionModal/index.tsx
+++ b/apps/app/src/components/DiscussionModal/index.tsx
@@ -93,7 +93,7 @@ export function DiscussionModal({
         }
       }}
     >
-      <DialogContent className="grid h-svh w-screen max-w-md grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden rounded-none p-0 text-start sm:max-h-[80svh] sm:max-w-[32rem] sm:rounded-lg">
+      <DialogContent className="grid h-svh w-screen max-w-md grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden rounded-none p-0 text-start sm:max-h-[80svh] sm:max-w-lg sm:rounded-lg">
         <DialogHeader>
           <DialogTitle>
             {t.rich("<bdi>{authorName}</bdi>'s Post", {

--- a/apps/app/src/components/ImageHeader/index.tsx
+++ b/apps/app/src/components/ImageHeader/index.tsx
@@ -20,7 +20,7 @@ export const ImageHeader = ({
       >
         {headerImage}
       </div>
-      <div className="absolute start-4 bottom-0 aspect-square size-16 overflow-hidden rounded-full border-2 border-white bg-background shadow-sm sm:size-[7.5rem] sm:border-4">
+      <div className="absolute start-4 bottom-0 aspect-square size-16 overflow-hidden rounded-full border-2 border-white bg-background shadow-sm sm:size-30 sm:border-4">
         {avatarImage}
       </div>
     </div>

--- a/apps/app/src/components/InviteUserModal/InviteNewOrganization.tsx
+++ b/apps/app/src/components/InviteUserModal/InviteNewOrganization.tsx
@@ -100,7 +100,7 @@ export const InviteNewOrganization = ({
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
           <label className="text-sm font-medium">{t('Send to')}</label>
-          <div className="flex min-h-[80px] flex-wrap gap-2 rounded-lg border border-neutral-gray2 p-2">
+          <div className="flex min-h-20 flex-wrap gap-2 rounded-lg border border-neutral-gray2 p-2">
             <TagGroup>
               {emailBadges.map((email, index) => (
                 <Tag className="sm:rounded-md" key={index}>
@@ -120,7 +120,7 @@ export const InviteNewOrganization = ({
                   ? `name1@${user.currentOrganization?.domain || 'solidarityseeds.org'}, name2@${user.currentOrganization?.domain || 'solidarityseeds.org'}, ...`
                   : t('Type emails followed by a comma or line break...')
               }
-              className="min-w-[200px] flex-1 resize-none border-none pt-1 outline-hidden"
+              className="min-w-50 flex-1 resize-none border-none pt-1 outline-hidden"
               rows={1}
             />
           </div>
@@ -135,7 +135,7 @@ export const InviteNewOrganization = ({
             value={personalMessage}
             onChange={(e) => setPersonalMessage(e.target.value)}
             placeholder={t('Add a personal note to your invitation')}
-            className="min-h-[80px] rounded-lg border border-neutral-gray2 p-2 outline-hidden focus-visible:border-primary-teal focus-visible:ring-1 focus-visible:ring-primary-teal"
+            className="min-h-20 rounded-lg border border-neutral-gray2 p-2 outline-hidden focus-visible:border-primary-teal focus-visible:ring-1 focus-visible:ring-primary-teal"
             rows={3}
           />
         </div>

--- a/apps/app/src/components/InviteUserModal/InviteToExistingOrganization.tsx
+++ b/apps/app/src/components/InviteUserModal/InviteToExistingOrganization.tsx
@@ -135,7 +135,7 @@ export const InviteToExistingOrganization = ({
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
           <label className="text-sm font-medium">{t('Send to')}</label>
-          <div className="flex min-h-[80px] flex-wrap gap-2 rounded-lg border border-neutral-gray2 p-2">
+          <div className="flex min-h-20 flex-wrap gap-2 rounded-lg border border-neutral-gray2 p-2">
             <TagGroup aria-label={t('Selected emails')}>
               {emailBadges.map((email, index) => (
                 <Tag className="sm:rounded-md" key={index}>
@@ -156,7 +156,7 @@ export const InviteToExistingOrganization = ({
                   ? `name1@${user.currentOrganization?.domain || 'example.org'}, name2@${user.currentOrganization?.domain || 'example.org'}, ...`
                   : t('Type emails followed by a comma or line break...')
               }
-              className="min-w-[200px] flex-1 resize-none border-none pt-1 outline-hidden"
+              className="min-w-50 flex-1 resize-none border-none pt-1 outline-hidden"
               rows={1}
             />
           </div>

--- a/apps/app/src/components/Onboarding/ToSAcceptanceScreen.tsx
+++ b/apps/app/src/components/Onboarding/ToSAcceptanceScreen.tsx
@@ -117,7 +117,7 @@ function PolicyCheckbox({
       <Dialog>
         <DialogTrigger
           render={
-            <Button variant="link" className="h-auto p-0 text-sm">
+            <Button variant="link" size="inline" className="text-sm">
               {label}
             </Button>
           }

--- a/apps/app/src/components/Onboarding/ToSAcceptanceScreen.tsx
+++ b/apps/app/src/components/Onboarding/ToSAcceptanceScreen.tsx
@@ -127,7 +127,7 @@ function PolicyCheckbox({
             container (top) instead of the first link in the legal text, which
             otherwise opens the dialog scrolled partway down. */}
         <DialogContent
-          className="flex max-h-[85vh] flex-col p-0 sm:max-w-[36rem]"
+          className="flex max-h-[85vh] flex-col p-0 sm:max-w-xl"
           initialFocus={scrollRef}
         >
           <DialogHeader>

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -6,9 +6,11 @@ import { Button } from '@op/sense/Button';
 import { Checkbox } from '@op/sense/Checkbox';
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from '@op/sense/Dialog';
 import { toast } from '@op/sense/Toast';
 import { type ReactNode, useState } from 'react';
@@ -46,9 +48,6 @@ const PolicyReacceptanceModalContent = () => {
   const utils = trpc.useUtils();
   const reaccept = trpc.account.completeOnboarding.useMutation();
   const [agreed, setAgreed] = useState(false);
-  const [activeDocument, setActiveDocument] = useState<PolicyDocument | null>(
-    null,
-  );
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleAgree = async () => {
@@ -72,26 +71,18 @@ const PolicyReacceptanceModalContent = () => {
     // Controlled `open` with no `onOpenChange`: Escape and the backdrop have
     // nowhere to write, so the gate can't be dismissed.
     <Dialog open disablePointerDismissal>
-      {/* Column, not the default grid, so each view can put the scroll on its
-          own body instead of on the whole card. */}
+      {/* Column, not the default grid, so the body scrolls rather than the
+          whole card. */}
       <DialogContent
         showCloseButton={false}
         className="flex flex-col overflow-hidden p-0 sm:max-w-[36rem]"
       >
-        {activeDocument ? (
-          <PolicyDocumentView
-            document={activeDocument}
-            onBack={() => setActiveDocument(null)}
-          />
-        ) : (
-          <PolicyReacceptanceMain
-            agreed={agreed}
-            onAgreedChange={setAgreed}
-            onOpenDocument={setActiveDocument}
-            onAgree={handleAgree}
-            isSubmitting={isSubmitting}
-          />
-        )}
+        <PolicyReacceptanceMain
+          agreed={agreed}
+          onAgreedChange={setAgreed}
+          onAgree={handleAgree}
+          isSubmitting={isSubmitting}
+        />
       </DialogContent>
     </Dialog>
   );
@@ -100,13 +91,11 @@ const PolicyReacceptanceModalContent = () => {
 const PolicyReacceptanceMain = ({
   agreed,
   onAgreedChange,
-  onOpenDocument,
   onAgree,
   isSubmitting,
 }: {
   agreed: boolean;
   onAgreedChange: (value: boolean) => void;
-  onOpenDocument: (document: PolicyDocument) => void;
   onAgree: () => void;
   isSubmitting: boolean;
 }) => {
@@ -141,19 +130,13 @@ const PolicyReacceptanceMain = ({
             'I have read and agree to the <terms>Terms of Use</terms>, <privacy>Privacy Policy</privacy>, and <conduct>Code of Conduct</conduct>.',
             {
               terms: (chunks: ReactNode) => (
-                <PolicyLink onOpen={() => onOpenDocument('terms')}>
-                  {chunks}
-                </PolicyLink>
+                <PolicyDocumentDialog document="terms" trigger={chunks} />
               ),
               privacy: (chunks: ReactNode) => (
-                <PolicyLink onOpen={() => onOpenDocument('privacy')}>
-                  {chunks}
-                </PolicyLink>
+                <PolicyDocumentDialog document="privacy" trigger={chunks} />
               ),
               conduct: (chunks: ReactNode) => (
-                <PolicyLink onOpen={() => onOpenDocument('conduct')}>
-                  {chunks}
-                </PolicyLink>
+                <PolicyDocumentDialog document="conduct" trigger={chunks} />
               ),
             },
           )}
@@ -178,12 +161,23 @@ const documentContent: Record<PolicyDocument, () => ReactNode> = {
   conduct: CommunityCommitmentsContent,
 };
 
-const PolicyDocumentView = ({
+/**
+ * A policy document, in its own dialog nested over the gate.
+ *
+ * Nested rather than swapping the gate's content, so base-ui owns the focus:
+ * opening scopes focus into the document and closing returns it to the link
+ * that opened it. Swapping unmounted that link mid-press, dropping focus to the
+ * body with nothing announced.
+ *
+ * The trigger sits next to (not inside) the consent Checkbox's label, so
+ * pressing a link never toggles it.
+ */
+const PolicyDocumentDialog = ({
   document,
-  onBack,
+  trigger,
 }: {
   document: PolicyDocument;
-  onBack: () => void;
+  trigger: ReactNode;
 }) => {
   const t = useTranslations();
   const documentTitle: Record<PolicyDocument, string> = {
@@ -194,39 +188,38 @@ const PolicyDocumentView = ({
   const Content = documentContent[document];
 
   return (
-    <>
-      <DialogHeader className="relative min-h-16 shrink-0 flex-row items-center px-4 py-0 pe-4">
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label={t('Back')}
-          onClick={onBack}
-        >
-          <LuArrowLeft className="size-5 rtl:-scale-x-100" aria-hidden />
-        </Button>
-        {/* Centred on the header, not on the Back button beside it, so `relative`
-            above is load-bearing. */}
-        <DialogTitle className="pointer-events-none absolute inset-x-0 text-center">
-          {documentTitle[document]}
-        </DialogTitle>
-      </DialogHeader>
-      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
-        <Content />
-      </div>
-    </>
+    <Dialog>
+      <DialogTrigger
+        render={
+          <Button variant="link" size="inline">
+            {trigger}
+          </Button>
+        }
+      />
+      <DialogContent
+        showCloseButton={false}
+        className="flex flex-col overflow-hidden p-0 sm:max-w-[36rem]"
+      >
+        <DialogHeader className="relative min-h-16 shrink-0 flex-row items-center px-4 py-0 pe-4">
+          {/* Back rather than a close X: this reads as a drill-down from the
+              gate, and it's the nested dialog's DialogClose either way. */}
+          <DialogClose
+            render={
+              <Button variant="ghost" size="icon" aria-label={t('Back')} />
+            }
+          >
+            <LuArrowLeft className="size-5 rtl:-scale-x-100" aria-hidden />
+          </DialogClose>
+          {/* Centred on the header, not on the Back button beside it, so
+              `relative` above is load-bearing. */}
+          <DialogTitle className="pointer-events-none absolute inset-x-0 text-center">
+            {documentTitle[document]}
+          </DialogTitle>
+        </DialogHeader>
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+          <Content />
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 };
-
-// Sits next to (not inside) the consent Checkbox's label, so pressing a link
-// never toggles it.
-const PolicyLink = ({
-  onOpen,
-  children,
-}: {
-  onOpen: () => void;
-  children: ReactNode;
-}) => (
-  <Button variant="link" size="inline" onClick={onOpen}>
-    {children}
-  </Button>
-);

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -2,12 +2,11 @@
 
 import { useMaybeUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
+import { Button } from '@op/sense/Button';
+import { Checkbox } from '@op/sense/Checkbox';
+import { Dialog, DialogContent, DialogTitle } from '@op/sense/Dialog';
+import { Header1 } from '@op/sense/Header';
 import { toast } from '@op/sense/Toast';
-import { Button } from '@op/ui/Button';
-import { Checkbox } from '@op/ui/Checkbox';
-import { Header1 } from '@op/ui/Header';
-import { Modal, ModalBody } from '@op/ui/Modal';
-import { Surface } from '@op/ui/Surface';
 import { type ReactNode, useState } from 'react';
 import { LuArrowLeft } from 'react-icons/lu';
 
@@ -66,22 +65,30 @@ const PolicyReacceptanceModalContent = () => {
   };
 
   return (
-    <Modal isOpen isDismissable={false} isKeyboardDismissDisabled>
-      {activeDocument ? (
-        <PolicyDocumentView
-          document={activeDocument}
-          onBack={() => setActiveDocument(null)}
-        />
-      ) : (
-        <PolicyReacceptanceMain
-          agreed={agreed}
-          onAgreedChange={setAgreed}
-          onOpenDocument={setActiveDocument}
-          onAgree={handleAgree}
-          isSubmitting={isSubmitting}
-        />
-      )}
-    </Modal>
+    // Controlled `open` with no `onOpenChange`, so nothing can close it: Escape
+    // and the backdrop have nowhere to write. `disablePointerDismissal` also
+    // keeps a non-modal outside press from trying.
+    <Dialog open disablePointerDismissal>
+      {/* p-0 because each view owns its padding, and the document view's header
+          has to sit flush to be sticky. Width matches the legal dialogs in
+          Onboarding/ToSAcceptanceScreen. */}
+      <DialogContent showCloseButton={false} className="p-0 sm:max-w-[36rem]">
+        {activeDocument ? (
+          <PolicyDocumentView
+            document={activeDocument}
+            onBack={() => setActiveDocument(null)}
+          />
+        ) : (
+          <PolicyReacceptanceMain
+            agreed={agreed}
+            onAgreedChange={setAgreed}
+            onOpenDocument={setActiveDocument}
+            onAgree={handleAgree}
+            isSubmitting={isSubmitting}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
   );
 };
 
@@ -101,36 +108,36 @@ const PolicyReacceptanceMain = ({
   const t = useTranslations();
 
   return (
-    <ModalBody className="gap-6 p-8 sm:px-10 sm:py-10">
+    <div className="flex flex-col gap-6 p-8 sm:px-10 sm:py-10">
       <div className="flex flex-col gap-2 text-center">
-        <Header1>{t("We've updated our policies.")}</Header1>
-        <p className="text-base text-neutral-charcoal">
+        <DialogTitle render={<Header1 />}>
+          {t("We've updated our policies.")}
+        </DialogTitle>
+        <p className="text-base text-muted-foreground">
           {t('Review the changes and accept to keep using Common.')}
         </p>
       </div>
 
-      <Surface variant="filled" className="flex flex-col gap-2 rounded-xl p-4">
-        <span className="font-serif text-title-sm text-neutral-charcoal">
+      {/* @op/ui's `Surface variant="filled"` has no sense counterpart; it was a
+          bordered box on the off-white tint, which is `bg-muted`. */}
+      <div className="flex flex-col gap-2 rounded-xl border border-border bg-muted p-4">
+        <span className="font-serif text-title text-foreground">
           {t("What's changed")}
         </span>
-        <p className="text-base text-neutral-charcoal">
+        <p className="text-base text-muted-foreground">
           {t(
             'Common now works with a third-party service that automatically reviews content posted on the platform to keep the community safe and uphold our Code of Conduct. Our Terms of Use and Privacy Policy now explain how this works and what it means for your data.',
           )}
         </p>
-      </Surface>
+      </div>
 
       <div className="flex items-start gap-2">
         <Checkbox
-          size="small"
           aria-labelledby="policy-consent-label"
-          isSelected={agreed}
-          onChange={onAgreedChange}
+          checked={agreed}
+          onCheckedChange={onAgreedChange}
         />
-        <span
-          id="policy-consent-label"
-          className="text-base text-neutral-charcoal"
-        >
+        <span id="policy-consent-label" className="text-base text-foreground">
           {t.rich(
             'I have read and agree to the <terms>Terms of Use</terms>, <privacy>Privacy Policy</privacy>, and <conduct>Code of Conduct</conduct>.',
             {
@@ -156,13 +163,13 @@ const PolicyReacceptanceMain = ({
 
       <Button
         className="w-full"
-        isDisabled={!agreed}
-        isLoading={isSubmitting}
-        onPress={onAgree}
+        disabled={!agreed}
+        loading={isSubmitting}
+        onClick={onAgree}
       >
         {t('Agree and continue')}
       </Button>
-    </ModalBody>
+    </div>
   );
 };
 
@@ -189,23 +196,22 @@ const PolicyDocumentView = ({
 
   return (
     <>
-      <div className="sticky top-0 z-30 flex min-h-16 items-center border-b bg-white px-4">
+      <div className="sticky top-0 z-30 flex min-h-16 items-center border-b border-border bg-background px-4">
         <Button
-          color="ghost"
-          size="inline"
+          variant="ghost"
+          size="icon"
           aria-label={t('Back')}
-          className="text-neutral-black hover:text-neutral-black pressed:text-neutral-black"
-          onPress={onBack}
+          onClick={onBack}
         >
           <LuArrowLeft className="size-5 rtl:-scale-x-100" aria-hidden />
         </Button>
-        <span className="pointer-events-none absolute inset-x-0 text-center font-serif text-title-sm">
+        <DialogTitle className="pointer-events-none absolute inset-x-0 text-center font-serif text-title">
           {documentTitle[document]}
-        </span>
+        </DialogTitle>
       </div>
-      <ModalBody>
+      <div className="px-6 py-4">
         <Content />
-      </ModalBody>
+      </div>
     </>
   );
 };
@@ -219,7 +225,9 @@ const PolicyLink = ({
   onOpen: () => void;
   children: ReactNode;
 }) => (
-  <Button variant="link" size="inline" onPress={onOpen}>
+  // `h-auto p-0` as in Onboarding/ToSAcceptanceScreen: the default height would
+  // break the sentence this sits inside.
+  <Button variant="link" className="h-auto p-0" onClick={onOpen}>
     {children}
   </Button>
 );

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -220,7 +220,7 @@ const PolicyDocumentDialog = ({
       <DialogContent
         showCloseButton={false}
         initialFocus={scrollRef}
-        className="flex flex-col overflow-hidden p-0 sm:max-w-[36rem]"
+        className="flex flex-col overflow-hidden p-0 sm:max-w-xl"
       >
         <DialogHeader className="relative min-h-16 shrink-0 flex-row items-center px-4 py-0 pe-4">
           {/* Back rather than a close X: this reads as a drill-down from the

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@op/sense/Dialog';
+import { Header3 } from '@op/sense/Header';
 import { toast } from '@op/sense/Toast';
 import { type ReactNode, useRef, useState } from 'react';
 import { LuArrowLeft } from 'react-icons/lu';
@@ -77,7 +78,7 @@ const PolicyReacceptanceModalContent = () => {
           whole card. */}
       <DialogContent
         showCloseButton={false}
-        className="flex flex-col overflow-hidden p-0 sm:max-w-[36rem]"
+        className="flex flex-col overflow-hidden p-0 sm:max-w-lg"
       >
         <PolicyReacceptanceMain
           agreed={agreed}
@@ -119,7 +120,7 @@ const PolicyReacceptanceMain = ({
 
       <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-8 py-6 sm:px-10">
         <div className="flex flex-col gap-2 rounded-xl border border-border bg-muted p-4">
-          <span className="font-serif text-title">{t("What's changed")}</span>
+          <Header3>{t("What's changed")}</Header3>
           <p>
             {t(
               'Common now works with a third-party service that automatically reviews content posted on the platform to keep the community safe and uphold our Code of Conduct. Our Terms of Use and Privacy Policy now explain how this works and what it means for your data.',
@@ -205,7 +206,11 @@ const PolicyDocumentDialog = ({
     <Dialog>
       <DialogTrigger
         render={
-          <Button variant="link" size="inline">
+          <Button
+            variant="link"
+            size="inline"
+            className="underline hover:no-underline"
+          >
             {trigger}
           </Button>
         }

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -5,7 +5,6 @@ import { trpc } from '@op/api/client';
 import { Button } from '@op/sense/Button';
 import { Checkbox } from '@op/sense/Checkbox';
 import { Dialog, DialogContent, DialogTitle } from '@op/sense/Dialog';
-import { Header1 } from '@op/sense/Header';
 import { toast } from '@op/sense/Toast';
 import { type ReactNode, useState } from 'react';
 import { LuArrowLeft } from 'react-icons/lu';
@@ -110,7 +109,11 @@ const PolicyReacceptanceMain = ({
   return (
     <div className="flex flex-col gap-6 p-8 sm:px-10 sm:py-10">
       <div className="flex flex-col gap-2 text-center">
-        <DialogTitle render={<Header1 />}>
+        {/* Sized here rather than `render={<Header1 />}`: base-ui concatenates
+            className without merging, so Header1's `text-display` and
+            DialogTitle's `text-title` would both ship and the cascade would
+            pick. */}
+        <DialogTitle className="text-display font-light">
           {t("We've updated our policies.")}
         </DialogTitle>
         <p className="text-base text-muted-foreground">
@@ -121,9 +124,7 @@ const PolicyReacceptanceMain = ({
       {/* @op/ui's `Surface variant="filled"` has no sense counterpart; it was a
           bordered box on the off-white tint, which is `bg-muted`. */}
       <div className="flex flex-col gap-2 rounded-xl border border-border bg-muted p-4">
-        <span className="font-serif text-title text-foreground">
-          {t("What's changed")}
-        </span>
+        <span className="font-serif text-title">{t("What's changed")}</span>
         <p className="text-base text-muted-foreground">
           {t(
             'Common now works with a third-party service that automatically reviews content posted on the platform to keep the community safe and uphold our Code of Conduct. Our Terms of Use and Privacy Policy now explain how this works and what it means for your data.',
@@ -137,7 +138,7 @@ const PolicyReacceptanceMain = ({
           checked={agreed}
           onCheckedChange={onAgreedChange}
         />
-        <span id="policy-consent-label" className="text-base text-foreground">
+        <span id="policy-consent-label" className="text-base">
           {t.rich(
             'I have read and agree to the <terms>Terms of Use</terms>, <privacy>Privacy Policy</privacy>, and <conduct>Code of Conduct</conduct>.',
             {
@@ -196,7 +197,9 @@ const PolicyDocumentView = ({
 
   return (
     <>
-      <div className="sticky top-0 z-30 flex min-h-16 items-center border-b border-border bg-background px-4">
+      {/* bg-popover, not bg-background: it has to occlude the text scrolling
+          under it, and the surface it sits on is the dialog's. */}
+      <div className="sticky top-0 z-30 flex min-h-16 items-center border-b border-border bg-popover px-4">
         <Button
           variant="ghost"
           size="icon"
@@ -205,7 +208,7 @@ const PolicyDocumentView = ({
         >
           <LuArrowLeft className="size-5 rtl:-scale-x-100" aria-hidden />
         </Button>
-        <DialogTitle className="pointer-events-none absolute inset-x-0 text-center font-serif text-title">
+        <DialogTitle className="pointer-events-none absolute inset-x-0 text-center">
           {documentTitle[document]}
         </DialogTitle>
       </div>

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -78,94 +78,69 @@ const PolicyReacceptanceModalContent = () => {
           whole card. */}
       <DialogContent
         showCloseButton={false}
-        className="flex flex-col overflow-hidden p-0 sm:max-w-lg"
+        className="flex flex-col overflow-hidden sm:max-w-lg"
       >
-        <PolicyReacceptanceMain
-          agreed={agreed}
-          onAgreedChange={setAgreed}
-          onAgree={handleAgree}
-          isSubmitting={isSubmitting}
-        />
+        {/* No divider, no room reserved for a close button, and centred: the
+          slot's chrome is for a titled dialog with an X, which this isn't. */}
+        <DialogHeader className="shrink-0 border-b-0 px-8 pt-8 pb-0 text-center sm:px-10 sm:pt-10">
+          <DialogTitle className="text-headline">
+            {t("We've updated our policies.")}
+          </DialogTitle>
+          {/* Not muted: this line is content, not a subtitle. */}
+          <DialogDescription className="text-foreground">
+            {t('Review the changes and accept to keep using Common.')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-8 py-6 sm:px-10">
+          <div className="flex flex-col gap-2 rounded-xl border bg-muted p-4">
+            <Header3>{t("What's changed")}</Header3>
+            <p>
+              {t(
+                'Common now works with a third-party service that automatically reviews content posted on the platform to keep the community safe and uphold our Code of Conduct. Our Terms of Use and Privacy Policy now explain how this works and what it means for your data.',
+              )}
+            </p>
+          </div>
+
+          <div className="flex items-start gap-2">
+            <Checkbox
+              aria-labelledby="policy-consent-label"
+              checked={agreed}
+              onCheckedChange={setAgreed}
+            />
+            <span id="policy-consent-label" className="-mt-1 text-base">
+              {t.rich(
+                'I have read and agree to the <terms>Terms of Use</terms>, <privacy>Privacy Policy</privacy>, and <conduct>Code of Conduct</conduct>.',
+                {
+                  terms: (chunks: ReactNode) => (
+                    <PolicyDocumentDialog document="terms" trigger={chunks} />
+                  ),
+                  privacy: (chunks: ReactNode) => (
+                    <PolicyDocumentDialog document="privacy" trigger={chunks} />
+                  ),
+                  conduct: (chunks: ReactNode) => (
+                    <PolicyDocumentDialog document="conduct" trigger={chunks} />
+                  ),
+                },
+              )}
+            </span>
+          </div>
+        </div>
+
+        {/* Untinted and undivided, and the button keeps its own full width rather
+          than being pushed to the inline end. */}
+        <DialogFooter className="shrink-0 border-t-0 bg-transparent px-8 pt-0 pb-8 sm:flex-col sm:px-10 sm:pb-10">
+          <Button
+            className="w-full"
+            disabled={!agreed}
+            loading={isSubmitting}
+            onClick={handleAgree}
+          >
+            {t('Agree and continue')}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-};
-
-const PolicyReacceptanceMain = ({
-  agreed,
-  onAgreedChange,
-  onAgree,
-  isSubmitting,
-}: {
-  agreed: boolean;
-  onAgreedChange: (value: boolean) => void;
-  onAgree: () => void;
-  isSubmitting: boolean;
-}) => {
-  const t = useTranslations();
-
-  return (
-    <>
-      {/* No divider, no room reserved for a close button, and centred: the
-          slot's chrome is for a titled dialog with an X, which this isn't. */}
-      <DialogHeader className="shrink-0 border-b-0 px-8 pe-8 pt-8 pb-0 text-center sm:px-10 sm:pt-10">
-        <DialogTitle className="text-headline">
-          {t("We've updated our policies.")}
-        </DialogTitle>
-        {/* Not muted: this line is content, not a subtitle. */}
-        <DialogDescription className="text-foreground">
-          {t('Review the changes and accept to keep using Common.')}
-        </DialogDescription>
-      </DialogHeader>
-
-      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-8 py-6 sm:px-10">
-        <div className="flex flex-col gap-2 rounded-xl border border-border bg-muted p-4">
-          <Header3>{t("What's changed")}</Header3>
-          <p>
-            {t(
-              'Common now works with a third-party service that automatically reviews content posted on the platform to keep the community safe and uphold our Code of Conduct. Our Terms of Use and Privacy Policy now explain how this works and what it means for your data.',
-            )}
-          </p>
-        </div>
-
-        <div className="flex items-start gap-2">
-          <Checkbox
-            aria-labelledby="policy-consent-label"
-            checked={agreed}
-            onCheckedChange={onAgreedChange}
-          />
-          <span id="policy-consent-label" className="-mt-1 text-base">
-            {t.rich(
-              'I have read and agree to the <terms>Terms of Use</terms>, <privacy>Privacy Policy</privacy>, and <conduct>Code of Conduct</conduct>.',
-              {
-                terms: (chunks: ReactNode) => (
-                  <PolicyDocumentDialog document="terms" trigger={chunks} />
-                ),
-                privacy: (chunks: ReactNode) => (
-                  <PolicyDocumentDialog document="privacy" trigger={chunks} />
-                ),
-                conduct: (chunks: ReactNode) => (
-                  <PolicyDocumentDialog document="conduct" trigger={chunks} />
-                ),
-              },
-            )}
-          </span>
-        </div>
-      </div>
-
-      {/* Untinted and undivided, and the button keeps its own full width rather
-          than being pushed to the inline end. */}
-      <DialogFooter className="shrink-0 border-t-0 bg-transparent px-8 pt-0 pb-8 sm:flex-col sm:px-10 sm:pb-10">
-        <Button
-          className="w-full"
-          disabled={!agreed}
-          loading={isSubmitting}
-          onClick={onAgree}
-        >
-          {t('Agree and continue')}
-        </Button>
-      </DialogFooter>
-    </>
   );
 };
 
@@ -183,8 +158,9 @@ const documentContent: Record<PolicyDocument, () => ReactNode> = {
  * that opened it. Swapping unmounted that link mid-press, dropping focus to the
  * body with nothing announced.
  *
- * The trigger sits next to (not inside) the consent Checkbox's label, so
- * pressing a link never toggles it.
+ * The trigger sits inside the consent Checkbox's label text, which is safe
+ * because the two are associated with `aria-labelledby` rather than a wrapping
+ * `<label>` — so a press inside the text never forwards to the control.
  */
 const PolicyDocumentDialog = ({
   document,
@@ -220,9 +196,9 @@ const PolicyDocumentDialog = ({
       <DialogContent
         showCloseButton={false}
         initialFocus={scrollRef}
-        className="flex flex-col overflow-hidden p-0 sm:max-w-xl"
+        className="flex flex-col overflow-hidden sm:max-w-xl"
       >
-        <DialogHeader className="relative min-h-16 shrink-0 flex-row items-center px-4 py-0 pe-4">
+        <DialogHeader className="relative min-h-16 shrink-0 flex-row items-center px-4 py-0">
           {/* Back rather than a close X: this reads as a drill-down from the
               gate, and it's the nested dialog's DialogClose either way. */}
           <DialogClose
@@ -234,7 +210,7 @@ const PolicyDocumentDialog = ({
           </DialogClose>
           {/* Centred on the header, not on the Back button beside it, so
               `relative` above is load-bearing. */}
-          <DialogTitle className="pointer-events-none absolute inset-x-0 text-center">
+          <DialogTitle className="pointer-events-none absolute inset-x-14 truncate text-center">
             {documentTitle[document]}
           </DialogTitle>
         </DialogHeader>

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -4,7 +4,12 @@ import { useMaybeUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
 import { Button } from '@op/sense/Button';
 import { Checkbox } from '@op/sense/Checkbox';
-import { Dialog, DialogContent, DialogTitle } from '@op/sense/Dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@op/sense/Dialog';
 import { toast } from '@op/sense/Toast';
 import { type ReactNode, useState } from 'react';
 import { LuArrowLeft } from 'react-icons/lu';
@@ -67,7 +72,12 @@ const PolicyReacceptanceModalContent = () => {
     // Controlled `open` with no `onOpenChange`: Escape and the backdrop have
     // nowhere to write, so the gate can't be dismissed.
     <Dialog open disablePointerDismissal>
-      <DialogContent showCloseButton={false} className="p-0 sm:max-w-[36rem]">
+      {/* Column, not the default grid, so each view can put the scroll on its
+          own body instead of on the whole card. */}
+      <DialogContent
+        showCloseButton={false}
+        className="flex flex-col overflow-hidden p-0 sm:max-w-[36rem]"
+      >
         {activeDocument ? (
           <PolicyDocumentView
             document={activeDocument}
@@ -103,17 +113,17 @@ const PolicyReacceptanceMain = ({
   const t = useTranslations();
 
   return (
-    <div className="flex flex-col gap-6 p-8 sm:px-10 sm:py-10">
+    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-8 sm:px-10 sm:py-10">
       <div className="flex flex-col gap-2 text-center">
-        <DialogTitle>{t("We've updated our policies.")}</DialogTitle>
-        <p className="text-base text-muted-foreground">
-          {t('Review the changes and accept to keep using Common.')}
-        </p>
+        <DialogTitle className="text-headline">
+          {t("We've updated our policies.")}
+        </DialogTitle>
+        <p>{t('Review the changes and accept to keep using Common.')}</p>
       </div>
 
       <div className="flex flex-col gap-2 rounded-xl border border-border bg-muted p-4">
         <span className="font-serif text-title">{t("What's changed")}</span>
-        <p className="text-base text-muted-foreground">
+        <p>
           {t(
             'Common now works with a third-party service that automatically reviews content posted on the platform to keep the community safe and uphold our Code of Conduct. Our Terms of Use and Privacy Policy now explain how this works and what it means for your data.',
           )}
@@ -126,7 +136,7 @@ const PolicyReacceptanceMain = ({
           checked={agreed}
           onCheckedChange={onAgreedChange}
         />
-        <span id="policy-consent-label" className="text-base">
+        <span id="policy-consent-label" className="-mt-1 text-base">
           {t.rich(
             'I have read and agree to the <terms>Terms of Use</terms>, <privacy>Privacy Policy</privacy>, and <conduct>Code of Conduct</conduct>.',
             {
@@ -185,7 +195,7 @@ const PolicyDocumentView = ({
 
   return (
     <>
-      <div className="sticky top-0 z-30 flex min-h-16 items-center border-b border-border bg-popover px-4">
+      <DialogHeader className="relative min-h-16 shrink-0 flex-row items-center px-4 py-0 pe-4">
         <Button
           variant="ghost"
           size="icon"
@@ -194,11 +204,13 @@ const PolicyDocumentView = ({
         >
           <LuArrowLeft className="size-5 rtl:-scale-x-100" aria-hidden />
         </Button>
+        {/* Centred on the header, not on the Back button beside it, so `relative`
+            above is load-bearing. */}
         <DialogTitle className="pointer-events-none absolute inset-x-0 text-center">
           {documentTitle[document]}
         </DialogTitle>
-      </div>
-      <div className="px-6 py-4">
+      </DialogHeader>
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
         <Content />
       </div>
     </>

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -8,12 +8,14 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '@op/sense/Dialog';
 import { toast } from '@op/sense/Toast';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useRef, useState } from 'react';
 import { LuArrowLeft } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
@@ -102,56 +104,67 @@ const PolicyReacceptanceMain = ({
   const t = useTranslations();
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-8 sm:px-10 sm:py-10">
-      <div className="flex flex-col gap-2 text-center">
+    <>
+      {/* No divider, no room reserved for a close button, and centred: the
+          slot's chrome is for a titled dialog with an X, which this isn't. */}
+      <DialogHeader className="shrink-0 border-b-0 px-8 pe-8 pt-8 pb-0 text-center sm:px-10 sm:pt-10">
         <DialogTitle className="text-headline">
           {t("We've updated our policies.")}
         </DialogTitle>
-        <p>{t('Review the changes and accept to keep using Common.')}</p>
+        {/* Not muted: this line is content, not a subtitle. */}
+        <DialogDescription className="text-foreground">
+          {t('Review the changes and accept to keep using Common.')}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-8 py-6 sm:px-10">
+        <div className="flex flex-col gap-2 rounded-xl border border-border bg-muted p-4">
+          <span className="font-serif text-title">{t("What's changed")}</span>
+          <p>
+            {t(
+              'Common now works with a third-party service that automatically reviews content posted on the platform to keep the community safe and uphold our Code of Conduct. Our Terms of Use and Privacy Policy now explain how this works and what it means for your data.',
+            )}
+          </p>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <Checkbox
+            aria-labelledby="policy-consent-label"
+            checked={agreed}
+            onCheckedChange={onAgreedChange}
+          />
+          <span id="policy-consent-label" className="-mt-1 text-base">
+            {t.rich(
+              'I have read and agree to the <terms>Terms of Use</terms>, <privacy>Privacy Policy</privacy>, and <conduct>Code of Conduct</conduct>.',
+              {
+                terms: (chunks: ReactNode) => (
+                  <PolicyDocumentDialog document="terms" trigger={chunks} />
+                ),
+                privacy: (chunks: ReactNode) => (
+                  <PolicyDocumentDialog document="privacy" trigger={chunks} />
+                ),
+                conduct: (chunks: ReactNode) => (
+                  <PolicyDocumentDialog document="conduct" trigger={chunks} />
+                ),
+              },
+            )}
+          </span>
+        </div>
       </div>
 
-      <div className="flex flex-col gap-2 rounded-xl border border-border bg-muted p-4">
-        <span className="font-serif text-title">{t("What's changed")}</span>
-        <p>
-          {t(
-            'Common now works with a third-party service that automatically reviews content posted on the platform to keep the community safe and uphold our Code of Conduct. Our Terms of Use and Privacy Policy now explain how this works and what it means for your data.',
-          )}
-        </p>
-      </div>
-
-      <div className="flex items-start gap-2">
-        <Checkbox
-          aria-labelledby="policy-consent-label"
-          checked={agreed}
-          onCheckedChange={onAgreedChange}
-        />
-        <span id="policy-consent-label" className="-mt-1 text-base">
-          {t.rich(
-            'I have read and agree to the <terms>Terms of Use</terms>, <privacy>Privacy Policy</privacy>, and <conduct>Code of Conduct</conduct>.',
-            {
-              terms: (chunks: ReactNode) => (
-                <PolicyDocumentDialog document="terms" trigger={chunks} />
-              ),
-              privacy: (chunks: ReactNode) => (
-                <PolicyDocumentDialog document="privacy" trigger={chunks} />
-              ),
-              conduct: (chunks: ReactNode) => (
-                <PolicyDocumentDialog document="conduct" trigger={chunks} />
-              ),
-            },
-          )}
-        </span>
-      </div>
-
-      <Button
-        className="w-full"
-        disabled={!agreed}
-        loading={isSubmitting}
-        onClick={onAgree}
-      >
-        {t('Agree and continue')}
-      </Button>
-    </div>
+      {/* Untinted and undivided, and the button keeps its own full width rather
+          than being pushed to the inline end. */}
+      <DialogFooter className="shrink-0 border-t-0 bg-transparent px-8 pt-0 pb-8 sm:flex-col sm:px-10 sm:pb-10">
+        <Button
+          className="w-full"
+          disabled={!agreed}
+          loading={isSubmitting}
+          onClick={onAgree}
+        >
+          {t('Agree and continue')}
+        </Button>
+      </DialogFooter>
+    </>
   );
 };
 
@@ -186,6 +199,7 @@ const PolicyDocumentDialog = ({
     conduct: t('Code of Conduct'),
   };
   const Content = documentContent[document];
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   return (
     <Dialog>
@@ -196,8 +210,11 @@ const PolicyDocumentDialog = ({
           </Button>
         }
       />
+      {/* Focus the body, not the first link buried in the legal text — base-ui
+          would otherwise scroll the document to wherever that link sits. */}
       <DialogContent
         showCloseButton={false}
+        initialFocus={scrollRef}
         className="flex flex-col overflow-hidden p-0 sm:max-w-[36rem]"
       >
         <DialogHeader className="relative min-h-16 shrink-0 flex-row items-center px-4 py-0 pe-4">
@@ -216,7 +233,11 @@ const PolicyDocumentDialog = ({
             {documentTitle[document]}
           </DialogTitle>
         </DialogHeader>
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+        <div
+          ref={scrollRef}
+          tabIndex={-1}
+          className="min-h-0 flex-1 overflow-y-auto px-6 py-4 outline-none"
+        >
           <Content />
         </div>
       </DialogContent>

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -225,9 +225,7 @@ const PolicyLink = ({
   onOpen: () => void;
   children: ReactNode;
 }) => (
-  // `h-auto p-0` as in Onboarding/ToSAcceptanceScreen: the default height would
-  // break the sentence this sits inside.
-  <Button variant="link" className="h-auto p-0" onClick={onOpen}>
+  <Button variant="link" size="inline" onClick={onOpen}>
     {children}
   </Button>
 );

--- a/apps/app/src/components/PolicyReacceptanceModal/index.tsx
+++ b/apps/app/src/components/PolicyReacceptanceModal/index.tsx
@@ -64,13 +64,9 @@ const PolicyReacceptanceModalContent = () => {
   };
 
   return (
-    // Controlled `open` with no `onOpenChange`, so nothing can close it: Escape
-    // and the backdrop have nowhere to write. `disablePointerDismissal` also
-    // keeps a non-modal outside press from trying.
+    // Controlled `open` with no `onOpenChange`: Escape and the backdrop have
+    // nowhere to write, so the gate can't be dismissed.
     <Dialog open disablePointerDismissal>
-      {/* p-0 because each view owns its padding, and the document view's header
-          has to sit flush to be sticky. Width matches the legal dialogs in
-          Onboarding/ToSAcceptanceScreen. */}
       <DialogContent showCloseButton={false} className="p-0 sm:max-w-[36rem]">
         {activeDocument ? (
           <PolicyDocumentView
@@ -109,20 +105,12 @@ const PolicyReacceptanceMain = ({
   return (
     <div className="flex flex-col gap-6 p-8 sm:px-10 sm:py-10">
       <div className="flex flex-col gap-2 text-center">
-        {/* Sized here rather than `render={<Header1 />}`: base-ui concatenates
-            className without merging, so Header1's `text-display` and
-            DialogTitle's `text-title` would both ship and the cascade would
-            pick. */}
-        <DialogTitle className="text-display font-light">
-          {t("We've updated our policies.")}
-        </DialogTitle>
+        <DialogTitle>{t("We've updated our policies.")}</DialogTitle>
         <p className="text-base text-muted-foreground">
           {t('Review the changes and accept to keep using Common.')}
         </p>
       </div>
 
-      {/* @op/ui's `Surface variant="filled"` has no sense counterpart; it was a
-          bordered box on the off-white tint, which is `bg-muted`. */}
       <div className="flex flex-col gap-2 rounded-xl border border-border bg-muted p-4">
         <span className="font-serif text-title">{t("What's changed")}</span>
         <p className="text-base text-muted-foreground">
@@ -197,8 +185,6 @@ const PolicyDocumentView = ({
 
   return (
     <>
-      {/* bg-popover, not bg-background: it has to occlude the text scrolling
-          under it, and the surface it sits on is the dialog's. */}
       <div className="sticky top-0 z-30 flex min-h-16 items-center border-b border-border bg-popover px-4">
         <Button
           variant="ghost"
@@ -219,8 +205,8 @@ const PolicyDocumentView = ({
   );
 };
 
-// Opens a policy document inside the modal. Rendered next to (not inside) the
-// consent Checkbox, so pressing a link never toggles it.
+// Sits next to (not inside) the consent Checkbox's label, so pressing a link
+// never toggles it.
 const PolicyLink = ({
   onOpen,
   children,

--- a/apps/app/src/components/PrivacyPolicyContent/index.tsx
+++ b/apps/app/src/components/PrivacyPolicyContent/index.tsx
@@ -6,14 +6,14 @@ export const PrivacyPolicyContent = () => {
   return (
     <div className="relative flex w-full flex-col gap-8 sm:pb-20">
       <FormalSection>
-        <Header3 className="font-serif">One Project Privacy Notice</Header3>
+        <Header3>One Project Privacy Notice</Header3>
         <p>
           <i>Last Updated: July 2, 2026</i>
         </p>
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Who We Are</Header3>
+        <Header3>Who We Are</Header3>
         <p className="mb-4">
           One Project (collectively One Project, we, our, or us) is a non-profit
           building infrastructure for economic democracy. We build the
@@ -30,7 +30,7 @@ export const PrivacyPolicyContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Purpose of this Privacy Notice</Header3>
+        <Header3>Purpose of this Privacy Notice</Header3>
         <p className="mb-4">
           This Notice describes the types of Personal Data that One Project may
           collect or process, how we may use and disclose that Personal Data,
@@ -75,7 +75,7 @@ export const PrivacyPolicyContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
+        <Header3>
           Special Privacy Standards for Specific Platform Instances
         </Header3>
         <p className="mb-4">
@@ -110,9 +110,7 @@ export const PrivacyPolicyContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          Personal Data Collected, Purposes, and Recipients
-        </Header3>
+        <Header3>Personal Data Collected, Purposes, and Recipients</Header3>
 
         <h4 className="mb-2 font-semibold">What is Personal Data?</h4>
         <p className="mb-4">
@@ -281,7 +279,7 @@ export const PrivacyPolicyContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Users of the Platform</Header3>
+        <Header3>Users of the Platform</Header3>
         <p className="mb-4">
           We may process your Personal Data when you (1) use the Platform (2)
           contact us or submit information in connection with your use of the
@@ -496,7 +494,7 @@ export const PrivacyPolicyContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Children</Header3>
+        <Header3>Children</Header3>
         <p className="mb-4">
           One Project does not knowingly collect data from children below the
           age of 13 in the United States, and does not knowingly collect,
@@ -525,7 +523,7 @@ export const PrivacyPolicyContent = () => {
 
       <div id="marketing-and-cookies">
         <FormalSection>
-          <Header3 className="font-serif">Marketing and Cookies</Header3>
+          <Header3>Marketing and Cookies</Header3>
           <p className="mb-4">
             To the extent permitted by law, including with your consent where
             required, we may engage in the following activities:
@@ -583,7 +581,7 @@ export const PrivacyPolicyContent = () => {
       </div>
 
       <FormalSection>
-        <Header3 className="font-serif">Chat Functions on Our Services</Header3>
+        <Header3>Chat Functions on Our Services</Header3>
         <p className="mb-4">
           We may offer a chat feature as a part of our services. If you interact
           with any chat functions, you consent to the processing of your
@@ -595,9 +593,7 @@ export const PrivacyPolicyContent = () => {
 
       <div id="service-providers">
         <FormalSection>
-          <Header3 className="font-serif">
-            Service Providers and Third Parties
-          </Header3>
+          <Header3>Service Providers and Third Parties</Header3>
           <p className="mb-4">
             Service providers or vendors (or processors) acting on our behalf
             must execute agreements requiring them to maintain confidentiality
@@ -611,7 +607,7 @@ export const PrivacyPolicyContent = () => {
       </div>
 
       <FormalSection>
-        <Header3 className="font-serif">
+        <Header3>
           Combination of Data with Data Received from Third Parties and
           Affiliates
         </Header3>
@@ -627,7 +623,7 @@ export const PrivacyPolicyContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Links to Other Websites</Header3>
+        <Header3>Links to Other Websites</Header3>
         <p className="mb-4">
           Our Services may contain links to other websites, applications, or
           services that are not owned or operated by One Project. Such links do
@@ -642,9 +638,7 @@ export const PrivacyPolicyContent = () => {
 
       <div id="your-rights">
         <FormalSection>
-          <Header3 className="font-serif">
-            Your Rights Regarding Your Personal Data
-          </Header3>
+          <Header3>Your Rights Regarding Your Personal Data</Header3>
           <p className="mb-4">
             Depending on where you live, you may have the following rights with
             respect to some or all of your Personal Data:
@@ -736,7 +730,7 @@ export const PrivacyPolicyContent = () => {
       </div>
 
       <FormalSection>
-        <Header3 className="font-serif">Safeguarding Personal Data</Header3>
+        <Header3>Safeguarding Personal Data</Header3>
         <p className="mb-4">
           Consistent with applicable laws and requirements, One Project has put
           in place physical, technical, and administrative safeguards designed
@@ -752,9 +746,7 @@ export const PrivacyPolicyContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          How Long Your Personal Data Will Be Kept
-        </Header3>
+        <Header3>How Long Your Personal Data Will Be Kept</Header3>
         <p className="mb-4">
           We generally retain Personal Data for as long as needed for the
           specific purpose or purposes for which it was collected or obtained,
@@ -777,7 +769,7 @@ export const PrivacyPolicyContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Transfer of Personal Data</Header3>
+        <Header3>Transfer of Personal Data</Header3>
         <p className="mb-4">
           We operate in various countries throughout the world, including, but
           not limited to, the United States and Canada. Please be aware that
@@ -791,7 +783,7 @@ export const PrivacyPolicyContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">Changes to This Privacy Notice</Header3>
+        <Header3>Changes to This Privacy Notice</Header3>
         <p className="mb-4">
           We reserve the right to change this Notice from time to time. We will
           alert you when changes have been made by indicating the date this
@@ -803,7 +795,7 @@ export const PrivacyPolicyContent = () => {
 
       <div id="contact-us">
         <FormalSection>
-          <Header3 className="font-serif">Contact Us</Header3>
+          <Header3>Contact Us</Header3>
           <p className="mb-4">
             If you have questions or comments about this Notice or about how
             your Personal Data is processed, or to exercise your privacy rights,

--- a/apps/app/src/components/PrivacyPolicyContent/index.tsx
+++ b/apps/app/src/components/PrivacyPolicyContent/index.tsx
@@ -4,7 +4,7 @@ import { FormalSection } from '../FormalSection';
 
 export const PrivacyPolicyContent = () => {
   return (
-    <div className="relative flex w-full flex-col gap-8 sm:pb-20">
+    <div dir="auto" className="relative flex w-full flex-col gap-8 sm:pb-20">
       <FormalSection>
         <Header3>One Project Privacy Notice</Header3>
         <p>

--- a/apps/app/src/components/Profile/ProfileDecisions/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDecisions/index.tsx
@@ -82,7 +82,7 @@ const EmptyDecisions = ({ profileId }: { profileId: string }) => {
   const isProcessAdmin = permission.decisions.create && isOwnProfile;
 
   return (
-    <div className="flex min-h-[400px] flex-col items-center justify-center gap-6 px-6 py-16 text-center">
+    <div className="flex min-h-100 flex-col items-center justify-center gap-6 px-6 py-16 text-center">
       <div className="flex size-10 items-center justify-center rounded-full bg-neutral-gray1">
         <LuLeaf className="size-6 text-neutral-gray4" />
       </div>

--- a/apps/app/src/components/SearchInput/index.tsx
+++ b/apps/app/src/components/SearchInput/index.tsx
@@ -282,7 +282,7 @@ export const SearchInput = ({ onBlur }: { onBlur?: () => void } = {}) => {
         className={cn(
           !dropdownShowing && 'hidden',
           isMobile
-            ? 'fixed inset-x-0 top-[60px] bottom-0 z-10 overflow-y-auto bg-popover text-base'
+            ? 'fixed inset-x-0 top-15 bottom-0 z-10 overflow-y-auto bg-popover text-base'
             : 'absolute top-12 z-10 w-full rounded border bg-popover text-base shadow',
         )}
       >

--- a/apps/app/src/components/SiteHeader/UserAvatarMenu.tsx
+++ b/apps/app/src/components/SiteHeader/UserAvatarMenu.tsx
@@ -471,7 +471,7 @@ const LegalDialogs = ({
           on the scroll container (top) instead of the first link deep in the
           legal text, which otherwise opens the dialog scrolled partway down. */}
       <DialogContent
-        className="flex max-h-[85vh] flex-col p-0 sm:max-w-[36rem]"
+        className="flex max-h-[85vh] flex-col p-0 sm:max-w-xl"
         initialFocus={scrollRef}
       >
         <DialogHeader>

--- a/apps/app/src/components/ToSContent/index.tsx
+++ b/apps/app/src/components/ToSContent/index.tsx
@@ -6,7 +6,7 @@ export const ToSContent = () => {
   return (
     <div className="relative flex w-full flex-col gap-8 sm:pb-20">
       <FormalSection>
-        <Header3 className="font-serif">
+        <Header3>
           TERMS OF SERVICE FOR COMMON PLATFORM AND ONE PROJECT SERVICES
         </Header3>
         <p className="mb-4">
@@ -73,9 +73,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          1. Changes to these Terms of Service
-        </Header3>
+        <Header3>1. Changes to these Terms of Service</Header3>
         <p className="mb-4">
           We reserve the right to update, add, remove, or otherwise change any
           portion of these Terms of Service from time to time in our sole
@@ -94,9 +92,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          2. Account and Use of the Services
-        </Header3>
+        <Header3>2. Account and Use of the Services</Header3>
         <p className="mb-4">
           To access some of the Services, you may be asked to provide certain
           information, including, but not limited to, personal information. We
@@ -124,7 +120,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">3. Our Mission</Header3>
+        <Header3>3. Our Mission</Header3>
         <p className="mb-4">
           One Project builds infrastructure for economic democracy. We build the
           technology, mobilize the resources, and make the case, so communities
@@ -142,7 +138,7 @@ export const ToSContent = () => {
 
       {/* Section text carried over from the previous revision — the July 2026 export omitted it; internal references (Section 6/19/27/28) require it here. Pending legal confirmation. */}
       <FormalSection>
-        <Header3 className="font-serif">4. The Code</Header3>
+        <Header3>4. The Code</Header3>
         <p className="mb-4">
           In connection with its collaborative mission, One Project endeavors to
           place all intellectual property developed in the course of its
@@ -162,7 +158,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">5. Suggestions</Header3>
+        <Header3>5. Suggestions</Header3>
         <p className="mb-4">
           We are continuously trying to improve and refine our activities and
           services. If you elect to provide or make available to One Project any
@@ -181,7 +177,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">6. License</Header3>
+        <Header3>6. License</Header3>
         <p className="mb-4">
           Subject to the terms and conditions of these Terms of Service, and any
           additional terms that accompany any additional features,
@@ -197,7 +193,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">7. System Requirements</Header3>
+        <Header3>7. System Requirements</Header3>
         <p className="mb-4">
           Use of the Services requires internet access. You acknowledge and
           agree that all such connectivity requirements are your responsibility.
@@ -210,7 +206,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">8. Use Restrictions</Header3>
+        <Header3>8. Use Restrictions</Header3>
         <p className="mb-4">
           The Services and any related documentation are protected by applicable
           intellectual property and other Laws, including without limitation
@@ -319,7 +315,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">9. Ownership</Header3>
+        <Header3>9. Ownership</Header3>
         <p className="mb-4">
           The Services are licensed, and not sold, to you under these Terms of
           Service. You have no ownership rights in the Services, any related
@@ -332,7 +328,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">10. Trademarks</Header3>
+        <Header3>10. Trademarks</Header3>
         <p className="mb-4">
           The One Project and Common names and logos, as well as other
           trademarks, names, and logos used in connection with the Services, are
@@ -345,7 +341,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">11. Your Content</Header3>
+        <Header3>11. Your Content</Header3>
         <p className="mb-4">
           You represent and warrant that you either own or have permission to
           use and disclose all of the information, content and other materials
@@ -364,7 +360,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">12. Prohibited Content</Header3>
+        <Header3>12. Prohibited Content</Header3>
         <p className="mb-4">
           You agree not to upload information, content or any other material
           that violates our{' '}
@@ -379,7 +375,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">13. Copyright Infringement</Header3>
+        <Header3>13. Copyright Infringement</Header3>
         <p className="mb-4">
           If you believe that Your Content has been copied in a way that
           constitutes copyright infringement, or that your intellectual property
@@ -488,7 +484,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">14. Limited Liability</Header3>
+        <Header3>14. Limited Liability</Header3>
         <p className="mb-4">
           You understand and acknowledge that you are responsible for Your
           Content, and you, not One Project, have full responsibility for such
@@ -508,7 +504,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">15. Payment</Header3>
+        <Header3>15. Payment</Header3>
         <p className="mb-4">
           During the initial release of the Platform, you may be offered use of
           the Services free of charge. We reserve the right to charge fees for
@@ -524,9 +520,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          16. Limitations Regarding the Services
-        </Header3>
+        <Header3>16. Limitations Regarding the Services</Header3>
         <p className="mb-4">
           One Project, without any liability to you, (a) may suspend or cease
           providing, may limit, or may disable access to all or part of the
@@ -542,7 +536,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">17. Storage</Header3>
+        <Header3>17. Storage</Header3>
         <p className="mb-4">
           The Platform may provide functionality through which you are able to
           store information (such as your profile, photos, and messages) in your
@@ -553,7 +547,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">18. Disclaimer of Warranty</Header3>
+        <Header3>18. Disclaimer of Warranty</Header3>
         <p className="mb-4 font-semibold">
           YOU UNDERSTAND THAT THE SERVICES ARE PROVIDED ON AN "AS IS" AND "AS
           AVAILABLE" BASIS, WITHOUT ANY WARRANTIES OF ANY KIND, EITHER EXPRESS,
@@ -583,7 +577,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">19. Limitation of Liability</Header3>
+        <Header3>19. Limitation of Liability</Header3>
         <p className="mb-4 font-semibold">
           TO THE FULLEST EXTENT PERMITTED BY LAW, IN NO EVENT WILL ONE PROJECT
           OR OUR PARENTS, SUBSIDIARIES, AFFILIATES, OR OTHER RELATED ENTITIES,
@@ -604,7 +598,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">20. Exclusions and Local Laws</Header3>
+        <Header3>20. Exclusions and Local Laws</Header3>
         <p className="mb-4">
           Some jurisdictions do not allow the exclusion of certain warranties or
           the limitation or exclusion of liability for incidental or
@@ -622,7 +616,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">21. Indemnification</Header3>
+        <Header3>21. Indemnification</Header3>
         <p className="mb-4">
           Except to the extent prohibited by Law, you agree to defend,
           indemnify, and hold harmless the One Project Parties from and against
@@ -639,7 +633,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">22. Termination</Header3>
+        <Header3>22. Termination</Header3>
         <p className="mb-4">
           These Terms of Service are effective until terminated. You may
           terminate these Terms of Service at any time by ceasing all use of the
@@ -656,7 +650,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">23. Export Laws</Header3>
+        <Header3>23. Export Laws</Header3>
         <p className="mb-4">
           You acknowledge that the laws and regulations of the United States and
           other countries restrict the export and re-export of commodities and
@@ -675,9 +669,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">
-          24. Use Outside the United States
-        </Header3>
+        <Header3>24. Use Outside the United States</Header3>
         <p className="mb-4">
           The Services may not be available for use in all countries or regions,
           nor are they necessarily translated into all languages. One Project
@@ -691,7 +683,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">25. Miscellaneous</Header3>
+        <Header3>25. Miscellaneous</Header3>
         <p className="mb-4">
           These Terms of Service are the entire agreement between you and One
           Project with respect to, and supersedes any previous oral or written
@@ -701,7 +693,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">26. Governing Law</Header3>
+        <Header3>26. Governing Law</Header3>
         <p className="mb-4">
           These Terms of Service are governed by the laws of the State of
           California, as such laws apply to contracts between California
@@ -722,7 +714,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">27. Dispute Resolution</Header3>
+        <Header3>27. Dispute Resolution</Header3>
         <p className="mb-4 font-semibold">
           PLEASE READ THIS SECTION CAREFULLY. YOU AND ONE PROJECT ARE AGREEING
           TO GIVE UP ANY RIGHTS TO LITIGATE CLAIMS IN A COURT OR BEFORE A JURY,
@@ -881,7 +873,7 @@ export const ToSContent = () => {
       </FormalSection>
 
       <FormalSection>
-        <Header3 className="font-serif">28. Contact Us</Header3>
+        <Header3>28. Contact Us</Header3>
         <p className="mb-4">
           All legal notices to us must be in writing and must reference these
           Terms of Service. The address for One Project for notice purposes

--- a/apps/app/src/components/ToSContent/index.tsx
+++ b/apps/app/src/components/ToSContent/index.tsx
@@ -4,7 +4,7 @@ import { FormalSection } from '../FormalSection';
 
 export const ToSContent = () => {
   return (
-    <div className="relative flex w-full flex-col gap-8 sm:pb-20">
+    <div dir="auto" className="relative flex w-full flex-col gap-8 sm:pb-20">
       <FormalSection>
         <Header3>
           TERMS OF SERVICE FOR COMMON PLATFORM AND ONE PROJECT SERVICES

--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -47,7 +47,7 @@ export const DecisionActionBar = ({
 
   return (
     <div className="flex w-full justify-center">
-      <div className="flex w-full max-w-[12rem] flex-col items-center justify-center gap-4 sm:flex-row">
+      <div className="flex w-full max-w-48 flex-col items-center justify-center gap-4 sm:flex-row">
         {description ? (
           <Dialog>
             <DialogTrigger

--- a/apps/app/src/components/decisions/DecisionCardHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionCardHeader.tsx
@@ -18,7 +18,6 @@ import { TranslatedText } from '../TranslatedText';
 export const DecisionCardHeader = ({
   name,
   currentState,
-  chipVariant = 'accent',
   stewardName,
   stewardAvatarPath,
   children,
@@ -26,8 +25,6 @@ export const DecisionCardHeader = ({
 }: {
   name: string;
   currentState?: string | null;
-  /** `secondary` for a draft, whose phase isn't a real phase. */
-  chipVariant?: 'accent' | 'secondary';
   stewardName?: string | null;
   stewardAvatarPath?: string | null;
   children?: React.ReactNode;
@@ -49,7 +46,7 @@ export const DecisionCardHeader = ({
     {currentState || children ? (
       <div className="flex flex-wrap items-center gap-3">
         {currentState ? (
-          <Badge variant={chipVariant}>
+          <Badge variant="accent">
             <TranslatedText text={currentState as TranslationKey} />
           </Badge>
         ) : null}

--- a/apps/app/src/components/decisions/DecisionCardHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionCardHeader.tsx
@@ -8,48 +8,53 @@ import type { TranslationKey } from '@/lib/i18n';
 
 import { TranslatedText } from '../TranslatedText';
 
+/**
+ * Name, then who stewards it, then the phase chip alongside whatever metadata
+ * the caller passes as `children` (Figma 17827:3655).
+ *
+ * The chip shares the last line rather than sitting beside the name, so a long
+ * process name gets the full width before it wraps.
+ */
 export const DecisionCardHeader = ({
   name,
   currentState,
+  chipVariant = 'accent',
   stewardName,
   stewardAvatarPath,
-  chipClassName,
   children,
   className,
 }: {
   name: string;
   currentState?: string | null;
+  /** `secondary` for a draft, whose phase isn't a real phase. */
+  chipVariant?: 'accent' | 'secondary';
   stewardName?: string | null;
   stewardAvatarPath?: string | null;
-  chipClassName?: string;
   children?: React.ReactNode;
   className?: string;
 }) => (
-  <div className={cn('flex flex-col gap-2', className)}>
-    <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-center sm:justify-start">
-      <Header3 className="font-serif text-neutral-black">{name}</Header3>
-      {currentState ? (
-        <Badge
-          variant="secondary"
-          className={
-            chipClassName ?? 'bg-primary-tealWhite text-primary-tealBlack'
-          }
-        >
-          <TranslatedText text={currentState as TranslationKey} />
-        </Badge>
-      ) : null}
-    </div>
+  <div className={cn('flex flex-col gap-3', className)}>
+    <Header3>{name}</Header3>
     {stewardName ? (
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-2">
         <ProfileAvatar
           name={stewardName}
           src={getPublicUrl(stewardAvatarPath)}
           alt={stewardName}
           size="sm"
         />
-        <span className="text-sm text-neutral-black">{stewardName}</span>
+        <span className="text-sm text-muted-foreground">{stewardName}</span>
       </div>
     ) : null}
-    {children}
+    {currentState || children ? (
+      <div className="flex flex-wrap items-center gap-3">
+        {currentState ? (
+          <Badge variant={chipVariant}>
+            <TranslatedText text={currentState as TranslationKey} />
+          </Badge>
+        ) : null}
+        {children}
+      </div>
+    ) : null}
   </div>
 );

--- a/apps/app/src/components/decisions/DecisionInviteCard.tsx
+++ b/apps/app/src/components/decisions/DecisionInviteCard.tsx
@@ -95,7 +95,8 @@ export const DecisionInviteCard = ({
       {showDecline && (
         <Button
           variant="link"
-          className="h-auto self-center p-0 text-sm font-normal text-primary-teal underline hover:text-primary-teal/80"
+          size="inline"
+          className="self-center text-sm font-normal text-primary-teal underline hover:text-primary-teal/80"
           onClick={() => onDecline(invite.id)}
           disabled={isDeclining || isAccepting}
         >

--- a/apps/app/src/components/decisions/DecisionListItem.tsx
+++ b/apps/app/src/components/decisions/DecisionListItem.tsx
@@ -94,7 +94,7 @@ export const DecisionListItem = ({
 
   return (
     <>
-      <div className="flex items-start gap-0 rounded-lg border hover:bg-primary-tealWhite sm:items-center sm:rounded-none sm:border-0 sm:border-b sm:border-b-neutral-gray1">
+      <div className="flex items-start gap-0 rounded-lg border hover:bg-accent sm:items-center sm:rounded-none sm:border-0 sm:border-b">
         <Link
           href={`/decisions/${item.slug}${isDraft ? '/edit' : ''}`}
           className={cn(
@@ -105,20 +105,14 @@ export const DecisionListItem = ({
           <DecisionCardHeader
             name={processInstance.name || item.name}
             currentState={currentPhaseName}
+            chipVariant={isDraft ? 'secondary' : 'accent'}
             stewardName={displayProfile?.name}
             stewardAvatarPath={displayProfile?.avatarImage?.name}
-            chipClassName={
-              isDraft ? 'bg-neutral-gray1 text-neutral-charcoal' : undefined
-            }
           >
-            {closingDate && (
-              <div className="flex flex-wrap items-center gap-2 py-1 text-xs sm:gap-6">
-                <DecisionClosingDate closingDate={closingDate} />
-              </div>
-            )}
+            {closingDate && <DecisionClosingDate closingDate={closingDate} />}
           </DecisionCardHeader>
 
-          <div className="flex items-end gap-4 text-neutral-black sm:items-center sm:gap-12">
+          <div className="flex items-end gap-4 sm:items-center sm:gap-10">
             <DecisionStat
               number={processInstance.participantCount ?? 0}
               label="Participants"
@@ -131,15 +125,14 @@ export const DecisionListItem = ({
         </Link>
 
         {(canManage || canDelete) && (
-          <div className="flex items-center pe-4 pt-4 sm:ps-6 sm:pt-0">
+          <div className="flex items-center pe-4 pt-4 sm:ps-8 sm:pt-0">
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={
                   <Button
                     aria-label={t('Decision options')}
-                    variant="outline"
-                    size="icon-sm"
-                    className="aspect-square rounded bg-white shadow-light"
+                    variant="ghost"
+                    size="icon"
                   />
                 }
               >
@@ -149,7 +142,7 @@ export const DecisionListItem = ({
                 {canManage && (
                   <DropdownMenuLinkItem
                     closeOnClick
-                    render={<Link href={`/decisions/${item.slug}/edit`} />}
+                    href={`/decisions/${item.slug}/edit`}
                   >
                     {t('Settings')}
                   </DropdownMenuLinkItem>
@@ -162,7 +155,7 @@ export const DecisionListItem = ({
                 {canDelete && (
                   <DropdownMenuItem
                     onClick={() => setShowDeleteModal(true)}
-                    className="text-functional-red"
+                    variant="destructive"
                   >
                     {t('Delete')}
                   </DropdownMenuItem>
@@ -255,9 +248,11 @@ export const ProfileDecisionListItem = ({
         name={processInstance.name || item.name}
         currentState={currentPhaseName}
       >
-        <div className="flex flex-col flex-wrap gap-2 py-1 text-xs sm:flex-row sm:items-center sm:justify-between">
+        {/* `w-full` so this takes its own line under the phase chip, which now
+            shares the header's last row. */}
+        <div className="flex w-full flex-col flex-wrap gap-2 sm:flex-row sm:items-center sm:justify-between">
           {closingDate && <DecisionClosingDate closingDate={closingDate} />}
-          <div className="flex items-end gap-4 text-neutral-black">
+          <div className="flex items-end gap-4">
             <DecisionStat
               number={processInstance.participantCount ?? 0}
               label="Participants"
@@ -297,7 +292,7 @@ export const LegacyDecisionListItem = ({
   return (
     <Link
       href={href}
-      className="flex flex-col gap-4 rounded-lg border p-4 hover:bg-primary-tealWhite hover:no-underline sm:flex-row sm:items-center sm:justify-between sm:rounded-none sm:border-0 sm:border-b sm:border-b-neutral-gray1"
+      className="flex flex-col gap-4 rounded-lg border p-4 hover:bg-accent hover:no-underline sm:flex-row sm:items-center sm:justify-between sm:rounded-none sm:border-0 sm:border-b"
     >
       <DecisionCardHeader
         name={name}
@@ -305,14 +300,10 @@ export const LegacyDecisionListItem = ({
         stewardName={ownerName}
         stewardAvatarPath={ownerAvatarPath}
       >
-        {closingDate && (
-          <div className="flex flex-wrap items-center gap-2 py-1 text-xs sm:gap-6">
-            <DecisionClosingDate closingDate={closingDate} />
-          </div>
-        )}
+        {closingDate && <DecisionClosingDate closingDate={closingDate} />}
       </DecisionCardHeader>
 
-      <div className="flex items-end gap-4 text-neutral-black sm:items-center sm:gap-12">
+      <div className="flex items-end gap-4 sm:items-center sm:gap-10">
         <DecisionStat number={participantCount} label="Participants" />
         <DecisionStat number={proposalCount} label="Proposals" />
       </div>
@@ -330,9 +321,12 @@ const DecisionStat = ({
   className?: string;
 }) => (
   <div
-    className={cn('flex items-center gap-1 sm:flex-col sm:gap-0', className)}
+    className={cn(
+      'flex items-center gap-1 sm:flex-col sm:items-center sm:gap-1',
+      className,
+    )}
   >
-    <span className="font-serif text-title-base">{number}</span>
+    <span className="font-serif text-title">{number}</span>
     <span className="text-sm text-muted-foreground">
       <TranslatedText text={label} />
     </span>
@@ -341,21 +335,20 @@ const DecisionStat = ({
 
 const DecisionClosingDate = ({ closingDate }: { closingDate: string }) => {
   const locale = useLocale();
+  const closingSoon = isClosingSoon(closingDate);
+
   return (
-    <div className="flex items-center gap-1">
-      <LuCalendar
-        className={`size-4 ${isClosingSoon(closingDate) ? 'text-functional-red' : 'text-neutral-charcoal'}`}
+    <div
+      className={cn(
+        'flex items-center gap-2 text-sm',
+        closingSoon ? 'text-destructive' : 'text-muted-foreground',
+      )}
+    >
+      <LuCalendar className="size-4" aria-hidden />
+      <TranslatedText
+        text="Closes on {date}"
+        values={{ date: formatDateShort(closingDate, locale) }}
       />
-      <span
-        className={cn(
-          isClosingSoon(closingDate)
-            ? 'text-functional-red'
-            : 'text-neutral-charcoal',
-          'text-sm',
-        )}
-      >
-        <TranslatedText text="Closes" /> {formatDateShort(closingDate, locale)}
-      </span>
     </div>
   );
 };

--- a/apps/app/src/components/decisions/DecisionListItem.tsx
+++ b/apps/app/src/components/decisions/DecisionListItem.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuLinkItem,
   DropdownMenuTrigger,
 } from '@op/sense/DropdownMenu';
+import { StatusBadge } from '@op/sense/StatusBadge';
 import { toast } from '@op/sense/Toast';
 import { cn } from '@op/sense/lib/utils';
 import { useLocale } from 'next-intl';
@@ -79,7 +80,10 @@ export const DecisionListItem = ({
   const currentPhase = processInstance.instanceData?.phases?.find(
     (phase) => phase.phaseId === processInstance.currentStateId,
   );
-  const currentPhaseName = isDraft ? t('Draft') : currentPhase?.name;
+  // A draft carries none of the running-process metadata (Figma 17827:9692): no
+  // phase chip, no closing date, no counts — just the name, its owner, and a
+  // Draft badge where the metrics sit.
+  const currentPhaseName = isDraft ? undefined : currentPhase?.name;
   const closingDate = isDraft ? undefined : currentPhase?.endDate;
 
   // For drafts show owner; for published prefer steward, fall back to owner
@@ -103,25 +107,30 @@ export const DecisionListItem = ({
           )}
         >
           <DecisionCardHeader
-            name={processInstance.name || item.name}
+            name={processInstance.name || item.name || t('Untitled')}
             currentState={currentPhaseName}
-            chipVariant={isDraft ? 'secondary' : 'accent'}
             stewardName={displayProfile?.name}
             stewardAvatarPath={displayProfile?.avatarImage?.name}
           >
             {closingDate && <DecisionClosingDate closingDate={closingDate} />}
           </DecisionCardHeader>
 
-          <div className="flex items-end gap-4 sm:items-center sm:gap-10">
-            <DecisionStat
-              number={processInstance.participantCount ?? 0}
-              label="Participants"
-            />
-            <DecisionStat
-              number={processInstance.proposalCount ?? 0}
-              label="Proposals"
-            />
-          </div>
+          {isDraft ? (
+            <StatusBadge variant="inactive" icon={false}>
+              {t('Draft')}
+            </StatusBadge>
+          ) : (
+            <div className="flex items-end gap-4 sm:items-center sm:gap-10">
+              <DecisionStat
+                number={processInstance.participantCount ?? 0}
+                label="Participants"
+              />
+              <DecisionStat
+                number={processInstance.proposalCount ?? 0}
+                label="Proposals"
+              />
+            </div>
+          )}
         </Link>
 
         {(canManage || canDelete) && (

--- a/apps/app/src/components/decisions/DecisionListItem.tsx
+++ b/apps/app/src/components/decisions/DecisionListItem.tsx
@@ -98,7 +98,7 @@ export const DecisionListItem = ({
 
   return (
     <>
-      <div className="flex items-start gap-0 rounded-lg border hover:bg-accent sm:items-center sm:rounded-none sm:border-0 sm:border-b">
+      <div className="flex items-start rounded-lg border hover:bg-muted sm:items-center sm:rounded-none sm:border-0 sm:border-b">
         <Link
           href={`/decisions/${item.slug}${isDraft ? '/edit' : ''}`}
           className={cn(
@@ -151,7 +151,7 @@ export const DecisionListItem = ({
                 {canManage && (
                   <DropdownMenuLinkItem
                     closeOnClick
-                    href={`/decisions/${item.slug}/edit`}
+                    render={<Link href={`/decisions/${item.slug}/edit`} />}
                   >
                     {t('Settings')}
                   </DropdownMenuLinkItem>
@@ -265,12 +265,12 @@ export const ProfileDecisionListItem = ({
             <DecisionStat
               number={processInstance.participantCount ?? 0}
               label="Participants"
-              className="sm:flex-row sm:gap-1"
+              className="sm:flex-row"
             />
             <DecisionStat
               number={processInstance.proposalCount ?? 0}
               label="Proposals"
-              className="sm:flex-row sm:gap-1"
+              className="sm:flex-row"
             />
           </div>
         </div>
@@ -301,7 +301,7 @@ export const LegacyDecisionListItem = ({
   return (
     <Link
       href={href}
-      className="flex flex-col gap-4 rounded-lg border p-4 hover:bg-accent hover:no-underline sm:flex-row sm:items-center sm:justify-between sm:rounded-none sm:border-0 sm:border-b"
+      className="flex flex-col gap-4 rounded-lg border p-4 hover:bg-muted hover:no-underline sm:flex-row sm:items-center sm:justify-between sm:rounded-none sm:border-0 sm:border-b"
     >
       <DecisionCardHeader
         name={name}
@@ -329,12 +329,7 @@ const DecisionStat = ({
   label: TranslationKey;
   className?: string;
 }) => (
-  <div
-    className={cn(
-      'flex items-center gap-1 sm:flex-col sm:items-center sm:gap-1',
-      className,
-    )}
-  >
+  <div className={cn('flex items-center gap-1 sm:flex-col', className)}>
     <span className="font-serif text-title">{number}</span>
     <span className="text-sm text-muted-foreground">
       <TranslatedText text={label} />

--- a/apps/app/src/components/decisions/DuplicateProcessModal.tsx
+++ b/apps/app/src/components/decisions/DuplicateProcessModal.tsx
@@ -45,7 +45,7 @@ export const DuplicateProcessModal = ({
       open
       onOpenChange={(open) => !open && !isPendingRef.current && onClose()}
     >
-      <DialogContent>
+      <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>{t('Duplicate process')}</DialogTitle>
         </DialogHeader>
@@ -155,24 +155,26 @@ const DuplicateFormContent = ({
           <FieldLegend className="font-serif text-title-sm12">
             {t('Include')}
           </FieldLegend>
-          {includeOptions.map((option) => (
-            <Field key={option.key} orientation="horizontal">
-              <Checkbox
-                id={`duplicate-include-${option.key}`}
-                checked={selectedIncludes.includes(option.key)}
-                onCheckedChange={(checked) =>
-                  setSelectedIncludes((prev) =>
-                    checked
-                      ? [...prev, option.key]
-                      : prev.filter((key) => key !== option.key),
-                  )
-                }
-              />
-              <FieldLabel htmlFor={`duplicate-include-${option.key}`}>
-                {option.label}
-              </FieldLabel>
-            </Field>
-          ))}
+          <div className="grid grid-cols-2 gap-2">
+            {includeOptions.map((option) => (
+              <Field key={option.key} orientation="horizontal">
+                <Checkbox
+                  id={`duplicate-include-${option.key}`}
+                  checked={selectedIncludes.includes(option.key)}
+                  onCheckedChange={(checked) =>
+                    setSelectedIncludes((prev) =>
+                      checked
+                        ? [...prev, option.key]
+                        : prev.filter((key) => key !== option.key),
+                    )
+                  }
+                />
+                <FieldLabel htmlFor={`duplicate-include-${option.key}`}>
+                  {option.label}
+                </FieldLabel>
+              </Field>
+            ))}
+          </div>
         </FieldSet>
       </div>
       <DialogFooter>

--- a/apps/app/src/components/decisions/JoinAccountModal.tsx
+++ b/apps/app/src/components/decisions/JoinAccountModal.tsx
@@ -95,7 +95,13 @@ export const JoinDecisionButton = ({
 export const JoinDecisionButtonFallback = () => {
   const t = useTranslations();
 
-  return <Button render={<a href="?join=1" />}>{t('Join')}</Button>;
+  // Same as ButtonLink: it renders an anchor, so tell base-ui it isn't a native
+  // button and keep link semantics rather than its `role="button"`.
+  return (
+    <Button nativeButton={false} role={undefined} render={<a href="?join=1" />}>
+      {t('Join')}
+    </Button>
+  );
 };
 
 /**

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderProcessSelector.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderProcessSelector.tsx
@@ -74,7 +74,7 @@ export const ProcessBuilderProcessCard = ({
 
   return (
     <button
-      className="flex w-full cursor-pointer flex-col gap-2 rounded-lg border bg-white p-6 text-start transition-shadow hover:border-neutral-300 hover:shadow-md sm:w-72 md:aspect-[4/3] md:w-[360px] md:p-12 md:text-center"
+      className="flex w-full cursor-pointer flex-col gap-2 rounded-lg border bg-white p-6 text-start transition-shadow hover:border-neutral-300 hover:shadow-md sm:w-72 md:aspect-[4/3] md:w-90 md:p-12 md:text-center"
       onClick={onSelect}
     >
       <div className="flex gap-2 md:flex-col md:items-center md:gap-6">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
@@ -393,7 +393,8 @@ export function TemplateEditorContent({
                     {t('These are the categories you defined in')}{' '}
                     <Button
                       variant="link"
-                      className="inline h-auto p-0"
+                      size="inline"
+                      className="inline"
                       onClick={() => {
                         void setStep('general');
                         void setSection('proposalCategories');

--- a/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
+++ b/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
@@ -47,9 +47,9 @@ export function AuthorRevisionNote({
             {respondedAt ? <RevisedOnBadge respondedAt={respondedAt} /> : null}
             <Button
               variant="link"
-              size="sm"
+              size="inline"
               onClick={() => setIsModalOpen(true)}
-              className="h-auto p-0 text-sm underline"
+              className="text-sm underline"
             >
               {t('View revision request')}
             </Button>

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -130,8 +130,8 @@ function MyReviewForm() {
               {t('Reviewing is paused until author submits a revision.')}{' '}
               <Button
                 variant="link"
-                size="sm"
-                className="h-auto p-0 underline"
+                size="inline"
+                className="text-sm underline"
                 onClick={() => setIsViewModalOpen(true)}
               >
                 {t('View feedback')}

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerDetail.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerDetail.tsx
@@ -49,9 +49,9 @@ export function ReviewerDetail({
     <div className="flex flex-col gap-6">
       <Button
         variant="link"
-        size="sm"
+        size="inline"
         onClick={onBack}
-        className="h-auto gap-1 self-start p-0 text-base"
+        className="self-start text-base"
       >
         <LuArrowLeft className="size-4 rtl:-scale-x-100" />
         {t('Back to all reviewers')}

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
@@ -194,9 +194,9 @@ function ReviewerRow({
 }) {
   const t = useTranslations();
   return (
-    // `bare` + `none`: the row keeps its card look and picks up the sense focus
-    // ring, which the hand-rolled `outline-data-blue` one it used to carry was
-    // never going to match.
+    // `bare`: the row keeps its card look and picks up the sense focus ring,
+    // which the hand-rolled `outline-data-blue` one it used to carry never
+    // matched.
     <Button
       variant="bare"
       onClick={() => onSelect(item.review.assignmentId)}

--- a/apps/app/src/components/decisions/TranslationNotice.tsx
+++ b/apps/app/src/components/decisions/TranslationNotice.tsx
@@ -31,8 +31,9 @@ export const TranslationNotice = ({
       <Bullet />
       <Button
         variant="link"
+        size="inline"
         onClick={onViewOriginal}
-        className="inline h-auto p-0 text-sm sm:text-sm"
+        className="inline text-sm sm:text-sm"
       >
         {t('View original')}
       </Button>

--- a/apps/app/src/components/decisions/proposalEditor/asides/ProposalVersionsAside.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/asides/ProposalVersionsAside.tsx
@@ -178,8 +178,8 @@ function VersionItem({
     // 16px collapsed, 12px expanded — Figma's 76 / 120.
     isSelected ? 'pb-3' : 'pb-4',
   );
-  // `bare` + `none`: own look, but keep the focus ring and disabled handling a
-  // raw `<button>` would drop.
+  // `bare`: own look, but keep the focus ring and disabled handling a raw
+  // `<button>` would drop.
   const rowButton = (
     <Button
       variant="bare"

--- a/apps/app/src/lib/i18n/Link.tsx
+++ b/apps/app/src/lib/i18n/Link.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useForesight } from '@/hooks/useForesight';
-import { cn } from '@op/sense/lib/utils';
 import type { AnchorHTMLAttributes } from 'react';
 
 import { NavLink, useRouter } from './routing';
@@ -28,14 +27,14 @@ export const Link = ({
   });
 
   return (
+    // No `hover:underline` here: base-ui concatenates className without merging,
+    // so a Link passed as a `render` target fights the primitive it renders as
+    // (a DropdownMenuLinkItem would underline on hover). Callers that want an
+    // underline declare it — many already do.
+    //
     // @ts-ignore — next-intl's NavLink expects a route literal; we forward
     // arbitrary string hrefs.
-    <NavLink
-      {...props}
-      ref={elementRef}
-      className={cn('hover:underline', className)}
-      prefetch={false}
-    >
+    <NavLink {...props} ref={elementRef} className={className} prefetch={false}>
       {children}
     </NavLink>
   );

--- a/apps/app/src/lib/i18n/Link.tsx
+++ b/apps/app/src/lib/i18n/Link.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useForesight } from '@/hooks/useForesight';
-import type { AnchorHTMLAttributes } from 'react';
+import { type AnchorHTMLAttributes, type Ref, useCallback } from 'react';
 
 import { NavLink, useRouter } from './routing';
 
@@ -10,8 +10,11 @@ import { NavLink, useRouter } from './routing';
 export const Link = ({
   children,
   className,
+  ref,
   ...props
-}: AnchorHTMLAttributes<HTMLAnchorElement>) => {
+}: AnchorHTMLAttributes<HTMLAnchorElement> & {
+  ref?: Ref<HTMLAnchorElement>;
+}) => {
   const router = useRouter();
   const { href } = props;
 
@@ -26,6 +29,23 @@ export const Link = ({
     name: href,
   });
 
+  // Two owners need this node: Foresight, to watch it for prefetch, and any
+  // caller passing this Link to a `render` prop. Keeping only Foresight's ref
+  // left base-ui unable to focus the element, so a DropdownMenuLinkItem never
+  // highlighted on hover and keyboard nav skipped it.
+  const setRef = useCallback(
+    (node: HTMLAnchorElement | null) => {
+      elementRef.current = node;
+
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    },
+    [elementRef, ref],
+  );
+
   return (
     // No `hover:underline` here: base-ui concatenates className without merging,
     // so a Link passed as a `render` target fights the primitive it renders as
@@ -34,7 +54,7 @@ export const Link = ({
     //
     // @ts-ignore — next-intl's NavLink expects a route literal; we forward
     // arbitrary string hrefs.
-    <NavLink {...props} ref={elementRef} className={className} prefetch={false}>
+    <NavLink {...props} ref={setRef} className={className} prefetch={false}>
       {children}
     </NavLink>
   );

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -5,7 +5,7 @@
   "Create proposal": "إنشاء مقترح",
   "Post": "منشور",
   "Posts": "منشورات",
-  "Closes": "ينتهي",
+  "Closes on {date}": "ينتهي في {date}",
   "Add your personal details": "أضف بياناتك الشخصية",
   "Tell us about yourself so others can find you.": "أخبرنا عن نفسك حتى يتمكن الآخرون من العثور عليك.",
   "Profile Picture": "صورة الملف الشخصي",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -5,7 +5,7 @@
   "Create proposal": "প্রস্তাব তৈরি করুন",
   "Post": "পোস্ট",
   "Posts": "পোস্টসমূহ",
-  "Closes": "বন্ধ হবে",
+  "Closes on {date}": "{date}-এ বন্ধ হবে",
   "Add your personal details": "আপনার ব্যক্তিগত বিবরণ যোগ করুন",
   "Tell us about yourself so others can find you.": "আপনার সম্পর্কে আমাদেরকে বলুন যাতে অন্যরা আপনাকে খুঁজে পেতে পারে।",
   "Profile Picture": "প্রোফাইল ছবি",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -4,7 +4,7 @@
   "Create proposal": "Create proposal",
   "Post": "Post",
   "Posts": "Posts",
-  "Closes": "Closes",
+  "Closes on {date}": "Closes on {date}",
   "Add your personal details": "Add your personal details",
   "Tell us about yourself so others can find you.": "Tell us about yourself so others can find you.",
   "Profile Picture": "Profile Picture",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -4,7 +4,7 @@
   "Couldn't add that image": "No se pudo añadir esa imagen",
   "Create proposal": "Crear propuesta",
   "Posts": "Publicaciones",
-  "Closes": "Cierra",
+  "Closes on {date}": "Cierra el {date}",
   "Add your personal details": "Agrega tus datos personales",
   "Tell us about yourself so others can find you.": "Cuéntanos sobre ti para que otros puedan encontrarte.",
   "Profile Picture": "Foto de perfil",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -5,7 +5,7 @@
   "Create proposal": "Créer une proposition",
   "Post": "Publier",
   "Posts": "Publications",
-  "Closes": "Ferme",
+  "Closes on {date}": "Clôture le {date}",
   "Add your personal details": "Ajoutez vos informations personnelles",
   "Tell us about yourself so others can find you.": "Parlez-nous de vous pour que d'autres puissent vous trouver.",
   "Profile Picture": "Photo de profil",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -5,7 +5,7 @@
   "Create proposal": "Criar proposta",
   "Post": "Publicar",
   "Posts": "Publicações",
-  "Closes": "Encerra",
+  "Closes on {date}": "Encerra em {date}",
   "Add your personal details": "Adicione seus dados pessoais",
   "Tell us about yourself so others can find you.": "Conte-nos sobre você para que outros possam encontrá-lo.",
   "Profile Picture": "Foto de Perfil",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -5,7 +5,7 @@
   "Create proposal": "Samee soo jeedin",
   "Post": "Qoraal",
   "Posts": "Qoraallo",
-  "Closes": "Xidhitaanka",
+  "Closes on {date}": "Wuxuu xidhmayaa {date}",
   "Add your personal details": "Ku dar xogta shakhsigaaga",
   "Tell us about yourself so others can find you.": "Noo sheeg wax ku saabsan adiga si dadka kale ay kuu helaan.",
   "Profile Picture": "Sawirka Bogga Shakhsiga",

--- a/packages/sense/src/components/FacePile/index.tsx
+++ b/packages/sense/src/components/FacePile/index.tsx
@@ -32,7 +32,7 @@ function FacePile({
         className={cn(
           // Ring each face in the background color so overlapping avatars read
           // as distinct instead of blurring together.
-          'flex [&_[data-slot=avatar]]:ring-1 [&_[data-slot=avatar]]:ring-background',
+          'flex [&_[data-slot=avatar]]:ring-1 [&_[data-slot=avatar]]:ring-background/40',
           listClassName,
         )}
       >

--- a/packages/sense/src/components/StatusBadge/index.tsx
+++ b/packages/sense/src/components/StatusBadge/index.tsx
@@ -14,7 +14,9 @@ import { cn } from '../../lib/utils';
 
 // Figma `StatusBadge` component set (cjLIVfBJVLadAaigW1hjyG node 31776:8610):
 // 36px tall, 6px radius, 8px inset, 4px gap, 14px/450 label, a 16px leading icon
-// tinted per variant, and an optional 12px trailing arrow. `Inactive` fills with
+// tinted per variant, and an optional 12px trailing arrow. The tint targets the
+// icon's `data-slot`, not `svg:first-child` — with `icon={false}` the arrow would
+// otherwise become the first child and inherit the leading icon's colour. `Inactive` fills with
 // gray-100 (`secondary`) and its icon stays foreground, not muted.
 //
 // The sheet also shows hover (base fill + white at 20%) and focus states. This
@@ -28,15 +30,15 @@ const statusBadgeVariants = cva(
       variant: {
         inactive: 'bg-secondary text-foreground',
         'in-progress':
-          'bg-teal-50 text-foreground [&>svg:first-child]:text-teal-600',
+          'bg-teal-50 text-foreground [&>[data-slot=status-badge-icon]]:text-teal-600',
         warning:
-          'bg-warning-muted text-foreground [&>svg:first-child]:text-warning',
+          'bg-warning-muted text-foreground [&>[data-slot=status-badge-icon]]:text-warning',
         revision:
-          'bg-warning-muted text-foreground [&>svg:first-child]:text-warning',
+          'bg-warning-muted text-foreground [&>[data-slot=status-badge-icon]]:text-warning',
         alert:
-          'bg-destructive-muted text-foreground [&>svg:first-child]:text-destructive',
+          'bg-destructive-muted text-foreground [&>[data-slot=status-badge-icon]]:text-destructive',
         success:
-          'bg-success-muted text-foreground [&>svg:first-child]:text-success',
+          'bg-success-muted text-foreground [&>[data-slot=status-badge-icon]]:text-success',
         ghost: 'bg-transparent text-foreground hover:bg-muted',
       },
     },
@@ -94,7 +96,13 @@ export function StatusBadge({
     <span className={cn(statusBadgeVariants({ variant }), className)}>
       {/* Leading icon is 16px, the trailing arrow 12px — sized individually
           rather than by one `[&>svg]` rule. */}
-      {LeadingIcon ? <LeadingIcon aria-hidden className="size-4" /> : null}
+      {LeadingIcon ? (
+        <LeadingIcon
+          aria-hidden
+          data-slot="status-badge-icon"
+          className="size-4"
+        />
+      ) : null}
       {children}
       {hasArrow ? (
         <LuArrowRight aria-hidden className="size-3 rtl:rotate-180" />

--- a/packages/sense/src/components/StatusBadge/index.tsx
+++ b/packages/sense/src/components/StatusBadge/index.tsx
@@ -65,8 +65,12 @@ export interface StatusBadgeProps extends VariantProps<
   children: ReactNode;
   /** Show the trailing arrow (the badge navigates / drills in). */
   hasArrow?: boolean;
-  /** Override the leading icon; defaults to the variant's icon. */
-  icon?: IconType;
+  /**
+   * Override the leading icon; defaults to the variant's icon. `false` drops it,
+   * as the Figma set's icon slot can be turned off — `p-2` then reads as even
+   * padding around a bare label.
+   */
+  icon?: IconType | false;
   className?: string;
 }
 
@@ -83,12 +87,14 @@ export function StatusBadge({
   icon,
   className,
 }: StatusBadgeProps) {
-  const LeadingIcon = icon ?? VARIANT_ICON[variant ?? 'inactive'];
+  const LeadingIcon =
+    icon === false ? null : (icon ?? VARIANT_ICON[variant ?? 'inactive']);
+
   return (
     <span className={cn(statusBadgeVariants({ variant }), className)}>
       {/* Leading icon is 16px, the trailing arrow 12px — sized individually
           rather than by one `[&>svg]` rule. */}
-      <LeadingIcon aria-hidden className="size-4" />
+      {LeadingIcon ? <LeadingIcon aria-hidden className="size-4" /> : null}
       {children}
       {hasArrow ? (
         <LuArrowRight aria-hidden className="size-3 rtl:rotate-180" />

--- a/packages/sense/src/components/ui/button.tsx
+++ b/packages/sense/src/components/ui/button.tsx
@@ -23,11 +23,12 @@ const buttonVariants = cva(
         // Paint removed, behaviour kept: the focus ring, disabled handling,
         // cursor and icon sizing in the base class still apply, so a surface
         // that owns its own appearance (a list row, a card, a cell) doesn't
-        // have to drop to a raw `<button>` and lose them. Carries its own
-        // geometry reset rather than relying on a paired `size`, which was only
-        // ever meaningful with this variant. `[font:inherit]` also resets
-        // line-height, which the base's `text-base` would otherwise impose.
-        bare: 'h-auto gap-0 rounded-none p-0 [font:inherit] text-current active:not-aria-[haspopup]:translate-y-0',
+        // have to drop to a raw `<button>` and lose them. `[font:inherit]` also
+        // resets line-height, which the base's `text-base` would otherwise
+        // impose. Its geometry reset is a compound variant below, not part of
+        // this string: `size` is emitted after `variant`, so `px-4` and
+        // `gap-1.5` would win here.
+        bare: 'rounded-none [font:inherit] text-current active:not-aria-[haspopup]:translate-y-0',
       },
       size: {
         default:
@@ -40,6 +41,10 @@ const buttonVariants = cva(
           "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
         'icon-sm': 'size-8 rounded-md in-data-[slot=button-group]:rounded-lg',
         'icon-lg': 'size-12',
+        // No button geometry: sits on the text baseline inside a sentence or a
+        // dense row, where a fixed height and side padding break the line. For
+        // `link` mostly; `bare` gets the same reset without asking.
+        inline: 'h-auto gap-1 p-0',
       },
     },
     compoundVariants: [
@@ -50,6 +55,14 @@ const buttonVariants = cva(
         size: ['sm', 'xs', 'icon-sm', 'icon-xs'],
         class:
           'bg-destructive-muted text-destructive hover:bg-red-100 active:bg-red-200 focus-visible:ring-destructive/20',
+      },
+      // `bare` means "no chrome", so it shouldn't need a paired size to shed
+      // the default one. Only the default size is overridden: asking for `bare`
+      // *and* an explicit size means you want that size's geometry.
+      {
+        variant: 'bare',
+        size: 'default',
+        class: 'h-auto gap-0 p-0',
       },
     ],
     defaultVariants: {

--- a/packages/sense/src/components/ui/button.tsx
+++ b/packages/sense/src/components/ui/button.tsx
@@ -43,7 +43,8 @@ const buttonVariants = cva(
         'icon-lg': 'size-12',
         // No button geometry: sits on the text baseline inside a sentence or a
         // dense row, where a fixed height and side padding break the line. For
-        // `link` mostly; `bare` gets the same reset without asking.
+        // `link` mostly — `bare` sheds its geometry via the compound variant
+        // below, which also collapses the gap this size keeps.
         inline: 'h-auto gap-1 p-0',
       },
     },

--- a/tests/e2e/tests/policy-reacceptance.spec.ts
+++ b/tests/e2e/tests/policy-reacceptance.spec.ts
@@ -51,38 +51,63 @@ test.describe('Policy re-acceptance modal', () => {
 
     await page.goto('/en/', { waitUntil: 'domcontentloaded' });
 
-    const dialog = page
+    // A policy document opens in its own dialog stacked over the gate, so both
+    // are `role="dialog"` at once — scope to each by content instead of relying
+    // on there being exactly one.
+    const dialogs = page
       .getByRole('dialog')
       .and(page.locator(':not([data-slot="toast"])'));
+    const gate = dialogs.filter({ hasText: "We've updated our policies." });
+    const doc = dialogs.filter({
+      hasText: 'TERMS OF SERVICE FOR COMMON PLATFORM',
+    });
+
     await expect(
-      dialog.getByRole('heading', { name: "We've updated our policies." }),
+      gate.getByRole('heading', { name: "We've updated our policies." }),
     ).toBeVisible({ timeout: 20000 });
 
     // Non-dismissable: Escape must not close it.
     await page.keyboard.press('Escape');
     await expect(
-      dialog.getByRole('heading', { name: "We've updated our policies." }),
+      gate.getByRole('heading', { name: "We've updated our policies." }),
     ).toBeVisible();
 
     // The action is gated on the consent checkbox.
-    const agree = dialog.getByRole('button', { name: 'Agree and continue' });
+    const agree = gate.getByRole('button', { name: 'Agree and continue' });
     await expect(agree).toBeDisabled();
 
-    // A policy link opens that document in-modal with a working back button.
-    await dialog.getByRole('button', { name: 'Terms of Use' }).click();
+    // A policy link opens that document over the gate, with a working back
+    // button. The gate stays mounted underneath.
+    const termsTrigger = gate.getByRole('button', { name: 'Terms of Use' });
+    await termsTrigger.click();
     await expect(
-      dialog.getByRole('heading', {
+      doc.getByRole('heading', {
         name: /TERMS OF SERVICE FOR COMMON PLATFORM/,
       }),
     ).toBeVisible({ timeout: 15000 });
-    await dialog.getByRole('button', { name: 'Back' }).click();
     await expect(
-      dialog.getByRole('heading', { name: "We've updated our policies." }),
+      gate.getByRole('heading', { name: "We've updated our policies." }),
     ).toBeVisible();
 
-    // Accept and continue. Force past the visually-hidden React Aria checkbox
-    // input (Playwright's actionability check never passes on it otherwise).
-    await dialog.getByRole('checkbox').check({ force: true });
+    // Escape closes the document only — the consent wall must survive it.
+    await page.keyboard.press('Escape');
+    await expect(doc).toBeHidden();
+    await expect(
+      gate.getByRole('heading', { name: "We've updated our policies." }),
+    ).toBeVisible();
+
+    // Reopen and leave via Back, which returns focus to the link that opened it.
+    await termsTrigger.click();
+    await expect(doc).toBeVisible();
+    await doc.getByRole('button', { name: 'Back' }).click();
+    await expect(doc).toBeHidden();
+    await expect(termsTrigger).toBeFocused();
+
+    // Accept and continue. `force` because the base-ui checkbox keeps the real
+    // input visually hidden, so Playwright's actionability check never passes.
+    await gate
+      .getByRole('checkbox', { name: /I have read and agree/ })
+      .check({ force: true });
     await expect(agree).toBeEnabled();
     await agree.click();
 

--- a/tests/e2e/tests/policy-reacceptance.spec.ts
+++ b/tests/e2e/tests/policy-reacceptance.spec.ts
@@ -103,11 +103,15 @@ test.describe('Policy re-acceptance modal', () => {
     await expect(doc).toBeHidden();
     await expect(termsTrigger).toBeFocused();
 
-    // Accept and continue. `force` because the base-ui checkbox keeps the real
-    // input visually hidden, so Playwright's actionability check never passes.
-    await gate
-      .getByRole('checkbox', { name: /I have read and agree/ })
-      .check({ force: true });
+    // Accept and continue. `click({ force: true })`, not `check()`: base-ui's
+    // checkbox is a span over a visually-hidden input, and check()'s state
+    // verification does not settle on it (same pattern as onboarding-resume).
+    // The aria-checked assertion below is what proves the toggle worked.
+    const consent = gate.getByRole('checkbox', {
+      name: /I have read and agree/,
+    });
+    await consent.click({ force: true });
+    await expect(consent).toBeChecked();
     await expect(agree).toBeEnabled();
     await agree.click();
 

--- a/tests/e2e/tests/policy-reacceptance.spec.ts
+++ b/tests/e2e/tests/policy-reacceptance.spec.ts
@@ -76,8 +76,9 @@ test.describe('Policy re-acceptance modal', () => {
     const agree = gate.getByRole('button', { name: 'Agree and continue' });
     await expect(agree).toBeDisabled();
 
-    // A policy link opens that document over the gate, with a working back
-    // button. The gate stays mounted underneath.
+    // A policy link opens that document over the gate. While it is open the
+    // gate is inert and out of the accessibility tree — correct for a stacked
+    // modal, and why nothing here asserts on the gate until the document closes.
     const termsTrigger = gate.getByRole('button', { name: 'Terms of Use' });
     await termsTrigger.click();
     await expect(
@@ -85,9 +86,6 @@ test.describe('Policy re-acceptance modal', () => {
         name: /TERMS OF SERVICE FOR COMMON PLATFORM/,
       }),
     ).toBeVisible({ timeout: 15000 });
-    await expect(
-      gate.getByRole('heading', { name: "We've updated our policies." }),
-    ).toBeVisible();
 
     // Escape closes the document only — the consent wall must survive it.
     await page.keyboard.press('Escape');


### PR DESCRIPTION
Finishes the info/static area's move off `@op/ui` and brings the decision list rows in line with Figma. Merges into `sense-migration` (#1662), not the default branch.

- **Info/static pages**: the `/info` routes had no `@op/ui` imports left, so this is the other two legal-content files plus the policy re-acceptance gate — `Modal` → sense `Dialog`, with a controlled `open` and no `onOpenChange` keeping the gate non-dismissable now that `isDismissable` is gone. `Surface variant="filled"` has no sense counterpart; inlined as the bordered `bg-muted` box it rendered.
- **Policy documents open in their own nested dialog** rather than swapping the gate's content. The swap unmounted the link mid-press, so focus fell to `<body>` with nothing announced, and Back never returned focus. Each dialog focuses its scroll container on open, so a document doesn't open scrolled to the first link in the legal text. The four legal texts also carry `dir="auto"`: they are English-only, so on an Arabic page they were inheriting RTL and throwing their punctuation to the front of each paragraph.
- **Decision list rows** match `17827:3655` and `17827:9692`: the phase chip moves off the name's line down beside the closing date, spacing is measured from the frames, and a draft drops its chip, date and both `0` counts for a `Draft` badge where the metrics sit. Rows hover to `bg-muted` — the accent hover was the exact fill of the accent phase chip, so the chip disappeared into the row.
- **`Link` was quietly breaking every base-ui `render` target**, found while reviewing this branch. It forced `hover:underline` on every instance, and base-ui concatenates `className` without merging, so a `DropdownMenuLinkItem` underlined on hover; and it overwrote the ref base-ui passes as a prop, so base-ui could not focus the element — no hover highlight and keyboard navigation skipped straight past it. Seven `render={<Link/>}` call sites were affected, including `SidebarNav` and the decision view toggle.
- **Three primitive fixes**: `Button`'s `bare` variant lost its own geometry reset to the `size` classes emitted after it, so every bare button carried 16px of side padding — now a compound variant. `size="inline"` covers a text-baseline button and has nine consumers, migrated off hand-rolled `h-auto p-0`. `StatusBadge` takes `icon={false}` per the Figma icon slot, and tints its leading icon by `data-slot` rather than `svg:first-child`, so dropping that icon can no longer retint the trailing arrow.
- Copy fix: `Closes on {date}` as one interpolated key, replacing a bare `Closes` concatenated with a date — word order that only worked in English. Real translations in all seven locales.
- Swept redundant classNames the sense components already provide (`font-serif` on 72 `Header3`s across the four legal files), legacy tokens on lines otherwise touched, and 16 arbitrary Tailwind values back onto the scale across 13 files (`max-w-[32rem]` → `max-w-lg`; px/rem values that are exact multiples of the spacing step → their numeric utilities).
- `tests/e2e/tests/policy-reacceptance.spec.ts` is updated for the new shape: named gate/document locators, Escape closes only the document while the consent wall survives, and Back restores focus to the trigger.

Filed rather than fixed here: the gate has no escape path at all (a modal with zero `DialogClose` descendants — a user who won't consent can't reach sign-out), and the three near-duplicate decision-row variants plus a third copy of the scrollable legal-document dialog.

Not included: `services/db/index.ts`, a local-only HMR guard that wants its own PR.
