### PR TITLE
feat(decision): let admins read reviews while the review phase is in progress

### DIFF
--- a/apps/app/src/components/decisions/ProposalReviewsCount.tsx
+++ b/apps/app/src/components/decisions/ProposalReviewsCount.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { type DecisionAccess } from '@op/api/encoders';
+import {
+  type ProposalReviewAggregates,
+  ProposalReviewAssignmentStatus,
+} from '@op/common/client';
+import { Link } from '@op/ui/Link';
+import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
+import { useRef } from 'react';
+import { useFocusable } from 'react-aria';
+
+import { useTranslations } from '@/lib/i18n';
+
+type Reviewers = ProposalReviewAggregates['reviewers'];
+
+interface ProposalReviewsCountProps {
+  reviewers: Reviewers;
+  /** Review summary route for the proposal. */
+  href: string;
+  access?: DecisionAccess;
+}
+
+/**
+ * Submitted-review count for a proposal, with the reviewer names in a tooltip.
+ * Links to the review summary for admins; plain text for everyone else.
+ */
+export function ProposalReviewsCount({
+  reviewers,
+  href,
+  access,
+}: ProposalReviewsCountProps) {
+  const t = useTranslations();
+
+  const completedReviewers = reviewers.filter(
+    (reviewer) => reviewer.status === ProposalReviewAssignmentStatus.COMPLETED,
+  );
+
+  if (completedReviewers.length === 0) {
+    return null;
+  }
+
+  const names = completedReviewers
+    .map((reviewer) => reviewer.profile.name)
+    .join(', ');
+  const label = t('{count} Reviews', { count: completedReviewers.length });
+  const className =
+    'shrink-0 text-base text-neutral-gray4 underline decoration-dotted underline-offset-2';
+
+  return (
+    <TooltipTrigger>
+      {access?.admin ? (
+        <Link href={href} variant="neutral" className={className}>
+          {label}
+        </Link>
+      ) : (
+        <FocusableSpan className={className}>{label}</FocusableSpan>
+      )}
+      <Tooltip>{names}</Tooltip>
+    </TooltipTrigger>
+  );
+}
+
+function FocusableSpan({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const { focusableProps } = useFocusable({}, ref);
+  return (
+    <span {...focusableProps} ref={ref} tabIndex={0} className={className}>
+      {children}
+    </span>
+  );
+}

--- a/apps/app/src/components/decisions/ReviewAssignmentCard.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentCard.tsx
@@ -1,13 +1,10 @@
+import { type DecisionAccess } from '@op/api/encoders';
 import {
-  ProposalReviewAssignmentStatus,
   type ProposalReviewAggregates,
   type ProposalReviewAssignment,
   type ReviewAssignmentExtended,
 } from '@op/common/client';
-import { Tooltip, TooltipTrigger } from '@op/ui/Tooltip';
 import { cn } from '@op/ui/utils';
-import { useRef } from 'react';
-import { useFocusable } from 'react-aria';
 import {
   LuCircleAlert,
   LuCircleCheck,
@@ -17,7 +14,6 @@ import {
 } from 'react-icons/lu';
 
 import type { TranslationKey } from '@/lib/i18n';
-import { useTranslations } from '@/lib/i18n';
 
 import { TranslatedText } from '@/components/TranslatedText';
 
@@ -30,6 +26,7 @@ import {
   ProposalCardHeader,
   ProposalCardPreview,
 } from './ProposalCard';
+import { ProposalReviewsCount } from './ProposalReviewsCount';
 
 type AssignmentStatus = ProposalReviewAssignment['status'];
 
@@ -39,6 +36,9 @@ interface ReviewAssignmentCardProps {
   assignment: ReviewAssignmentExtended;
   viewHref?: string;
   reviewers?: Reviewers;
+  /** Review summary route for the assignment's proposal. */
+  reviewsHref: string;
+  access?: DecisionAccess;
   /** Whether to show the proposal's category tag (see ReviewAssignmentsList). */
   showCategory?: boolean;
 }
@@ -47,6 +47,8 @@ export function ReviewAssignmentCard({
   assignment: { assignment },
   viewHref,
   reviewers,
+  reviewsHref,
+  access,
   showCategory = true,
 }: ReviewAssignmentCardProps) {
   const { proposal, status } = assignment;
@@ -75,48 +77,15 @@ export function ReviewAssignmentCard({
       </ProposalCardContent>
       <div className="flex items-center justify-between gap-2">
         <ReviewStatusBadge status={status} />
-        {reviewers ? <ReviewersTooltip reviewers={reviewers} /> : null}
+        {reviewers ? (
+          <ProposalReviewsCount
+            reviewers={reviewers}
+            href={reviewsHref}
+            access={access}
+          />
+        ) : null}
       </div>
     </ProposalCard>
-  );
-}
-
-function ReviewersTooltip({ reviewers }: { reviewers: Reviewers }) {
-  const t = useTranslations();
-
-  const completedReviewers = reviewers.filter(
-    (r) => r.status === ProposalReviewAssignmentStatus.COMPLETED,
-  );
-
-  if (completedReviewers.length === 0) {
-    return null;
-  }
-
-  const names = completedReviewers.map((r) => r.profile.name).join(', ');
-
-  return (
-    <TooltipTrigger>
-      <FocusableSpan className="text-neutral-gray4 underline decoration-dotted underline-offset-2">
-        {t('{count} Reviewed', { count: completedReviewers.length })}
-      </FocusableSpan>
-      <Tooltip>{names}</Tooltip>
-    </TooltipTrigger>
-  );
-}
-
-function FocusableSpan({
-  className,
-  children,
-}: {
-  className?: string;
-  children: React.ReactNode;
-}) {
-  const ref = useRef<HTMLSpanElement>(null);
-  const { focusableProps } = useFocusable({}, ref);
-  return (
-    <span {...focusableProps} ref={ref} tabIndex={0} className={className}>
-      {children}
-    </span>
   );
 }
 

--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -4,6 +4,7 @@ import { useTrackPageView } from '@/hooks/useTrackPageView';
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { getDecisionCommonProperties } from '@op/analytics/client-utils';
 import { trpc } from '@op/api/client';
+import { type DecisionAccess } from '@op/api/encoders';
 import {
   ProposalReviewAssignmentStatus,
   REVIEW_ASSIGNMENT_SORTS,
@@ -32,12 +33,13 @@ const ASSIGNMENT_STATUSES = Object.values(ProposalReviewAssignmentStatus) as [
 export function ReviewAssignmentsList({
   processInstanceId,
   decisionSlug,
-  canViewReviewers = false,
+  access,
 }: {
   processInstanceId: string;
   decisionSlug: string;
-  canViewReviewers?: boolean;
+  access?: DecisionAccess;
 }) {
+  const canViewReviewers = Boolean(access?.admin);
   const t = useTranslations();
 
   const [statusFilter, setStatusFilter] = useQueryState(
@@ -191,6 +193,8 @@ export function ReviewAssignmentsList({
                   (i) => i.proposal.id === item.assignment.proposal.id,
                 )?.aggregates.reviewers
               }
+              reviewsHref={`/decisions/${decisionSlug}/proposal/${item.assignment.proposal.profileId}/reviews`}
+              access={access}
               showCategory={showCategory}
             />
           ))}

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
@@ -5,7 +5,7 @@ import {
 } from '@op/api/server';
 import { createClient } from '@op/api/serverClient';
 import { CommonError } from '@op/common';
-import { isReviewPhase } from '@op/common/client';
+import { assertInstancePhase, isReviewPhase } from '@op/common/client';
 import { forbidden, notFound } from 'next/navigation';
 
 import { ReviewSummaryView } from './ReviewSummaryView';
@@ -81,6 +81,13 @@ export async function ReviewSummaryLayout({
   const proposalId = proposal.id;
   const phaseId = resolveReviewPhaseId(instance);
 
+  // isReviewPhase guards the resolver's fallback, which returns the current
+  // phase when the instance has no review phase at all.
+  const isPhaseInProgress =
+    !!phaseId &&
+    phaseId === instance.currentStateId &&
+    isReviewPhase(assertInstancePhase({ instance, phaseId }));
+
   await utils.decision.getProposalWithReviewAggregates.prefetch({
     processInstanceId: instanceId,
     proposalId,
@@ -95,6 +102,7 @@ export async function ReviewSummaryLayout({
         proposalId={proposalId}
         proposalProfileId={proposalProfileId}
         phaseId={phaseId}
+        isPhaseInProgress={isPhaseInProgress}
       />
     </HydrationBoundary>
   );

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
@@ -2,6 +2,7 @@
 
 import { trpc } from '@op/api/client';
 import { SplitPane } from '@op/ui/SplitPane';
+import { cn } from '@op/ui/utils';
 import { useQueryState } from 'nuqs';
 
 import { useTranslations } from '@/lib/i18n';
@@ -19,6 +20,7 @@ interface ReviewSummaryViewProps {
   proposalId: string;
   proposalProfileId: string;
   phaseId: string | undefined;
+  isPhaseInProgress?: boolean;
 }
 
 export function ReviewSummaryView({
@@ -27,6 +29,7 @@ export function ReviewSummaryView({
   proposalId,
   proposalProfileId,
   phaseId,
+  isPhaseInProgress = false,
 }: ReviewSummaryViewProps) {
   const t = useTranslations();
   const [[proposalWithReviews, proposal]] = trpc.useSuspenseQueries((t) => [
@@ -46,7 +49,12 @@ export function ReviewSummaryView({
   );
 
   return (
-    <div className="flex h-dvh flex-col bg-white pb-14">
+    <div
+      className={cn(
+        'flex h-dvh flex-col bg-white',
+        !isPhaseInProgress && 'pb-14',
+      )}
+    >
       <DecisionSubpageHeader
         backHref={`/decisions/${decisionSlug}/current`}
         backLabel={t('Back')}
@@ -61,22 +69,31 @@ export function ReviewSummaryView({
         </SplitPane.Pane>
         <SplitPane.Pane
           id="summary"
-          label={<TranslatedText text="Review Summary" />}
+          label={
+            isPhaseInProgress ? (
+              <TranslatedText text="Review Progress" />
+            ) : (
+              <TranslatedText text="Review Summary" />
+            )
+          }
         >
           <ReviewsPanel
             proposalWithReviews={proposalWithReviews}
             rubricTemplate={rubricTemplate}
             selectedAssignmentId={selectedAssignmentId}
             onSelectAssignment={setSelectedAssignmentId}
+            title={isPhaseInProgress ? t('Review Progress') : undefined}
           />
         </SplitPane.Pane>
       </SplitPane>
 
-      <ReviewSummaryAdvanceFooter
-        instanceId={instanceId}
-        proposalId={proposalId}
-        phaseId={phaseId}
-      />
+      {!isPhaseInProgress && (
+        <ReviewSummaryAdvanceFooter
+          instanceId={instanceId}
+          proposalId={proposalId}
+          phaseId={phaseId}
+        />
+      )}
     </div>
   );
 }

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
@@ -27,6 +27,7 @@ interface ReviewerListProps {
   rubricSummary: RubricSummary;
   onSelectAssignment: (assignmentId: string) => void;
   hideSummaryHeader?: boolean;
+  title?: string;
 }
 
 export function ReviewerList({
@@ -36,6 +37,7 @@ export function ReviewerList({
   rubricSummary,
   onSelectAssignment,
   hideSummaryHeader,
+  title,
 }: ReviewerListProps) {
   const t = useTranslations();
   const { reviewsSubmittedCount, assignmentsCount, averageScore } =
@@ -63,7 +65,9 @@ export function ReviewerList({
     <div className="flex flex-col gap-6">
       {!hideSummaryHeader && (
         <header className="flex flex-col gap-2">
-          <Header3 className="font-serif">{t('Review Summary')}</Header3>
+          <Header3 className="font-serif">
+            {title ?? t('Review Summary')}
+          </Header3>
           <p className="text-base text-neutral-charcoal">
             {t(
               '{submitted} out of {total} reviewers submitted a review for this proposal',

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewsPanel.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewsPanel.tsx
@@ -27,6 +27,8 @@ interface ReviewsPanelProps {
   excludeProfileId?: string;
   /** Hides the "Review Summary" header + submitted-count line in the list view. */
   hideSummaryHeader?: boolean;
+  /** Header text; defaults to "Review Summary". */
+  title?: string;
 }
 
 export function ReviewsPanel({
@@ -36,6 +38,7 @@ export function ReviewsPanel({
   onSelectAssignment,
   excludeProfileId,
   hideSummaryHeader,
+  title,
 }: ReviewsPanelProps) {
   const rubricSummary = useMemo<RubricSummary>(() => {
     if (!rubricTemplate) {
@@ -91,6 +94,7 @@ export function ReviewsPanel({
       rubricSummary={rubricSummary}
       onSelectAssignment={onSelectAssignment}
       hideSummaryHeader={hideSummaryHeader}
+      title={title}
     />
   );
 }

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -134,7 +134,7 @@ export function ReviewPage({
                     <ReviewAssignmentsList
                       processInstanceId={instance.id}
                       decisionSlug={decisionSlug}
-                      canViewReviewers={isAdmin}
+                      access={instance.access}
                     />
                   </Suspense>
                 </APIErrorBoundary>

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1165,7 +1165,7 @@
   "Filter by status": "تصفية حسب الحالة",
   "in {categories}": "في {categories}",
   "Sort order": "ترتيب الفرز",
-  "{count} Reviewed": "تمت مراجعة {count}",
+  "{count} Reviews": "{count} مراجعة",
   "{count} of {total} completed": "{count} من {total} مكتمل",
   "Revision Request": "طلب تعديل",
   "A reviewer has requested changes to {proposalName}": "طلب أحد المراجعين إجراء تغييرات على {proposalName}",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1253,7 +1253,7 @@
   "Filter by status": "স্ট্যাটাস অনুযায়ী ফিল্টার",
   "in {categories}": "{categories}-এ",
   "Sort order": "সাজানোর ক্রম",
-  "{count} Reviewed": "{count} পর্যালোচিত",
+  "{count} Reviews": "{count} পর্যালোচনা",
   "{count} of {total} completed": "{count} / {total} সম্পন্ন",
   "Revision Request": "সংশোধনের অনুরোধ",
   "A reviewer has requested changes to {proposalName}": "একজন পর্যালোচক {proposalName}-এ পরিবর্তনের অনুরোধ করেছেন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1264,7 +1264,7 @@
   "Filter by status": "Filter by status",
   "in {categories}": "in {categories}",
   "Sort order": "Sort order",
-  "{count} Reviewed": "{count} Reviewed",
+  "{count} Reviews": "{count} Reviews",
   "{count} of {total} completed": "{count} of {total} completed",
   "Revision Request": "Revision Request",
   "A reviewer has requested changes to {proposalName}": "A reviewer has requested changes to {proposalName}",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1252,7 +1252,7 @@
   "Filter by status": "Filtrar por estado",
   "in {categories}": "en {categories}",
   "Sort order": "Orden",
-  "{count} Reviewed": "{count} Revisados",
+  "{count} Reviews": "{count} evaluaciones",
   "{count} of {total} completed": "{count} de {total} completados",
   "Revision Request": "Solicitud de revisión",
   "A reviewer has requested changes to {proposalName}": "Un revisor ha solicitado cambios en {proposalName}",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1252,7 +1252,7 @@
   "Filter by status": "Filtrer par statut",
   "in {categories}": "dans {categories}",
   "Sort order": "Ordre de tri",
-  "{count} Reviewed": "{count} Examinés",
+  "{count} Reviews": "{count} évaluations",
   "{count} of {total} completed": "{count} sur {total} terminés",
   "Revision Request": "Demande de révision",
   "A reviewer has requested changes to {proposalName}": "Un examinateur a demandé des modifications à {proposalName}",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1252,7 +1252,7 @@
   "Filter by status": "Filtrar por status",
   "in {categories}": "em {categories}",
   "Sort order": "Ordenar",
-  "{count} Reviewed": "{count} Revisados",
+  "{count} Reviews": "{count} avaliações",
   "{count} of {total} completed": "{count} de {total} concluídos",
   "Revision Request": "Solicitação de revisão",
   "A reviewer has requested changes to {proposalName}": "Um revisor solicitou alterações em {proposalName}",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1184,7 +1184,7 @@
   "Filter by status": "Ku shaandhee xaaladda",
   "in {categories}": "gudaha {categories}",
   "Sort order": "Habka kala soocida",
-  "{count} Reviewed": "{count} La dib u eegay",
+  "{count} Reviews": "{count} dib-u-eegis",
   "{count} of {total} completed": "{count} ee {total} la dhammaystiray",
   "Revision Request": "Codsiga Dib-u-habeynta",
   "A reviewer has requested changes to {proposalName}": "Dib-u-eegahe wuxuu codsaday isbeddelo {proposalName}",

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -19,6 +19,7 @@ export {
   isVotingPhase,
   type ReviewSettings,
 } from './services/decision/utils/phaseSettings';
+export { assertInstancePhase } from './services/decision/utils/instance';
 export {
   getPhaseIndex,
   getPreviousPhases,

--- a/tests/e2e/tests/review-summary.spec.ts
+++ b/tests/e2e/tests/review-summary.spec.ts
@@ -269,9 +269,14 @@ test.describe('Review Summary page', () => {
     // Step 1: Header reflects submitted/total + Average Score
     // ====================================================================
 
+    // The instance sits in the review phase, so no shortlisting yet.
     await expect(
-      page.getByRole('heading', { name: 'Review Summary' }),
+      page.getByRole('heading', { name: 'Review Progress' }),
     ).toBeVisible({ timeout: 36_000 });
+
+    await expect(
+      page.getByRole('button', { name: /^Advanc(e|ing) proposal$/ }),
+    ).toHaveCount(0);
 
     await expect(
       page


### PR DESCRIPTION
Admins could already open a proposal's review summary, but nothing linked to it until the review phase ended. The "N Reviews" count on the review-assignment cards (Review tab) is now a link to that summary for admins. While the review phase is still running, the summary follows the design (Figma 19943-40282): it is titled "Review Progress" and the shortlisting footer is hidden — advancing belongs to the post-phase selection step.

Not in this PR (per design node, tracked separately): the "+ Add review" action, and the map-browse-mode entry point (https://app.asana.com/1/1108348036672214/project/1215134887533545/task/1217317355321649).