### PR TITLE
fix(decision): scope the reviewer queue to one phase

### DIFF
--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -40,15 +40,23 @@ const STATUS_SORT_RANK: Record<string, number> = {
 /** Any unmapped (future) status sorts after all known ones. */
 const UNKNOWN_STATUS_RANK = Object.keys(STATUS_SORT_RANK).length;
 
-/** Returns all authorized review assignments for the current reviewer in a process instance. */
+/**
+ * Returns the reviewer's authorized review assignments for a single phase of a
+ * process instance — the requested `phaseId`, else the instance's current phase.
+ * Without the phase scope a reviewer who holds assignments in more than one
+ * review phase sees the past phase's work mixed into the current queue.
+ */
 export async function listReviewAssignments({
   processInstanceId,
+  phaseId: requestedPhaseId,
   status,
   categoryIds,
   sort = 'leastReviewed',
   user,
 }: {
   processInstanceId: string;
+  /** Phase to scope the queue to — defaults to the instance's current phase. */
+  phaseId?: string;
   status?: string;
   /** Taxonomy term ids — limits results to assignments whose proposal is in any of the categories. */
   categoryIds?: string[];
@@ -67,6 +75,11 @@ export async function listReviewAssignments({
   if (!instance.access.review && !instance.access.admin) {
     throw new UnauthorizedError("You don't have access to review proposals");
   }
+
+  // Same resolution as listProposalsWithReviewAggregates: explicit phase, else
+  // the current one. `phaseId` is NOT NULL on every assignment row, so the
+  // filter can only be skipped when the instance itself has no current phase.
+  const phaseId = requestedPhaseId ?? instance.currentStateId ?? undefined;
 
   // Resolve the categories' proposal IDs up front (same approach as
   // resolveProposalListScope): assignments have no category column, so the
@@ -94,13 +107,18 @@ export async function listReviewAssignments({
   // COMPLETED reviews for the proposal across *all* reviewers — the same
   // "≥1 completed = reviewed" definition shown as the "N Reviewed" badge. A
   // correlated subquery (own `pra_completed` alias) so it isn't constrained by
-  // the outer query's per-reviewer filter.
+  // the outer query's per-reviewer filter. Phase-scoped like the list itself,
+  // so a previous phase's completed reviews don't inflate the badge or skew
+  // the least-reviewed sort.
+  const completedPhaseFilter = phaseId
+    ? sql` AND pra_completed.phase_id = ${phaseId}`
+    : sql``;
   const completedReviewCount = (t: typeof proposalReviewAssignments) =>
     sql<number>`(
       SELECT COUNT(*)::int FROM ${proposalReviewAssignments} AS pra_completed
       WHERE pra_completed.proposal_id = ${t.proposalId}
         AND pra_completed.process_instance_id = ${processInstanceId}
-        AND pra_completed.status = ${ProposalReviewAssignmentStatus.COMPLETED}
+        AND pra_completed.status = ${ProposalReviewAssignmentStatus.COMPLETED}${completedPhaseFilter}
     )`;
 
   const statusRank = (t: typeof proposalReviewAssignments) =>
@@ -121,6 +139,7 @@ export async function listReviewAssignments({
     where: {
       processInstanceId,
       reviewerProfileId: dbUser.profileId,
+      ...(phaseId && { phaseId }),
       ...(status && { status }),
       ...(categoryProposalIds && {
         proposalId: { in: categoryProposalIds },
@@ -200,7 +219,8 @@ export async function listReviewAssignments({
           htmlContent,
         },
       },
-      // Assignments in this list can span phases, each with its own rubric.
+      // Resolved from the assignment's own phase, which each carries its own
+      // rubric (the list is phase-scoped, so this is uniform in practice).
       rubricTemplate: getPhaseRubricTemplate(
         instance.instanceData,
         assignment.phaseId,

--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -41,10 +41,9 @@ const STATUS_SORT_RANK: Record<string, number> = {
 const UNKNOWN_STATUS_RANK = Object.keys(STATUS_SORT_RANK).length;
 
 /**
- * Returns the reviewer's authorized review assignments for a single phase of a
- * process instance — the requested `phaseId`, else the instance's current phase.
- * Without the phase scope a reviewer who holds assignments in more than one
- * review phase sees the past phase's work mixed into the current queue.
+ * Returns the reviewer's authorized review assignments for a single phase — the
+ * requested `phaseId`, else the current one. Unscoped, a reviewer with
+ * assignments in two review phases sees the past phase's work in their queue.
  */
 export async function listReviewAssignments({
   processInstanceId,
@@ -55,7 +54,7 @@ export async function listReviewAssignments({
   user,
 }: {
   processInstanceId: string;
-  /** Phase to scope the queue to — defaults to the instance's current phase. */
+  /** Defaults to the instance's current phase. */
   phaseId?: string;
   status?: string;
   /** Taxonomy term ids — limits results to assignments whose proposal is in any of the categories. */
@@ -76,9 +75,8 @@ export async function listReviewAssignments({
     throw new UnauthorizedError("You don't have access to review proposals");
   }
 
-  // Same resolution as listProposalsWithReviewAggregates: explicit phase, else
-  // the current one. `phaseId` is NOT NULL on every assignment row, so the
-  // filter can only be skipped when the instance itself has no current phase.
+  // Same resolution as listProposalsWithReviewAggregates. Assignment rows are
+  // never unphased, so only a phase-less instance skips the filter.
   const phaseId = requestedPhaseId ?? instance.currentStateId ?? undefined;
 
   // Resolve the categories' proposal IDs up front (same approach as
@@ -107,9 +105,8 @@ export async function listReviewAssignments({
   // COMPLETED reviews for the proposal across *all* reviewers — the same
   // "≥1 completed = reviewed" definition shown as the "N Reviewed" badge. A
   // correlated subquery (own `pra_completed` alias) so it isn't constrained by
-  // the outer query's per-reviewer filter. Phase-scoped like the list itself,
-  // so a previous phase's completed reviews don't inflate the badge or skew
-  // the least-reviewed sort.
+  // the outer query's per-reviewer filter. Phase-scoped like the list, so a
+  // past phase's reviews don't inflate the badge or skew the sort.
   const completedPhaseFilter = phaseId
     ? sql` AND pra_completed.phase_id = ${phaseId}`
     : sql``;
@@ -219,8 +216,7 @@ export async function listReviewAssignments({
           htmlContent,
         },
       },
-      // Resolved from the assignment's own phase, which each carries its own
-      // rubric (the list is phase-scoped, so this is uniform in practice).
+      // From the assignment's own phase, each of which can carry a rubric.
       rubricTemplate: getPhaseRubricTemplate(
         instance.instanceData,
         assignment.phaseId,

--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -42,8 +42,7 @@ const UNKNOWN_STATUS_RANK = Object.keys(STATUS_SORT_RANK).length;
 
 /**
  * Returns the reviewer's authorized review assignments for a single phase — the
- * requested `phaseId`, else the current one. Unscoped, a reviewer with
- * assignments in two review phases sees the past phase's work in their queue.
+ * requested `phaseId`, else the current one.
  */
 export async function listReviewAssignments({
   processInstanceId,
@@ -105,8 +104,8 @@ export async function listReviewAssignments({
   // COMPLETED reviews for the proposal across *all* reviewers — the same
   // "≥1 completed = reviewed" definition shown as the "N Reviewed" badge. A
   // correlated subquery (own `pra_completed` alias) so it isn't constrained by
-  // the outer query's per-reviewer filter. Phase-scoped like the list, so a
-  // past phase's reviews don't inflate the badge or skew the sort.
+  // the outer query's per-reviewer filter. Phase-scoped like the list, so the
+  // badge and the sort count this phase's reviews only.
   const completedPhaseFilter = phaseId
     ? sql` AND pra_completed.phase_id = ${phaseId}`
     : sql``;

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
@@ -1,5 +1,8 @@
 import { mockCollab } from '@op/collab/testing';
-import type { RubricTemplateSchema } from '@op/common';
+import type {
+  DecisionSchemaDefinition,
+  RubricTemplateSchema,
+} from '@op/common';
 import {
   ProposalReviewAssignmentStatus,
   ProposalReviewRequestState,
@@ -50,9 +53,69 @@ const rubricTemplate: RubricTemplateSchema = {
   required: ['impact'],
 };
 
+/** Phase the test fixtures pin their assignments to (`createReviewScenario`'s default). */
+const REVIEW_PHASE = 'review';
+
+const FEASIBILITY_PHASE = 'feasibility';
+const COMMUNITY_PHASE = 'community';
+
+/** Two back-to-back review phases — the shape that exposed the missing phase filter. */
+const twoReviewPhaseSchema = {
+  id: 'two-review-phases',
+  version: '1.0.0',
+  name: 'Two Review Phases',
+  description: 'Feasibility review followed by a community review.',
+  phases: [
+    {
+      id: 'submission',
+      name: 'Proposal Submission',
+      rules: {
+        proposals: { submit: true },
+        advancement: { method: 'date' as const, endDate: '2026-01-01' },
+      },
+    },
+    {
+      id: FEASIBILITY_PHASE,
+      name: 'Feasibility Review',
+      rules: {
+        reviews: { submit: true },
+        advancement: { method: 'date' as const, endDate: '2026-01-02' },
+      },
+    },
+    {
+      id: COMMUNITY_PHASE,
+      name: 'Community Review',
+      rules: {
+        reviews: { submit: true },
+        advancement: { method: 'date' as const, endDate: '2026-01-03' },
+      },
+    },
+  ],
+} satisfies DecisionSchemaDefinition;
+
 async function createAuthenticatedCaller(email: string) {
   const { session } = await createIsolatedSession(email);
   return createCaller(await createTestContextWithSession(session));
+}
+
+/**
+ * The queue is phase-scoped to the instance's current phase, and fixtures pin
+ * assignments to `'review'`, so the instance has to sit on that phase — the
+ * default context starts on `'submission'`.
+ */
+async function createReviewPhaseContext(testData: TestReviewsDataManager) {
+  const context = await testData.createContext();
+  await testData.setCurrentPhase(context.instance.instance.id, REVIEW_PHASE);
+  return context;
+}
+
+/** Two-review-phase instance sitting on the second (community) review phase. */
+async function createTwoReviewPhaseContext(testData: TestReviewsDataManager) {
+  const context = await testData.createContext({
+    processSchema: twoReviewPhaseSchema,
+  });
+  await testData.setCurrentPhase(context.instance.instance.id, COMMUNITY_PHASE);
+  return context;
 }
 
 async function attachCategoryToProposal({
@@ -99,6 +162,7 @@ describe.concurrent('listReviewAssignments', () => {
   }) => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const created = await testData.createReviewAssignment({
+      context: await createReviewPhaseContext(testData),
       title: 'Live Proposal Review',
     });
 
@@ -125,12 +189,13 @@ describe.concurrent('listReviewAssignments', () => {
     });
   });
 
-  it('returns all assignments for the reviewer in the instance', async ({
+  it('returns all assignments for the reviewer in the current phase', async ({
     task,
     onTestFinished,
   }) => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const first = await testData.createReviewAssignment({
+      context: await createReviewPhaseContext(testData),
       title: 'Community Garden Expansion',
     });
 
@@ -168,6 +233,7 @@ describe.concurrent('listReviewAssignments', () => {
   }) => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const created = await testData.createReviewAssignment({
+      context: await createReviewPhaseContext(testData),
       title: 'Community Garden Expansion',
     });
 
@@ -225,6 +291,7 @@ describe.concurrent('listReviewAssignments', () => {
   }) => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const created = await testData.createReviewAssignment({
+      context: await createReviewPhaseContext(testData),
       title: 'Needs Revision',
       status: ProposalReviewAssignmentStatus.AWAITING_AUTHOR_REVISION,
     });
@@ -269,6 +336,7 @@ describe.concurrent('listReviewAssignments', () => {
 
     // Three proposals assigned to the same reviewer, all pending for them.
     const zero = await testData.createReviewAssignment({
+      context: await createReviewPhaseContext(testData),
       title: 'Zero completed reviews',
     });
     const context = zero.context;
@@ -334,6 +402,7 @@ describe.concurrent('listReviewAssignments', () => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
 
     const pending = await testData.createReviewAssignment({
+      context: await createReviewPhaseContext(testData),
       title: 'Not started',
     });
     const context = pending.context;
@@ -365,12 +434,130 @@ describe.concurrent('listReviewAssignments', () => {
     );
   });
 
+  it('scopes the queue to the current phase and honors an explicit phase', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoReviewPhaseContext(testData);
+
+    // The playtest case: one reviewer, one proposal, an assignment in each
+    // review phase. Instance-scoped reads listed the proposal twice — once
+    // Completed (feasibility), once Not Started (community).
+    const feasibility = await testData.createReviewAssignment({
+      context,
+      title: 'Reviewed in both phases',
+      phaseId: FEASIBILITY_PHASE,
+      status: ProposalReviewAssignmentStatus.COMPLETED,
+    });
+    const communityAssignment = await createReviewAssignmentRow({
+      processInstanceId: context.instance.instance.id,
+      proposalId: feasibility.proposal.id,
+      reviewerProfileId: feasibility.reviewer.profileId,
+      phaseId: COMMUNITY_PHASE,
+    });
+
+    const { collaborationDocId } = feasibility.proposal.proposalData as {
+      collaborationDocId: string;
+    };
+    seedMockCollab(collaborationDocId);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      feasibility.reviewer.email,
+    );
+
+    const current = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+    });
+    expect(current.assignments.map((a) => a.assignment.id)).toEqual([
+      communityAssignment.id,
+    ]);
+
+    // The past phase is still reachable when asked for explicitly.
+    const past = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+      phaseId: FEASIBILITY_PHASE,
+    });
+    expect(past.assignments.map((a) => a.assignment.id)).toEqual([
+      feasibility.assignment.id,
+    ]);
+  });
+
+  it('counts only the scoped phase’s completed reviews for the least-reviewed sort', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoReviewPhaseContext(testData);
+    const instanceId = context.instance.instance.id;
+
+    // Covered once in the current phase.
+    const coveredNow = await testData.createReviewAssignment({
+      context,
+      title: 'One completed review this phase',
+      phaseId: COMMUNITY_PHASE,
+    });
+    const reviewer = coveredNow.reviewer;
+    // Covered twice, but only in the past phase — zero coverage for this one.
+    const coveredBefore = await testData.createReviewAssignment({
+      context,
+      reviewer,
+      title: 'Two completed reviews last phase',
+      phaseId: COMMUNITY_PHASE,
+    });
+
+    for (const created of [coveredNow, coveredBefore]) {
+      const { collaborationDocId } = created.proposal.proposalData as {
+        collaborationDocId: string;
+      };
+      seedMockCollab(collaborationDocId);
+    }
+
+    const otherA = await testData.createReviewer(context);
+    const otherB = await testData.createReviewer(context);
+    await createReviewAssignmentRow({
+      processInstanceId: instanceId,
+      proposalId: coveredNow.proposal.id,
+      reviewerProfileId: otherA.profileId,
+      phaseId: COMMUNITY_PHASE,
+      status: ProposalReviewAssignmentStatus.COMPLETED,
+    });
+    await createReviewAssignmentRow({
+      processInstanceId: instanceId,
+      proposalId: coveredBefore.proposal.id,
+      reviewerProfileId: otherA.profileId,
+      phaseId: FEASIBILITY_PHASE,
+      status: ProposalReviewAssignmentStatus.COMPLETED,
+    });
+    await createReviewAssignmentRow({
+      processInstanceId: instanceId,
+      proposalId: coveredBefore.proposal.id,
+      reviewerProfileId: otherB.profileId,
+      phaseId: FEASIBILITY_PHASE,
+      status: ProposalReviewAssignmentStatus.COMPLETED,
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+    const result = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: instanceId,
+      sort: 'leastReviewed',
+    });
+
+    // Instance-scoped counting would rank the past phase's two completions
+    // above the current phase's single one, flipping this order.
+    expect(result.assignments.map((a) => a.assignment.proposal.id)).toEqual([
+      coveredBefore.proposal.id,
+      coveredNow.proposal.id,
+    ]);
+  });
+
   it('filters assignments by category, matching any of the requested categories', async ({
     task,
     onTestFinished,
   }) => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const inDistrictOne = await testData.createReviewAssignment({
+      context: await createReviewPhaseContext(testData),
       title: 'District 1 proposal',
     });
     const inDistrictTwo = await testData.createReviewAssignment({
@@ -440,6 +627,7 @@ describe.concurrent('listReviewAssignments', () => {
   }) => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const created = await testData.createReviewAssignment({
+      context: await createReviewPhaseContext(testData),
       title: 'Uncategorized proposal',
     });
 

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
@@ -53,13 +53,12 @@ const rubricTemplate: RubricTemplateSchema = {
   required: ['impact'],
 };
 
-/** Phase the test fixtures pin their assignments to (`createReviewScenario`'s default). */
+/** Phase the fixtures pin assignments to (`createReviewScenario`'s default). */
 const REVIEW_PHASE = 'review';
 
 const FEASIBILITY_PHASE = 'feasibility';
 const COMMUNITY_PHASE = 'community';
 
-/** Two back-to-back review phases — the shape that exposed the missing phase filter. */
 const twoReviewPhaseSchema = {
   id: 'two-review-phases',
   version: '1.0.0',
@@ -98,11 +97,7 @@ async function createAuthenticatedCaller(email: string) {
   return createCaller(await createTestContextWithSession(session));
 }
 
-/**
- * The queue is phase-scoped to the instance's current phase, and fixtures pin
- * assignments to `'review'`, so the instance has to sit on that phase — the
- * default context starts on `'submission'`.
- */
+/** The default context starts on `'submission'`; the queue reads the current phase. */
 async function createReviewPhaseContext(testData: TestReviewsDataManager) {
   const context = await testData.createContext();
   await testData.setCurrentPhase(context.instance.instance.id, REVIEW_PHASE);
@@ -441,9 +436,8 @@ describe.concurrent('listReviewAssignments', () => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const context = await createTwoReviewPhaseContext(testData);
 
-    // The playtest case: one reviewer, one proposal, an assignment in each
-    // review phase. Instance-scoped reads listed the proposal twice — once
-    // Completed (feasibility), once Not Started (community).
+    // One reviewer, one proposal, an assignment in each review phase — the
+    // playtest case that listed the proposal twice.
     const feasibility = await testData.createReviewAssignment({
       context,
       title: 'Reviewed in both phases',
@@ -473,7 +467,7 @@ describe.concurrent('listReviewAssignments', () => {
       communityAssignment.id,
     ]);
 
-    // The past phase is still reachable when asked for explicitly.
+    // The past phase stays reachable when asked for explicitly.
     const past = await reviewerCaller.decision.listReviewAssignments({
       processInstanceId: context.instance.instance.id,
       phaseId: FEASIBILITY_PHASE,
@@ -491,14 +485,12 @@ describe.concurrent('listReviewAssignments', () => {
     const context = await createTwoReviewPhaseContext(testData);
     const instanceId = context.instance.instance.id;
 
-    // Covered once in the current phase.
     const coveredNow = await testData.createReviewAssignment({
       context,
       title: 'One completed review this phase',
       phaseId: COMMUNITY_PHASE,
     });
     const reviewer = coveredNow.reviewer;
-    // Covered twice, but only in the past phase — zero coverage for this one.
     const coveredBefore = await testData.createReviewAssignment({
       context,
       reviewer,
@@ -544,7 +536,7 @@ describe.concurrent('listReviewAssignments', () => {
     });
 
     // Instance-scoped counting would rank the past phase's two completions
-    // above the current phase's single one, flipping this order.
+    // above this phase's single one, flipping the order.
     expect(result.assignments.map((a) => a.assignment.proposal.id)).toEqual([
       coveredBefore.proposal.id,
       coveredNow.proposal.id,

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
@@ -436,8 +436,7 @@ describe.concurrent('listReviewAssignments', () => {
     const testData = new TestReviewsDataManager(task.id, onTestFinished);
     const context = await createTwoReviewPhaseContext(testData);
 
-    // One reviewer, one proposal, an assignment in each review phase — the
-    // playtest case that listed the proposal twice.
+    // One reviewer, one proposal, an assignment in each review phase.
     const feasibility = await testData.createReviewAssignment({
       context,
       title: 'Reviewed in both phases',
@@ -535,8 +534,8 @@ describe.concurrent('listReviewAssignments', () => {
       sort: 'leastReviewed',
     });
 
-    // Instance-scoped counting would rank the past phase's two completions
-    // above this phase's single one, flipping the order.
+    // Coverage counts within the scoped phase, so the proposal whose two
+    // completions sit in the feasibility phase leads with zero.
     expect(result.assignments.map((a) => a.assignment.proposal.id)).toEqual([
       coveredBefore.proposal.id,
       coveredNow.proposal.id,

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.ts
@@ -14,6 +14,8 @@ export const listReviewAssignmentsRouter = router({
     .input(
       z.object({
         processInstanceId: z.uuid(),
+        /** Defaults to the instance's current phase. */
+        phaseId: z.string().optional(),
         status: z.enum(ProposalReviewAssignmentStatus).optional(),
         categoryIds: z.array(z.string()).optional(),
         sort: z.enum(REVIEW_ASSIGNMENT_SORTS).optional(),
@@ -27,6 +29,7 @@ export const listReviewAssignmentsRouter = router({
 
       return await listReviewAssignments({
         processInstanceId: input.processInstanceId,
+        phaseId: input.phaseId,
         status: input.status,
         categoryIds: input.categoryIds,
         sort: input.sort,

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.ts
@@ -14,7 +14,7 @@ export const listReviewAssignmentsRouter = router({
     .input(
       z.object({
         processInstanceId: z.uuid(),
-        /** Defaults to the instance's current phase. */
+        /** Defaults to the current phase. */
         phaseId: z.string().optional(),
         status: z.enum(ProposalReviewAssignmentStatus).optional(),
         categoryIds: z.array(z.string()).optional(),

--- a/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
+++ b/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
@@ -217,8 +217,7 @@ describe.concurrent('per-phase rubric templates', () => {
     });
 
     const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
-    // The queue is phase-scoped, so each phase is listed on its own — the
-    // rubric still comes from the listed assignment's phase.
+    // The queue is phase-scoped, so each phase is listed on its own.
     const feasibilityList = await reviewerCaller.decision.listReviewAssignments(
       {
         processInstanceId: context.instance.instance.id,
@@ -232,7 +231,7 @@ describe.concurrent('per-phase rubric templates', () => {
       properties: { viability: { title: 'Viability' } },
     });
 
-    // Community is the current phase, so the default scope lands there.
+    // Community is current, so the default scope lands there.
     const communityList = await reviewerCaller.decision.listReviewAssignments({
       processInstanceId: context.instance.instance.id,
     });

--- a/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
+++ b/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
@@ -217,17 +217,29 @@ describe.concurrent('per-phase rubric templates', () => {
     });
 
     const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
-    const { assignments } = await reviewerCaller.decision.listReviewAssignments(
+    // The queue is phase-scoped, so each phase is listed on its own — the
+    // rubric still comes from the listed assignment's phase.
+    const feasibilityList = await reviewerCaller.decision.listReviewAssignments(
       {
         processInstanceId: context.instance.instance.id,
+        phaseId: FEASIBILITY_PHASE,
       },
     );
+    expect(feasibilityList.assignments.map((a) => a.assignment.id)).toEqual([
+      feasibilityScenario.assignment.id,
+    ]);
+    expect(feasibilityList.assignments[0]?.rubricTemplate).toMatchObject({
+      properties: { viability: { title: 'Viability' } },
+    });
 
-    const byId = new Map(assignments.map((a) => [a.assignment.id, a]));
-    expect(
-      byId.get(feasibilityScenario.assignment.id)?.rubricTemplate,
-    ).toMatchObject({ properties: { viability: { title: 'Viability' } } });
-    expect(byId.get(communityAssignment.id)?.rubricTemplate).toMatchObject({
+    // Community is the current phase, so the default scope lands there.
+    const communityList = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+    });
+    expect(communityList.assignments.map((a) => a.assignment.id)).toEqual([
+      communityAssignment.id,
+    ]);
+    expect(communityList.assignments[0]?.rubricTemplate).toMatchObject({
       properties: { impact: { title: 'Impact' } },
     });
   });


### PR DESCRIPTION
A reviewer with assignments in more than one review phase saw the past phase's work mixed into their current queue, so the list contradicted the phase-aware header stats. The queue now reads a single phase (the current one by default) and counts review coverage within that phase only.