### PR TITLE
fix(app): RTL direction context, side-panel mirroring, and link-button semantics

### DIFF
--- a/apps/app/src/app/[locale]/layout.tsx
+++ b/apps/app/src/app/[locale]/layout.tsx
@@ -1,7 +1,9 @@
 import { setupSSR } from '@/utils/setupSSR';
+import { DirectionProvider } from '@op/sense/Direction';
 import { getMessages } from 'next-intl/server';
 
 import { I18nProvider } from '@/lib/i18n';
+import { getLocaleDirection } from '@/lib/i18n/config';
 
 import { LocaleDirSync } from '@/components/LocaleDirSync';
 import { ReactAriaRouterProvider } from '@/components/ReactAriaRouterProvider';
@@ -24,8 +26,16 @@ const AppLayout = async ({
 
   return (
     <I18nProvider locale={locale} messages={messages}>
-      <LocaleDirSync />
-      <ReactAriaRouterProvider>{children}</ReactAriaRouterProvider>
+      {/* The root layout sits above [locale], so its getLocale() goes stale on
+          locale navigation — LocaleDirSync patches <html dir> for that, but the
+          root DirectionProvider keeps serving the stale value to base-ui. Any
+          component reading direction from context instead of CSS (the Sidebar's
+          side, menu/select positioning, arrow-key nav) stays LTR in Arabic.
+          Re-provide it here, where params.locale is authoritative. */}
+      <DirectionProvider direction={getLocaleDirection(locale)}>
+        <LocaleDirSync />
+        <ReactAriaRouterProvider>{children}</ReactAriaRouterProvider>
+      </DirectionProvider>
     </I18nProvider>
   );
 };

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -25,6 +25,8 @@ import { LuBookOpen, LuTriangleAlert } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 import { Link } from '@/lib/i18n/routing';
 
+import { ButtonLink } from '@/components/ButtonLink';
+
 import { DecisionHeroBackgroundImage } from './DecisionHeroBanner';
 import { DecisionPhaseTimeline } from './DecisionPhaseTimeline';
 import { useDecisionTranslation } from './DecisionTranslationContext';
@@ -424,13 +426,13 @@ const OverviewHero = ({
         </div>
         {showCtas ? (
           <div className="align-stretch flex w-full flex-col gap-4 md:flex-row md:justify-center">
-            <Button
-              render={<Link href={currentPhaseHref} />}
+            <ButtonLink
+              href={currentPhaseHref}
               variant="outline"
               className="w-auto"
             >
               {t('Browse proposals')}
-            </Button>
+            </ButtonLink>
             {canSubmitProposal ? (
               <Button
                 className="w-auto"

--- a/apps/app/src/components/decisions/DecisionSidePanel.tsx
+++ b/apps/app/src/components/decisions/DecisionSidePanel.tsx
@@ -5,6 +5,7 @@ import { trpc } from '@op/api/client';
 import type { DecisionAccess } from '@op/api/encoders';
 import { useInfiniteScroll } from '@op/hooks';
 import { Button } from '@op/sense/Button';
+import { useDirection } from '@op/sense/Direction';
 import {
   Empty,
   EmptyDescription,
@@ -48,6 +49,8 @@ export const DecisionSidePanel = ({
 }) => {
   const t = useTranslations();
   const [panel, setPanel] = useQueryState('panel', panelStateParser);
+  // Sheet's side is physical, so it has to be mirrored to stay at inline-end.
+  const isRtl = useDirection() === 'rtl';
 
   const isOpen = panel !== null;
   const close = useCallback(() => setPanel(null), [setPanel]);
@@ -74,7 +77,7 @@ export const DecisionSidePanel = ({
       }}
     >
       <SheetContent
-        side="right"
+        side={isRtl ? 'left' : 'right'}
         showCloseButton={false}
         // Desktop: sit below the fixed decision header (h-12/h-14) instead of
         // running full-height under it. Mobile stays full-screen.

--- a/apps/app/src/components/decisions/DecisionViewToggle.tsx
+++ b/apps/app/src/components/decisions/DecisionViewToggle.tsx
@@ -26,16 +26,21 @@ export function DecisionViewToggle({ decisionSlug }: DecisionViewToggleProps) {
   return (
     <Tabs value={activeView}>
       <TabsList>
+        {/* nativeButton={false}: each tab renders an <a>, not a <button>, so
+            base-ui must skip the native-button semantics (and the invalid
+            type="button" it would otherwise put on the anchor). */}
         <TabsTrigger
           value="overview"
-          className="font-normal hover:no-underline"
+          nativeButton={false}
+          className="hover:no-underline"
           render={<Link href={`/decisions/${decisionSlug}`} />}
         >
           {t('Overview')}
         </TabsTrigger>
         <TabsTrigger
           value="current"
-          className="font-normal hover:no-underline"
+          nativeButton={false}
+          className="hover:no-underline"
           render={<Link href={`/decisions/${decisionSlug}/current`} />}
         >
           {t('Current Phase')}

--- a/apps/app/src/components/decisions/ProposalEditorAside.tsx
+++ b/apps/app/src/components/decisions/ProposalEditorAside.tsx
@@ -2,6 +2,7 @@
 
 import { useMediaQuery } from '@op/hooks';
 import { Button } from '@op/sense/Button';
+import { useDirection } from '@op/sense/Direction';
 import { Drawer, DrawerContent, DrawerTitle } from '@op/sense/Drawer';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@op/sense/Sheet';
 import { cn } from '@op/sense/lib/utils';
@@ -24,7 +25,7 @@ interface ProposalEditorAsideProps {
 }
 
 /**
- * Responsive editor aside shell: a right-side sheet on desktop and a bottom
+ * Responsive editor aside shell: an inline-end sheet on desktop and a bottom
  * drawer on mobile (Figma "Sheet" instance, 384 wide, header/body padding 24).
  *
  * The desktop sheet is non-modal so a version can be previewed beside the
@@ -40,6 +41,10 @@ export function ProposalEditorAside({
   bodyClassName,
 }: ProposalEditorAsideProps) {
   const isMobile = useMediaQuery(`(max-width: ${screens.sm})`) ?? false;
+  // Sheet takes a physical side, but callers reserve the gap beside it with
+  // logical padding (`sm:pe-96`) — hardcoding "right" put the panel and its
+  // reserved space on opposite edges in Arabic.
+  const isRtl = useDirection() === 'rtl';
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
@@ -80,7 +85,7 @@ export function ProposalEditorAside({
       disablePointerDismissal
       onOpenChange={handleOpenChange}
     >
-      <SheetContent side="right" showOverlay={false}>
+      <SheetContent side={isRtl ? 'left' : 'right'} showOverlay={false}>
         <SheetHeader>
           <SheetTitle>
             <bdi>{title}</bdi>

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -270,7 +270,7 @@ function RubricCriterionSection({
           <FieldContent>
             <FieldTitle
               render={<h4 />}
-              className="flex w-full justify-between gap-2"
+              className="flex w-full items-start justify-between gap-2"
             >
               {label}
             </FieldTitle>
@@ -291,7 +291,7 @@ function RubricCriterionSection({
           ) : (
             <FieldTitle
               render={<h4 />}
-              className="flex w-full justify-between gap-2"
+              className="flex w-full items-start justify-between gap-2"
             >
               {label}
             </FieldTitle>

--- a/services/db/index.ts
+++ b/services/db/index.ts
@@ -47,34 +47,17 @@ const startupParameters = isMaintenance
       ),
     };
 
-const createDb = () =>
-  drizzle({
-    connection: {
-      url: process.env.DATABASE_URL,
-      max: poolMax,
-      connect_timeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT_S, 30),
-      connection: startupParameters,
-      onnotice: () => {},
-      prepare: false,
-    },
-    casing: config.casing,
-    schema,
-    relations,
-    logger: false,
-  });
-
-// Next dev/HMR re-evaluates this module on every recompile — and a single new
-// Tailwind class forces a ~50-route recompile storm (the global stylesheet
-// regenerates, so the whole route graph under the root layout invalidates).
-// Without a global guard, each pass spins up a fresh postgres-js pool and leaks
-// the previous one, quickly exhausting the DB pool and ballooning RAM. Reuse a
-// single pool across reloads in dev.
-declare global {
-  var __opDb: ReturnType<typeof createDb> | undefined;
-}
-
-export const db = globalThis.__opDb ?? createDb();
-
-if (process.env.NODE_ENV !== 'production') {
-  globalThis.__opDb = db;
-}
+export const db = drizzle({
+  connection: {
+    url: process.env.DATABASE_URL,
+    max: poolMax,
+    connect_timeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT_S, 30),
+    connection: startupParameters,
+    onnotice: () => {},
+    prepare: false,
+  },
+  casing: config.casing,
+  schema,
+  relations,
+  logger: false,
+});

--- a/services/db/index.ts
+++ b/services/db/index.ts
@@ -47,17 +47,34 @@ const startupParameters = isMaintenance
       ),
     };
 
-export const db = drizzle({
-  connection: {
-    url: process.env.DATABASE_URL,
-    max: poolMax,
-    connect_timeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT_S, 30),
-    connection: startupParameters,
-    onnotice: () => {},
-    prepare: false,
-  },
-  casing: config.casing,
-  schema,
-  relations,
-  logger: false,
-});
+const createDb = () =>
+  drizzle({
+    connection: {
+      url: process.env.DATABASE_URL,
+      max: poolMax,
+      connect_timeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT_S, 30),
+      connection: startupParameters,
+      onnotice: () => {},
+      prepare: false,
+    },
+    casing: config.casing,
+    schema,
+    relations,
+    logger: false,
+  });
+
+// Next dev/HMR re-evaluates this module on every recompile — and a single new
+// Tailwind class forces a ~50-route recompile storm (the global stylesheet
+// regenerates, so the whole route graph under the root layout invalidates).
+// Without a global guard, each pass spins up a fresh postgres-js pool and leaks
+// the previous one, quickly exhausting the DB pool and ballooning RAM. Reuse a
+// single pool across reloads in dev.
+declare global {
+  var __opDb: ReturnType<typeof createDb> | undefined;
+}
+
+export const db = globalThis.__opDb ?? createDb();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.__opDb = db;
+}


### PR DESCRIPTION
Small RTL and accessibility fixes found while checking Arabic.

- The root layout sits above the `[locale]` segment, so its `getLocale()` goes stale on locale navigation. `LocaleDirSync` already patched `<html dir>` for that, but the root `DirectionProvider` kept feeding base-ui the stale value — anything reading direction from context rather than CSS (the sidebar's side, menu/select positioning, arrow-key nav) stayed LTR in Arabic. Re-provided in `[locale]/layout.tsx`, where `params.locale` is authoritative.
- `Sheet` takes a physical side, but callers reserve the gap beside it with logical padding (`sm:pe-96`) — so the proposal version-history aside and the decision side panel sat on the opposite edge from their own reserved space in Arabic. Both now mirror.
- Base-ui's button-like primitives default `nativeButton` to true, so rendering a `Link` through `render` left an invalid `type="button"` on the anchor and a `role="button"` that pulls it out of the screen reader's links list. The decision view toggle's tabs declare `nativeButton={false}`; the overview CTA uses the existing `ButtonLink` wrapper.

Targets `sense-migration`, not `dev`.
