### PR TITLE
feat(decision): add a `none` review coverage policy

### DIFF
--- a/packages/common/src/services/decision/backfillReviewAssignments.ts
+++ b/packages/common/src/services/decision/backfillReviewAssignments.ts
@@ -30,10 +30,10 @@ export type BackfillReviewAssignmentsResult =
  * phase membership: mid-phase submissions were never assigned to existing
  * reviewers, and the new reviewer must match them exactly. Never prunes —
  * deleting non-pending assignments would cascade-delete submitted reviews.
- * Expected no-op states (wrong phase, no reviewers, nothing to assign,
- * `single_reviewer` policy) are logged skips, not errors — but corrupt instance
- * data still throws, which event-driven callers should surface (e.g. as a
- * retried job) rather than swallow.
+ * Expected no-op states (wrong phase, no reviewers, nothing to assign, a
+ * non-`full_coverage` policy) are logged skips, not errors — but corrupt
+ * instance data still throws, which event-driven callers should surface (e.g.
+ * as a retried job) rather than swallow.
  */
 export async function backfillReviewAssignments({
   instanceId,
@@ -74,10 +74,11 @@ export async function backfillReviewAssignments({
 
   const reviewSettings = getPhaseReviewSettings(instanceData, currentPhaseId);
 
-  // No backfill under `single_reviewer`: adding a mid-phase reviewer would put
-  // a second reviewer on every proposal they cover.
-  if (reviewSettings.policy === 'single_reviewer') {
-    return skip('current phase policy is single_reviewer');
+  // Backfill only makes sense under `full_coverage`: under `single_reviewer` a
+  // mid-phase reviewer would land as a second reviewer on every proposal they
+  // cover, and under `none` nothing is ever assigned automatically.
+  if (reviewSettings.policy !== 'full_coverage') {
+    return skip(`current phase policy is ${reviewSettings.policy}`);
   }
 
   // Most recent transition INTO the current phase — the one whose attachment

--- a/packages/common/src/services/decision/generateReviewAssignments.ts
+++ b/packages/common/src/services/decision/generateReviewAssignments.ts
@@ -36,7 +36,7 @@ interface SelectedProposal {
  *
  * The scope builds the candidate set; the policy decides how much of it is
  * written — `full_coverage` all of it, `single_reviewer` one balanced pick
- * (`pickSingleReviewerAssignments`).
+ * (`pickSingleReviewerAssignments`), `none` nothing at all.
  */
 export async function generateReviewAssignments({
   instanceId,
@@ -67,6 +67,22 @@ export async function generateReviewAssignments({
     return;
   }
 
+  const { scope, policy } = getPhaseReviewSettings(
+    instance.instanceData as DecisionInstanceData,
+    phaseId,
+  );
+
+  // Policy `none`: the phase gets no automatic assignments at all — the
+  // operator creates them manually in the backend.
+  if (policy === 'none') {
+    logger.info('generateReviewAssignments: skipped', {
+      instanceId,
+      phaseId,
+      reason: 'phase policy is none',
+    });
+    return;
+  }
+
   const [selectedProposals, reviewerProfileIds, transitionProposalRows] =
     await Promise.all([
       db.query.proposals.findMany({
@@ -88,11 +104,6 @@ export async function generateReviewAssignments({
 
   const historyByProposalId = new Map(
     transitionProposalRows.map((r) => [r.proposalId, r.proposalHistoryId]),
-  );
-
-  const { scope, policy } = getPhaseReviewSettings(
-    instance.instanceData as DecisionInstanceData,
-    phaseId,
   );
 
   const candidateProposals =

--- a/packages/common/src/services/decision/reconcileReviewAssignments.ts
+++ b/packages/common/src/services/decision/reconcileReviewAssignments.ts
@@ -111,10 +111,12 @@ export async function reconcileReviewAssignments({
   }
   const reviewSettings = getPhaseReviewSettings(instanceData, currentPhaseId);
 
-  // No reconcile under `single_reviewer`: reconcile's expected set is the whole
-  // scope⨝eligibility intersection, so it would fan out full-coverage inserts.
-  if (reviewSettings.policy === 'single_reviewer') {
-    return skip('current phase policy is single_reviewer');
+  // Reconcile only runs under `full_coverage`: its expected set is the whole
+  // scope⨝eligibility intersection, so under `single_reviewer` it would fan out
+  // full-coverage inserts, and under `none` it would create the very rows the
+  // policy exists to suppress.
+  if (reviewSettings.policy !== 'full_coverage') {
+    return skip(`current phase policy is ${reviewSettings.policy}`);
   }
   if (reviewSettings.scope !== 'by_category') {
     return skip('current phase scope is not by_category');

--- a/packages/common/src/services/decision/schemas/types.ts
+++ b/packages/common/src/services/decision/schemas/types.ts
@@ -69,7 +69,14 @@ export interface ProposalCategory {
   description: string;
 }
 
-export const REVIEWS_POLICIES = ['full_coverage', 'single_reviewer'] as const;
+export const REVIEWS_POLICIES = [
+  /** Every candidate reviewer reviews each proposal. */
+  'full_coverage',
+  /** Each proposal gets exactly one reviewer, balanced and deterministic. */
+  'single_reviewer',
+  /** No reviewer is assigned. Escape hatch for processes whose assignments are created manually in the backend (config-only, no Process Builder control). */
+  'none',
+] as const;
 
 export type ReviewsPolicy = (typeof REVIEWS_POLICIES)[number];
 
@@ -98,8 +105,7 @@ export const phaseReviewSettingsSchema = z.object({
   scope: z.enum(REVIEWS_SCOPES).optional(),
   /**
    * How proposals are distributed to reviewers within `scope`. Absent =
-   * `'full_coverage'` (every candidate reviewer). `'single_reviewer'` assigns
-   * each proposal exactly one, balanced and deterministic.
+   * `'full_coverage'`. See `REVIEWS_POLICIES` for the meaning of each value.
    */
   policy: z.enum(REVIEWS_POLICIES).optional(),
   allowRevisions: z.boolean().optional(),

--- a/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/instances/generateReviewAssignments.test.ts
@@ -288,6 +288,49 @@ describe.concurrent('generateReviewAssignments', () => {
     expect(assignments).toHaveLength(0);
   });
 
+  it("policy 'none' writes nothing", async ({ task, onTestFinished }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const { setup, instance } = await createReviewInstance(testData, {
+      reviewsPolicy: 'none',
+    });
+
+    // The author is a plain member, not the creator-admin — so the admin's
+    // default REVIEW capability is not cancelled out by the self-review
+    // exclusion, and full_coverage would write one assignment here.
+    const author = await testData.createMemberUser({
+      organization: setup.organization,
+      instanceProfileIds: [instance.profileId],
+    });
+
+    await testData.createProposal({
+      userEmail: author.email,
+      processInstanceId: instance.instance.id,
+      proposalData: { title: 'Proposal under policy none' },
+      status: ProposalStatus.SUBMITTED,
+    });
+
+    const advanceResult = await advanceToReviewPhase(instance.instance.id);
+    // Guard against a vacuous pass: the empty-selection early return sits above
+    // the policy check, so the proposal has to actually reach the review phase.
+    expect(advanceResult.selectedProposalIds).toHaveLength(1);
+
+    await generateReviewAssignments({
+      instanceId: instance.instance.id,
+      phaseId: 'review',
+      selectedProposalIds: advanceResult.selectedProposalIds,
+      transitionHistoryId: advanceResult.transitionHistoryId,
+    });
+
+    const assignments = await db
+      .select()
+      .from(proposalReviewAssignments)
+      .where(
+        eq(proposalReviewAssignments.processInstanceId, instance.instance.id),
+      );
+
+    expect(assignments).toEqual([]);
+  });
+
   it('is idempotent — calling twice does not duplicate rows', async ({
     task,
     onTestFinished,


### PR DESCRIPTION
An escape hatch for processes whose reviewer split the single-axis category system cannot express: under policy `none` no automatic writer creates assignments, and the operator builds the rows by hand in the backend. Config-only — the default stays full_coverage.