### PR TITLE
refactor(app): swap hex-identical neutral-* classes for sense semantic tokens

### DIFF
--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -91,7 +91,7 @@ const RootLayout = async ({ children }: { children: React.ReactNode }) => {
       <TRPCProvider ssrCookies={ssrCookies}>
         <QueryInvalidationSubscriber />
         <body
-          className={`${roboto.variable} ${robotoSerif.variable} h-full overflow-x-hidden text-base text-neutral-black antialiased`}
+          className={`${roboto.variable} ${robotoSerif.variable} h-full overflow-x-hidden text-base text-foreground antialiased`}
         >
           <FileDropGuard />
           {/* base-ui reads direction from this context and nowhere else — its

--- a/apps/app/src/components/AuthPanel.tsx
+++ b/apps/app/src/components/AuthPanel.tsx
@@ -88,7 +88,7 @@ export const AuthPanelShell = ({
         <div className="flex flex-col gap-12 sm:gap-8">
           <section className="flex flex-col items-center justify-center gap-2 sm:gap-4">
             <Header1 className="text-center sm:text-headline">{title}</Header1>
-            <div className="px-4 text-center text-sm leading-[130%] text-neutral-gray4 sm:text-base">
+            <div className="px-4 text-center text-sm leading-[130%] text-muted-foreground sm:text-base">
               {subtitle}
             </div>
           </section>
@@ -122,9 +122,9 @@ export const AuthDivider = () => {
 
   return (
     <div className="flex w-full items-center justify-center gap-4">
-      <div className="h-px grow bg-neutral-gray1" />
-      <span className="text-sm text-neutral-gray4">{t('or')}</span>
-      <div className="h-px grow bg-neutral-gray1" />
+      <div className="h-px grow bg-secondary" />
+      <span className="text-sm text-muted-foreground">{t('or')}</span>
+      <div className="h-px grow bg-secondary" />
     </div>
   );
 };

--- a/apps/app/src/components/Bullet/index.tsx
+++ b/apps/app/src/components/Bullet/index.tsx
@@ -1,7 +1,7 @@
 // Decorative separator between inline metadata. aria-hidden so screen readers
 // don't announce "bullet" mid-sentence.
 export const Bullet = () => (
-  <span aria-hidden className="text-neutral-gray4">
+  <span aria-hidden className="text-muted-foreground">
     •
   </span>
 );

--- a/apps/app/src/components/LinkPreview/index.tsx
+++ b/apps/app/src/components/LinkPreview/index.tsx
@@ -68,11 +68,11 @@ export const LinkPreview = memo(
             className,
           )}
         >
-          <div className="flex aspect-video w-full items-center justify-center bg-neutral-gray1">
+          <div className="flex aspect-video w-full items-center justify-center bg-secondary">
             <Spinner className="size-8" />
           </div>
-          <div className="border-t border-neutral-gray2 px-4 py-3">
-            <span className="text-sm text-neutral-gray4">{domain}</span>
+          <div className="border-t border-input px-4 py-3">
+            <span className="text-sm text-muted-foreground">{domain}</span>
           </div>
         </div>
       );
@@ -94,8 +94,10 @@ export const LinkPreview = memo(
             rel="noopener noreferrer"
             className="flex items-center gap-3 p-4"
           >
-            <LuGlobe className="size-5 shrink-0 text-neutral-gray4" />
-            <span className="truncate text-sm text-neutral-gray4">{url}</span>
+            <LuGlobe className="size-5 shrink-0 text-muted-foreground" />
+            <span className="truncate text-sm text-muted-foreground">
+              {url}
+            </span>
           </a>
         </div>
       );
@@ -107,7 +109,7 @@ export const LinkPreview = memo(
       <div
         className={cn(
           'overflow-hidden rounded border bg-white',
-          'group relative rounded-lg border-neutral-gray1 bg-white',
+          'group relative rounded-lg border-border bg-white',
           className,
         )}
       >
@@ -119,7 +121,7 @@ export const LinkPreview = memo(
               e.stopPropagation();
               onRemove();
             }}
-            className="absolute end-2 top-2 z-10 flex size-8 items-center justify-center rounded border border-neutral-gray1 bg-white text-neutral-black opacity-0 transition-opacity group-hover:opacity-100 hover:bg-neutral-gray1 focus-visible:opacity-100"
+            className="absolute end-2 top-2 z-10 flex size-8 items-center justify-center rounded border border-border bg-white text-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:bg-secondary focus-visible:opacity-100"
             aria-label={t('Remove preview')}
           >
             <LuX className="size-4" />
@@ -146,12 +148,12 @@ export const LinkPreview = memo(
             </div>
           ) : null}
           <div className="px-4 py-4">
-            <span className="text-sm text-neutral-black">
+            <span className="text-sm text-foreground">
               {title ?? domain}
               {title && (
                 <>
                   {' '}
-                  <span className="text-neutral-gray4">· {domain}</span>
+                  <span className="text-muted-foreground">· {domain}</span>
                 </>
               )}
             </span>

--- a/apps/app/src/components/Onboarding/DecisionInvitesForm.tsx
+++ b/apps/app/src/components/Onboarding/DecisionInvitesForm.tsx
@@ -105,10 +105,10 @@ export const DecisionInvitesForm = ({
       <FormContainer className="gap-6">
         {/* Header section - gap-2 (8px) between title and subtitle */}
         <div className="flex flex-col gap-2 text-center">
-          <Header1 className="text-neutral-black">
+          <Header1 className="text-foreground">
             {t('Join decision-making processes')}
           </Header1>
-          <p className="text-sm text-neutral-gray4">
+          <p className="text-sm text-muted-foreground">
             {t(
               "You've been invited to join the following decision-making processes",
             )}

--- a/apps/app/src/components/Onboarding/FundingInformationForm.tsx
+++ b/apps/app/src/components/Onboarding/FundingInformationForm.tsx
@@ -132,12 +132,10 @@ export const FundingInformationForm = ({
                           label={t(
                             'Where can people contribute to your organization?',
                           )}
-                          icon={
-                            <LuLink className="size-4 text-neutral-black" />
-                          }
+                          icon={<LuLink className="size-4 text-foreground" />}
                           placeholder={t('Add your contribution page here')}
                         />
-                        <span className="text-sm text-neutral-gray4">
+                        <span className="text-sm text-muted-foreground">
                           {t(
                             'Add a link to your donation page, Open Collective, GoFundMe or any platform where supporters can contribute or learn more about how.',
                           )}
@@ -193,7 +191,7 @@ export const FundingInformationForm = ({
                                     : t('Where can organizations learn more?')
                                 }
                                 icon={
-                                  <LuLink className="size-4 text-neutral-black" />
+                                  <LuLink className="size-4 text-foreground" />
                                 }
                                 placeholder={
                                   acceptingApplicationsField.state.value
@@ -205,7 +203,7 @@ export const FundingInformationForm = ({
                                       )
                                 }
                               />
-                              <span className="text-sm text-neutral-gray4">
+                              <span className="text-sm text-muted-foreground">
                                 {acceptingApplicationsField.state.value
                                   ? null
                                   : t(

--- a/apps/app/src/components/Onboarding/OnboardingCenterLayout.tsx
+++ b/apps/app/src/components/Onboarding/OnboardingCenterLayout.tsx
@@ -14,10 +14,10 @@ export const OnboardingCenterLayout = ({
     <div className="flex h-[calc(100dvh-80px)] w-full items-center justify-center">
       <div className="flex w-full max-w-lg flex-col items-center gap-8 px-4 sm:px-0">
         <div className="flex flex-col gap-2 text-center">
-          <Header1 className="text-neutral-black sm:text-headline">
+          <Header1 className="text-foreground sm:text-headline">
             {title}
           </Header1>
-          <p className="text-base leading-normal text-neutral-gray4">
+          <p className="text-base leading-normal text-muted-foreground">
             {subtitle}
           </p>
         </div>

--- a/apps/app/src/components/Onboarding/OrganizationSearchScreen.tsx
+++ b/apps/app/src/components/Onboarding/OrganizationSearchScreen.tsx
@@ -136,7 +136,7 @@ export const OrganizationSearchScreen = ({
           <div ref={containerRef} className="relative">
             <InputGroup>
               <InputGroupAddon align="inline-start">
-                <LuSearch className="size-4 text-neutral-gray4" />
+                <LuSearch className="size-4 text-muted-foreground" />
               </InputGroupAddon>
               <InputGroupInput
                 value={searchQuery}
@@ -147,7 +147,7 @@ export const OrganizationSearchScreen = ({
             </InputGroup>
 
             {isDropdownOpen && (
-              <div className="absolute start-0 end-0 top-full z-10 mt-1 max-h-72 overflow-y-auto rounded-lg border border-neutral-gray1 bg-white shadow-lg">
+              <div className="absolute start-0 end-0 top-full z-10 mt-1 max-h-72 overflow-y-auto rounded-lg border border-border bg-white shadow-lg">
                 <SearchDropdown
                   searchResults={searchResults}
                   isFetching={isFetching}
@@ -229,7 +229,7 @@ function SearchDropdown({
               key={org.id}
               type="button"
               disabled={isMember}
-              className="flex w-full items-center px-4 py-3 text-start hover:bg-neutral-offWhite disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+              className="flex w-full items-center px-4 py-3 text-start hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
               onClick={() => onSelect(result)}
             >
               <ProfileItem
@@ -244,14 +244,16 @@ function SearchDropdown({
                 title={org.profile?.name ?? ''}
               >
                 {location && (
-                  <div className="text-xs text-neutral-gray4">{location}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {location}
+                  </div>
                 )}
               </ProfileItem>
             </button>
           );
         })
       ) : (
-        <div className="px-4 py-3 text-sm text-neutral-gray4">
+        <div className="px-4 py-3 text-sm text-muted-foreground">
           {t('No results')}
         </div>
       )}
@@ -259,7 +261,7 @@ function SearchDropdown({
       {onAddOrganization && searchQuery && (
         <button
           type="button"
-          className="flex w-full items-center gap-2 border-t border-neutral-gray1 px-4 py-3 text-start text-primary-teal hover:bg-neutral-offWhite"
+          className="flex w-full items-center gap-2 border-t border-border px-4 py-3 text-start text-primary-teal hover:bg-muted"
           onClick={() => onAddOrganization(searchQuery)}
         >
           <LuPlus className="size-4" />
@@ -283,7 +285,7 @@ function SelectedOrgChip({
   const location = getOrgLocation(org);
 
   return (
-    <div className="flex items-center gap-6 rounded-lg border border-neutral-gray1 bg-white px-3 py-2">
+    <div className="flex items-center gap-6 rounded-lg border border-border bg-white px-3 py-2">
       <div className="flex items-center gap-2">
         <OrganizationAvatar
           profile={org.profile}
@@ -295,13 +297,13 @@ function SelectedOrgChip({
             {org.profile?.name}
           </span>
           {location && (
-            <span className="text-xs text-neutral-gray4">{location}</span>
+            <span className="text-xs text-muted-foreground">{location}</span>
           )}
         </div>
       </div>
       <button
         type="button"
-        className="rounded-full p-1 text-neutral-gray4 hover:bg-neutral-gray1 hover:text-neutral-charcoal"
+        className="rounded-full p-1 text-muted-foreground hover:bg-secondary hover:text-neutral-charcoal"
         onClick={onRemove}
         aria-label={t('Remove')}
       >
@@ -315,9 +317,9 @@ function OrDivider() {
   const t = useTranslations();
   return (
     <div className="flex items-center gap-4">
-      <div className="h-px flex-1 bg-neutral-gray1" />
+      <div className="h-px flex-1 bg-secondary" />
       <span className="text-sm text-muted-foreground">{t('or')}</span>
-      <div className="h-px flex-1 bg-neutral-gray1" />
+      <div className="h-px flex-1 bg-secondary" />
     </div>
   );
 }

--- a/apps/app/src/components/Onboarding/shared/OrganizationFormFields.tsx
+++ b/apps/app/src/components/Onboarding/shared/OrganizationFormFields.tsx
@@ -167,7 +167,7 @@ export const OrganizationFormFields = ({
           <field.TextField
             label={t('Website')}
             isRequired
-            icon={<LuLink className="size-4 text-neutral-black" />}
+            icon={<LuLink className="size-4 text-foreground" />}
             placeholder={t("Enter your organization's website here")}
             // Not `type="url"`: our zodUrl validation accepts a bare domain
             // (e.g. "venuecms.com") and auto-prefixes `https://`, but the

--- a/apps/app/src/components/OrganizationList/index.tsx
+++ b/apps/app/src/components/OrganizationList/index.tsx
@@ -136,7 +136,7 @@ export const OrganizationCardList = ({
             <div className="flex flex-col gap-2">
               <div className="flex flex-col gap-2">
                 <Link
-                  className="truncate font-semibold text-neutral-black"
+                  className="truncate font-semibold text-foreground"
                   href={`/org/${relationshipOrg.profile.slug}`}
                 >
                   <bdi>{relationshipOrg.profile.name}</bdi>
@@ -190,7 +190,7 @@ export const OrganizationSummaryList = ({
                 className="size-8 sm:size-12"
               />
 
-              <div className="flex flex-col gap-3 text-neutral-black">
+              <div className="flex flex-col gap-3 text-foreground">
                 <div className="flex flex-col gap-2">
                   <Link
                     href={`/org/${org.profile.slug}`}
@@ -201,7 +201,7 @@ export const OrganizationSummaryList = ({
                   {org.whereWeWork?.length > 0 ? (
                     <span
                       dir="auto"
-                      className="text-sm text-neutral-gray4 sm:text-base"
+                      className="text-sm text-muted-foreground sm:text-base"
                     >
                       {whereWeWork}
                     </span>

--- a/apps/app/src/components/Organizations/AllOrganizations/index.tsx
+++ b/apps/app/src/components/Organizations/AllOrganizations/index.tsx
@@ -59,7 +59,7 @@ export const AllOrganizationsSuspense = ({
       {shouldShowTrigger && (
         <div ref={ref} className="flex justify-center py-4">
           {isFetchingNextPage ? (
-            <div className="text-sm text-neutral-gray4">
+            <div className="text-sm text-muted-foreground">
               <SkeletonText lines={3} />
             </div>
           ) : null}

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -34,7 +34,7 @@ export const PlatformHighlights = () => {
                 {t('new organizations to explore')}
               </HighlightLabel>
             </Highlight>
-            <hr className="hidden h-20 w-0.5 border-0 bg-neutral-gray1 sm:block" />
+            <hr className="hidden h-20 w-0.5 border-0 bg-secondary sm:block" />
           </>
         )}
         <Highlight>
@@ -48,14 +48,14 @@ export const PlatformHighlights = () => {
             )}
           </HighlightLabel>
         </Highlight>
-        <hr className="hidden h-20 w-0.5 border-0 bg-neutral-gray1 sm:block" />
+        <hr className="hidden h-20 w-0.5 border-0 bg-secondary sm:block" />
         <Highlight>
           <HighlightNumber className="bg-redTeal">
             {stats.totalOrganizations}
           </HighlightNumber>
           <HighlightLabel>{t('organizations on Common')}</HighlightLabel>
         </Highlight>
-        <hr className="hidden h-20 w-0.5 border-0 bg-neutral-gray1 sm:block" />
+        <hr className="hidden h-20 w-0.5 border-0 bg-secondary sm:block" />
         <Highlight>
           <HighlightNumber className="bg-redPurple">
             {stats.totalUsers}
@@ -63,7 +63,7 @@ export const PlatformHighlights = () => {
           <HighlightLabel>{t('people on Common')}</HighlightLabel>
         </Highlight>
       </div>
-      <div className="flex flex-col justify-center gap-2 border-0 border-t bg-neutral-offWhite p-6 text-sm sm:flex-row sm:items-center">
+      <div className="flex flex-col justify-center gap-2 border-0 border-t bg-muted p-6 text-sm sm:flex-row sm:items-center">
         <Suspense>
           <div className="flex max-w-full items-center gap-2">
             <OrganizationFacePile>

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -78,7 +78,7 @@ const PostDisplayName = ({
 const PostTimestamp = ({ createdAt }: { createdAt: Date | string }) => {
   const relativeTime = useRelativeTime(createdAt);
 
-  return <span className="text-sm text-neutral-gray4">{relativeTime}</span>;
+  return <span className="text-sm text-muted-foreground">{relativeTime}</span>;
 };
 
 const PostContent = ({ content }: { content?: string }) => {
@@ -154,7 +154,7 @@ const AttachmentImage = ({
   if (!mimetype.startsWith('image/')) return null;
 
   return (
-    <div className="relative flex h-fit w-full items-center justify-center rounded bg-neutral-gray1 text-white">
+    <div className="relative flex h-fit w-full items-center justify-center rounded bg-secondary text-white">
       <Image
         src={getPublicUrl(storageObjectName) ?? ''}
         alt={fileName}
@@ -283,7 +283,7 @@ const PostMenu = ({
               variant="ghost"
               size="icon-xs"
               aria-label={t('Post options')}
-              className="absolute end-0 top-0 aspect-square aria-expanded:bg-neutral-gray1"
+              className="absolute end-0 top-0 aspect-square aria-expanded:bg-secondary"
             >
               <LuEllipsis className="size-4" />
             </Button>
@@ -311,8 +311,8 @@ export const EmptyPostsState = () => {
   return (
     <FeedItem>
       <FeedMain className="flex w-full flex-col items-center justify-center py-6">
-        <FeedContent className="flex flex-col items-center justify-center text-neutral-gray4">
-          <div className="flex size-10 items-center justify-center gap-4 rounded-full bg-neutral-gray1">
+        <FeedContent className="flex flex-col items-center justify-center text-muted-foreground">
+          <div className="flex size-10 items-center justify-center gap-4 rounded-full bg-secondary">
             <LuLeaf />
           </div>
           <span>{t('No posts yet')}</span>

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -623,7 +623,7 @@ const PostUpdateWithUser = ({
               className="size-8 bg-white"
             />
           ) : (
-            <div className="size-8 rounded-full bg-neutral-gray1" />
+            <div className="size-8 rounded-full bg-secondary" />
           )}
         </InputGroupAddon>
         <div className="flex min-w-0 flex-1 flex-col">
@@ -642,7 +642,7 @@ const PostUpdateWithUser = ({
                   {filePreview.uploading ? (
                     <Skeleton className="relative flex aspect-video w-full items-center justify-center rounded text-white" />
                   ) : filePreview.file.type.startsWith('image/') ? (
-                    <div className="relative flex aspect-video w-full items-center justify-center rounded bg-neutral-gray1 text-white">
+                    <div className="relative flex aspect-video w-full items-center justify-center rounded bg-secondary text-white">
                       {filePreview.error ? (
                         <p className="text-sm">{filePreview.error}</p>
                       ) : (

--- a/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
@@ -162,7 +162,7 @@ const MemberMenu = ({
             aria-label={t('Member options')}
             variant="ghost"
             size="icon-xs"
-            className="aria-expanded:bg-neutral-gray1"
+            className="aria-expanded:bg-secondary"
           >
             <LuEllipsis className="size-4" />
           </Button>
@@ -244,7 +244,7 @@ const MembersListContent = ({
                       reach it (walled garden), otherwise plain text. */}
                   {profile && canLinkToProfile ? (
                     <Link
-                      className="truncate font-semibold text-neutral-black"
+                      className="truncate font-semibold text-foreground"
                       href={
                         profile.type === 'org'
                           ? `/org/${profile.slug}`
@@ -254,7 +254,7 @@ const MembersListContent = ({
                       {displayName}
                     </Link>
                   ) : (
-                    <div className="truncate font-semibold text-neutral-black">
+                    <div className="truncate font-semibold text-foreground">
                       {displayName}
                     </div>
                   )}
@@ -337,10 +337,10 @@ export const MembersList = ({ profileId }: { profileId: string }) => {
   if (!members || members.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
-        <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-neutral-gray1">
-          <LuUsers className="h-6 w-6 text-neutral-gray4" />
+        <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-secondary">
+          <LuUsers className="h-6 w-6 text-muted-foreground" />
         </div>
-        <div className="mb-2 font-serif text-title-base text-neutral-black">
+        <div className="mb-2 font-serif text-title-base text-foreground">
           {t('No members found')}
         </div>
         <p className="max-w-md text-sm text-neutral-charcoal">

--- a/apps/app/src/components/Profile/ProfileDecisions/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDecisions/index.tsx
@@ -83,8 +83,8 @@ const EmptyDecisions = ({ profileId }: { profileId: string }) => {
 
   return (
     <div className="flex min-h-100 flex-col items-center justify-center gap-6 px-6 py-16 text-center">
-      <div className="flex size-10 items-center justify-center rounded-full bg-neutral-gray1">
-        <LuLeaf className="size-6 text-neutral-gray4" />
+      <div className="flex size-10 items-center justify-center rounded-full bg-secondary">
+        <LuLeaf className="size-6 text-muted-foreground" />
       </div>
       <div className="flex max-w-md flex-col gap-2">
         <Header2 className="font-serif text-title-base">

--- a/apps/app/src/components/Profile/ProfileDetails/CreateOrganizationForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/CreateOrganizationForm.tsx
@@ -224,7 +224,7 @@ export const CreateOrganizationForm = forwardRef<
             <field.TextField
               label={t('Website')}
               isRequired
-              icon={<LuLink className="size-4 text-neutral-black" />}
+              icon={<LuLink className="size-4 text-foreground" />}
               placeholder={t("Enter your organization's website here")}
               // Not `type="url"`: our zodUrl validation accepts a bare domain
               // (e.g. "venuecms.com") and auto-prefixes `https://`, but the
@@ -398,12 +398,10 @@ export const CreateOrganizationForm = forwardRef<
                             label={t(
                               'Where can people contribute to your organization?',
                             )}
-                            icon={
-                              <LuLink className="size-4 text-neutral-black" />
-                            }
+                            icon={<LuLink className="size-4 text-foreground" />}
                             placeholder={t('Add your contribution page here')}
                           />
-                          <span className="text-start text-sm text-neutral-gray4">
+                          <span className="text-start text-sm text-muted-foreground">
                             {t(
                               'Add a link to your donation page, Open Collective, GoFundMe or any platform where supporters can contribute or learn more about how.',
                             )}
@@ -466,7 +464,7 @@ export const CreateOrganizationForm = forwardRef<
                                       : t('Where can organizations learn more?')
                                   }
                                   icon={
-                                    <LuLink className="size-4 text-neutral-black" />
+                                    <LuLink className="size-4 text-foreground" />
                                   }
                                   placeholder={
                                     acceptingApplicationsField.state.value
@@ -478,7 +476,7 @@ export const CreateOrganizationForm = forwardRef<
                                         )
                                   }
                                 />
-                                <span className="text-sm text-neutral-gray4">
+                                <span className="text-sm text-muted-foreground">
                                   {acceptingApplicationsField.state.value
                                     ? null
                                     : t(

--- a/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationForm.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/UpdateOrganizationForm.tsx
@@ -305,7 +305,7 @@ export const UpdateOrganizationForm = forwardRef<
             <field.TextField
               label={t('Website')}
               isRequired
-              icon={<LuLink className="size-4 text-neutral-black" />}
+              icon={<LuLink className="size-4 text-foreground" />}
               placeholder={t("Enter your organization's website here")}
               // Not `type="url"`: our zodUrl validation accepts a bare domain
               // (e.g. "venuecms.com") and auto-prefixes `https://`, but the
@@ -479,12 +479,10 @@ export const UpdateOrganizationForm = forwardRef<
                             label={t(
                               'Where can people contribute to your organization?',
                             )}
-                            icon={
-                              <LuLink className="size-4 text-neutral-black" />
-                            }
+                            icon={<LuLink className="size-4 text-foreground" />}
                             placeholder={t('Add your contribution page here')}
                           />
-                          <span className="text-start text-sm text-neutral-gray4">
+                          <span className="text-start text-sm text-muted-foreground">
                             {t(
                               'Add a link to your donation page, Open Collective, GoFundMe or any platform where supporters can contribute or learn more about how.',
                             )}
@@ -547,7 +545,7 @@ export const UpdateOrganizationForm = forwardRef<
                                       : t('Where can organizations learn more?')
                                   }
                                   icon={
-                                    <LuLink className="size-4 text-neutral-black" />
+                                    <LuLink className="size-4 text-foreground" />
                                   }
                                   placeholder={
                                     acceptingApplicationsField.state.value
@@ -559,7 +557,7 @@ export const UpdateOrganizationForm = forwardRef<
                                         )
                                   }
                                 />
-                                <span className="text-sm text-neutral-gray4">
+                                <span className="text-sm text-muted-foreground">
                                   {acceptingApplicationsField.state.value
                                     ? null
                                     : t(

--- a/apps/app/src/components/Profile/ProfileSummary/index.tsx
+++ b/apps/app/src/components/Profile/ProfileSummary/index.tsx
@@ -46,7 +46,7 @@ export const ProfileSummary = ({ profile }: { profile: Organization }) => {
       </Header1>
 
       {whereWeWork.length ? (
-        <div dir="auto" className="text-base text-neutral-gray4">
+        <div dir="auto" className="text-base text-muted-foreground">
           {whereWeWork}
         </div>
       ) : null}
@@ -57,7 +57,7 @@ export const ProfileSummary = ({ profile }: { profile: Organization }) => {
 
       <ErrorBoundary fallback={null}>
         <div className="flex flex-col-reverse gap-6 sm:flex-col">
-          <div className="flex gap-1 text-base text-neutral-gray4">
+          <div className="flex gap-1 text-base text-muted-foreground">
             <Suspense fallback={<Skeleton className="h-5 w-32" />}>
               <RelationshipCount profile={profile} />
             </Suspense>

--- a/apps/app/src/components/RelationshipList/index.tsx
+++ b/apps/app/src/components/RelationshipList/index.tsx
@@ -84,7 +84,7 @@ const RelationshipListContent = ({
                   {/* Public/non-member viewers can't reach the profile page. */}
                   {canLinkToProfile ? (
                     <Link
-                      className="truncate font-semibold text-neutral-black"
+                      className="truncate font-semibold text-foreground"
                       href={
                         profile.type === 'org'
                           ? `/org/${profile.slug}`
@@ -94,14 +94,14 @@ const RelationshipListContent = ({
                       <bdi>{profile.name}</bdi>
                     </Link>
                   ) : (
-                    <span className="truncate font-semibold text-neutral-black">
+                    <span className="truncate font-semibold text-foreground">
                       <bdi>{profile.name}</bdi>
                     </span>
                   )}
 
                   {/* Show relationship types if available */}
                   {profile.relationships && relationshipMap ? (
-                    <div className="text-neutral-black">
+                    <div className="text-foreground">
                       {profile.relationships.map((relationship, i, arr) => (
                         <React.Fragment key={relationship.relationshipType}>
                           {relationshipMap[relationship.relationshipType]

--- a/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
+++ b/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
@@ -145,7 +145,7 @@ export const AddResourceDocumentForm = ({
     <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
       <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 sm:px-6">
         <div className="flex flex-col gap-1">
-          <span className="text-sm text-neutral-black">{t('Upload file')}</span>
+          <span className="text-sm text-foreground">{t('Upload file')}</span>
           <input
             ref={inputRef}
             type="file"
@@ -155,7 +155,7 @@ export const AddResourceDocumentForm = ({
           />
           {file ? (
             isImage ? (
-              <div className="relative h-44 w-full overflow-hidden rounded-lg border border-neutral-gray1 bg-neutral-offWhite">
+              <div className="relative h-44 w-full overflow-hidden rounded-lg border border-border bg-muted">
                 {previewUrl ? (
                   <img
                     src={previewUrl}
@@ -180,9 +180,9 @@ export const AddResourceDocumentForm = ({
                 </Button>
               </div>
             ) : (
-              <div className="flex items-center gap-4 rounded-lg border border-neutral-gray1 bg-white p-4">
+              <div className="flex items-center gap-4 rounded-lg border border-border bg-white p-4">
                 <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary-tealWhite">
-                  <LuFileText className="size-5 text-neutral-gray4" />
+                  <LuFileText className="size-5 text-muted-foreground" />
                 </div>
                 <div className="flex min-w-0 flex-1 flex-col">
                   {uploading ? (
@@ -195,7 +195,7 @@ export const AddResourceDocumentForm = ({
                       <span className="truncate text-base font-medium text-neutral-charcoal">
                         {file.name}
                       </span>
-                      <span className="text-sm text-neutral-gray4">
+                      <span className="text-sm text-muted-foreground">
                         {fileMetaLabel(file)}
                       </span>
                     </>
@@ -231,17 +231,17 @@ export const AddResourceDocumentForm = ({
               onDragLeave={() => setIsDragging(false)}
               onDrop={handleDrop}
               className={cn(
-                'flex min-h-52 cursor-pointer flex-col items-center justify-center gap-6 rounded-lg border border-dashed bg-neutral-offWhite px-12 py-6 text-center transition-colors',
+                'flex min-h-52 cursor-pointer flex-col items-center justify-center gap-6 rounded-lg border border-dashed bg-muted px-12 py-6 text-center transition-colors',
                 isDragging
                   ? 'bg-primary-teal50 border-primary-teal'
-                  : 'border-neutral-gray2 hover:border-neutral-gray3',
+                  : 'border-input hover:border-neutral-gray3',
               )}
             >
-              <div className="flex size-20 items-center justify-center rounded-full bg-neutral-gray1 text-neutral-charcoal">
+              <div className="flex size-20 items-center justify-center rounded-full bg-secondary text-neutral-charcoal">
                 <LuFilePlus2 className="size-10" />
               </div>
               <div className="flex flex-col gap-2 text-base">
-                <p className="text-neutral-black">
+                <p className="text-foreground">
                   {t.rich('Drag a file here or <browse>browse</browse>', {
                     browse: (chunks: ReactNode) => (
                       <span className="text-primary-teal underline">
@@ -250,7 +250,7 @@ export const AddResourceDocumentForm = ({
                     ),
                   })}
                 </p>
-                <p className="text-neutral-gray4">
+                <p className="text-muted-foreground">
                   {t('Accepts PDF, DOCX, XLSX, and images up to {size} MB', {
                     size: MAX_SIZE_MB,
                   })}

--- a/apps/app/src/components/Resources/AddResourceLinkForm.tsx
+++ b/apps/app/src/components/Resources/AddResourceLinkForm.tsx
@@ -100,7 +100,7 @@ export const AddResourceLinkForm = ({
           </FieldLabel>
           <InputGroup>
             <InputGroupAddon align="inline-start">
-              <LuLink className="size-4 text-neutral-gray4" />
+              <LuLink className="size-4 text-muted-foreground" />
             </InputGroupAddon>
             <InputGroupInput
               id="resource-url"

--- a/apps/app/src/components/Resources/CollectionSection.tsx
+++ b/apps/app/src/components/Resources/CollectionSection.tsx
@@ -26,7 +26,7 @@ export const CollectionSection = ({
       value={collectionId}
       className="rounded-none border-0 bg-transparent"
     >
-      <AccordionTrigger className="w-full gap-1 text-sm font-normal text-neutral-black">
+      <AccordionTrigger className="w-full gap-1 text-sm font-normal text-foreground">
         <span className="truncate">{name}</span>
       </AccordionTrigger>
       <AccordionContent>

--- a/apps/app/src/components/Resources/PinnedResourceCard.tsx
+++ b/apps/app/src/components/Resources/PinnedResourceCard.tsx
@@ -59,14 +59,14 @@ export const PinnedResourceCard = ({
     >
       <div className="flex items-center gap-2">
         <div className="flex size-8 shrink-0 items-center justify-center rounded-sm bg-primary-tealWhite group-hover:bg-white">
-          <Icon className="size-4 text-neutral-black" />
+          <Icon className="size-4 text-foreground" />
         </div>
         <div className="flex min-w-0 flex-col gap-0.5">
-          <p dir="auto" className="truncate text-base text-neutral-black">
+          <p dir="auto" className="truncate text-base text-foreground">
             {title}
           </p>
           {resource.createdAt ? (
-            <p className="truncate text-sm text-neutral-gray4">
+            <p className="truncate text-sm text-muted-foreground">
               {t('Added {date}', { date: formatDate(resource.createdAt) })}
             </p>
           ) : null}

--- a/apps/app/src/components/Resources/ResourceCard.tsx
+++ b/apps/app/src/components/Resources/ResourceCard.tsx
@@ -163,7 +163,7 @@ const ResourceCardShell = ({
       <p
         dir="auto"
         className={cn(
-          'truncate font-serif text-title-sm text-neutral-black',
+          'truncate font-serif text-title-sm text-foreground',
           trailing && 'pe-8',
         )}
       >
@@ -177,7 +177,7 @@ const ResourceCardShell = ({
           </p>
         ) : null}
         {subtitle ? (
-          <p dir="auto" className="truncate text-sm text-neutral-gray4">
+          <p dir="auto" className="truncate text-sm text-muted-foreground">
             {subtitle}
           </p>
         ) : null}
@@ -216,7 +216,7 @@ const ResourcePreviewImage = ({
   src: string;
   onError?: () => void;
 }) => (
-  <div className="h-44 w-full overflow-hidden rounded-lg border border-neutral-gray2">
+  <div className="h-44 w-full overflow-hidden rounded-lg border border-input">
     <img
       src={src}
       alt=""
@@ -228,7 +228,7 @@ const ResourcePreviewImage = ({
 );
 
 const ResourcePreviewFallback = ({ icon }: { icon: ReactNode }) => (
-  <div className="flex h-44 w-full items-center justify-center rounded-lg border border-neutral-gray2 bg-neutral-gray1 text-neutral-gray4">
+  <div className="flex h-44 w-full items-center justify-center rounded-lg border border-input bg-secondary text-muted-foreground">
     {icon}
   </div>
 );

--- a/apps/app/src/components/Resources/ResourcesList.tsx
+++ b/apps/app/src/components/Resources/ResourcesList.tsx
@@ -120,7 +120,7 @@ export const ResourcesList = ({
         renderItem={renderItem}
       >
         {items.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-neutral-gray2 px-6 py-10 text-center text-neutral-gray4">
+          <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-input px-6 py-10 text-center text-muted-foreground">
             <LuUpload className="size-6" />
             <p className="text-sm">{t('Drag a file or link here to add it')}</p>
           </div>

--- a/apps/app/src/components/Resources/ResourcesTabContent.tsx
+++ b/apps/app/src/components/Resources/ResourcesTabContent.tsx
@@ -63,7 +63,7 @@ export const ResourcesTabContent = ({
         </div>
       </div>
       {canManage && !adding && !isEmpty ? (
-        <div className="shrink-0 border-t border-neutral-gray1 bg-white px-4 py-6 sm:px-6">
+        <div className="shrink-0 border-t border-border bg-white px-4 py-6 sm:px-6">
           <Button
             variant="outline"
             size="sm"
@@ -76,7 +76,7 @@ export const ResourcesTabContent = ({
         </div>
       ) : null}
       {canManage && adding ? (
-        <div className="absolute inset-0 z-10 flex flex-col overflow-hidden rounded-t-lg border-t border-neutral-gray1 bg-white shadow-lg">
+        <div className="absolute inset-0 z-10 flex flex-col overflow-hidden rounded-t-lg border-t border-border bg-white shadow-lg">
           <AddResourcePanel
             profileId={profileId}
             onClose={() => setAdding(false)}

--- a/apps/app/src/components/RichTextEditor/RichTextEditorFloatingToolbar.tsx
+++ b/apps/app/src/components/RichTextEditor/RichTextEditorFloatingToolbar.tsx
@@ -78,7 +78,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleHeading({ level: 1 }).run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 1 }) ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 1 }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Heading 1')}
       >
         <LuHeading1 className="size-4" />
@@ -88,7 +88,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleHeading({ level: 2 }).run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 2 }) ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 2 }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Heading 2')}
       >
         <LuHeading2 className="size-4" />
@@ -98,7 +98,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleHeading({ level: 3 }).run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 3 }) ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 3 }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Heading 3')}
       >
         <LuHeading3 className="size-4" />
@@ -112,7 +112,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleBold().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('bold') ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('bold') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Bold')}
       >
         <LuBold className="size-4" />
@@ -122,7 +122,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleItalic().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('italic') ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('italic') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Italic')}
       >
         <LuItalic className="size-4" />
@@ -132,7 +132,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleUnderline().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('underline') ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('underline') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Underline')}
       >
         <LuUnderline className="size-4" />
@@ -142,7 +142,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleStrike().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('strike') ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('strike') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Strikethrough')}
       >
         <LuStrikethrough className="size-4" />
@@ -152,7 +152,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleCode().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('code') ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('code') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Code')}
       >
         <LuCode className="size-4" />
@@ -166,7 +166,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleBulletList().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('bulletList') ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('bulletList') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Bullet List')}
       >
         <LuList className="size-4" />
@@ -176,7 +176,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleOrderedList().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('orderedList') ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('orderedList') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Numbered List')}
       >
         <LuListOrdered className="size-4" />
@@ -186,7 +186,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleBlockquote().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('blockquote') ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('blockquote') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Blockquote')}
       >
         <LuQuote className="size-4" />
@@ -200,7 +200,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().setTextAlign('left').run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'left' }) ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'left' }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Align Left')}
       >
         <LuAlignLeft className="size-4" />
@@ -210,7 +210,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().setTextAlign('center').run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'center' }) ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'center' }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Align Center')}
       >
         <LuAlignCenter className="size-4" />
@@ -220,7 +220,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().setTextAlign('right').run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'right' }) ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'right' }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Align Right')}
       >
         <LuAlignRight className="size-4" />
@@ -234,7 +234,7 @@ export function RichTextEditorFloatingToolbar({
           addLink();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('link') ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('link') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
         title={t('Add Link')}
       >
         <LuLink className="size-4" />

--- a/apps/app/src/components/decisions/AdminOverviewBar.tsx
+++ b/apps/app/src/components/decisions/AdminOverviewBar.tsx
@@ -60,13 +60,15 @@ export function AdminOverviewBar({
         </span>
         {phaseName ? (
           <>
-            <span aria-hidden="true" className="text-neutral-black">
+            <span aria-hidden="true" className="text-foreground">
               |
             </span>
             <span className="flex items-end gap-1.5">
-              <span className="text-neutral-black">{phaseName}</span>
+              <span className="text-foreground">{phaseName}</span>
               {endsLabel ? (
-                <span className="text-sm text-neutral-gray4">{endsLabel}</span>
+                <span className="text-sm text-muted-foreground">
+                  {endsLabel}
+                </span>
               ) : null}
             </span>
           </>
@@ -86,7 +88,7 @@ export function AdminOverviewBar({
           <div className="flex min-w-full flex-col">
             <button
               type="button"
-              className="px-6 py-4 text-start text-base hover:bg-neutral-gray1"
+              className="px-6 py-4 text-start text-base hover:bg-secondary"
               onClick={() => {
                 setSheetOpen(false);
                 setBannerOpen(true);
@@ -96,7 +98,7 @@ export function AdminOverviewBar({
             </button>
             <button
               type="button"
-              className="px-6 py-4 text-start text-base hover:bg-neutral-gray1"
+              className="px-6 py-4 text-start text-base hover:bg-secondary"
               onClick={() => router.push(`/decisions/${decisionSlug}/edit`)}
             >
               {t('Process settings')}

--- a/apps/app/src/components/decisions/AllDecisions/index.tsx
+++ b/apps/app/src/components/decisions/AllDecisions/index.tsx
@@ -18,7 +18,7 @@ import { TranslatedText } from '@/components/TranslatedText';
 import { DecisionListItem } from '../DecisionListItem';
 
 const DecisionListItemSkeleton = () => (
-  <div className="flex flex-col gap-4 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between sm:rounded-none sm:border-0 sm:border-b sm:border-b-neutral-gray1">
+  <div className="flex flex-col gap-4 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between sm:rounded-none sm:border-0 sm:border-b sm:border-b-border">
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
         <Skeleton className="h-5 w-48" />
@@ -86,7 +86,7 @@ const DecisionsListSuspense = ({
 
   if (paginatedItems.length === 0) {
     return (
-      <div className="py-8 text-center text-neutral-gray4">
+      <div className="py-8 text-center text-muted-foreground">
         {t('No processes found')}
       </div>
     );

--- a/apps/app/src/components/decisions/DecisionHeroBanner.tsx
+++ b/apps/app/src/components/decisions/DecisionHeroBanner.tsx
@@ -51,10 +51,7 @@ export function DecisionHeroBackgroundImage({
       />
       {/* Dark scrim so the white banner text stays legible over arbitrary
           photos. */}
-      <div
-        aria-hidden="true"
-        className="absolute inset-0 bg-neutral-black/50"
-      />
+      <div aria-hidden="true" className="absolute inset-0 bg-foreground/50" />
     </>
   );
 }

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -185,7 +185,7 @@ const DecisionUpdatesToggle = ({
       aria-label={ariaLabel}
       aria-pressed={isOpen}
       className={
-        isOpen ? 'bg-primary-tealWhite text-primary-teal' : 'text-neutral-black'
+        isOpen ? 'bg-primary-tealWhite text-primary-teal' : 'text-foreground'
       }
     >
       <MegaphoneIcon className="size-4 stroke-[1.5]" />

--- a/apps/app/src/components/decisions/DecisionInviteCard.tsx
+++ b/apps/app/src/components/decisions/DecisionInviteCard.tsx
@@ -83,7 +83,7 @@ export const DecisionInviteCard = ({
             title={steward?.name ?? ''}
           />
         </div>
-        <div className="flex items-end gap-4 text-neutral-black sm:items-center sm:gap-12">
+        <div className="flex items-end gap-4 text-foreground sm:items-center sm:gap-12">
           <DecisionStat
             number={invite.participantCount}
             label={t('Participants')}

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -218,7 +218,7 @@ function DecisionOverviewContent({
       <div className="mx-auto grid w-full max-w-5xl grid-cols-1 gap-12 px-4 py-6 md:grid-cols-12 md:gap-x-6 md:px-6 md:py-12">
         <div className="flex flex-col gap-6 md:col-span-4">
           <div className="flex flex-col gap-4">
-            <Header3 className="font-sans text-sm text-neutral-gray4">
+            <Header3 className="font-sans text-sm text-muted-foreground">
               {t('Process Overview')}
             </Header3>
             <DecisionPhaseTimeline
@@ -323,7 +323,7 @@ const OverviewHero = ({
   return (
     // Admin-uploaded background sits behind the content as an <Image fill>; the
     // offWhite gradient is the empty-state fallback when no image is set.
-    <section className="relative grid w-full grid-cols-1 justify-center overflow-hidden border-b bg-neutral-offWhite md:grid-cols-12">
+    <section className="relative grid w-full grid-cols-1 justify-center overflow-hidden border-b bg-muted md:grid-cols-12">
       {heroImageUrl ? (
         <DecisionHeroBackgroundImage imageUrl={heroImageUrl} />
       ) : null}
@@ -397,7 +397,9 @@ const OverviewHero = ({
               {stewardName && isPublic ? (
                 <span
                   aria-hidden="true"
-                  className={hasImage ? 'text-white/80' : 'text-neutral-gray4'}
+                  className={
+                    hasImage ? 'text-white/80' : 'text-muted-foreground'
+                  }
                 >
                   •
                 </span>

--- a/apps/app/src/components/decisions/DecisionSidePanel.tsx
+++ b/apps/app/src/components/decisions/DecisionSidePanel.tsx
@@ -126,7 +126,7 @@ const PanelContents = ({
       }}
       className="min-h-0 flex-1 gap-0"
     >
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-neutral-gray1 pe-4 sm:pt-4">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border pe-4 sm:pt-4">
         <TabsList
           variant="line"
           aria-label={t('Decision side panel tabs')}

--- a/apps/app/src/components/decisions/DocumentNotAvailable.tsx
+++ b/apps/app/src/components/decisions/DocumentNotAvailable.tsx
@@ -16,10 +16,10 @@ export function DocumentNotAvailable({ className }: { className?: string }) {
         className,
       )}
     >
-      <div className="flex size-8 items-center justify-center rounded-full bg-neutral-gray1">
-        <LuFileQuestion className="size-4 text-neutral-gray4" />
+      <div className="flex size-8 items-center justify-center rounded-full bg-secondary">
+        <LuFileQuestion className="size-4 text-muted-foreground" />
       </div>
-      <p className="text-sm text-neutral-gray4">
+      <p className="text-sm text-muted-foreground">
         {t('Content could not be loaded')}
       </p>
     </div>

--- a/apps/app/src/components/decisions/FinalPhaseSelectionFooter.tsx
+++ b/apps/app/src/components/decisions/FinalPhaseSelectionFooter.tsx
@@ -36,7 +36,7 @@ export const FinalPhaseSelectionFooter = ({
   const t = useTranslations();
 
   return (
-    <FooterBar position="fixed" className="bg-neutral-offWhite/95">
+    <FooterBar position="fixed" className="bg-muted/95">
       <FooterBarStart>
         <span className="flex items-center gap-2 text-base text-foreground">
           <LuCircleCheck className="size-5 shrink-0" aria-hidden />
@@ -95,7 +95,7 @@ const FinalPhaseProposalCard = ({ proposal }: { proposal: Proposal }) => {
   const voteCount = proposal.voteCount ?? 0;
 
   return (
-    <div className="flex flex-col gap-1 rounded-lg border border-neutral-gray1 bg-neutral-offWhite p-3">
+    <div className="flex flex-col gap-1 rounded-lg border border-border bg-muted p-3">
       <div className="flex items-start justify-between gap-2">
         <span className="truncate font-serif text-title-sm14 text-foreground">
           <bdi>{title}</bdi>

--- a/apps/app/src/components/decisions/HiddenProposalsBanner.tsx
+++ b/apps/app/src/components/decisions/HiddenProposalsBanner.tsx
@@ -37,7 +37,7 @@ export function HiddenProposalsBanner({
   return (
     <Alert
       variant="warning"
-      className="rounded-none border-x-0 border-t-0 border-b-neutral-gray1"
+      className="rounded-none border-x-0 border-t-0 border-b-border"
       role="status"
       aria-live="polite"
     >

--- a/apps/app/src/components/decisions/OverviewPinnedResources.tsx
+++ b/apps/app/src/components/decisions/OverviewPinnedResources.tsx
@@ -38,7 +38,7 @@ export const OverviewPinnedResourcesSuspense = ({
           actual resources — an empty list returns null above, no orphan rule. */}
       <Separator />
       <section className="flex flex-col gap-2">
-        <Header3 className="font-sans text-sm text-neutral-gray4">
+        <Header3 className="font-sans text-sm text-muted-foreground">
           {t('Pinned Resources')}
         </Header3>
         {items.map((resource) => (
@@ -70,7 +70,7 @@ export const PinnedResourcesError = () => {
     <>
       <Separator />
       <section className="flex flex-col gap-2">
-        <Header3 className="font-sans text-sm text-neutral-gray4">
+        <Header3 className="font-sans text-sm text-muted-foreground">
           {t('Pinned Resources')}
         </Header3>
         <p className="text-neutral-charcoal">

--- a/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
@@ -106,14 +106,14 @@ export const LaunchProcessModal = ({
           )}
 
           {/* Summary Section */}
-          <div className="flex flex-col gap-2 rounded-lg border border-neutral-gray1 p-4">
-            <div className="flex items-center justify-between border-b border-neutral-gray1 pb-2">
-              <span className="text-neutral-gray4">{t('Phases')}</span>
+          <div className="flex flex-col gap-2 rounded-lg border border-border p-4">
+            <div className="flex items-center justify-between border-b border-border pb-2">
+              <span className="text-muted-foreground">{t('Phases')}</span>
               <span className="text-neutral-charcoal">{phasesCount}</span>
             </div>
             {organizeByCategories && (
               <div className="flex items-center justify-between">
-                <span className="text-neutral-gray4">{t('Categories')}</span>
+                <span className="text-muted-foreground">{t('Categories')}</span>
                 <span className="text-neutral-charcoal">
                   {categoriesCount === 0 ? t('None') : categoriesCount}
                 </span>

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderFooter.tsx
@@ -159,7 +159,7 @@ export const ProcessBuilderFooter = ({
             {/* Desktop action buttons */}
             <div className="flex shrink-0 items-center gap-2">
               {hasUnsavedChanges && (
-                <span className="text-sm text-neutral-gray4">
+                <span className="text-sm text-muted-foreground">
                   {t('Unsaved changes')}
                 </span>
               )}

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderProcessSelector.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderProcessSelector.tsx
@@ -14,7 +14,7 @@ export const ProcessBuilderProcessSelector = () => {
 
   return (
     <div className="size-full grow p-4 sm:p-8">
-      <div className="flex min-h-full w-full flex-col items-center justify-center gap-6 overflow-y-auto rounded-lg border bg-neutral-offWhite p-4 md:gap-8 md:p-8">
+      <div className="flex min-h-full w-full flex-col items-center justify-center gap-6 overflow-y-auto rounded-lg border bg-muted p-4 md:gap-8 md:p-8">
         <Header1 className="text-center">
           {t('How do you want to structure your decision-making process?')}
         </Header1>
@@ -83,7 +83,7 @@ export const ProcessBuilderProcessCard = ({
           {name}
         </Header2>
       </div>
-      <p className="text-neutral-gray4">{description}</p>
+      <p className="text-muted-foreground">{description}</p>
     </button>
   );
 };

--- a/apps/app/src/components/decisions/ProcessBuilder/components/ProgressIndicator.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/components/ProgressIndicator.tsx
@@ -49,7 +49,7 @@ export function ProgressIndicator({
         className={
           clamped === 100
             ? 'shrink-0 bg-linear-to-r from-functional-green to-primary-teal bg-clip-text text-base text-transparent'
-            : 'shrink-0 text-base text-neutral-black'
+            : 'shrink-0 text-base text-foreground'
         }
       >
         {t('{count}% complete', { count: clamped })}

--- a/apps/app/src/components/decisions/ProcessBuilder/components/SaveStatusIndicator.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/components/SaveStatusIndicator.tsx
@@ -30,13 +30,13 @@ export function SaveStatusIndicator({
       {status === 'saving' && (
         <>
           <Spinner className="size-4" />
-          <span className="text-neutral-gray4">{t('Saving...')}</span>
+          <span className="text-muted-foreground">{t('Saving...')}</span>
         </>
       )}
       {status === 'saved' && (
         <>
           <LuCheck className="size-4 text-functional-green" />
-          <span className="text-neutral-gray4">
+          <span className="text-muted-foreground">
             {savedAt
               ? t('Saved at {time}', { time: formatTime(savedAt) })
               : t('Saved')}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewSection.tsx
@@ -133,7 +133,7 @@ function OverviewSectionContent({
           />
         </div>
 
-        <hr className="border-neutral-gray1" />
+        <hr className="border-border" />
 
         <RichTextEditor
           extensions={extensions}
@@ -177,7 +177,7 @@ function OverviewSectionSkeleton() {
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-5 w-full" />
       </div>
-      <hr className="border-neutral-gray1" />
+      <hr className="border-border" />
       <div className="flex flex-col gap-2">
         <Skeleton className="h-4 w-full" />
         <Skeleton className="h-4 w-3/4" />

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
@@ -51,11 +51,12 @@ export function OverviewTextField({
       className={cn(
         // field-sizing-content grows the textarea with its content so long
         // headlines/descriptions wrap instead of getting cut off.
-        // neutral-black (not charcoal) so the description matches the headline:
-        // twMerge misreads the headline's custom `text-title-lg` as a color and
-        // strips this class, letting the headline inherit neutral-black, while
-        // the description keeps it — charcoal here made the subhead too light.
-        'field-sizing-content resize-none overflow-hidden bg-transparent text-neutral-black placeholder:text-neutral-gray3 focus:outline-none',
+        // text-foreground (not charcoal) so the description matches the
+        // headline: twMerge misreads the headline's custom `text-title-lg` as a
+        // color and strips this class, letting the headline inherit the
+        // foreground, while the description keeps it — charcoal here made the
+        // subhead too light.
+        'field-sizing-content resize-none overflow-hidden bg-transparent text-foreground placeholder:text-neutral-gray3 focus:outline-none',
         showCount ? 'min-w-0 flex-1' : 'w-full',
         variant === 'headline' && 'font-serif text-title-lg',
         variant === 'description' && 'text-base',

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -246,7 +246,7 @@ function PhaseDetailForm({
     <div className="mx-auto w-full space-y-10 p-4 [scrollbar-gutter:stable] md:max-w-160 md:p-8">
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-4">
-          <p className="text-sm text-neutral-gray4">
+          <p className="text-sm text-muted-foreground">
             {t('Phase {index} of {total}', {
               index: phaseIndex,
               total: phaseCount,
@@ -313,7 +313,7 @@ function PhaseDetailForm({
             className="rounded-lg border border-input"
             editorClassName="min-h-24 p-3"
           />
-          <p className="text-sm text-neutral-gray4">
+          <p className="text-sm text-muted-foreground">
             {t(
               'Any additional information will appear in a modal titled "About the process"',
             )}
@@ -652,7 +652,7 @@ function PhaseField({
           {maxLength != null && (
             <span
               className={cn(
-                'text-sm text-neutral-gray4',
+                'text-sm text-muted-foreground',
                 (value.length === maxLength || isInvalid) &&
                   'text-functional-red',
               )}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
@@ -166,7 +166,7 @@ export function PhasesSectionContent({
       {phases.length === 0 ? (
         <div className="space-y-4">
           <div className="rounded-lg border border-dashed border-neutral-gray3 p-8 text-center">
-            <p className="text-neutral-gray4">{t('No phases defined')}</p>
+            <p className="text-muted-foreground">{t('No phases defined')}</p>
           </div>
           <Button
             variant="ghost"
@@ -220,7 +220,7 @@ export function PhasesSectionContent({
                           {phaseDateRange(phase)}
                         </span>
                       ) : (
-                        <span className="text-sm text-neutral-gray4">
+                        <span className="text-sm text-muted-foreground">
                           {t('Not configured yet')}
                         </span>
                       )}
@@ -316,7 +316,7 @@ const PhaseDragPreview = ({
               {dateRange}
             </span>
           ) : (
-            <span className="text-sm text-neutral-gray4">
+            <span className="text-sm text-muted-foreground">
               {t('Not configured yet')}
             </span>
           )}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProcessSettingsForm.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProcessSettingsForm.tsx
@@ -175,7 +175,7 @@ export function ProcessSettingsForm({
                   savedAt={autosaveStatus.savedAt}
                 />
               </div>
-              <p className="mt-2 text-neutral-gray4">
+              <p className="mt-2 text-muted-foreground">
                 {t('Define the key details for your decision process.')}
               </p>
             </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProcessSettingsSkeleton.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProcessSettingsSkeleton.tsx
@@ -20,7 +20,7 @@ export function ProcessSettingsSkeleton() {
         </div>
       </section>
 
-      <hr className="border-neutral-gray1" />
+      <hr className="border-border" />
 
       {/* Process Details Section */}
       <section className="space-y-6">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
@@ -178,7 +178,7 @@ export function ProposalCategoriesSectionContent({
             savedAt={autosaveStatus.savedAt}
           />
         </div>
-        <p className="text-neutral-gray4">
+        <p className="text-muted-foreground">
           {t(
             'Define the categories that proposals in this process should advance. Proposers will select which categories their proposal supports.',
           )}
@@ -235,7 +235,7 @@ export function ProposalCategoriesSectionContent({
                   <span className="text-neutral-charcoal">
                     {category.label}
                   </span>
-                  <p className="text-sm text-neutral-gray4">
+                  <p className="text-sm text-muted-foreground">
                     {category.description}
                   </p>
                 </div>
@@ -432,7 +432,7 @@ function CategoryField({
           {maxLength != null && (
             <span
               className={cn(
-                'text-sm text-neutral-gray4',
+                'text-sm text-muted-foreground',
                 value.length === maxLength && 'text-functional-red',
               )}
             >

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/RolesSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/RolesSection.tsx
@@ -447,7 +447,7 @@ function RolesSectionContent({
 
       <Suspense
         fallback={
-          <div className="h-48 animate-pulse rounded-lg bg-neutral-gray1" />
+          <div className="h-48 animate-pulse rounded-lg bg-secondary" />
         }
       >
         <RolesTable
@@ -600,7 +600,7 @@ function MobileRoleCard({
   const t = useTranslations();
 
   return (
-    <div className="flex flex-col gap-4 rounded-lg border border-neutral-gray1 p-4">
+    <div className="flex flex-col gap-4 rounded-lg border border-border p-4">
       <div className="flex items-center justify-between">
         <Header3 className="font-serif text-base">{role.name}</Header3>
         {(onDelete || onEdit) && (
@@ -669,7 +669,7 @@ function MobileRoleFormCard({
   };
 
   return (
-    <div className="flex flex-col gap-4 rounded-md border border-neutral-gray1 p-4">
+    <div className="flex flex-col gap-4 rounded-md border border-border p-4">
       <div className="flex items-center justify-between gap-2">
         <Input
           placeholder={t('Role name…')}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/SummarySectionInner.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/SummarySectionInner.tsx
@@ -82,12 +82,12 @@ export function SummarySectionInner({
     return (
       <div className="mx-auto flex w-full flex-col gap-6 p-4 md:max-w-160 md:p-8">
         <div className="flex flex-col gap-2">
-          <p className="text-sm text-neutral-gray4">{t('Summary')}</p>
+          <p className="text-sm text-muted-foreground">{t('Summary')}</p>
           <Header2 className="font-serif text-title-base">
             {t('Your process still needs more information')}
           </Header2>
         </div>
-        <p className="text-base text-neutral-black">
+        <p className="text-base text-foreground">
           {t.rich(
             '<highlight>{processName}</highlight> is missing information in order to go live.',
             {
@@ -102,7 +102,7 @@ export function SummarySectionInner({
           {incompleteItems.map((item, index) => (
             <div key={item.id}>
               <div className="flex items-center justify-between">
-                <span className="text-base text-neutral-black">
+                <span className="text-base text-foreground">
                   {t(item.labelKey)}
                 </span>
                 <Button
@@ -119,7 +119,7 @@ export function SummarySectionInner({
                 </Button>
               </div>
               {index < incompleteItems.length - 1 && (
-                <div className="mt-2 border-t border-neutral-gray1" />
+                <div className="mt-2 border-t border-border" />
               )}
             </div>
           ))}
@@ -131,7 +131,7 @@ export function SummarySectionInner({
   return (
     <div className="mx-auto flex w-full flex-col gap-6 p-4 md:max-w-160 md:p-8">
       <div className="flex flex-col gap-2">
-        <p className="text-sm text-neutral-gray4">{t('Summary')} 🚀</p>
+        <p className="text-sm text-muted-foreground">{t('Summary')} 🚀</p>
         <Header2 className="font-serif text-title-base">
           {t('Review your process')}
         </Header2>
@@ -151,28 +151,30 @@ export function SummarySectionInner({
       <div className="flex flex-col space-y-2 rounded-lg border p-4">
         <div>
           <div className="flex items-center justify-between">
-            <span className="text-base text-neutral-gray4">{t('Phases')}</span>
+            <span className="text-base text-muted-foreground">
+              {t('Phases')}
+            </span>
             <span className="text-base text-neutral-charcoal">
               {phasesCount}
             </span>
           </div>
-          <div className="mt-2 border-t border-neutral-gray1" />
+          <div className="mt-2 border-t border-border" />
         </div>
         {organizeByCategories && (
           <div>
             <div className="flex items-center justify-between">
-              <span className="text-base text-neutral-gray4">
+              <span className="text-base text-muted-foreground">
                 {t('Categories')}
               </span>
               <span className="text-base text-neutral-charcoal">
                 {categories.length}
               </span>
             </div>
-            <div className="mt-2 border-t border-neutral-gray1" />
+            <div className="mt-2 border-t border-border" />
           </div>
         )}
         <div className="flex items-center justify-between">
-          <span className="text-base text-neutral-gray4">
+          <span className="text-base text-muted-foreground">
             {t('Participants Invited')}
           </span>
           <span className="text-base text-neutral-charcoal">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
@@ -133,14 +133,14 @@ export function CategoryReviewerCard({
       data-testid={`category-reviewer-card-${category.name}`}
     >
       <div className="flex items-end justify-between gap-2">
-        <span className="font-serif text-title-sm14 text-neutral-black">
+        <span className="font-serif text-title-sm14 text-foreground">
           {category.name}
         </span>
         <span
           className={
             isEmpty
               ? 'text-sm text-primary-orange2'
-              : 'text-sm text-neutral-gray4'
+              : 'text-sm text-muted-foreground'
           }
         >
           {t(
@@ -187,13 +187,13 @@ export function CategoryReviewerCard({
             return (
               <div
                 key={reviewer.scopeId}
-                className="flex items-center gap-6 rounded-lg border border-neutral-gray1 bg-white px-3 py-2"
+                className="flex items-center gap-6 rounded-lg border border-border bg-white px-3 py-2"
               >
                 <div className="flex items-center gap-2">
                   <Avatar className="size-6 shrink-0">
                     <AvatarFallback name={reviewer.profile.name} />
                   </Avatar>
-                  <span className="text-base text-neutral-black">
+                  <span className="text-base text-foreground">
                     {reviewer.profile.name}
                   </span>
                 </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCards.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCards.tsx
@@ -101,7 +101,7 @@ function CategoryReviewerCardsContent({
           </AlertTitle>
         </Alert>
       ) : (
-        <p className="text-base text-neutral-black">
+        <p className="text-base text-foreground">
           {t.rich(
             'Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.',
             {
@@ -135,14 +135,14 @@ function CategoryReviewerCardsContent({
 function CategoryReviewerCardsSkeleton() {
   return (
     <div className="flex animate-pulse flex-col gap-6">
-      <div className="h-4 w-80 rounded bg-neutral-gray1" />
+      <div className="h-4 w-80 rounded bg-secondary" />
       {[0, 1, 2].map((i) => (
         <div key={i} className="flex flex-col gap-2">
           <div className="flex items-center justify-between">
-            <div className="h-4 w-40 rounded bg-neutral-gray1" />
-            <div className="h-4 w-20 rounded bg-neutral-gray1" />
+            <div className="h-4 w-40 rounded bg-secondary" />
+            <div className="h-4 w-20 rounded bg-secondary" />
           </div>
-          <div className="h-10 w-full rounded-lg bg-neutral-gray1" />
+          <div className="h-10 w-full rounded-lg bg-secondary" />
         </div>
       ))}
     </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
@@ -186,13 +186,13 @@ export function ReviewSettingsContent({
 
         {byCategoryEnabled && settings.scope === 'by_category' && (
           <>
-            <hr className="border-neutral-gray1" />
+            <hr className="border-border" />
             <CategoryReviewerCards instanceId={instanceId} />
           </>
         )}
       </section>
 
-      <hr className="border-neutral-gray1" />
+      <hr className="border-border" />
 
       {/* Revisions */}
       <section className="space-y-4">

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsSection.tsx
@@ -19,21 +19,21 @@ export default function ReviewSettingsSection(props: SectionProps) {
 function ReviewSettingsSkeleton() {
   return (
     <div className="mx-auto w-full animate-pulse space-y-8 p-4 md:max-w-160 md:p-8">
-      <div className="h-7 w-24 rounded bg-neutral-gray1" />
+      <div className="h-7 w-24 rounded bg-secondary" />
       <div className="space-y-4">
-        <div className="h-5 w-20 rounded bg-neutral-gray1" />
-        <div className="h-4 w-64 rounded bg-neutral-gray1" />
+        <div className="h-5 w-20 rounded bg-secondary" />
+        <div className="h-4 w-64 rounded bg-secondary" />
         <div className="space-y-3">
-          <div className="h-10 w-full rounded bg-neutral-gray1" />
-          <div className="h-10 w-full rounded bg-neutral-gray1" />
-          <div className="h-10 w-full rounded bg-neutral-gray1" />
+          <div className="h-10 w-full rounded bg-secondary" />
+          <div className="h-10 w-full rounded bg-secondary" />
+          <div className="h-10 w-full rounded bg-secondary" />
         </div>
       </div>
-      <div className="h-px w-full bg-neutral-gray1" />
+      <div className="h-px w-full bg-secondary" />
       <div className="space-y-4">
-        <div className="h-5 w-24 rounded bg-neutral-gray1" />
-        <div className="h-12 w-full rounded bg-neutral-gray1" />
-        <div className="h-12 w-full rounded bg-neutral-gray1" />
+        <div className="h-5 w-24 rounded bg-secondary" />
+        <div className="h-12 w-full rounded bg-secondary" />
+        <div className="h-12 w-full rounded bg-secondary" />
       </div>
     </div>
   );

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -513,7 +513,7 @@ function SingleSelectCriterionConfig({
     return (
       <div className="flex items-center gap-2">
         <LuGripVertical className="size-4 text-neutral-gray3" />
-        <span className="me-12 grow rounded-lg border border-neutral-gray2 bg-white px-4 py-3 text-neutral-charcoal shadow-lg">
+        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 text-neutral-charcoal shadow-lg">
           {item.value || t('Option')}
         </span>
       </div>
@@ -591,7 +591,7 @@ function SingleSelectCriterionConfig({
                 <DragHandle
                   {...dragHandleProps}
                   aria-label={t('Drag to reorder option')}
-                  className="text-neutral-gray3 hover:text-neutral-gray4"
+                  className="text-neutral-gray3 hover:text-muted-foreground"
                 />
                 <Input
                   value={option.value}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -365,7 +365,7 @@ export function RubricEditorContent({
             />
           </ToggleRow>
 
-          <hr className="border-neutral-gray1" />
+          <hr className="border-border" />
           {criteria.length > 0 && (
             <Sortable
               items={criteria}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
@@ -88,7 +88,7 @@ function FieldConfigDropdownOptions({
     return (
       <div className="flex items-center gap-2">
         <LuGripVertical className="size-4 text-neutral-gray3" />
-        <span className="me-12 grow rounded-lg border border-neutral-gray2 bg-white px-4 py-3 text-neutral-charcoal shadow-lg">
+        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 text-neutral-charcoal shadow-lg">
           {item.value || t('Option')}
         </span>
       </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigLocation.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigLocation.tsx
@@ -36,13 +36,13 @@ export function FieldConfigLocation({
   return (
     <div className="space-y-2">
       <Header4>{t('Map view')}</Header4>
-      <p className="text-sm text-neutral-gray4">
+      <p className="text-sm text-muted-foreground">
         {t(
           'Pan and zoom to set the starting map position participants see before they add a location.',
         )}
       </p>
 
-      <div className="overflow-hidden rounded-lg border border-neutral-gray1">
+      <div className="overflow-hidden rounded-lg border border-border">
         <MapCanvas
           styleUrl={styleUrl}
           center={initialView.current.center}

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -91,7 +91,7 @@ const PromoteAccountModalContent = ({
       </div>
 
       <div className="flex flex-col gap-4">
-        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-white p-4 text-start">
+        <section className="flex flex-col gap-2.5 rounded-xl border border-border bg-white p-4 text-start">
           <div className="flex items-center gap-1">
             <LuUserRoundMinus
               className="size-4 text-neutral-charcoal"
@@ -139,7 +139,7 @@ const PromoteAccountModalContent = ({
           </Button>
         </section>
 
-        <section className="flex flex-col gap-2.5 rounded-xl border border-neutral-gray1 bg-neutral-off-white p-4 text-start">
+        <section className="flex flex-col gap-2.5 rounded-xl border border-border bg-neutral-off-white p-4 text-start">
           <div className="flex items-center gap-1">
             <LuUserRoundPlus
               className="size-4 text-neutral-charcoal"

--- a/apps/app/src/components/decisions/ProposalCount.tsx
+++ b/apps/app/src/components/decisions/ProposalCount.tsx
@@ -13,7 +13,7 @@ export const ProposalCount = ({
   const narrowed = total != null && count < total;
   if (!narrowed) {
     return (
-      <span className="font-serif text-title-base text-neutral-black">
+      <span className="font-serif text-title-base text-foreground">
         <TranslatedText
           text="{count, plural, one {# proposal} other {# proposals}}"
           values={{ count: total ?? count }}
@@ -23,10 +23,10 @@ export const ProposalCount = ({
   }
   return (
     <span className="flex items-baseline gap-1">
-      <span className="font-serif text-title-base text-neutral-black">
+      <span className="font-serif text-title-base text-foreground">
         {count}
       </span>
-      <span className="text-base text-neutral-gray4">
+      <span className="text-base text-muted-foreground">
         <TranslatedText
           text="of {total, plural, one {# proposal} other {# proposals}}"
           values={{ total }}

--- a/apps/app/src/components/decisions/ProposalMapListItem.tsx
+++ b/apps/app/src/components/decisions/ProposalMapListItem.tsx
@@ -44,9 +44,7 @@ export function ProposalMapListItem({
         showMetrics
         className={cn(
           'min-w-0 transition-colors',
-          isActive
-            ? 'border-neutral-gray2 bg-neutral-offWhite'
-            : 'hover:bg-neutral-offWhite',
+          isActive ? 'border-input bg-muted' : 'hover:bg-muted',
         )}
         aside={
           canManage ? (

--- a/apps/app/src/components/decisions/ProposalsFilterBar.tsx
+++ b/apps/app/src/components/decisions/ProposalsFilterBar.tsx
@@ -21,7 +21,7 @@ export const ProposalsListHeader = ({
   const t = useTranslations();
   if (hideFilters) {
     return (
-      <span className="font-serif text-title-base text-neutral-black">
+      <span className="font-serif text-title-base text-foreground">
         {t('My proposals')}
       </span>
     );

--- a/apps/app/src/components/decisions/ProposalsGrid.tsx
+++ b/apps/app/src/components/decisions/ProposalsGrid.tsx
@@ -426,9 +426,9 @@ const VotingProposalsList = ({
       </ProposalMasonry>
 
       {canVote && !isReadOnly && (
-        <FooterBar position="fixed" className="bg-neutral-offWhite/95">
+        <FooterBar position="fixed" className="bg-muted/95">
           <FooterBarStart>
-            <span className="text-base text-neutral-black">
+            <span className="text-base text-foreground">
               {maxVotesPerMember !== undefined
                 ? t.rich(
                     '<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected',

--- a/apps/app/src/components/decisions/ProposalsMapView.tsx
+++ b/apps/app/src/components/decisions/ProposalsMapView.tsx
@@ -201,7 +201,7 @@ export function ProposalsMapView({
         ))}
         {listFooter && <li>{listFooter}</li>}
       </ul>
-      <aside className="sticky top-20 hidden h-[calc(100dvh_-_10rem)] overflow-hidden rounded-lg border border-neutral-gray1 sm:block">
+      <aside className="sticky top-20 hidden h-[calc(100dvh_-_10rem)] overflow-hidden rounded-lg border border-border sm:block">
         {map}
       </aside>
     </div>

--- a/apps/app/src/components/decisions/ResponsiveSelect.tsx
+++ b/apps/app/src/components/decisions/ResponsiveSelect.tsx
@@ -94,7 +94,7 @@ export function ResponsiveSelect<T extends string>({
                   disabled={item.isDisabled}
                   className={cn(
                     'bg-transparent px-6 py-4 text-start outline-0 focus-visible:bg-primary-tealWhite focus-visible:outline-1 focus-visible:-outline-offset-1 focus-visible:outline-primary-teal disabled:pointer-events-none disabled:opacity-50',
-                    index < items.length - 1 && 'border-b border-neutral-gray1',
+                    index < items.length - 1 && 'border-b border-border',
                     item.id === selectedKey && 'bg-primary-tealWhite',
                   )}
                   onClick={() => {

--- a/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
+++ b/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
@@ -33,7 +33,7 @@ export function AuthorRevisionNote({
   return (
     <>
       <div className="flex flex-col gap-3 rounded-lg bg-muted p-4">
-        <span className="font-serif text-title-sm14 text-neutral-black">
+        <span className="font-serif text-title-sm14 text-foreground">
           {t("Author's note")}
         </span>
         <div className="flex flex-col gap-2">

--- a/apps/app/src/components/decisions/Review/ReviewTabs.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewTabs.tsx
@@ -161,7 +161,7 @@ function ReviewsTabPanel({
       <APIErrorBoundary
         fallbacks={{
           default: () => (
-            <p className="py-8 text-center text-base text-neutral-gray4">
+            <p className="py-8 text-center text-base text-muted-foreground">
               {t('Failed to load reviews')}
             </p>
           ),
@@ -232,7 +232,7 @@ function PhaseReviews({
 
   if (visibleReviews.length === 0) {
     return (
-      <p className="py-8 text-center text-base text-neutral-gray4">
+      <p className="py-8 text-center text-base text-muted-foreground">
         {emptyMessage}
       </p>
     );

--- a/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
+++ b/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
@@ -54,7 +54,7 @@ export function ViewRevisionRequestModal({
         </DialogHeader>
 
         <div className="flex flex-col gap-2 px-6 py-4">
-          <span className="text-base text-neutral-black">
+          <span className="text-base text-foreground">
             {t('Feedback to Author')}
           </span>
 
@@ -63,7 +63,7 @@ export function ViewRevisionRequestModal({
               {revisionRequest.requestComment}
             </p>
             {sentDate && (
-              <p className="text-sm text-neutral-gray4">
+              <p className="text-sm text-muted-foreground">
                 {t('Sent {date}', {
                   date: sentDate.toLocaleDateString(undefined, {
                     month: 'short',

--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -326,7 +326,7 @@ const AssignedCategoriesLabel = ({
 
   return (
     <span
-      className="min-w-0 truncate text-base text-neutral-gray4"
+      className="min-w-0 truncate text-base text-muted-foreground"
       title={label}
     >
       {label}

--- a/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionList.tsx
+++ b/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionList.tsx
@@ -101,11 +101,11 @@ export function ReviewSelectionList({
     <div className="flex flex-col gap-6 pb-20">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-2">
-          <span className="font-serif text-title-base text-neutral-black">
+          <span className="font-serif text-title-base text-foreground">
             {t('All proposals')}
           </span>
           <Bullet />
-          <span className="font-serif text-title-base text-neutral-black">
+          <span className="font-serif text-title-base text-foreground">
             {total}
           </span>
         </div>
@@ -156,7 +156,7 @@ export function ReviewSelectionList({
 export function ReviewSelectionListSkeleton() {
   return (
     <div className="flex flex-col gap-6">
-      <div className="h-8 w-32 animate-pulse rounded bg-neutral-gray1" />
+      <div className="h-8 w-32 animate-pulse rounded bg-secondary" />
       <ReviewSelectionTableSkeleton />
     </div>
   );

--- a/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionTable.tsx
+++ b/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionTable.tsx
@@ -112,7 +112,7 @@ export function ReviewSelectionTable({
                     <bdi>{title}</bdi>
                   </Link>
                   {submitterName && (
-                    <span className="line-clamp-1 text-sm text-neutral-gray4">
+                    <span className="line-clamp-1 text-sm text-muted-foreground">
                       <bdi>{submitterName}</bdi>
                     </span>
                   )}
@@ -159,7 +159,7 @@ export function ReviewSelectionTable({
 export function ReviewSelectionTableSkeleton() {
   return (
     <div className="flex w-full flex-col gap-2">
-      <div className="flex w-full items-center justify-between border-b border-neutral-gray1 py-2">
+      <div className="flex w-full items-center justify-between border-b border-border py-2">
         <Skeleton className="h-4 w-20" />
         <div className="hidden gap-8 md:flex">
           <Skeleton className="h-4 w-12" />
@@ -172,7 +172,7 @@ export function ReviewSelectionTableSkeleton() {
       {Array.from({ length: 4 }).map((_, i) => (
         <div
           key={i}
-          className="flex w-full items-center justify-between gap-4 border-b border-neutral-gray1 py-2"
+          className="flex w-full items-center justify-between gap-4 border-b border-border py-2"
         >
           <div className="flex flex-col gap-1">
             <Skeleton className="h-4 w-40" />
@@ -215,7 +215,7 @@ function ProposalCard({
           {title}
         </Link>
         {submitterName && (
-          <span className="text-sm text-neutral-gray4">{submitterName}</span>
+          <span className="text-sm text-muted-foreground">{submitterName}</span>
         )}
       </div>
 

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryAdvanceFooter.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryAdvanceFooter.tsx
@@ -42,7 +42,7 @@ export function ReviewSummaryAdvanceFooter({
   };
 
   return (
-    <FooterBar position="fixed" className="bg-neutral-offWhite/95">
+    <FooterBar position="fixed" className="bg-muted/95">
       <FooterBarStart>
         <span className="flex items-center gap-2 text-base text-foreground">
           <LuCircleCheck className="size-4 text-muted-foreground" aria-hidden />

--- a/apps/app/src/components/decisions/ReviewsPanel/AverageScoreBar.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/AverageScoreBar.tsx
@@ -13,13 +13,13 @@ export function AverageScoreBar({
 }: AverageScoreBarProps) {
   const t = useTranslations();
   return (
-    <div className="flex items-center justify-between rounded-lg bg-neutral-offWhite p-4">
-      <span className="font-serif text-title-sm text-neutral-black">
+    <div className="flex items-center justify-between rounded-lg bg-muted p-4">
+      <span className="font-serif text-title-sm text-foreground">
         {t('Average Score')}
       </span>
-      <span className="font-serif text-title-sm text-neutral-black">
+      <span className="font-serif text-title-sm text-foreground">
         {formatScore(averageScore)}
-        <span className="text-neutral-gray4">/{totalPoints}pts</span>
+        <span className="text-muted-foreground">/{totalPoints}pts</span>
       </span>
     </div>
   );

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerDetail.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerDetail.tsx
@@ -57,7 +57,7 @@ export function ReviewerDetail({
         {t('Back to all reviewers')}
       </Button>
 
-      <div className="flex items-center justify-between border-b border-neutral-gray1 pb-4">
+      <div className="flex items-center justify-between border-b border-border pb-4">
         <div className="flex items-center gap-2">
           <ProfileAvatar
             profile={item.reviewer}
@@ -74,13 +74,13 @@ export function ReviewerDetail({
               <StatusDot
                 intent={recommendationIntent(item.overallRecommendation)}
               >
-                <span className="text-sm text-neutral-black">
+                <span className="text-sm text-foreground">
                   {recommendationLabel}
                 </span>
               </StatusDot>
             )}
             {hasScoring && (
-              <span className="text-sm text-neutral-gray4">
+              <span className="text-sm text-muted-foreground">
                 ({item.score}/{totalPoints})
               </span>
             )}

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
@@ -172,7 +172,7 @@ function RecommendationGroup({
   return (
     <div className="flex flex-col gap-4">
       <StatusDot intent={recommendationIntent(value)} className="gap-2">
-        <span className="font-serif !text-title-sm14 text-neutral-black">
+        <span className="font-serif !text-title-sm14 text-foreground">
           {label} ({count})
         </span>
       </StatusDot>
@@ -212,18 +212,18 @@ function ReviewerRow({
           className="size-6"
         />
         <div className="flex flex-col">
-          <span className="text-base text-neutral-black">
+          <span className="text-base text-foreground">
             {item.reviewer.name ?? item.reviewer.slug}
           </span>
           {showScore && (
-            <span className="text-sm text-neutral-black">
+            <span className="text-sm text-foreground">
               {item.score}
-              <span className="text-neutral-gray4">/{totalPoints}pts</span>
+              <span className="text-muted-foreground">/{totalPoints}pts</span>
             </span>
           )}
         </div>
       </div>
-      <LuChevronRight className="size-4 text-neutral-gray4 rtl:-scale-x-100" />
+      <LuChevronRight className="size-4 text-muted-foreground rtl:-scale-x-100" />
     </Button>
   );
 }

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -92,9 +92,9 @@ const SlashCommandsList = forwardRef<
       {props.items.length ? (
         props.items.map((item, index) => (
           <button
-            className={`flex w-full items-center space-x-2 rounded-md px-2 py-1 text-start hover:bg-neutral-gray1 ${
+            className={`flex w-full items-center space-x-2 rounded-md px-2 py-1 text-start hover:bg-secondary ${
               index === selectedIndex
-                ? 'bg-neutral-gray1 text-neutral-black'
+                ? 'bg-secondary text-foreground'
                 : 'text-neutral-charcoal'
             }`}
             key={index}

--- a/apps/app/src/components/decisions/StandardSelectionFooter.tsx
+++ b/apps/app/src/components/decisions/StandardSelectionFooter.tsx
@@ -36,7 +36,7 @@ export const StandardSelectionFooter = ({
   const t = useTranslations();
 
   return (
-    <FooterBar position="fixed" className="bg-neutral-offWhite/95">
+    <FooterBar position="fixed" className="bg-muted/95">
       <FooterBarStart>
         <span className="flex items-center gap-2 text-base text-foreground">
           <LuCircleCheck className="size-5 shrink-0" aria-hidden />
@@ -64,7 +64,7 @@ export const StandardSelectionFooter = ({
             </p>
 
             <div className="space-y-2">
-              <div className="text-sm tracking-wider text-neutral-gray4 uppercase">
+              <div className="text-sm tracking-wider text-muted-foreground uppercase">
                 {t('PROPOSALS TO ADVANCE')}
               </div>
 

--- a/apps/app/src/components/decisions/StickyFilterBar.tsx
+++ b/apps/app/src/components/decisions/StickyFilterBar.tsx
@@ -82,10 +82,10 @@ export const StickyFilterBar = ({
           'group sticky z-20 flex flex-wrap items-center justify-between gap-4 overflow-visible bg-white py-3 transition-shadow md:top-0!',
           // Top hairline fades in on pin — mobile only (>=md has no floating
           // toggle above the bar, so no top edge to delineate).
-          "max-md:before:pointer-events-none max-md:before:absolute max-md:before:top-0 max-md:before:left-1/2 max-md:before:w-screen max-md:before:-translate-x-1/2 max-md:before:border-t max-md:before:border-neutral-gray1 max-md:before:opacity-0 max-md:before:content-['']",
+          "max-md:before:pointer-events-none max-md:before:absolute max-md:before:top-0 max-md:before:left-1/2 max-md:before:w-screen max-md:before:-translate-x-1/2 max-md:before:border-t max-md:before:border-border max-md:before:opacity-0 max-md:before:content-['']",
           'max-md:data-[pinned=true]:before:opacity-100',
           // Bottom hairline fades in on pin — all breakpoints.
-          "after:pointer-events-none after:absolute after:-bottom-px after:left-1/2 after:w-screen after:-translate-x-1/2 after:border-b after:border-neutral-gray1 after:opacity-0 after:content-['']",
+          "after:pointer-events-none after:absolute after:-bottom-px after:left-1/2 after:w-screen after:-translate-x-1/2 after:border-b after:border-border after:opacity-0 after:content-['']",
           'data-[pinned=true]:after:opacity-100',
           className,
         )}

--- a/apps/app/src/components/decisions/TranslationNotice.tsx
+++ b/apps/app/src/components/decisions/TranslationNotice.tsx
@@ -25,7 +25,7 @@ export const TranslationNotice = ({
 
   return (
     <div className="flex items-center gap-1">
-      <p className={cn('text-sm text-neutral-gray4', className)}>
+      <p className={cn('text-sm text-muted-foreground', className)}>
         {t('Translated from {language}', { language: sourceLanguageName })}
       </p>
       <Bullet />

--- a/apps/app/src/components/decisions/location/LocationMapField.tsx
+++ b/apps/app/src/components/decisions/location/LocationMapField.tsx
@@ -155,7 +155,7 @@ export function LocationMapField({
 
       <div
         className={`overflow-hidden rounded-lg border ${
-          isWithinArea ? 'border-neutral-gray1' : 'border-functional-red'
+          isWithinArea ? 'border-border' : 'border-functional-red'
         }`}
       >
         <MapCanvas
@@ -174,7 +174,7 @@ export function LocationMapField({
           <div className="flex min-w-0 flex-col gap-0.5">
             <span
               className={
-                isWithinArea ? 'text-neutral-black' : 'text-functional-red'
+                isWithinArea ? 'text-foreground' : 'text-functional-red'
               }
               dir="auto"
             >

--- a/apps/app/src/components/decisions/location/LocationMapView.tsx
+++ b/apps/app/src/components/decisions/location/LocationMapView.tsx
@@ -27,16 +27,16 @@ export function LocationMapView({ value }: LocationMapViewProps) {
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border border-neutral-gray1">
+    <div className="overflow-hidden rounded-lg border border-border">
       <MapCanvas
         styleUrl={styleUrl}
         center={{ lng: value.lng, lat: value.lat }}
         marker={{ lng: value.lng, lat: value.lat }}
         ariaLabel={t('Project location map')}
-        className="border-b border-neutral-gray1"
+        className="border-b border-border"
       />
       <div className="flex flex-col gap-0.5 p-4">
-        <span className="text-neutral-black" dir="auto">
+        <span className="text-foreground" dir="auto">
           {value.address ?? `${value.lat.toFixed(5)}, ${value.lng.toFixed(5)}`}
         </span>
       </div>

--- a/apps/app/src/components/decisions/location/LocationSearchField.tsx
+++ b/apps/app/src/components/decisions/location/LocationSearchField.tsx
@@ -126,7 +126,7 @@ export function LocationSearchField({
       >
         <InputGroupAddon align="inline-start">
           {isSearching ? (
-            <Spinner className="size-4 text-neutral-gray4" />
+            <Spinner className="size-4 text-muted-foreground" />
           ) : (
             <LuSearch aria-hidden className="size-4" />
           )}
@@ -147,7 +147,7 @@ export function LocationSearchField({
                   "Starbucks" + "123 Main St", not as the bare street address. */}
               <div className="flex min-w-0 flex-col">
                 {item.name && (
-                  <span className="truncate text-neutral-black" dir="auto">
+                  <span className="truncate text-foreground" dir="auto">
                     {item.name}
                   </span>
                 )}
@@ -155,7 +155,7 @@ export function LocationSearchField({
                   className={
                     item.name
                       ? 'truncate text-sm text-neutral-charcoal'
-                      : 'truncate text-neutral-black'
+                      : 'truncate text-foreground'
                   }
                   dir="auto"
                 >

--- a/apps/app/src/components/decisions/selection/SelectionCard.tsx
+++ b/apps/app/src/components/decisions/selection/SelectionCard.tsx
@@ -22,7 +22,7 @@ export function SelectionCard({
         'flex flex-col gap-3 rounded-lg border p-4',
         isSelected
           ? 'border-primary-teal bg-primary-tealWhite'
-          : 'border-neutral-gray1 bg-white',
+          : 'border-border bg-white',
         className,
       )}
     >

--- a/apps/app/src/components/layout/split/form/ToggleRow.tsx
+++ b/apps/app/src/components/layout/split/form/ToggleRow.tsx
@@ -45,14 +45,14 @@ export const ToggleRow = ({
       className={cn('rounded-xl py-2', className)}
     >
       <FieldContent>
-        <FieldLabel
-          htmlFor={controlId}
-          className="text-base text-neutral-black"
-        >
+        <FieldLabel htmlFor={controlId} className="text-base text-foreground">
           {label}
         </FieldLabel>
         {description && (
-          <FieldDescription id={descriptionId} className="text-neutral-gray4">
+          <FieldDescription
+            id={descriptionId}
+            className="text-muted-foreground"
+          >
             {description}
           </FieldDescription>
         )}

--- a/apps/app/src/components/posts/Comments.tsx
+++ b/apps/app/src/components/posts/Comments.tsx
@@ -55,7 +55,7 @@ export function Comments({
   if (comments.length === 0) {
     return (
       <div
-        className="py-8 text-center text-neutral-gray4"
+        className="py-8 text-center text-muted-foreground"
         role="status"
         aria-label={t('No comments yet. Be the first to comment!')}
       >

--- a/apps/app/src/components/posts/PostDetailHeader.tsx
+++ b/apps/app/src/components/posts/PostDetailHeader.tsx
@@ -21,7 +21,7 @@ export const PostDetailHeader = () => {
       <div className="flex items-center gap-3">
         <Link
           href="/"
-          className="flex items-center gap-2 text-base text-neutral-black hover:text-primary-tealBlack md:text-primary-teal"
+          className="flex items-center gap-2 text-base text-foreground hover:text-primary-tealBlack md:text-primary-teal"
         >
           <LuArrowLeft className="size-6 md:size-4 rtl:-scale-x-100" />
           <span className="hidden md:flex">{t('Home')}</span>

--- a/apps/app/src/components/screens/ProfileOrganizations/index.tsx
+++ b/apps/app/src/components/screens/ProfileOrganizations/index.tsx
@@ -79,8 +79,8 @@ export const OrganizationNameSuspense = ({ slug }: { slug: string }) => {
       href={`/org/${organization.profile.slug}`}
       className="flex items-center gap-2"
     >
-      <LuArrowLeft className="size-6 text-neutral-black rtl:-scale-x-100" />
-      <div className="flex items-center gap-1 text-sm font-semibold text-neutral-black">
+      <LuArrowLeft className="size-6 text-foreground rtl:-scale-x-100" />
+      <div className="flex items-center gap-1 text-sm font-semibold text-foreground">
         <OrganizationAvatar profile={organization.profile} className="size-6" />
         {organization.profile.name}
       </div>

--- a/apps/app/src/components/screens/ProfileRelationships/index.tsx
+++ b/apps/app/src/components/screens/ProfileRelationships/index.tsx
@@ -161,7 +161,7 @@ export const ProfileRelationships = ({ slug }: { slug: string }) => {
         <ErrorBoundary
           errorComponent={() => (
             <Link href="/" className="flex items-center gap-2">
-              <LuArrowLeft className="size-6 text-neutral-black rtl:-scale-x-100" />
+              <LuArrowLeft className="size-6 text-foreground rtl:-scale-x-100" />
             </Link>
           )}
         >


### PR DESCRIPTION
Mechanical sweep of the legacy `@op/ui` neutral palette in `apps/app`, limited to the mappings that are **exact hex matches** against the sense theme — so nothing renders differently.

| From | Hex | To |
| --- | --- | --- |
| `text-neutral-black` / `bg-neutral-black` | `#142426` (gray-900) | `text-foreground` / `bg-foreground` |
| `text-neutral-gray4` | `#606A6C` (gray-600) | `text-muted-foreground` |
| `bg-neutral-offWhite` | `#FAFBFB` (gray-50) | `bg-muted` |
| `bg-neutral-gray1` | `#EDEEEE` (gray-100) | `bg-secondary` |
| `border-neutral-gray1` | `#EDEEEE` | `border-border` |
| `border-neutral-gray2` | `#D0D3D4` (gray-300) | `border-input` |

91 files, 274 replacements, all substring swaps that preserve variant prefixes (`hover:`, `sm:`, `before:`) and opacity suffixes (`/50`).

Deliberately **not** included:

- `text-neutral-charcoal` (97 occurrences, the biggest bucket). The original task mapped it to `text-foreground`, but charcoal is gray-700 `#3A4749` and sense's `--foreground` is gray-900 `#142426`. That swap would darken most body text in the app — a design decision, not a rename. It needs either a sign-off or a gray-700 text semantic added to `sense-theme.css`.
- `text-neutral-gray3` (7), `border-neutral-gray3` (3), `bg-neutral-gray2` (5), `text-neutral-gray2` (1), `text-neutral-offWhite` (4) — no clean semantic target, per-use calls.

Targets `sense-migration`, not `dev` — these legacy tokens only exist to be replaced by sense ones, and sweeping them on `dev` would conflict across ~90 files with the migration branch.

Asana: https://app.asana.com/1/1108348036672214/project/1216361907129487/task/1217037046671302
