### PR TITLE
refactor(app): retire the legacy neutral palette and split the style tokens

### DIFF
--- a/apps/app/src/app/[locale]/(main)/decisions/page.tsx
+++ b/apps/app/src/app/[locale]/(main)/decisions/page.tsx
@@ -23,7 +23,7 @@ const DecisionsListingPage = () => {
         <Header1 className="text-headline">
           <TranslatedText text="Decision-making processes" />
         </Header1>
-        <p className="text-foreground">
+        <p>
           <TranslatedText text="Discover new ways to collectively decide together." />
         </p>
       </div>

--- a/apps/app/src/app/[locale]/(main)/decisions/page.tsx
+++ b/apps/app/src/app/[locale]/(main)/decisions/page.tsx
@@ -23,7 +23,7 @@ const DecisionsListingPage = () => {
         <Header1 className="text-headline">
           <TranslatedText text="Decision-making processes" />
         </Header1>
-        <p className="text-neutral-charcoal">
+        <p className="text-foreground">
           <TranslatedText text="Discover new ways to collectively decide together." />
         </p>
       </div>

--- a/apps/app/src/components/AuthPanel.tsx
+++ b/apps/app/src/components/AuthPanel.tsx
@@ -107,7 +107,7 @@ export const AuthGoogleButton = ({ onPress }: { onPress: () => void }) => {
   return (
     <Button
       variant="outline"
-      className="w-full text-neutral-charcoal"
+      className="w-full text-foreground"
       onClick={onPress}
     >
       <GoogleIcon className="size-4 stroke-none" />

--- a/apps/app/src/components/AuthPanel.tsx
+++ b/apps/app/src/components/AuthPanel.tsx
@@ -105,11 +105,7 @@ export const AuthGoogleButton = ({ onPress }: { onPress: () => void }) => {
   const t = useTranslations();
 
   return (
-    <Button
-      variant="outline"
-      className="w-full text-foreground"
-      onClick={onPress}
-    >
+    <Button variant="outline" className="w-full" onClick={onPress}>
       <GoogleIcon className="size-4 stroke-none" />
       {t('Continue with Google')}
     </Button>

--- a/apps/app/src/components/FormalSection/index.tsx
+++ b/apps/app/src/components/FormalSection/index.tsx
@@ -1,6 +1,6 @@
 export const FormalSection = ({ children }: { children: React.ReactNode }) => {
   return (
-    <section className="flex flex-col gap-6 text-neutral-charcoal">
+    <section className="flex flex-col gap-6 text-foreground">
       {children}
     </section>
   );

--- a/apps/app/src/components/FormalSection/index.tsx
+++ b/apps/app/src/components/FormalSection/index.tsx
@@ -1,7 +1,3 @@
 export const FormalSection = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <section className="flex flex-col gap-6 text-foreground">
-      {children}
-    </section>
-  );
+  return <section className="flex flex-col gap-6">{children}</section>;
 };

--- a/apps/app/src/components/GeoNamesMultiSelect/index.tsx
+++ b/apps/app/src/components/GeoNamesMultiSelect/index.tsx
@@ -73,7 +73,7 @@ export const GeoNamesMultiSelect = ({
     <div className="flex w-full flex-col gap-2">
       <Label>
         {label}
-        {isRequired && <span className="text-functional-red"> *</span>}
+        {isRequired && <span className="text-destructive"> *</span>}
       </Label>
       <Combobox
         multiple

--- a/apps/app/src/components/LinkAccountPanel.tsx
+++ b/apps/app/src/components/LinkAccountPanel.tsx
@@ -165,7 +165,7 @@ export const LinkAccountPanel = () => {
   const subtitle = (() => {
     if (errorMessage) {
       return (
-        <span className={tokenError ? 'text-functional-red' : undefined}>
+        <span className={tokenError ? 'text-destructive' : undefined}>
           {errorMessage}
         </span>
       );

--- a/apps/app/src/components/LinkPreview/index.tsx
+++ b/apps/app/src/components/LinkPreview/index.tsx
@@ -121,7 +121,7 @@ export const LinkPreview = memo(
               e.stopPropagation();
               onRemove();
             }}
-            className="absolute end-2 top-2 z-10 flex size-8 items-center justify-center rounded border border-border bg-white text-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:bg-secondary focus-visible:opacity-100"
+            className="absolute end-2 top-2 z-10 flex size-8 items-center justify-center rounded border border-border bg-white opacity-0 transition-opacity group-hover:opacity-100 hover:bg-secondary focus-visible:opacity-100"
             aria-label={t('Remove preview')}
           >
             <LuX className="size-4" />
@@ -148,7 +148,7 @@ export const LinkPreview = memo(
             </div>
           ) : null}
           <div className="px-4 py-4">
-            <span className="text-sm text-foreground">
+            <span className="text-sm">
               {title ?? domain}
               {title && (
                 <>

--- a/apps/app/src/components/LoginPanel.tsx
+++ b/apps/app/src/components/LoginPanel.tsx
@@ -183,7 +183,7 @@ export const LoginPanel = () => {
     }
     if (combinedError || tokenError) {
       return (
-        <span className={cn(tokenError && 'text-functional-red')}>
+        <span className={cn(tokenError && 'text-destructive')}>
           {combinedError ||
             tokenError ||
             t('There was an error signing you in.')}
@@ -253,7 +253,7 @@ export const LoginPanel = () => {
               }}
             >
               {isRefetchingUser ? (
-                <div className="m-0.5 aspect-square w-5 animate-spin rounded-full border-2 border-b-0 border-neutral-gray3" />
+                <div className="m-0.5 aspect-square w-5 animate-spin rounded-full border-2 border-b-0 border-input" />
               ) : (
                 t('Try again')
               )}
@@ -298,7 +298,7 @@ export const LoginPanel = () => {
               {t('Back to home')}
             </ButtonLink>
 
-            <SocialLinks iconClassName="size-5 stroke-none text-neutral-gray3" />
+            <SocialLinks iconClassName="size-5 stroke-none text-muted-foreground" />
           </div>
         )}
 

--- a/apps/app/src/components/MultiStepForm/index.tsx
+++ b/apps/app/src/components/MultiStepForm/index.tsx
@@ -159,7 +159,7 @@ export const MultiStepForm: React.FC<{
         error={error}
       />
       {error && (
-        <div className="mt-4 font-medium text-functional-red">{error}</div>
+        <div className="mt-4 font-medium text-destructive">{error}</div>
       )}
       {ProgressComponent ? (
         <ProgressComponent numItems={steps.length} currentStep={step + 1} />

--- a/apps/app/src/components/Onboarding/OrganizationSearchScreen.tsx
+++ b/apps/app/src/components/Onboarding/OrganizationSearchScreen.tsx
@@ -293,9 +293,7 @@ function SelectedOrgChip({
           className="size-6"
         />
         <div className="flex flex-col leading-normal">
-          <span className="text-sm text-neutral-charcoal">
-            {org.profile?.name}
-          </span>
+          <span className="text-sm text-foreground">{org.profile?.name}</span>
           {location && (
             <span className="text-xs text-muted-foreground">{location}</span>
           )}
@@ -303,7 +301,7 @@ function SelectedOrgChip({
       </div>
       <button
         type="button"
-        className="rounded-full p-1 text-muted-foreground hover:bg-secondary hover:text-neutral-charcoal"
+        className="rounded-full p-1 text-muted-foreground hover:bg-secondary hover:text-foreground"
         onClick={onRemove}
         aria-label={t('Remove')}
       >

--- a/apps/app/src/components/Onboarding/PrivacyPolicyForm.tsx
+++ b/apps/app/src/components/Onboarding/PrivacyPolicyForm.tsx
@@ -43,7 +43,7 @@ export const PrivacyPolicyForm = ({
     >
       <FormContainer className="max-w-lg">
         <FormHeader text={t('Privacy Policy Overview')}></FormHeader>
-        <span className="text-neutral-charcoal">
+        <span className="text-foreground">
           {t('Effective Date: March 15, 2025')}
         </span>
         <PrivacyPolicyContentShort />

--- a/apps/app/src/components/Onboarding/PrivacyPolicyForm.tsx
+++ b/apps/app/src/components/Onboarding/PrivacyPolicyForm.tsx
@@ -43,9 +43,7 @@ export const PrivacyPolicyForm = ({
     >
       <FormContainer className="max-w-lg">
         <FormHeader text={t('Privacy Policy Overview')}></FormHeader>
-        <span className="text-foreground">
-          {t('Effective Date: March 15, 2025')}
-        </span>
+        <span>{t('Effective Date: March 15, 2025')}</span>
         <PrivacyPolicyContentShort />
 
         <FormHeader text={t('Privacy Policy')}></FormHeader>

--- a/apps/app/src/components/Onboarding/ToSForm.tsx
+++ b/apps/app/src/components/Onboarding/ToSForm.tsx
@@ -43,7 +43,7 @@ export const ToSForm = ({
     >
       <FormContainer className="max-w-lg">
         <FormHeader text={t('Terms of Service Overview')}></FormHeader>
-        <span className="text-neutral-charcoal">
+        <span className="text-foreground">
           {t('Effective Date: March 15, 2025')}
         </span>
 

--- a/apps/app/src/components/Onboarding/ToSForm.tsx
+++ b/apps/app/src/components/Onboarding/ToSForm.tsx
@@ -43,9 +43,7 @@ export const ToSForm = ({
     >
       <FormContainer className="max-w-lg">
         <FormHeader text={t('Terms of Service Overview')}></FormHeader>
-        <span className="text-foreground">
-          {t('Effective Date: March 15, 2025')}
-        </span>
+        <span>{t('Effective Date: March 15, 2025')}</span>
 
         <ToSContentShort />
 

--- a/apps/app/src/components/OrganizationList/index.tsx
+++ b/apps/app/src/components/OrganizationList/index.tsx
@@ -143,7 +143,7 @@ export const OrganizationCardList = ({
                 </Link>
               </div>
 
-              <div dir="auto" className="line-clamp-3 text-neutral-charcoal">
+              <div dir="auto" className="line-clamp-3 text-foreground">
                 {relationshipOrg.profile.bio &&
                 relationshipOrg.profile.bio.length > 200
                   ? `${relationshipOrg.profile.bio.slice(0, 200)}...`
@@ -207,7 +207,7 @@ export const OrganizationSummaryList = ({
                     </span>
                   ) : null}
                 </div>
-                <span dir="auto" className="text-neutral-charcoal">
+                <span dir="auto" className="text-foreground">
                   {trimmedBio}
                 </span>
               </div>

--- a/apps/app/src/components/OrganizationList/index.tsx
+++ b/apps/app/src/components/OrganizationList/index.tsx
@@ -143,7 +143,7 @@ export const OrganizationCardList = ({
                 </Link>
               </div>
 
-              <div dir="auto" className="line-clamp-3 text-foreground">
+              <div dir="auto" className="line-clamp-3">
                 {relationshipOrg.profile.bio &&
                 relationshipOrg.profile.bio.length > 200
                   ? `${relationshipOrg.profile.bio.slice(0, 200)}...`
@@ -190,7 +190,7 @@ export const OrganizationSummaryList = ({
                 className="size-8 sm:size-12"
               />
 
-              <div className="flex flex-col gap-3 text-foreground">
+              <div className="flex flex-col gap-3">
                 <div className="flex flex-col gap-2">
                   <Link
                     href={`/org/${org.profile.slug}`}
@@ -207,9 +207,7 @@ export const OrganizationSummaryList = ({
                     </span>
                   ) : null}
                 </div>
-                <span dir="auto" className="text-foreground">
-                  {trimmedBio}
-                </span>
+                <span dir="auto">{trimmedBio}</span>
               </div>
             </div>
           </div>

--- a/apps/app/src/components/OrganizationsSearchResults/index.tsx
+++ b/apps/app/src/components/OrganizationsSearchResults/index.tsx
@@ -47,18 +47,14 @@ export const ProfileSearchResultsSuspense = ({
           <span className="text-muted-foreground">
             {t.rich('Results for <highlight>{query}</highlight>', {
               query: query,
-              highlight: (chunks: React.ReactNode) => (
-                <span className="text-foreground">{chunks}</span>
-              ),
+              highlight: (chunks: React.ReactNode) => <span>{chunks}</span>,
             })}
           </span>
         ) : (
           <span className="text-muted-foreground">
             {t.rich('No results for <highlight>{query}</highlight>', {
               query: query,
-              highlight: (chunks: React.ReactNode) => (
-                <span className="text-foreground">{chunks}</span>
-              ),
+              highlight: (chunks: React.ReactNode) => <span>{chunks}</span>,
             })}
           </span>
         )}
@@ -68,7 +64,7 @@ export const ProfileSearchResultsSuspense = ({
         <TabbedProfileSearchResults profiles={profileSearchResults} />
       ) : (
         <div className="flex justify-center">
-          <span className="max-w-96 text-center text-foreground">
+          <span className="max-w-96 text-center">
             {t(
               'You may want to try using different keywords, checking for typos, or adjusting your filters.',
             )}

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -101,7 +101,7 @@ const HighlightNumber = ({
 
 const HighlightLabel = ({ children }: { children?: ReactNode }) => {
   return (
-    <div className="col-span-2 flex h-12 max-w-32 items-center text-neutral-charcoal xxs:col-span-3">
+    <div className="col-span-2 flex h-12 max-w-32 items-center text-foreground xxs:col-span-3">
       {children}
     </div>
   );
@@ -138,7 +138,7 @@ const OrganizationFacePile = ({ children }: { children?: ReactNode }) => {
       renderOverflow={(count) => (
         <Link href="/org" className={avatarLinkClassName}>
           <Avatar>
-            <AvatarFallback className="bg-neutral-charcoal text-sm text-neutral-offWhite">
+            <AvatarFallback className="bg-foreground text-sm text-neutral-offWhite">
               <span className="align-super">+</span>
               {count}
             </AvatarFallback>

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -101,7 +101,7 @@ const HighlightNumber = ({
 
 const HighlightLabel = ({ children }: { children?: ReactNode }) => {
   return (
-    <div className="col-span-2 flex h-12 max-w-32 items-center text-foreground xxs:col-span-3">
+    <div className="col-span-2 flex h-12 max-w-32 items-center xxs:col-span-3">
       {children}
     </div>
   );

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -138,7 +138,7 @@ const OrganizationFacePile = ({ children }: { children?: ReactNode }) => {
       renderOverflow={(count) => (
         <Link href="/org" className={avatarLinkClassName}>
           <Avatar>
-            <AvatarFallback className="bg-foreground text-sm text-neutral-offWhite">
+            <AvatarFallback className="bg-foreground text-sm text-background">
               <span className="align-super">+</span>
               {count}
             </AvatarFallback>

--- a/apps/app/src/components/PostFeed/index.tsx
+++ b/apps/app/src/components/PostFeed/index.tsx
@@ -104,7 +104,7 @@ const PostFlaggedIndicator = ({ post }: { post: Post }) => {
   }
 
   return (
-    <div className="flex items-center gap-1 text-sm text-functional-red">
+    <div className="flex items-center gap-1 text-sm text-destructive">
       <LuFlag className="size-4" />
       <span>{t('Flagged')}</span>
     </div>

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -719,7 +719,7 @@ const PostUpdateWithUser = ({
             >
               <LuImage /> {t('Media')}
             </InputGroupButton>
-            <div className="flex items-center gap-2 text-foreground">
+            <div className="flex items-center gap-2">
               <TextCounter text={content} max={characterLimit} />
               {lastFailedPost && (
                 <InputGroupButton

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -40,10 +40,7 @@ const TextCounter = ({ text, max }: { text: string; max: number }) => {
 
   return (
     <span
-      className={cn(
-        'text-neutral-charcoal',
-        countDown < 0 && 'text-functional-red',
-      )}
+      className={cn('text-foreground', countDown < 0 && 'text-functional-red')}
     >
       {countDown}
     </span>
@@ -722,7 +719,7 @@ const PostUpdateWithUser = ({
             >
               <LuImage /> {t('Media')}
             </InputGroupButton>
-            <div className="flex items-center gap-2 text-neutral-charcoal">
+            <div className="flex items-center gap-2 text-foreground">
               <TextCounter text={content} max={characterLimit} />
               {lastFailedPost && (
                 <InputGroupButton

--- a/apps/app/src/components/PostUpdate/index.tsx
+++ b/apps/app/src/components/PostUpdate/index.tsx
@@ -40,7 +40,7 @@ const TextCounter = ({ text, max }: { text: string; max: number }) => {
 
   return (
     <span
-      className={cn('text-foreground', countDown < 0 && 'text-functional-red')}
+      className={cn('text-foreground', countDown < 0 && 'text-destructive')}
     >
       {countDown}
     </span>

--- a/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
@@ -254,9 +254,7 @@ const MembersListContent = ({
                       {displayName}
                     </Link>
                   ) : (
-                    <div className="truncate font-semibold text-foreground">
-                      {displayName}
-                    </div>
+                    <div className="truncate font-semibold">{displayName}</div>
                   )}
 
                   {/* Show role information */}
@@ -271,12 +269,12 @@ const MembersListContent = ({
                       </TagGroup>
                     </div>
                   ) : (
-                    <div className="text-sm text-foreground">{t('Member')}</div>
+                    <div className="text-sm">{t('Member')}</div>
                   )}
 
                   {/* Show email if different from display name */}
                   {(member.name || profile?.name) && (
-                    <div className="text-sm text-foreground">
+                    <div className="text-sm">
                       {member.profile?.email || member.email}
                     </div>
                   )}
@@ -284,7 +282,7 @@ const MembersListContent = ({
 
                 {/* Show about/bio information if available */}
                 {bio && (
-                  <div className="line-clamp-3 text-foreground">
+                  <div className="line-clamp-3">
                     {bio.length > 200 ? `${bio.slice(0, 200)}...` : bio}
                   </div>
                 )}
@@ -338,10 +336,10 @@ export const MembersList = ({ profileId }: { profileId: string }) => {
         <div className="mb-4 flex size-12 items-center justify-center rounded-full bg-secondary">
           <LuUsers className="h-6 w-6 text-muted-foreground" />
         </div>
-        <div className="mb-2 font-serif text-title-base text-foreground">
+        <div className="mb-2 font-serif text-title-base">
           {t('No members found')}
         </div>
-        <p className="max-w-md text-sm text-foreground">
+        <p className="max-w-md text-sm">
           {t("This organization doesn't have any members yet.")}
         </p>
       </div>

--- a/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
@@ -271,14 +271,12 @@ const MembersListContent = ({
                       </TagGroup>
                     </div>
                   ) : (
-                    <div className="text-sm text-neutral-charcoal">
-                      {t('Member')}
-                    </div>
+                    <div className="text-sm text-foreground">{t('Member')}</div>
                   )}
 
                   {/* Show email if different from display name */}
                   {(member.name || profile?.name) && (
-                    <div className="text-sm text-neutral-charcoal">
+                    <div className="text-sm text-foreground">
                       {member.profile?.email || member.email}
                     </div>
                   )}
@@ -286,7 +284,7 @@ const MembersListContent = ({
 
                 {/* Show about/bio information if available */}
                 {bio && (
-                  <div className="line-clamp-3 text-neutral-charcoal">
+                  <div className="line-clamp-3 text-foreground">
                     {bio.length > 200 ? `${bio.slice(0, 200)}...` : bio}
                   </div>
                 )}
@@ -343,7 +341,7 @@ export const MembersList = ({ profileId }: { profileId: string }) => {
         <div className="mb-2 font-serif text-title-base text-foreground">
           {t('No members found')}
         </div>
-        <p className="max-w-md text-sm text-neutral-charcoal">
+        <p className="max-w-md text-sm text-foreground">
           {t("This organization doesn't have any members yet.")}
         </p>
       </div>

--- a/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/MembersList.tsx
@@ -174,7 +174,7 @@ const MemberMenu = ({
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={handleRemoveFromOrganization}
-          className="px-3 py-1 text-functional-red"
+          className="px-3 py-1 text-destructive"
         >
           {t('Remove from organization')}
         </DropdownMenuItem>

--- a/apps/app/src/components/Profile/ProfileContent/index.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/index.tsx
@@ -50,7 +50,7 @@ const FocusAreas = ({
   const t = useTranslations();
 
   return (
-    <section className="flex flex-col gap-2 text-foreground">
+    <section className="flex flex-col gap-2">
       <Header3 className="font-sans text-base font-strong">
         {t('Focus Areas')}
       </Header3>
@@ -100,7 +100,7 @@ const CommunitiesServed = ({ profileId }: { profileId: string }) => {
   if (!communitiesServed?.length) return null;
 
   return (
-    <section className="flex flex-col gap-2 text-foreground">
+    <section className="flex flex-col gap-2">
       <Header3 className="font-sans text-base font-strong">
         {t('Communities We Serve')}
       </Header3>
@@ -186,7 +186,7 @@ const ProfileAbout = ({
         ) : null}
 
         {orgType ? (
-          <section className="flex flex-col gap-2 text-foreground">
+          <section className="flex flex-col gap-2">
             <Header3 className="font-sans text-base font-strong">
               {t('Organizational Status')}
             </Header3>
@@ -199,7 +199,7 @@ const ProfileAbout = ({
         ) : null}
 
         {mission ? (
-          <section className="flex flex-col gap-2 text-foreground">
+          <section className="flex flex-col gap-2">
             <Header3 className="font-sans text-base font-strong">
               {t('Mission Statement')}
             </Header3>
@@ -208,7 +208,7 @@ const ProfileAbout = ({
         ) : null}
 
         {strategies?.length > 0 ? (
-          <section className="flex flex-col gap-2 text-foreground">
+          <section className="flex flex-col gap-2">
             <Header3 className="font-sans text-base font-strong">
               {t('Strategies')}
             </Header3>
@@ -228,7 +228,7 @@ const ProfileAbout = ({
         <ErrorBoundary fallback={null}>
           <Suspense
             fallback={
-              <section className="flex flex-col gap-2 text-foreground">
+              <section className="flex flex-col gap-2">
                 <Header3 className="font-sans text-base font-strong">
                   {t('Focus Areas')}
                 </Header3>
@@ -251,7 +251,7 @@ const ProfileAbout = ({
         <ErrorBoundary fallback={null}>
           <Suspense
             fallback={
-              <section className="flex flex-col gap-2 text-foreground">
+              <section className="flex flex-col gap-2">
                 <Header3 className="font-sans text-base font-strong">
                   {t('Communities We Serve')}
                 </Header3>

--- a/apps/app/src/components/Profile/ProfileContent/index.tsx
+++ b/apps/app/src/components/Profile/ProfileContent/index.tsx
@@ -50,7 +50,7 @@ const FocusAreas = ({
   const t = useTranslations();
 
   return (
-    <section className="flex flex-col gap-2 text-neutral-charcoal">
+    <section className="flex flex-col gap-2 text-foreground">
       <Header3 className="font-sans text-base font-strong">
         {t('Focus Areas')}
       </Header3>
@@ -100,7 +100,7 @@ const CommunitiesServed = ({ profileId }: { profileId: string }) => {
   if (!communitiesServed?.length) return null;
 
   return (
-    <section className="flex flex-col gap-2 text-neutral-charcoal">
+    <section className="flex flex-col gap-2 text-foreground">
       <Header3 className="font-sans text-base font-strong">
         {t('Communities We Serve')}
       </Header3>
@@ -186,7 +186,7 @@ const ProfileAbout = ({
         ) : null}
 
         {orgType ? (
-          <section className="flex flex-col gap-2 text-neutral-charcoal">
+          <section className="flex flex-col gap-2 text-foreground">
             <Header3 className="font-sans text-base font-strong">
               {t('Organizational Status')}
             </Header3>
@@ -199,7 +199,7 @@ const ProfileAbout = ({
         ) : null}
 
         {mission ? (
-          <section className="flex flex-col gap-2 text-neutral-charcoal">
+          <section className="flex flex-col gap-2 text-foreground">
             <Header3 className="font-sans text-base font-strong">
               {t('Mission Statement')}
             </Header3>
@@ -208,7 +208,7 @@ const ProfileAbout = ({
         ) : null}
 
         {strategies?.length > 0 ? (
-          <section className="flex flex-col gap-2 text-neutral-charcoal">
+          <section className="flex flex-col gap-2 text-foreground">
             <Header3 className="font-sans text-base font-strong">
               {t('Strategies')}
             </Header3>
@@ -228,7 +228,7 @@ const ProfileAbout = ({
         <ErrorBoundary fallback={null}>
           <Suspense
             fallback={
-              <section className="flex flex-col gap-2 text-neutral-charcoal">
+              <section className="flex flex-col gap-2 text-foreground">
                 <Header3 className="font-sans text-base font-strong">
                   {t('Focus Areas')}
                 </Header3>
@@ -251,7 +251,7 @@ const ProfileAbout = ({
         <ErrorBoundary fallback={null}>
           <Suspense
             fallback={
-              <section className="flex flex-col gap-2 text-neutral-charcoal">
+              <section className="flex flex-col gap-2 text-foreground">
                 <Header3 className="font-sans text-base font-strong">
                   {t('Communities We Serve')}
                 </Header3>

--- a/apps/app/src/components/Profile/ProfileDecisions/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDecisions/index.tsx
@@ -93,7 +93,7 @@ const EmptyDecisions = ({ profileId }: { profileId: string }) => {
             : t('There are no current decision-making processes')}
         </Header2>
         {isProcessAdmin && (
-          <p className="text-base text-foreground">
+          <p className="text-base">
             {t(
               'Create your first participatory budgeting or grantmaking process to start collecting proposals from your community.',
             )}
@@ -154,9 +154,7 @@ export const ProfileDecisionsSuspense = ({
     <Suspense
       fallback={
         <div className="flex min-h-96 items-center justify-center">
-          <div className="animate-pulse text-base text-foreground">
-            {t('Loading...')}
-          </div>
+          <div className="animate-pulse text-base">{t('Loading...')}</div>
         </div>
       }
     >

--- a/apps/app/src/components/Profile/ProfileDecisions/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDecisions/index.tsx
@@ -93,7 +93,7 @@ const EmptyDecisions = ({ profileId }: { profileId: string }) => {
             : t('There are no current decision-making processes')}
         </Header2>
         {isProcessAdmin && (
-          <p className="text-base text-neutral-charcoal">
+          <p className="text-base text-foreground">
             {t(
               'Create your first participatory budgeting or grantmaking process to start collecting proposals from your community.',
             )}
@@ -154,7 +154,7 @@ export const ProfileDecisionsSuspense = ({
     <Suspense
       fallback={
         <div className="flex min-h-96 items-center justify-center">
-          <div className="animate-pulse text-base text-neutral-charcoal">
+          <div className="animate-pulse text-base text-foreground">
             {t('Loading...')}
           </div>
         </div>

--- a/apps/app/src/components/Profile/ProfileDetails/RespondButton.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/RespondButton.tsx
@@ -94,7 +94,7 @@ const RespondButtonSuspense = ({ profile }: { profile: Organization }) => {
     {
       id: 'decline',
       label: 'Decline',
-      icon: <LuX className="size-4 text-functional-red" />,
+      icon: <LuX className="size-4 text-destructive" />,
       onAction: handleDecline,
     },
   ];
@@ -107,7 +107,7 @@ const RespondButtonSuspense = ({ profile }: { profile: Organization }) => {
         render={
           <Button
             loading={isPending}
-            className="min-w-full bg-primary-teal text-neutral-offWhite sm:min-w-fit"
+            className="min-w-full bg-primary-teal text-background sm:min-w-fit"
           >
             <LuUserPlus className="size-4" />
             Respond

--- a/apps/app/src/components/Profile/ProfileDetails/RespondButton.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/RespondButton.tsx
@@ -105,10 +105,7 @@ const RespondButtonSuspense = ({ profile }: { profile: Organization }) => {
     <DropdownMenu>
       <DropdownMenuTrigger
         render={
-          <Button
-            loading={isPending}
-            className="min-w-full bg-primary-teal text-background sm:min-w-fit"
-          >
+          <Button loading={isPending} className="min-w-full sm:min-w-fit">
             <LuUserPlus className="size-4" />
             Respond
           </Button>

--- a/apps/app/src/components/Profile/ProfileDetails/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/index.tsx
@@ -120,7 +120,7 @@ const ProfileInteractions = ({ profile }: { profile: Organization }) => {
                     ) : null}
 
                     {description ? (
-                      <div className="flex w-full items-center justify-center text-sm text-foreground sm:hidden">
+                      <div className="flex w-full items-center justify-center text-sm sm:hidden">
                         {description}
                       </div>
                     ) : null}
@@ -153,7 +153,7 @@ const ProfileInteractions = ({ profile }: { profile: Organization }) => {
                       <TooltipContent>{description}</TooltipContent>
                     ) : null}
                     {description ? (
-                      <div className="flex w-full items-center justify-center text-sm text-foreground sm:hidden">
+                      <div className="flex w-full items-center justify-center text-sm sm:hidden">
                         {description}
                       </div>
                     ) : null}

--- a/apps/app/src/components/Profile/ProfileDetails/index.tsx
+++ b/apps/app/src/components/Profile/ProfileDetails/index.tsx
@@ -120,7 +120,7 @@ const ProfileInteractions = ({ profile }: { profile: Organization }) => {
                     ) : null}
 
                     {description ? (
-                      <div className="flex w-full items-center justify-center text-sm text-neutral-charcoal sm:hidden">
+                      <div className="flex w-full items-center justify-center text-sm text-foreground sm:hidden">
                         {description}
                       </div>
                     ) : null}
@@ -153,7 +153,7 @@ const ProfileInteractions = ({ profile }: { profile: Organization }) => {
                       <TooltipContent>{description}</TooltipContent>
                     ) : null}
                     {description ? (
-                      <div className="flex w-full items-center justify-center text-sm text-neutral-charcoal sm:hidden">
+                      <div className="flex w-full items-center justify-center text-sm text-foreground sm:hidden">
                         {description}
                       </div>
                     ) : null}

--- a/apps/app/src/components/Profile/ProfileSummary/index.tsx
+++ b/apps/app/src/components/Profile/ProfileSummary/index.tsx
@@ -51,7 +51,7 @@ export const ProfileSummary = ({ profile }: { profile: Organization }) => {
         </div>
       ) : null}
 
-      <div dir="auto" className="max-w-xl text-base text-neutral-charcoal">
+      <div dir="auto" className="max-w-xl text-base text-foreground">
         {profile.profile.bio}
       </div>
 

--- a/apps/app/src/components/Profile/ProfileSummary/index.tsx
+++ b/apps/app/src/components/Profile/ProfileSummary/index.tsx
@@ -51,7 +51,7 @@ export const ProfileSummary = ({ profile }: { profile: Organization }) => {
         </div>
       ) : null}
 
-      <div dir="auto" className="max-w-xl text-base text-foreground">
+      <div dir="auto" className="max-w-xl text-base">
         {profile.profile.bio}
       </div>
 

--- a/apps/app/src/components/ProfileList/index.tsx
+++ b/apps/app/src/components/ProfileList/index.tsx
@@ -56,7 +56,7 @@ export const ProfileSummaryList = ({
                 className="size-8 sm:size-12"
               />
 
-              <div className="flex flex-col gap-2 text-foreground">
+              <div className="flex flex-col gap-2">
                 <div className="flex flex-col gap-1">
                   {canLinkToProfile ? (
                     <Link
@@ -79,7 +79,7 @@ export const ProfileSummaryList = ({
                     </span>
                   ) : null}
                 </div>
-                <span dir="auto" className="leading-5 text-foreground">
+                <span dir="auto" className="leading-5">
                   {trimmedBio}
                 </span>
               </div>

--- a/apps/app/src/components/RelationshipList/index.tsx
+++ b/apps/app/src/components/RelationshipList/index.tsx
@@ -121,7 +121,7 @@ const RelationshipListContent = ({
                     </div>
                   ) : (
                     /* Show profile type if no relationships */
-                    <div className="text-sm text-neutral-charcoal capitalize">
+                    <div className="text-sm text-foreground capitalize">
                       {profile.type === 'org'
                         ? t('Organization')
                         : t('Individual')}
@@ -130,10 +130,7 @@ const RelationshipListContent = ({
                 </div>
 
                 {profile.bio && (
-                  <div
-                    dir="auto"
-                    className="line-clamp-3 text-neutral-charcoal"
-                  >
+                  <div dir="auto" className="line-clamp-3 text-foreground">
                     {profile.bio.length > 200
                       ? `${profile.bio.slice(0, 200)}...`
                       : profile.bio}

--- a/apps/app/src/components/RelationshipList/index.tsx
+++ b/apps/app/src/components/RelationshipList/index.tsx
@@ -94,14 +94,14 @@ const RelationshipListContent = ({
                       <bdi>{profile.name}</bdi>
                     </Link>
                   ) : (
-                    <span className="truncate font-semibold text-foreground">
+                    <span className="truncate font-semibold">
                       <bdi>{profile.name}</bdi>
                     </span>
                   )}
 
                   {/* Show relationship types if available */}
                   {profile.relationships && relationshipMap ? (
-                    <div className="text-foreground">
+                    <div>
                       {profile.relationships.map((relationship, i, arr) => (
                         <React.Fragment key={relationship.relationshipType}>
                           {relationshipMap[relationship.relationshipType]
@@ -121,7 +121,7 @@ const RelationshipListContent = ({
                     </div>
                   ) : (
                     /* Show profile type if no relationships */
-                    <div className="text-sm text-foreground capitalize">
+                    <div className="text-sm capitalize">
                       {profile.type === 'org'
                         ? t('Organization')
                         : t('Individual')}
@@ -130,7 +130,7 @@ const RelationshipListContent = ({
                 </div>
 
                 {profile.bio && (
-                  <div dir="auto" className="line-clamp-3 text-foreground">
+                  <div dir="auto" className="line-clamp-3">
                     {profile.bio.length > 200
                       ? `${profile.bio.slice(0, 200)}...`
                       : profile.bio}

--- a/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
+++ b/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
@@ -145,7 +145,7 @@ export const AddResourceDocumentForm = ({
     <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
       <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 sm:px-6">
         <div className="flex flex-col gap-1">
-          <span className="text-sm text-foreground">{t('Upload file')}</span>
+          <span className="text-sm">{t('Upload file')}</span>
           <input
             ref={inputRef}
             type="file"
@@ -192,7 +192,7 @@ export const AddResourceDocumentForm = ({
                     </>
                   ) : (
                     <>
-                      <span className="truncate text-base font-medium text-foreground">
+                      <span className="truncate text-base font-medium">
                         {file.name}
                       </span>
                       <span className="text-sm text-muted-foreground">
@@ -237,11 +237,11 @@ export const AddResourceDocumentForm = ({
                   : 'border-input hover:border-neutral-gray3',
               )}
             >
-              <div className="flex size-20 items-center justify-center rounded-full bg-secondary text-foreground">
+              <div className="flex size-20 items-center justify-center rounded-full bg-secondary">
                 <LuFilePlus2 className="size-10" />
               </div>
               <div className="flex flex-col gap-2 text-base">
-                <p className="text-foreground">
+                <p>
                   {t.rich('Drag a file here or <browse>browse</browse>', {
                     browse: (chunks: ReactNode) => (
                       <span className="text-primary-teal underline">

--- a/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
+++ b/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
@@ -234,7 +234,7 @@ export const AddResourceDocumentForm = ({
                 'flex min-h-52 cursor-pointer flex-col items-center justify-center gap-6 rounded-lg border border-dashed bg-muted px-12 py-6 text-center transition-colors',
                 isDragging
                   ? 'bg-primary-teal50 border-primary-teal'
-                  : 'border-input hover:border-neutral-gray3',
+                  : 'border-input hover:border-input',
               )}
             >
               <div className="flex size-20 items-center justify-center rounded-full bg-secondary">

--- a/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
+++ b/apps/app/src/components/Resources/AddResourceDocumentForm.tsx
@@ -192,7 +192,7 @@ export const AddResourceDocumentForm = ({
                     </>
                   ) : (
                     <>
-                      <span className="truncate text-base font-medium text-neutral-charcoal">
+                      <span className="truncate text-base font-medium text-foreground">
                         {file.name}
                       </span>
                       <span className="text-sm text-muted-foreground">
@@ -237,7 +237,7 @@ export const AddResourceDocumentForm = ({
                   : 'border-input hover:border-neutral-gray3',
               )}
             >
-              <div className="flex size-20 items-center justify-center rounded-full bg-secondary text-neutral-charcoal">
+              <div className="flex size-20 items-center justify-center rounded-full bg-secondary text-foreground">
                 <LuFilePlus2 className="size-10" />
               </div>
               <div className="flex flex-col gap-2 text-base">

--- a/apps/app/src/components/Resources/PinnedResourceCard.tsx
+++ b/apps/app/src/components/Resources/PinnedResourceCard.tsx
@@ -62,7 +62,7 @@ export const PinnedResourceCard = ({
           <Icon className="size-4 text-foreground" />
         </div>
         <div className="flex min-w-0 flex-col gap-0.5">
-          <p dir="auto" className="truncate text-base text-foreground">
+          <p dir="auto" className="truncate text-base">
             {title}
           </p>
           {resource.createdAt ? (

--- a/apps/app/src/components/Resources/ResourceCard.tsx
+++ b/apps/app/src/components/Resources/ResourceCard.tsx
@@ -172,7 +172,7 @@ const ResourceCardShell = ({
       {preview}
       <div className="flex flex-col gap-0.5">
         {description ? (
-          <p dir="auto" className="line-clamp-2 text-sm text-neutral-charcoal">
+          <p dir="auto" className="line-clamp-2 text-sm text-foreground">
             {description}
           </p>
         ) : null}

--- a/apps/app/src/components/Resources/ResourceCard.tsx
+++ b/apps/app/src/components/Resources/ResourceCard.tsx
@@ -162,17 +162,14 @@ const ResourceCardShell = ({
     <div className="flex flex-col gap-2">
       <p
         dir="auto"
-        className={cn(
-          'truncate font-serif text-title-sm text-foreground',
-          trailing && 'pe-8',
-        )}
+        className={cn('truncate font-serif text-title-sm', trailing && 'pe-8')}
       >
         {title}
       </p>
       {preview}
       <div className="flex flex-col gap-0.5">
         {description ? (
-          <p dir="auto" className="line-clamp-2 text-sm text-foreground">
+          <p dir="auto" className="line-clamp-2 text-sm">
             {description}
           </p>
         ) : null}

--- a/apps/app/src/components/RichTextEditor/RichTextEditorFloatingToolbar.tsx
+++ b/apps/app/src/components/RichTextEditor/RichTextEditorFloatingToolbar.tsx
@@ -78,7 +78,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleHeading({ level: 1 }).run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 1 }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 1 }) ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Heading 1')}
       >
         <LuHeading1 className="size-4" />
@@ -88,7 +88,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleHeading({ level: 2 }).run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 2 }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 2 }) ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Heading 2')}
       >
         <LuHeading2 className="size-4" />
@@ -98,7 +98,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleHeading({ level: 3 }).run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 3 }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('heading', { level: 3 }) ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Heading 3')}
       >
         <LuHeading3 className="size-4" />
@@ -112,7 +112,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleBold().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('bold') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('bold') ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Bold')}
       >
         <LuBold className="size-4" />
@@ -122,7 +122,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleItalic().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('italic') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('italic') ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Italic')}
       >
         <LuItalic className="size-4" />
@@ -132,7 +132,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleUnderline().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('underline') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('underline') ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Underline')}
       >
         <LuUnderline className="size-4" />
@@ -142,7 +142,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleStrike().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('strike') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('strike') ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Strikethrough')}
       >
         <LuStrikethrough className="size-4" />
@@ -152,7 +152,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleCode().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('code') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('code') ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Code')}
       >
         <LuCode className="size-4" />
@@ -166,7 +166,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleBulletList().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('bulletList') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('bulletList') ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Bullet List')}
       >
         <LuList className="size-4" />
@@ -176,7 +176,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleOrderedList().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('orderedList') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('orderedList') ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Numbered List')}
       >
         <LuListOrdered className="size-4" />
@@ -186,7 +186,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().toggleBlockquote().run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('blockquote') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('blockquote') ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Blockquote')}
       >
         <LuQuote className="size-4" />
@@ -200,7 +200,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().setTextAlign('left').run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'left' }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'left' }) ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Align Left')}
       >
         <LuAlignLeft className="size-4" />
@@ -210,7 +210,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().setTextAlign('center').run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'center' }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'center' }) ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Align Center')}
       >
         <LuAlignCenter className="size-4" />
@@ -220,7 +220,7 @@ export function RichTextEditorFloatingToolbar({
           editor.chain().focus().setTextAlign('right').run();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'right' }) ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive({ textAlign: 'right' }) ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Align Right')}
       >
         <LuAlignRight className="size-4" />
@@ -234,7 +234,7 @@ export function RichTextEditorFloatingToolbar({
           addLink();
           onSelectionChange();
         }}
-        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('link') ? 'bg-gray-200 text-foreground' : 'text-neutral-charcoal'}`}
+        className={`rounded p-1.5 hover:bg-gray-100 ${editor.isActive('link') ? 'bg-gray-200 text-foreground' : 'text-foreground'}`}
         title={t('Add Link')}
       >
         <LuLink className="size-4" />

--- a/apps/app/src/components/SearchInput/index.tsx
+++ b/apps/app/src/components/SearchInput/index.tsx
@@ -330,7 +330,7 @@ const ProfileCommandItem = ({
         <AvatarFallback name={profile.name} />
       </Avatar>
 
-      <div className="flex flex-col font-semibold text-foreground">
+      <div className="flex flex-col font-semibold">
         {highlightName(profile.name, query)}
         <span dir="auto" className="text-sm text-muted-foreground capitalize">
           {subtitle}

--- a/apps/app/src/components/TermsMultiSelect/index.tsx
+++ b/apps/app/src/components/TermsMultiSelect/index.tsx
@@ -117,7 +117,7 @@ export const TermsMultiSelect = ({
       {label && (
         <Label>
           {label}
-          {isRequired && <span className="text-functional-red"> *</span>}
+          {isRequired && <span className="text-destructive"> *</span>}
         </Label>
       )}
       <Combobox
@@ -169,7 +169,7 @@ export const TermsMultiSelect = ({
         </ComboboxContent>
       </Combobox>
       {errorMessage && (
-        <p className="text-sm text-functional-red">{errorMessage}</p>
+        <p className="text-sm text-destructive">{errorMessage}</p>
       )}
     </div>
   );

--- a/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
+++ b/apps/app/src/components/collaboration/CollaborativeTitleField.tsx
@@ -91,7 +91,7 @@ export function CollaborativeTitleField({
         // strong character, and plaintext resolves that to LTR rather than to
         // the surrounding direction, which parked the caret on the wrong side.
         class:
-          'w-full border-0 bg-transparent p-0 text-base whitespace-pre-wrap text-foreground outline-none [&_p]:[unicode-bidi:plaintext] [&_p:has(>br:only-child)]:[unicode-bidi:normal]',
+          'w-full border-0 bg-transparent p-0 text-base whitespace-pre-wrap outline-none [&_p]:[unicode-bidi:plaintext] [&_p:has(>br:only-child)]:[unicode-bidi:normal]',
         // `role="textbox"` first: the aria attributes below are illegal on a
         // generic element. Enter is swallowed in handleKeyDown.
         role: 'textbox',

--- a/apps/app/src/components/decisions/AdminOverviewBar.tsx
+++ b/apps/app/src/components/decisions/AdminOverviewBar.tsx
@@ -54,7 +54,7 @@ export function AdminOverviewBar({
         onClick={() => setSheetOpen(true)}
         className="flex w-full items-center justify-center gap-2 bg-primary-tealWhite px-4 py-2 text-base md:hidden"
       >
-        <span className="flex items-center gap-1.5 text-neutral-charcoal">
+        <span className="flex items-center gap-1.5 text-foreground">
           <LuEye className="size-4" aria-hidden="true" />
           {t('Admin')}
         </span>

--- a/apps/app/src/components/decisions/AdminOverviewBar.tsx
+++ b/apps/app/src/components/decisions/AdminOverviewBar.tsx
@@ -54,17 +54,15 @@ export function AdminOverviewBar({
         onClick={() => setSheetOpen(true)}
         className="flex w-full items-center justify-center gap-2 bg-primary-tealWhite px-4 py-2 text-base md:hidden"
       >
-        <span className="flex items-center gap-1.5 text-foreground">
+        <span className="flex items-center gap-1.5">
           <LuEye className="size-4" aria-hidden="true" />
           {t('Admin')}
         </span>
         {phaseName ? (
           <>
-            <span aria-hidden="true" className="text-foreground">
-              |
-            </span>
+            <span aria-hidden="true">|</span>
             <span className="flex items-end gap-1.5">
-              <span className="text-foreground">{phaseName}</span>
+              <span>{phaseName}</span>
               {endsLabel ? (
                 <span className="text-sm text-muted-foreground">
                   {endsLabel}

--- a/apps/app/src/components/decisions/DecisionHero.tsx
+++ b/apps/app/src/components/decisions/DecisionHero.tsx
@@ -46,7 +46,7 @@ export function DecisionHero({
           className={cn(
             'flex flex-col gap-2 text-base',
             variant !== 'results' &&
-              (hasImage ? 'text-white' : 'text-neutral-charcoal'),
+              (hasImage ? 'text-white' : 'text-foreground'),
           )}
         >
           {typeof description === 'string' ? (

--- a/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
+++ b/apps/app/src/components/decisions/DecisionInstanceHeader.tsx
@@ -86,7 +86,7 @@ export const DecisionInstanceHeader = ({
               {canInteract && (
                 <span
                   aria-hidden
-                  className="hidden h-6 w-px shrink-0 bg-neutral-gray2 md:block"
+                  className="hidden h-6 w-px shrink-0 bg-border md:block"
                 />
               )}
               <DecisionTitle title={title} className="hidden md:block" />

--- a/apps/app/src/components/decisions/DecisionInviteCard.tsx
+++ b/apps/app/src/components/decisions/DecisionInviteCard.tsx
@@ -83,7 +83,7 @@ export const DecisionInviteCard = ({
             title={steward?.name ?? ''}
           />
         </div>
-        <div className="flex items-end gap-4 text-foreground sm:items-center sm:gap-12">
+        <div className="flex items-end gap-4 sm:items-center sm:gap-12">
           <DecisionStat
             number={invite.participantCount}
             label={t('Participants')}

--- a/apps/app/src/components/decisions/DecisionOverview.tsx
+++ b/apps/app/src/components/decisions/DecisionOverview.tsx
@@ -105,7 +105,7 @@ export function DecisionOverview({
               <EmptyTitle className="font-light">
                 {t("Couldn't load the overview")}
               </EmptyTitle>
-              <EmptyDescription className="text-base text-neutral-charcoal">
+              <EmptyDescription className="text-base text-foreground">
                 {t('Refresh the page to try again.')}
               </EmptyDescription>
             </EmptyHeader>
@@ -363,7 +363,7 @@ const OverviewHero = ({
             <div
               className={cn(
                 'flex flex-wrap items-center justify-center gap-x-2 gap-y-1',
-                hasImage ? 'text-white' : 'text-neutral-charcoal',
+                hasImage ? 'text-white' : 'text-foreground',
               )}
             >
               {stewardName ? (
@@ -419,7 +419,7 @@ const OverviewHero = ({
               dir="auto"
               className={cn(
                 'text-base text-balance',
-                hasImage ? 'text-white' : 'text-neutral-charcoal',
+                hasImage ? 'text-white' : 'text-foreground',
               )}
             >
               {subhead}

--- a/apps/app/src/components/decisions/FinalPhaseSelectionFooter.tsx
+++ b/apps/app/src/components/decisions/FinalPhaseSelectionFooter.tsx
@@ -65,7 +65,7 @@ export const FinalPhaseSelectionFooter = ({
           onConfirm={onConfirm}
         >
           <div className="space-y-4">
-            <p className="text-base text-neutral-charcoal">
+            <p className="text-base text-foreground">
               {t(
                 'These {numProposals} proposals will be funded and results will be shared with all participants.',
                 { numProposals: numSelected },
@@ -101,12 +101,12 @@ const FinalPhaseProposalCard = ({ proposal }: { proposal: Proposal }) => {
           <bdi>{title}</bdi>
         </span>
         {budget ? (
-          <span className="font-serif text-title-sm14 text-neutral-charcoal">
+          <span className="font-serif text-title-sm14 text-foreground">
             {budget}
           </span>
         ) : null}
       </div>
-      <div className="flex flex-wrap items-center gap-2 text-sm text-neutral-charcoal">
+      <div className="flex flex-wrap items-center gap-2 text-sm text-foreground">
         {submitterName ? <span>{submitterName}</span> : null}
         {submitterName && hasCategories ? <Bullet /> : null}
         {categories.map((category) => (

--- a/apps/app/src/components/decisions/FinalPhaseSelectionFooter.tsx
+++ b/apps/app/src/components/decisions/FinalPhaseSelectionFooter.tsx
@@ -38,7 +38,7 @@ export const FinalPhaseSelectionFooter = ({
   return (
     <FooterBar position="fixed" className="bg-muted/95">
       <FooterBarStart>
-        <span className="flex items-center gap-2 text-base text-foreground">
+        <span className="flex items-center gap-2 text-base">
           <LuCircleCheck className="size-5 shrink-0" aria-hidden />
           {/* Keeps "winning": this footer drives the irreversible final-phase
               publish, and Figma has no frame for this variant. */}
@@ -65,7 +65,7 @@ export const FinalPhaseSelectionFooter = ({
           onConfirm={onConfirm}
         >
           <div className="space-y-4">
-            <p className="text-base text-foreground">
+            <p className="text-base">
               {t(
                 'These {numProposals} proposals will be funded and results will be shared with all participants.',
                 { numProposals: numSelected },
@@ -97,16 +97,14 @@ const FinalPhaseProposalCard = ({ proposal }: { proposal: Proposal }) => {
   return (
     <div className="flex flex-col gap-1 rounded-lg border border-border bg-muted p-3">
       <div className="flex items-start justify-between gap-2">
-        <span className="truncate font-serif text-title-sm14 text-foreground">
+        <span className="truncate font-serif text-title-sm14">
           <bdi>{title}</bdi>
         </span>
         {budget ? (
-          <span className="font-serif text-title-sm14 text-foreground">
-            {budget}
-          </span>
+          <span className="font-serif text-title-sm14">{budget}</span>
         ) : null}
       </div>
-      <div className="flex flex-wrap items-center gap-2 text-sm text-foreground">
+      <div className="flex flex-wrap items-center gap-2 text-sm">
         {submitterName ? <span>{submitterName}</span> : null}
         {submitterName && hasCategories ? <Bullet /> : null}
         {categories.map((category) => (

--- a/apps/app/src/components/decisions/MemberParticipationFacePile.tsx
+++ b/apps/app/src/components/decisions/MemberParticipationFacePile.tsx
@@ -70,7 +70,7 @@ export const MemberParticipationFacePile = ({
         <span
           className={cn(
             'w-fit text-sm',
-            hasImage ? 'text-white' : 'text-neutral-charcoal',
+            hasImage ? 'text-white' : 'text-foreground',
           )}
         >
           {t(

--- a/apps/app/src/components/decisions/OverviewPinnedResources.tsx
+++ b/apps/app/src/components/decisions/OverviewPinnedResources.tsx
@@ -73,7 +73,7 @@ export const PinnedResourcesError = () => {
         <Header3 className="font-sans text-sm text-muted-foreground">
           {t('Pinned Resources')}
         </Header3>
-        <p className="text-neutral-charcoal">
+        <p className="text-foreground">
           {t("Couldn't load pinned resources.")}
         </p>
       </section>

--- a/apps/app/src/components/decisions/OverviewPinnedResources.tsx
+++ b/apps/app/src/components/decisions/OverviewPinnedResources.tsx
@@ -73,9 +73,7 @@ export const PinnedResourcesError = () => {
         <Header3 className="font-sans text-sm text-muted-foreground">
           {t('Pinned Resources')}
         </Header3>
-        <p className="text-foreground">
-          {t("Couldn't load pinned resources.")}
-        </p>
+        <p>{t("Couldn't load pinned resources.")}</p>
       </section>
     </>
   );

--- a/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
@@ -87,7 +87,7 @@ export const LaunchProcessModal = ({
           {invitesLoading ? (
             <Skeleton className="h-6 w-full" />
           ) : pendingNotificationCount > 0 ? (
-            <p className="text-neutral-charcoal">
+            <p className="text-foreground">
               {t('Launching your process will notify')}{' '}
               <span className="font-bold">
                 {t(
@@ -97,7 +97,7 @@ export const LaunchProcessModal = ({
               </span>
             </p>
           ) : (
-            <p className="text-neutral-charcoal">
+            <p className="text-foreground">
               {t(
                 'This will open {processName} for proposal submissions. Participants will be notified and can begin submitting proposals.',
                 { processName },
@@ -109,19 +109,19 @@ export const LaunchProcessModal = ({
           <div className="flex flex-col gap-2 rounded-lg border border-border p-4">
             <div className="flex items-center justify-between border-b border-border pb-2">
               <span className="text-muted-foreground">{t('Phases')}</span>
-              <span className="text-neutral-charcoal">{phasesCount}</span>
+              <span className="text-foreground">{phasesCount}</span>
             </div>
             {organizeByCategories && (
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">{t('Categories')}</span>
-                <span className="text-neutral-charcoal">
+                <span className="text-foreground">
                   {categoriesCount === 0 ? t('None') : categoriesCount}
                 </span>
               </div>
             )}
           </div>
 
-          <p className="text-sm text-neutral-charcoal">
+          <p className="text-sm text-foreground">
             {t('You can edit settings and advance phases after launching.')}
           </p>
 

--- a/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/LaunchProcessModal.tsx
@@ -87,7 +87,7 @@ export const LaunchProcessModal = ({
           {invitesLoading ? (
             <Skeleton className="h-6 w-full" />
           ) : pendingNotificationCount > 0 ? (
-            <p className="text-foreground">
+            <p>
               {t('Launching your process will notify')}{' '}
               <span className="font-bold">
                 {t(
@@ -97,7 +97,7 @@ export const LaunchProcessModal = ({
               </span>
             </p>
           ) : (
-            <p className="text-foreground">
+            <p>
               {t(
                 'This will open {processName} for proposal submissions. Participants will be notified and can begin submitting proposals.',
                 { processName },
@@ -109,19 +109,19 @@ export const LaunchProcessModal = ({
           <div className="flex flex-col gap-2 rounded-lg border border-border p-4">
             <div className="flex items-center justify-between border-b border-border pb-2">
               <span className="text-muted-foreground">{t('Phases')}</span>
-              <span className="text-foreground">{phasesCount}</span>
+              <span>{phasesCount}</span>
             </div>
             {organizeByCategories && (
               <div className="flex items-center justify-between">
                 <span className="text-muted-foreground">{t('Categories')}</span>
-                <span className="text-foreground">
+                <span>
                   {categoriesCount === 0 ? t('None') : categoriesCount}
                 </span>
               </div>
             )}
           </div>
 
-          <p className="text-sm text-foreground">
+          <p className="text-sm">
             {t('You can edit settings and advance phases after launching.')}
           </p>
 

--- a/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderProcessSelector.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/ProcessBuilderProcessSelector.tsx
@@ -74,7 +74,7 @@ export const ProcessBuilderProcessCard = ({
 
   return (
     <button
-      className="flex w-full cursor-pointer flex-col gap-2 rounded-lg border bg-white p-6 text-start transition-shadow hover:border-neutral-300 hover:shadow-md sm:w-72 md:aspect-[4/3] md:w-90 md:p-12 md:text-center"
+      className="flex w-full cursor-pointer flex-col gap-2 rounded-lg border bg-white p-6 text-start transition-shadow hover:border-input hover:shadow-md sm:w-72 md:aspect-[4/3] md:w-90 md:p-12 md:text-center"
       onClick={onSelect}
     >
       <div className="flex gap-2 md:flex-col md:items-center md:gap-6">

--- a/apps/app/src/components/decisions/ProcessBuilder/components/ProgressIndicator.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/components/ProgressIndicator.tsx
@@ -20,7 +20,7 @@ export function ProgressIndicator({
         aria-valuemax={100}
         aria-valuenow={clamped}
         aria-label={t('{count}% complete', { count: clamped })}
-        className="absolute inset-x-0 top-0 h-1 overflow-hidden bg-neutral-gray2 md:hidden"
+        className="absolute inset-x-0 top-0 h-1 overflow-hidden bg-secondary md:hidden"
       >
         <div
           className="h-full bg-linear-to-r from-functional-green to-primary-teal transition-all duration-300"
@@ -38,7 +38,7 @@ export function ProgressIndicator({
         aria-valuemax={100}
         aria-valuenow={clamped}
         aria-label={t('{count}% complete', { count: clamped })}
-        className="h-1 flex-1 overflow-hidden rounded-full bg-neutral-gray2"
+        className="h-1 flex-1 overflow-hidden rounded-full bg-secondary"
       >
         <div
           className="h-full rounded-full bg-linear-to-r from-functional-green to-primary-teal transition-all duration-300"

--- a/apps/app/src/components/decisions/ProcessBuilder/components/ProgressIndicator.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/components/ProgressIndicator.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Progress } from '@op/sense/Progress';
+
 import { useTranslations } from '@/lib/i18n';
 
 export function ProgressIndicator({
@@ -11,48 +13,31 @@ export function ProgressIndicator({
 }) {
   const t = useTranslations();
   const clamped = Math.min(100, Math.max(0, percentage));
+  const label = t('{count}% complete', { count: clamped });
 
+  // Progress owns role="progressbar" and the aria-value* attributes, so the
+  // only thing left to supply is the accessible name.
   if (variant === 'strip') {
     return (
-      <div
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={clamped}
-        aria-label={t('{count}% complete', { count: clamped })}
-        className="absolute inset-x-0 top-0 h-1 overflow-hidden bg-secondary md:hidden"
-      >
-        <div
-          className="h-full bg-linear-to-r from-functional-green to-primary-teal transition-all duration-300"
-          style={{ width: `${clamped}%` }}
-        />
-      </div>
+      <Progress
+        value={clamped}
+        aria-label={label}
+        className="absolute inset-x-0 top-0 md:hidden"
+      />
     );
   }
 
   return (
     <div className="mx-auto flex w-full max-w-160 items-center gap-4">
-      <div
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={clamped}
-        aria-label={t('{count}% complete', { count: clamped })}
-        className="h-1 flex-1 overflow-hidden rounded-full bg-secondary"
-      >
-        <div
-          className="h-full rounded-full bg-linear-to-r from-functional-green to-primary-teal transition-all duration-300"
-          style={{ width: `${clamped}%` }}
-        />
-      </div>
+      <Progress value={clamped} aria-label={label} className="flex-1" />
       <span
         className={
           clamped === 100
-            ? 'shrink-0 bg-linear-to-r from-functional-green to-primary-teal bg-clip-text text-base text-transparent'
+            ? 'shrink-0 text-base text-primary'
             : 'shrink-0 text-base text-foreground'
         }
       >
-        {t('{count}% complete', { count: clamped })}
+        {label}
       </span>
     </div>
   );

--- a/apps/app/src/components/decisions/ProcessBuilder/components/SaveStatusIndicator.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/components/SaveStatusIndicator.tsx
@@ -45,8 +45,8 @@ export function SaveStatusIndicator({
       )}
       {status === 'error' && (
         <>
-          <LuX className="size-4 text-functional-red" />
-          <span className="text-functional-red">{t('Failed to save')}</span>
+          <LuX className="size-4 text-destructive" />
+          <span className="text-destructive">{t('Failed to save')}</span>
         </>
       )}
     </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
@@ -56,7 +56,7 @@ export function OverviewTextField({
         // color and strips this class, letting the headline inherit the
         // foreground, while the description keeps it — charcoal here made the
         // subhead too light.
-        'field-sizing-content resize-none overflow-hidden bg-transparent text-foreground placeholder:text-neutral-gray3 focus:outline-none',
+        'field-sizing-content resize-none overflow-hidden bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-none',
         showCount ? 'min-w-0 flex-1' : 'w-full',
         variant === 'headline' && 'font-serif text-title-lg',
         variant === 'description' && 'text-base',
@@ -77,7 +77,7 @@ export function OverviewTextField({
         className={cn(
           'shrink-0 text-sm transition-opacity',
           value.length > 0 ? 'opacity-100' : 'opacity-0',
-          value.length >= maxLength ? 'text-functional-red' : 'text-foreground',
+          value.length >= maxLength ? 'text-destructive' : 'text-foreground',
         )}
       >
         {value.length}/{maxLength}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/OverviewTextField.tsx
@@ -77,9 +77,7 @@ export function OverviewTextField({
         className={cn(
           'shrink-0 text-sm transition-opacity',
           value.length > 0 ? 'opacity-100' : 'opacity-0',
-          value.length >= maxLength
-            ? 'text-functional-red'
-            : 'text-neutral-charcoal',
+          value.length >= maxLength ? 'text-functional-red' : 'text-foreground',
         )}
       >
         {value.length}/{maxLength}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -653,8 +653,7 @@ function PhaseField({
             <span
               className={cn(
                 'text-sm text-muted-foreground',
-                (value.length === maxLength || isInvalid) &&
-                  'text-functional-red',
+                (value.length === maxLength || isInvalid) && 'text-destructive',
               )}
             >
               {value.length}/{maxLength}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
@@ -165,7 +165,7 @@ export function PhasesSectionContent({
 
       {phases.length === 0 ? (
         <div className="space-y-4">
-          <div className="rounded-lg border border-dashed border-neutral-gray3 p-8 text-center">
+          <div className="rounded-lg border border-dashed border-input p-8 text-center">
             <p className="text-muted-foreground">{t('No phases defined')}</p>
           </div>
           <Button

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
@@ -250,7 +250,7 @@ export function ProposalCategoriesSectionContent({
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    className="size-5 p-0 text-foreground hover:text-red"
+                    className="size-5 p-0 text-foreground hover:text-destructive"
                     onClick={() => handleDelete(category.id)}
                     aria-label={`Delete ${category.label}`}
                   >
@@ -431,7 +431,7 @@ function CategoryField({
             <span
               className={cn(
                 'text-sm text-muted-foreground',
-                value.length === maxLength && 'text-functional-red',
+                value.length === maxLength && 'text-destructive',
               )}
             >
               {value.length}/{maxLength}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
@@ -232,9 +232,7 @@ export function ProposalCategoriesSectionContent({
                 className="group flex items-start gap-2 border-b py-3"
               >
                 <div className="min-w-0 flex-1">
-                  <span className="text-neutral-charcoal">
-                    {category.label}
-                  </span>
+                  <span className="text-foreground">{category.label}</span>
                   <p className="text-sm text-muted-foreground">
                     {category.description}
                   </p>
@@ -243,7 +241,7 @@ export function ProposalCategoriesSectionContent({
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    className="size-5 p-0 text-neutral-charcoal"
+                    className="size-5 p-0 text-foreground"
                     onClick={() => handleEdit(category)}
                     aria-label={`Edit ${category.label}`}
                   >
@@ -252,7 +250,7 @@ export function ProposalCategoriesSectionContent({
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    className="size-5 p-0 text-neutral-charcoal hover:text-red"
+                    className="size-5 p-0 text-foreground hover:text-red"
                     onClick={() => handleDelete(category.id)}
                     aria-label={`Delete ${category.label}`}
                   >

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
@@ -232,7 +232,7 @@ export function ProposalCategoriesSectionContent({
                 className="group flex items-start gap-2 border-b py-3"
               >
                 <div className="min-w-0 flex-1">
-                  <span className="text-foreground">{category.label}</span>
+                  <span>{category.label}</span>
                   <p className="text-sm text-muted-foreground">
                     {category.description}
                   </p>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/ProposalCategoriesSectionContent.tsx
@@ -241,7 +241,7 @@ export function ProposalCategoriesSectionContent({
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    className="size-5 p-0 text-foreground"
+                    className="size-5 p-0"
                     onClick={() => handleEdit(category)}
                     aria-label={`Edit ${category.label}`}
                   >
@@ -250,7 +250,7 @@ export function ProposalCategoriesSectionContent({
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    className="size-5 p-0 text-foreground hover:text-destructive"
+                    className="size-5 p-0 hover:text-destructive"
                     onClick={() => handleDelete(category.id)}
                     aria-label={`Delete ${category.label}`}
                   >

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/RolesSection.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/RolesSection.tsx
@@ -702,7 +702,7 @@ function MobileRoleFormCard({
             size="icon-sm"
             onClick={() => onDelete(role)}
             aria-label={t('Delete')}
-            className="text-functional-red"
+            className="text-destructive"
           >
             <LuTrash2 className="size-4" />
           </Button>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/SummarySectionInner.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/SummarySectionInner.tsx
@@ -154,9 +154,7 @@ export function SummarySectionInner({
             <span className="text-base text-muted-foreground">
               {t('Phases')}
             </span>
-            <span className="text-base text-neutral-charcoal">
-              {phasesCount}
-            </span>
+            <span className="text-base text-foreground">{phasesCount}</span>
           </div>
           <div className="mt-2 border-t border-border" />
         </div>
@@ -166,7 +164,7 @@ export function SummarySectionInner({
               <span className="text-base text-muted-foreground">
                 {t('Categories')}
               </span>
-              <span className="text-base text-neutral-charcoal">
+              <span className="text-base text-foreground">
                 {categories.length}
               </span>
             </div>
@@ -177,9 +175,7 @@ export function SummarySectionInner({
           <span className="text-base text-muted-foreground">
             {t('Participants Invited')}
           </span>
-          <span className="text-base text-neutral-charcoal">
-            {participantsCount}
-          </span>
+          <span className="text-base text-foreground">{participantsCount}</span>
         </div>
       </div>
     </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/SummarySectionInner.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/SummarySectionInner.tsx
@@ -87,7 +87,7 @@ export function SummarySectionInner({
             {t('Your process still needs more information')}
           </Header2>
         </div>
-        <p className="text-base text-foreground">
+        <p className="text-base">
           {t.rich(
             '<highlight>{processName}</highlight> is missing information in order to go live.',
             {
@@ -102,9 +102,7 @@ export function SummarySectionInner({
           {incompleteItems.map((item, index) => (
             <div key={item.id}>
               <div className="flex items-center justify-between">
-                <span className="text-base text-foreground">
-                  {t(item.labelKey)}
-                </span>
+                <span className="text-base">{t(item.labelKey)}</span>
                 <Button
                   variant="outline"
                   className="shrink-0"
@@ -154,7 +152,7 @@ export function SummarySectionInner({
             <span className="text-base text-muted-foreground">
               {t('Phases')}
             </span>
-            <span className="text-base text-foreground">{phasesCount}</span>
+            <span className="text-base">{phasesCount}</span>
           </div>
           <div className="mt-2 border-t border-border" />
         </div>
@@ -164,9 +162,7 @@ export function SummarySectionInner({
               <span className="text-base text-muted-foreground">
                 {t('Categories')}
               </span>
-              <span className="text-base text-foreground">
-                {categories.length}
-              </span>
+              <span className="text-base">{categories.length}</span>
             </div>
             <div className="mt-2 border-t border-border" />
           </div>
@@ -175,7 +171,7 @@ export function SummarySectionInner({
           <span className="text-base text-muted-foreground">
             {t('Participants Invited')}
           </span>
-          <span className="text-base text-foreground">{participantsCount}</span>
+          <span className="text-base">{participantsCount}</span>
         </div>
       </div>
     </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
@@ -133,9 +133,7 @@ export function CategoryReviewerCard({
       data-testid={`category-reviewer-card-${category.name}`}
     >
       <div className="flex items-end justify-between gap-2">
-        <span className="font-serif text-title-sm14 text-foreground">
-          {category.name}
-        </span>
+        <span className="font-serif text-title-sm14">{category.name}</span>
         <span
           className={
             isEmpty
@@ -193,9 +191,7 @@ export function CategoryReviewerCard({
                   <Avatar className="size-6 shrink-0">
                     <AvatarFallback name={reviewer.profile.name} />
                   </Avatar>
-                  <span className="text-base text-foreground">
-                    {reviewer.profile.name}
-                  </span>
+                  <span className="text-base">{reviewer.profile.name}</span>
                 </div>
                 <Button
                   variant="ghost"

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCards.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCards.tsx
@@ -101,7 +101,7 @@ function CategoryReviewerCardsContent({
           </AlertTitle>
         </Alert>
       ) : (
-        <p className="text-base text-foreground">
+        <p className="text-base">
           {t.rich(
             'Categories come from <link>Proposal Categories</link>. Add reviewers to each, or invite someone new.',
             {

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -512,7 +512,7 @@ function SingleSelectCriterionConfig({
     }
     return (
       <div className="flex items-center gap-2">
-        <LuGripVertical className="size-4 text-neutral-gray3" />
+        <LuGripVertical className="size-4 text-muted-foreground" />
         <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 shadow-lg">
           {item.value || t('Option')}
         </span>
@@ -591,7 +591,7 @@ function SingleSelectCriterionConfig({
                 <DragHandle
                   {...dragHandleProps}
                   aria-label={t('Drag to reorder option')}
-                  className="text-neutral-gray3 hover:text-muted-foreground"
+                  className="text-muted-foreground hover:text-muted-foreground"
                 />
                 <Input
                   value={option.value}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -398,7 +398,7 @@ function ScoredCriterionConfig({
       />
 
       <div className="space-y-2">
-        <h4 className="text-foreground">{t('Define what each score means')}</h4>
+        <h4>{t('Define what each score means')}</h4>
         <p className="text-sm">
           {t(
             'Help reviewers score consistently by describing what each point value represents',
@@ -513,7 +513,7 @@ function SingleSelectCriterionConfig({
     return (
       <div className="flex items-center gap-2">
         <LuGripVertical className="size-4 text-neutral-gray3" />
-        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 text-foreground shadow-lg">
+        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 shadow-lg">
           {item.value || t('Option')}
         </span>
       </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -242,10 +242,7 @@ export function RubricCriterionCard({
           {/* Footer: Required toggle + Delete button */}
           <div className="flex items-center justify-between gap-4 border-t pt-4">
             <Field orientation="horizontal" className="w-auto">
-              <FieldLabel
-                className="text-foreground"
-                htmlFor={requiredToggleId}
-              >
+              <FieldLabel htmlFor={requiredToggleId}>
                 {t('Required?')}
               </FieldLabel>
               <Switch

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -243,7 +243,7 @@ export function RubricCriterionCard({
           <div className="flex items-center justify-between gap-4 border-t pt-4">
             <Field orientation="horizontal" className="w-auto">
               <FieldLabel
-                className="text-neutral-charcoal"
+                className="text-foreground"
                 htmlFor={requiredToggleId}
               >
                 {t('Required?')}
@@ -513,7 +513,7 @@ function SingleSelectCriterionConfig({
     return (
       <div className="flex items-center gap-2">
         <LuGripVertical className="size-4 text-neutral-gray3" />
-        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 text-neutral-charcoal shadow-lg">
+        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 text-foreground shadow-lg">
           {item.value || t('Option')}
         </span>
       </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldCard.tsx
@@ -250,10 +250,7 @@ export function FieldCard({
         {/* Footer: Required toggle + Delete button */}
         <div className="flex items-center justify-between gap-4 border-t pt-4">
           <Field orientation="horizontal" className="w-auto">
-            <FieldLabel
-              className="text-neutral-charcoal"
-              htmlFor={requiredToggleId}
-            >
+            <FieldLabel className="text-foreground" htmlFor={requiredToggleId}>
               {t('Required?')}
             </FieldLabel>
             <Switch

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldCard.tsx
@@ -240,7 +240,7 @@ export function FieldCard({
         {errors.length > 0 && (
           <div className="space-y-1">
             {errors.map((error) => (
-              <p key={error} className="text-functional-red">
+              <p key={error} className="text-destructive">
                 {t(error as TranslationKey)}
               </p>
             ))}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldCard.tsx
@@ -250,9 +250,7 @@ export function FieldCard({
         {/* Footer: Required toggle + Delete button */}
         <div className="flex items-center justify-between gap-4 border-t pt-4">
           <Field orientation="horizontal" className="w-auto">
-            <FieldLabel className="text-foreground" htmlFor={requiredToggleId}>
-              {t('Required?')}
-            </FieldLabel>
+            <FieldLabel htmlFor={requiredToggleId}>{t('Required?')}</FieldLabel>
             <Switch
               id={requiredToggleId}
               checked={isLocation || field.required}

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
@@ -87,7 +87,7 @@ function FieldConfigDropdownOptions({
     }
     return (
       <div className="flex items-center gap-2">
-        <LuGripVertical className="size-4 text-neutral-gray3" />
+        <LuGripVertical className="size-4 text-muted-foreground" />
         <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 shadow-lg">
           {item.value || t('Option')}
         </span>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
@@ -88,7 +88,7 @@ function FieldConfigDropdownOptions({
     return (
       <div className="flex items-center gap-2">
         <LuGripVertical className="size-4 text-neutral-gray3" />
-        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 text-foreground shadow-lg">
+        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 shadow-lg">
           {item.value || t('Option')}
         </span>
       </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/FieldConfigDropdown.tsx
@@ -88,7 +88,7 @@ function FieldConfigDropdownOptions({
     return (
       <div className="flex items-center gap-2">
         <LuGripVertical className="size-4 text-neutral-gray3" />
-        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 text-neutral-charcoal shadow-lg">
+        <span className="me-12 grow rounded-lg border border-input bg-white px-4 py-3 text-foreground shadow-lg">
           {item.value || t('Option')}
         </span>
       </div>

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/TemplateEditorContent.tsx
@@ -388,13 +388,13 @@ export function TemplateEditorContent({
                 }
                 locked
               >
-                <div className="-mt-4 px-11 pb-4">
-                  <p className="m-0">
+                <div className="-mt-3 px-11 pb-4">
+                  <p className="m-0 text-sm">
                     {t('These are the categories you defined in')}{' '}
                     <Button
                       variant="link"
                       size="inline"
-                      className="inline"
+                      className="inline text-sm underline"
                       onClick={() => {
                         void setStep('general');
                         void setSection('proposalCategories');

--- a/apps/app/src/components/decisions/ProcessSurveyModal.tsx
+++ b/apps/app/src/components/decisions/ProcessSurveyModal.tsx
@@ -258,7 +258,7 @@ export const ProcessSurveyModal = ({
           className="flex min-h-0 flex-1 flex-col gap-0"
         >
           <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-6 py-4">
-            <p className="text-base text-neutral-charcoal">
+            <p className="text-base text-foreground">
               {t(
                 'Take our 1-minute survey. Your responses are always anonymous.',
               )}

--- a/apps/app/src/components/decisions/ProcessSurveyModal.tsx
+++ b/apps/app/src/components/decisions/ProcessSurveyModal.tsx
@@ -258,7 +258,7 @@ export const ProcessSurveyModal = ({
           className="flex min-h-0 flex-1 flex-col gap-0"
         >
           <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-6 py-4">
-            <p className="text-base text-foreground">
+            <p className="text-base">
               {t(
                 'Take our 1-minute survey. Your responses are always anonymous.',
               )}

--- a/apps/app/src/components/decisions/ProfileInviteModal.tsx
+++ b/apps/app/src/components/decisions/ProfileInviteModal.tsx
@@ -548,9 +548,7 @@ function ProfileInviteModalContent({
         {/* People list for current role */}
         <div className="flex flex-col gap-2">
           {!hasNoItems && (
-            <span className="text-sm text-foreground">
-              {t('People with access')}
-            </span>
+            <span className="text-sm">{t('People with access')}</span>
           )}
 
           <div className="flex flex-col gap-2">
@@ -648,7 +646,7 @@ function ProfileInviteModalContent({
       </div>
 
       <DialogFooter className="flex-row items-center justify-between sm:justify-between">
-        <div className="text-base text-foreground">
+        <div className="text-base">
           {totalPeople > 0
             ? t('{count, plural, =1 {1 person} other {# people}}', {
                 count: totalPeople,

--- a/apps/app/src/components/decisions/ProfileUsersAccessTable.tsx
+++ b/apps/app/src/components/decisions/ProfileUsersAccessTable.tsx
@@ -485,13 +485,11 @@ const MobileProfileUserCard = ({
                 {displayName}
               </Link>
             ) : (
-              <span className="text-base text-foreground">{displayName}</span>
+              <span className="text-base">{displayName}</span>
             )}
             <span className="text-sm text-muted-foreground">{status}</span>
           </div>
-          <span className="truncate text-base text-foreground">
-            {profileUser.email}
-          </span>
+          <span className="truncate text-base">{profileUser.email}</span>
         </div>
       </div>
       <ProfileUserRoleSelect
@@ -532,15 +530,13 @@ const MobileInviteCard = ({
         />
         <div className="flex min-w-0 flex-col gap-1">
           <div className="flex flex-col">
-            <span className="text-base text-foreground">{displayName}</span>
+            <span className="text-base">{displayName}</span>
             <InviteStatusLabel
               notifiedAt={invite.notifiedAt}
               isDraft={isDraft}
             />
           </div>
-          <span className="truncate text-base text-foreground">
-            {invite.email}
-          </span>
+          <span className="truncate text-base">{invite.email}</span>
         </div>
       </div>
       <InviteRoleSelect
@@ -726,9 +722,7 @@ const ProfileUsersAccessTableContent = ({
                       profile={invite.inviteeProfile ?? { email: invite.email }}
                     />
                     <div className="flex min-w-0 flex-col">
-                      <span className="truncate text-base text-foreground">
-                        {displayName}
-                      </span>
+                      <span className="truncate text-base">{displayName}</span>
                       <InviteStatusLabel
                         notifiedAt={invite.notifiedAt}
                         isDraft={isDraft}
@@ -737,7 +731,7 @@ const ProfileUsersAccessTableContent = ({
                   </div>
                 </TableCell>
                 <TableCell>
-                  <span className="block truncate text-base text-foreground">
+                  <span className="block truncate text-base">
                     {invite.email}
                   </span>
                 </TableCell>
@@ -780,7 +774,7 @@ const ProfileUsersAccessTableContent = ({
                           {displayName}
                         </Link>
                       ) : (
-                        <span className="truncate text-base text-foreground">
+                        <span className="truncate text-base">
                           {displayName}
                         </span>
                       )}
@@ -791,7 +785,7 @@ const ProfileUsersAccessTableContent = ({
                   </div>
                 </TableCell>
                 <TableCell>
-                  <span className="block truncate text-base text-foreground">
+                  <span className="block truncate text-base">
                     {profileUser.email}
                   </span>
                 </TableCell>

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -134,7 +134,7 @@ const PromoteAccountModalContent = ({
           </Button>
         </section>
 
-        <section className="flex flex-col gap-2.5 rounded-xl border border-border bg-neutral-off-white p-4 text-start">
+        <section className="flex flex-col gap-2.5 rounded-xl border border-border bg-muted p-4 text-start">
           <div className="flex items-center gap-1">
             <LuUserRoundPlus className="size-4 text-foreground" aria-hidden />
             <span className="font-serif text-title-sm">

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -5,7 +5,7 @@ import { Button } from '@op/sense/Button';
 import { Checkbox } from '@op/sense/Checkbox';
 import { Dialog, DialogContent } from '@op/sense/Dialog';
 import { Field, FieldLabel } from '@op/sense/Field';
-import { Header1 } from '@op/sense/Header';
+import { Header2 } from '@op/sense/Header';
 import { CheckIcon } from '@op/sense/icons';
 import { useQueryState } from 'nuqs';
 import { type ReactNode, useState } from 'react';
@@ -40,7 +40,7 @@ export const PromoteAccountModal = () => {
 
   return (
     <Dialog open={isOpen}>
-      <DialogContent showCloseButton={false} className="sm:max-w-[29rem]">
+      <DialogContent showCloseButton={false} className="sm:max-w-lg">
         <PromoteAccountModalContent
           onContinueAsGuest={close}
           proposalId={proposalId}
@@ -83,7 +83,7 @@ const PromoteAccountModalContent = ({
       <div className="flex flex-col items-center gap-4 text-center">
         <CheckIcon />
         <div className="flex flex-col gap-2">
-          <Header1>{t('Your idea was submitted.')}</Header1>
+          <Header2>{t('Your idea was submitted.')}</Header2>
           <p className="text-base">{t('Want to follow what happens next?')}</p>
         </div>
       </div>

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -84,7 +84,7 @@ const PromoteAccountModalContent = ({
         <CheckIcon />
         <div className="flex flex-col gap-2">
           <Header1>{t('Your idea was submitted.')}</Header1>
-          <p className="text-base text-neutral-charcoal">
+          <p className="text-base text-foreground">
             {t('Want to follow what happens next?')}
           </p>
         </div>
@@ -93,15 +93,12 @@ const PromoteAccountModalContent = ({
       <div className="flex flex-col gap-4">
         <section className="flex flex-col gap-2.5 rounded-xl border border-border bg-white p-4 text-start">
           <div className="flex items-center gap-1">
-            <LuUserRoundMinus
-              className="size-4 text-neutral-charcoal"
-              aria-hidden
-            />
-            <span className="font-serif text-title-sm text-neutral-charcoal">
+            <LuUserRoundMinus className="size-4 text-foreground" aria-hidden />
+            <span className="font-serif text-title-sm text-foreground">
               {t('Continue as a guest')}
             </span>
           </div>
-          <p className="text-base text-neutral-charcoal">
+          <p className="text-base text-foreground">
             {t('Stay anonymous. React to comments with emoji.')}
           </p>
           {/* TODO(anon-upgrade): this checkbox only gates the button; ToS/privacy
@@ -141,15 +138,12 @@ const PromoteAccountModalContent = ({
 
         <section className="flex flex-col gap-2.5 rounded-xl border border-border bg-neutral-off-white p-4 text-start">
           <div className="flex items-center gap-1">
-            <LuUserRoundPlus
-              className="size-4 text-neutral-charcoal"
-              aria-hidden
-            />
-            <span className="font-serif text-title-sm text-neutral-charcoal">
+            <LuUserRoundPlus className="size-4 text-foreground" aria-hidden />
+            <span className="font-serif text-title-sm text-foreground">
               {t('With an account')}
             </span>
           </div>
-          <p className="text-base text-neutral-charcoal">
+          <p className="text-base text-foreground">
             {t(
               'Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.',
             )}

--- a/apps/app/src/components/decisions/PromoteAccountModal.tsx
+++ b/apps/app/src/components/decisions/PromoteAccountModal.tsx
@@ -84,9 +84,7 @@ const PromoteAccountModalContent = ({
         <CheckIcon />
         <div className="flex flex-col gap-2">
           <Header1>{t('Your idea was submitted.')}</Header1>
-          <p className="text-base text-foreground">
-            {t('Want to follow what happens next?')}
-          </p>
+          <p className="text-base">{t('Want to follow what happens next?')}</p>
         </div>
       </div>
 
@@ -94,11 +92,11 @@ const PromoteAccountModalContent = ({
         <section className="flex flex-col gap-2.5 rounded-xl border border-border bg-white p-4 text-start">
           <div className="flex items-center gap-1">
             <LuUserRoundMinus className="size-4 text-foreground" aria-hidden />
-            <span className="font-serif text-title-sm text-foreground">
+            <span className="font-serif text-title-sm">
               {t('Continue as a guest')}
             </span>
           </div>
-          <p className="text-base text-foreground">
+          <p className="text-base">
             {t('Stay anonymous. React to comments with emoji.')}
           </p>
           {/* TODO(anon-upgrade): this checkbox only gates the button; ToS/privacy
@@ -139,11 +137,11 @@ const PromoteAccountModalContent = ({
         <section className="flex flex-col gap-2.5 rounded-xl border border-border bg-neutral-off-white p-4 text-start">
           <div className="flex items-center gap-1">
             <LuUserRoundPlus className="size-4 text-foreground" aria-hidden />
-            <span className="font-serif text-title-sm text-foreground">
+            <span className="font-serif text-title-sm">
               {t('With an account')}
             </span>
           </div>
-          <p className="text-base text-foreground">
+          <p className="text-base">
             {t(
               'Edit your idea before review begins, get notified when it moves to the next phase, and like, comment, and follow other ideas.',
             )}

--- a/apps/app/src/components/decisions/ProposalContentRenderer.tsx
+++ b/apps/app/src/components/decisions/ProposalContentRenderer.tsx
@@ -117,7 +117,7 @@ function FieldChrome({
         <div className="flex flex-col gap-2">
           {title && <Header3 dir="auto">{title}</Header3>}
           {description && (
-            <p dir="auto" className="text-sm text-foreground">
+            <p dir="auto" className="text-sm">
               {description}
             </p>
           )}

--- a/apps/app/src/components/decisions/ProposalCount.tsx
+++ b/apps/app/src/components/decisions/ProposalCount.tsx
@@ -13,7 +13,7 @@ export const ProposalCount = ({
   const narrowed = total != null && count < total;
   if (!narrowed) {
     return (
-      <span className="font-serif text-title-base text-foreground">
+      <span className="font-serif text-title-base">
         <TranslatedText
           text="{count, plural, one {# proposal} other {# proposals}}"
           values={{ count: total ?? count }}
@@ -23,9 +23,7 @@ export const ProposalCount = ({
   }
   return (
     <span className="flex items-baseline gap-1">
-      <span className="font-serif text-title-base text-foreground">
-        {count}
-      </span>
+      <span className="font-serif text-title-base">{count}</span>
       <span className="text-base text-muted-foreground">
         <TranslatedText
           text="of {total, plural, one {# proposal} other {# proposals}}"

--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -227,7 +227,7 @@ export function ProposalPreview({
                 />
                 <div className="flex flex-col">
                   {proposal.submittedBy.isAnonymous || !canLinkToProfile ? (
-                    <span className="text-base text-foreground">
+                    <span className="text-base">
                       {proposal.submittedBy.name || proposal.submittedBy.slug}
                     </span>
                   ) : (

--- a/apps/app/src/components/decisions/ProposalRevisionSubmittedPanel.tsx
+++ b/apps/app/src/components/decisions/ProposalRevisionSubmittedPanel.tsx
@@ -23,7 +23,7 @@ export function ProposalRevisionSubmittedPanel({
       <div className="flex flex-col gap-4 border-b border-border pb-4">
         <Header3>{t('Revision submitted')}</Header3>
 
-        <p className="text-base text-foreground">
+        <p className="text-base">
           {t(
             'Your revision has been submitted and reviewers have been notified.',
           )}

--- a/apps/app/src/components/decisions/ProposalsFilterBar.tsx
+++ b/apps/app/src/components/decisions/ProposalsFilterBar.tsx
@@ -21,9 +21,7 @@ export const ProposalsListHeader = ({
   const t = useTranslations();
   if (hideFilters) {
     return (
-      <span className="font-serif text-title-base text-foreground">
-        {t('My proposals')}
-      </span>
+      <span className="font-serif text-title-base">{t('My proposals')}</span>
     );
   }
   return <ProposalCount count={count} total={total} />;

--- a/apps/app/src/components/decisions/ProposalsGrid.tsx
+++ b/apps/app/src/components/decisions/ProposalsGrid.tsx
@@ -428,7 +428,7 @@ const VotingProposalsList = ({
       {canVote && !isReadOnly && (
         <FooterBar position="fixed" className="bg-muted/95">
           <FooterBarStart>
-            <span className="text-base text-foreground">
+            <span className="text-base">
               {maxVotesPerMember !== undefined
                 ? t.rich(
                     '<highlight>{numSelected}</highlight> of {max, plural, one {# proposal} other {# proposals}} selected',

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -551,7 +551,7 @@ const ProposalsListContent = ({
             <APIErrorBoundary
               fallbacks={{
                 default: () => (
-                  <div className="py-8 text-center text-sm text-foreground">
+                  <div className="py-8 text-center text-sm">
                     {t("Couldn't load the map. Refresh to try again.")}
                   </div>
                 ),

--- a/apps/app/src/components/decisions/ProposalsList.tsx
+++ b/apps/app/src/components/decisions/ProposalsList.tsx
@@ -551,7 +551,7 @@ const ProposalsListContent = ({
             <APIErrorBoundary
               fallbacks={{
                 default: () => (
-                  <div className="py-8 text-center text-sm text-neutral-charcoal">
+                  <div className="py-8 text-center text-sm text-foreground">
                     {t("Couldn't load the map. Refresh to try again.")}
                   </div>
                 ),

--- a/apps/app/src/components/decisions/ProposalsStickyFilterBar.tsx
+++ b/apps/app/src/components/decisions/ProposalsStickyFilterBar.tsx
@@ -82,7 +82,7 @@ export const ProposalsStickyFilterBar = ({
           />
           {hasLocationField && (
             <div className="hidden items-center gap-4 sm:flex">
-              <span aria-hidden className="h-6 w-px bg-neutral-gray2" />
+              <span aria-hidden className="h-6 w-px bg-border" />
               <ProposalViewToggle
                 value={effectiveView}
                 onChange={onViewChange}

--- a/apps/app/src/components/decisions/ReportProposalDialog.tsx
+++ b/apps/app/src/components/decisions/ReportProposalDialog.tsx
@@ -63,7 +63,7 @@ export function ReportProposalDialog({ proposalId }: { proposalId: string }) {
           </DialogHeader>
 
           <div className="px-6 py-4">
-            <p className="text-base text-foreground">
+            <p className="text-base">
               {t(
                 "This proposal will be sent to an independent moderation service for review. It stays visible while the review is in progress. If it violates Common's Code of Conduct, it will be hidden and the author will be notified.",
               )}

--- a/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
+++ b/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
@@ -39,7 +39,7 @@ export function AuthorRevisionNote({
         <div className="flex flex-col gap-2">
           <p
             dir="auto"
-            className="text-base whitespace-pre-wrap text-neutral-charcoal"
+            className="text-base whitespace-pre-wrap text-foreground"
           >
             {comment}
           </p>

--- a/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
+++ b/apps/app/src/components/decisions/Review/AuthorRevisionNote.tsx
@@ -33,14 +33,9 @@ export function AuthorRevisionNote({
   return (
     <>
       <div className="flex flex-col gap-3 rounded-lg bg-muted p-4">
-        <span className="font-serif text-title-sm14 text-foreground">
-          {t("Author's note")}
-        </span>
+        <span className="font-serif text-title-sm14">{t("Author's note")}</span>
         <div className="flex flex-col gap-2">
-          <p
-            dir="auto"
-            className="text-base whitespace-pre-wrap text-foreground"
-          >
+          <p dir="auto" className="text-base whitespace-pre-wrap">
             {comment}
           </p>
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">

--- a/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
@@ -45,7 +45,7 @@ export function TotalScoreCard({
   return (
     // The one filled row in the panel: a 16/450 label against a 20px figure.
     <Card className="flex-row items-center justify-between bg-muted p-4">
-      <span className="text-base font-strong text-foreground">
+      <span className="text-base font-strong">
         <TranslatedText text="Total score:" />
       </span>
       <span className="font-serif text-title">{display}</span>

--- a/apps/app/src/components/decisions/Review/ReviewProgressStats.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewProgressStats.tsx
@@ -108,7 +108,7 @@ function ReviewProgressStat({
     <div
       className={cn(
         'flex flex-col items-center',
-        hasImage ? 'text-white' : 'text-neutral-charcoal',
+        hasImage ? 'text-white' : 'text-foreground',
       )}
     >
       <span className="font-serif text-title-lg">{value}</span>

--- a/apps/app/src/components/decisions/Review/ReviewProgressStats.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewProgressStats.tsx
@@ -118,5 +118,5 @@ function ReviewProgressStat({
 }
 
 function Divider() {
-  return <div className="h-8 w-px bg-neutral-gray2" />;
+  return <div className="h-8 w-px bg-border" />;
 }

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -113,13 +113,9 @@ function ResultCard({
     <div className="mt-1 flex flex-col gap-3 rounded-lg border p-6">
       {hasTopRow && (
         <div className="flex items-start gap-4">
-          {hasValue && (
-            <span className="font-serif text-title text-foreground">
-              {value}
-            </span>
-          )}
+          {hasValue && <span className="font-serif text-title">{value}</span>}
           {hasDescription && (
-            <div className="mt-0.75 min-w-0 flex-1 text-base whitespace-pre-wrap text-foreground">
+            <div className="mt-0.75 min-w-0 flex-1 text-base whitespace-pre-wrap">
               {description}
             </div>
           )}

--- a/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
+++ b/apps/app/src/components/decisions/Review/ViewRevisionRequestModal.tsx
@@ -54,12 +54,10 @@ export function ViewRevisionRequestModal({
         </DialogHeader>
 
         <div className="flex flex-col gap-2 px-6 py-4">
-          <span className="text-base text-foreground">
-            {t('Feedback to Author')}
-          </span>
+          <span className="text-base">{t('Feedback to Author')}</span>
 
           <div className="flex flex-col gap-2 rounded-lg border border-border p-3">
-            <p dir="auto" className="text-base text-foreground">
+            <p dir="auto" className="text-base">
               {revisionRequest.requestComment}
             </p>
             {sentDate && (

--- a/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionList.tsx
+++ b/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionList.tsx
@@ -101,13 +101,11 @@ export function ReviewSelectionList({
     <div className="flex flex-col gap-6 pb-20">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-2">
-          <span className="font-serif text-title-base text-foreground">
+          <span className="font-serif text-title-base">
             {t('All proposals')}
           </span>
           <Bullet />
-          <span className="font-serif text-title-base text-foreground">
-            {total}
-          </span>
+          <span className="font-serif text-title-base">{total}</span>
         </div>
       </div>
 

--- a/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionTable.tsx
+++ b/apps/app/src/components/decisions/ReviewSelection/ReviewSelectionTable.tsx
@@ -119,7 +119,7 @@ export function ReviewSelectionTable({
                 </div>
               </TableCell>
               <TableCell>
-                <span className="text-base text-foreground">
+                <span className="text-base">
                   {budget
                     ? formatCurrency(budget.amount, undefined, budget.currency)
                     : '—'}
@@ -136,7 +136,7 @@ export function ReviewSelectionTable({
                 />
               </TableCell>
               <TableCell>
-                <span className="text-base text-foreground">
+                <span className="text-base">
                   <ScoreText value={item.aggregates.averageScore} />
                 </span>
               </TableCell>
@@ -221,7 +221,7 @@ function ProposalCard({
 
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
         {budget && (
-          <span className="text-base text-foreground">
+          <span className="text-base">
             {formatCurrency(budget.amount, undefined, budget.currency)}
           </span>
         )}
@@ -233,7 +233,7 @@ function ProposalCard({
       />
 
       <div className="flex items-center justify-between">
-        <span className="text-base text-foreground">
+        <span className="text-base">
           <ScoreText value={item.aggregates.averageScore} />
         </span>
         <AdvanceToggleButton
@@ -254,7 +254,7 @@ function RecommendationCounts({
   const t = useTranslations();
 
   return (
-    <div className="flex flex-wrap items-center gap-4 text-base text-foreground">
+    <div className="flex flex-wrap items-center gap-4 text-base">
       {Object.values(RECOMMENDATION_OPTION).map((opt) => (
         <CountLabel
           key={opt.value}

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryAdvanceFooter.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryAdvanceFooter.tsx
@@ -44,7 +44,7 @@ export function ReviewSummaryAdvanceFooter({
   return (
     <FooterBar position="fixed" className="bg-muted/95">
       <FooterBarStart>
-        <span className="flex items-center gap-2 text-base text-foreground">
+        <span className="flex items-center gap-2 text-base">
           <LuCircleCheck className="size-4 text-muted-foreground" aria-hidden />
           {t('{count} proposals advancing', { count })}
         </span>

--- a/apps/app/src/components/decisions/ReviewsPanel/AverageScoreBar.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/AverageScoreBar.tsx
@@ -14,10 +14,8 @@ export function AverageScoreBar({
   const t = useTranslations();
   return (
     <div className="flex items-center justify-between rounded-lg bg-muted p-4">
-      <span className="font-serif text-title-sm text-foreground">
-        {t('Average Score')}
-      </span>
-      <span className="font-serif text-title-sm text-foreground">
+      <span className="font-serif text-title-sm">{t('Average Score')}</span>
+      <span className="font-serif text-title-sm">
         {formatScore(averageScore)}
         <span className="text-muted-foreground">/{totalPoints}pts</span>
       </span>

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerDetail.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerDetail.tsx
@@ -74,9 +74,7 @@ export function ReviewerDetail({
               <StatusDot
                 intent={recommendationIntent(item.overallRecommendation)}
               >
-                <span className="text-sm text-foreground">
-                  {recommendationLabel}
-                </span>
+                <span className="text-sm">{recommendationLabel}</span>
               </StatusDot>
             )}
             {hasScoring && (

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
@@ -64,7 +64,7 @@ export function ReviewerList({
       {!hideSummaryHeader && (
         <header className="flex flex-col gap-2">
           <Header3 className="font-serif">{t('Review Summary')}</Header3>
-          <p className="text-base text-foreground">
+          <p className="text-base">
             {t(
               '{submitted} out of {total} reviewers submitted a review for this proposal',
               { submitted: reviewsSubmittedCount, total: assignmentsCount },
@@ -172,7 +172,7 @@ function RecommendationGroup({
   return (
     <div className="flex flex-col gap-4">
       <StatusDot intent={recommendationIntent(value)} className="gap-2">
-        <span className="font-serif !text-title-sm14 text-foreground">
+        <span className="font-serif !text-title-sm14">
           {label} ({count})
         </span>
       </StatusDot>
@@ -212,11 +212,11 @@ function ReviewerRow({
           className="size-6"
         />
         <div className="flex flex-col">
-          <span className="text-base text-foreground">
+          <span className="text-base">
             {item.reviewer.name ?? item.reviewer.slug}
           </span>
           {showScore && (
-            <span className="text-sm text-foreground">
+            <span className="text-sm">
               {item.score}
               <span className="text-muted-foreground">/{totalPoints}pts</span>
             </span>

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
@@ -64,7 +64,7 @@ export function ReviewerList({
       {!hideSummaryHeader && (
         <header className="flex flex-col gap-2">
           <Header3 className="font-serif">{t('Review Summary')}</Header3>
-          <p className="text-base text-neutral-charcoal">
+          <p className="text-base text-foreground">
             {t(
               '{submitted} out of {total} reviewers submitted a review for this proposal',
               { submitted: reviewsSubmittedCount, total: assignmentsCount },

--- a/apps/app/src/components/decisions/ShareProposalModal.tsx
+++ b/apps/app/src/components/decisions/ShareProposalModal.tsx
@@ -453,9 +453,7 @@ function ShareProposalModalContent({
         </Combobox>
 
         <div className="flex flex-col gap-2">
-          <span className="text-sm text-foreground">
-            {t('People with access')}
-          </span>
+          <span className="text-sm">{t('People with access')}</span>
 
           <div className="flex flex-col gap-2">
             {pendingInvites.map((item) => (

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -95,7 +95,7 @@ const SlashCommandsList = forwardRef<
             className={`flex w-full items-center space-x-2 rounded-md px-2 py-1 text-start hover:bg-secondary ${
               index === selectedIndex
                 ? 'bg-secondary text-foreground'
-                : 'text-neutral-charcoal'
+                : 'text-foreground'
             }`}
             key={index}
             onClick={() => selectItem(index)}

--- a/apps/app/src/components/decisions/SlashCommands.tsx
+++ b/apps/app/src/components/decisions/SlashCommands.tsx
@@ -105,7 +105,9 @@ const SlashCommandsList = forwardRef<
             </div>
             <div>
               <p className="font-medium">{item.title}</p>
-              <p className="text-xs text-neutral-gray2">{item.description}</p>
+              <p className="text-xs text-muted-foreground">
+                {item.description}
+              </p>
             </div>
           </button>
         ))

--- a/apps/app/src/components/decisions/StandardSelectionFooter.tsx
+++ b/apps/app/src/components/decisions/StandardSelectionFooter.tsx
@@ -38,7 +38,7 @@ export const StandardSelectionFooter = ({
   return (
     <FooterBar position="fixed" className="bg-muted/95">
       <FooterBarStart>
-        <span className="flex items-center gap-2 text-base text-foreground">
+        <span className="flex items-center gap-2 text-base">
           <LuCircleCheck className="size-5 shrink-0" aria-hidden />
           {t('{count} proposals selected', { count: numSelected })}
         </span>
@@ -56,7 +56,7 @@ export const StandardSelectionFooter = ({
           onConfirm={onConfirm}
         >
           <div className="space-y-4">
-            <p className="text-base text-foreground">
+            <p className="text-base">
               {t(
                 'These {numProposals} proposals will move on to the {phaseName} phase',
                 { numProposals: numSelected, phaseName },

--- a/apps/app/src/components/decisions/StandardSelectionFooter.tsx
+++ b/apps/app/src/components/decisions/StandardSelectionFooter.tsx
@@ -56,7 +56,7 @@ export const StandardSelectionFooter = ({
           onConfirm={onConfirm}
         >
           <div className="space-y-4">
-            <p className="text-base text-neutral-charcoal">
+            <p className="text-base text-foreground">
               {t(
                 'These {numProposals} proposals will move on to the {phaseName} phase',
                 { numProposals: numSelected, phaseName },

--- a/apps/app/src/components/decisions/ViewerCollapsible.tsx
+++ b/apps/app/src/components/decisions/ViewerCollapsible.tsx
@@ -38,7 +38,7 @@ export function ViewerCollapsibleSummary({
   return (
     <CollapsibleTrigger
       render={<button type="button" />}
-      className="group/summary flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-start font-serif text-lg text-foreground transition-colors outline-none hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50"
+      className="group/summary flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-start font-serif text-lg transition-colors outline-none hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50"
     >
       <LuChevronRight className="size-5 shrink-0 text-muted-foreground transition-transform group-data-panel-open/summary:rotate-90 rtl:-scale-x-100" />
       {/* The node's children are already-rendered prose, so they can't be

--- a/apps/app/src/components/decisions/VoteSuccessModal.tsx
+++ b/apps/app/src/components/decisions/VoteSuccessModal.tsx
@@ -72,7 +72,7 @@ const VoteSuccessModalSuspense = ({
               </div>
 
               {nextSteps.length > 0 && (
-                <div className="flex w-full flex-col gap-6 text-start text-base text-foreground">
+                <div className="flex w-full flex-col gap-6 text-start text-base">
                   <Header3 className="font-sans">
                     {t("Here's what will happen next:")}
                   </Header3>

--- a/apps/app/src/components/decisions/location/LocationMapField.tsx
+++ b/apps/app/src/components/decisions/location/LocationMapField.tsx
@@ -155,7 +155,7 @@ export function LocationMapField({
 
       <div
         className={`overflow-hidden rounded-lg border ${
-          isWithinArea ? 'border-border' : 'border-functional-red'
+          isWithinArea ? 'border-border' : 'border-destructive'
         }`}
       >
         <MapCanvas
@@ -173,9 +173,7 @@ export function LocationMapField({
         <div className="flex flex-col justify-between gap-2.5 p-4 sm:flex-row sm:items-center">
           <div className="flex min-w-0 flex-col gap-0.5">
             <span
-              className={
-                isWithinArea ? 'text-foreground' : 'text-functional-red'
-              }
+              className={isWithinArea ? 'text-foreground' : 'text-destructive'}
               dir="auto"
             >
               {/* While reverse geocoding is in flight `address` is undefined —
@@ -183,7 +181,7 @@ export function LocationMapField({
               {value ? value.address : t('No location selected')}
             </span>
             {!isWithinArea && (
-              <span className="text-sm text-functional-red">
+              <span className="text-sm text-destructive">
                 {t('This address is outside the allowed proposal area.')}
               </span>
             )}

--- a/apps/app/src/components/decisions/location/LocationMapView.tsx
+++ b/apps/app/src/components/decisions/location/LocationMapView.tsx
@@ -36,7 +36,7 @@ export function LocationMapView({ value }: LocationMapViewProps) {
         className="border-b border-border"
       />
       <div className="flex flex-col gap-0.5 p-4">
-        <span className="text-foreground" dir="auto">
+        <span dir="auto">
           {value.address ?? `${value.lat.toFixed(5)}, ${value.lng.toFixed(5)}`}
         </span>
       </div>

--- a/apps/app/src/components/decisions/location/LocationMapView.tsx
+++ b/apps/app/src/components/decisions/location/LocationMapView.tsx
@@ -23,7 +23,7 @@ export function LocationMapView({ value }: LocationMapViewProps) {
   const styleUrl = useMapStyleUrl();
 
   if (!value) {
-    return <p className="text-sm text-neutral-gray3 italic">—</p>;
+    return <p className="text-sm text-muted-foreground italic">—</p>;
   }
 
   return (

--- a/apps/app/src/components/decisions/location/LocationSearchField.tsx
+++ b/apps/app/src/components/decisions/location/LocationSearchField.tsx
@@ -154,7 +154,7 @@ export function LocationSearchField({
                 <span
                   className={
                     item.name
-                      ? 'truncate text-sm text-neutral-charcoal'
+                      ? 'truncate text-sm text-foreground'
                       : 'truncate text-foreground'
                   }
                   dir="auto"

--- a/apps/app/src/components/decisions/location/LocationSearchField.tsx
+++ b/apps/app/src/components/decisions/location/LocationSearchField.tsx
@@ -147,7 +147,7 @@ export function LocationSearchField({
                   "Starbucks" + "123 Main St", not as the bare street address. */}
               <div className="flex min-w-0 flex-col">
                 {item.name && (
-                  <span className="truncate text-foreground" dir="auto">
+                  <span className="truncate" dir="auto">
                     {item.name}
                   </span>
                 )}

--- a/apps/app/src/components/decisions/pages/ResultsPage.tsx
+++ b/apps/app/src/components/decisions/pages/ResultsPage.tsx
@@ -164,7 +164,7 @@ function ResultsPageContent({
       <FinalPhaseSubmissionSuccessDialog />
       <ProcessSurveyGate instanceId={instanceId} isLegacy={isLegacy} />
       {/* Hero section — owns the results gradient; the header above stays neutral */}
-      <div className="bg-redPurple px-4 pt-16 pb-8 text-neutral-offWhite md:pt-8">
+      <div className="bg-redPurple px-4 pt-16 pb-8 text-background md:pt-8">
         <div className="mx-auto flex max-w-3xl flex-col justify-center gap-4">
           <DecisionHero
             title={heroContent.title}

--- a/apps/app/src/components/decisions/pages/ResultsPage.tsx
+++ b/apps/app/src/components/decisions/pages/ResultsPage.tsx
@@ -164,7 +164,7 @@ function ResultsPageContent({
       <FinalPhaseSubmissionSuccessDialog />
       <ProcessSurveyGate instanceId={instanceId} isLegacy={isLegacy} />
       {/* Hero section — owns the results gradient; the header above stays neutral */}
-      <div className="bg-redPurple px-4 pt-16 pb-8 text-background md:pt-8">
+      <div className="bg-redPurple px-4 pt-16 pb-8 text-white md:pt-8">
         <div className="mx-auto flex max-w-3xl flex-col justify-center gap-4">
           <DecisionHero
             title={heroContent.title}

--- a/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
+++ b/apps/app/src/components/decisions/pages/StandardDecisionPage.tsx
@@ -127,7 +127,7 @@ export function StandardDecisionPage({
                 <EmptyTitle className="font-light">
                   {t('Results pending')}
                 </EmptyTitle>
-                <EmptyDescription className="text-base text-neutral-charcoal">
+                <EmptyDescription className="text-base text-foreground">
                   {t("Results for this process haven't been processed yet.")}
                 </EmptyDescription>
               </EmptyHeader>
@@ -144,7 +144,7 @@ export function StandardDecisionPage({
                       <EmptyTitle className="font-light">
                         {t("Couldn't load manual selection")}
                       </EmptyTitle>
-                      <EmptyDescription className="text-base text-neutral-charcoal">
+                      <EmptyDescription className="text-base text-foreground">
                         {t('Refresh the page to try again.')}
                       </EmptyDescription>
                     </EmptyHeader>
@@ -172,7 +172,7 @@ export function StandardDecisionPage({
                       <EmptyTitle className="font-light">
                         {t("Couldn't load proposals")}
                       </EmptyTitle>
-                      <EmptyDescription className="text-base text-neutral-charcoal">
+                      <EmptyDescription className="text-base text-foreground">
                         {t('Refresh the page to try again.')}
                       </EmptyDescription>
                     </EmptyHeader>

--- a/apps/app/src/components/decisions/proposalEditor/RevisionFeedbackCard.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/RevisionFeedbackCard.tsx
@@ -31,7 +31,7 @@ export function RevisionFeedbackCard({
       <p
         dir="auto"
         className={cn(
-          'text-base whitespace-pre-wrap text-foreground',
+          'text-base whitespace-pre-wrap',
           variant === 'reviewer' && 'italic',
         )}
       >

--- a/apps/app/src/components/decisions/proposalEditor/RevisionFeedbackPanel.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/RevisionFeedbackPanel.tsx
@@ -21,7 +21,7 @@ export function RevisionFeedbackPanel({
       <div className="flex flex-col gap-4 border-b pb-4">
         <Header3>{t('Revision feedback')}</Header3>
 
-        <p className="text-foreground">
+        <p>
           {t(
             'A reviewer has requested changes to your proposal. Edit your proposal and resubmit when ready.',
           )}
@@ -29,9 +29,7 @@ export function RevisionFeedbackPanel({
       </div>
 
       <div className="flex flex-col gap-4">
-        <span className="font-serif text-label text-foreground">
-          {t('Reviewer feedback')}
-        </span>
+        <span className="font-serif text-label">{t('Reviewer feedback')}</span>
 
         <RevisionFeedbackCard
           comment={revisionRequest.requestComment}

--- a/apps/app/src/components/decisions/proposalEditor/asides/ProposalVersionsAside.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/asides/ProposalVersionsAside.tsx
@@ -190,7 +190,7 @@ function VersionItem({
   );
   const rowContent = (
     <>
-      <span className="text-base font-strong text-foreground">{label}</span>
+      <span className="text-base font-strong">{label}</span>
       <span className="text-sm text-muted-foreground">{sublabel}</span>
     </>
   );

--- a/apps/app/src/components/decisions/proposalEditor/asides/RestoreProposalVersionModal.tsx
+++ b/apps/app/src/components/decisions/proposalEditor/asides/RestoreProposalVersionModal.tsx
@@ -59,7 +59,7 @@ export function RestoreProposalVersionModal({
           </span>
           <DialogTitle>{t('Restore this version?')}</DialogTitle>
         </DialogHeader>
-        <div className="flex flex-col gap-4 px-6 py-4 text-base text-foreground">
+        <div className="flex flex-col gap-4 px-6 py-4 text-base">
           <p>
             {t.rich(
               'Your proposal will be restored to the version from <bold>{date}</bold>.',

--- a/apps/app/src/components/layout/split/form/ToggleRow.tsx
+++ b/apps/app/src/components/layout/split/form/ToggleRow.tsx
@@ -45,7 +45,7 @@ export const ToggleRow = ({
       className={cn('rounded-xl py-2', className)}
     >
       <FieldContent>
-        <FieldLabel htmlFor={controlId} className="text-base text-foreground">
+        <FieldLabel htmlFor={controlId} className="text-base">
           {label}
         </FieldLabel>
         {description && (

--- a/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
+++ b/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
@@ -29,7 +29,7 @@ export const ComingSoonScreen = () => {
           initial={{ y: '-100%', opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
           transition={{ duration: 0.6, ease: [0, 0.71, 0.2, 1.01] }}
-          className="relative flex flex-wrap items-center justify-center gap-x-3 gap-y-1 bg-primary-tealWhite px-6 py-2.5 text-center text-foreground"
+          className="relative flex flex-wrap items-center justify-center gap-x-3 gap-y-1 bg-primary-tealWhite px-6 py-2.5 text-center"
         >
           <div className="pointer-events-none absolute inset-x-0 top-full h-30 bg-gradient-to-b from-[white] from-10% via-[rgba(255,255,255,0.35)] via-45%" />
           <p>
@@ -74,7 +74,7 @@ export const ComingSoonScreen = () => {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             transition={{ duration: 2, delay: 0.25 }}
           >
-            <h1 className="flex flex-col font-serif text-title-md font-normal text-balance text-foreground sm:text-3xl">
+            <h1 className="flex flex-col font-serif text-title-md font-normal text-balance sm:text-3xl">
               <span>
                 {t('Helping people decide together how to use their resources')}
               </span>

--- a/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
+++ b/apps/app/src/components/screens/ComingSoon/ComingSoonScreen.tsx
@@ -29,7 +29,7 @@ export const ComingSoonScreen = () => {
           initial={{ y: '-100%', opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
           transition={{ duration: 0.6, ease: [0, 0.71, 0.2, 1.01] }}
-          className="relative flex flex-wrap items-center justify-center gap-x-3 gap-y-1 bg-primary-tealWhite px-6 py-2.5 text-center text-neutral-charcoal"
+          className="relative flex flex-wrap items-center justify-center gap-x-3 gap-y-1 bg-primary-tealWhite px-6 py-2.5 text-center text-foreground"
         >
           <div className="pointer-events-none absolute inset-x-0 top-full h-30 bg-gradient-to-b from-[white] from-10% via-[rgba(255,255,255,0.35)] via-45%" />
           <p>
@@ -74,7 +74,7 @@ export const ComingSoonScreen = () => {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             transition={{ duration: 2, delay: 0.25 }}
           >
-            <h1 className="flex flex-col font-serif text-title-md font-normal text-balance text-neutral-charcoal sm:text-3xl">
+            <h1 className="flex flex-col font-serif text-title-md font-normal text-balance text-foreground sm:text-3xl">
               <span>
                 {t('Helping people decide together how to use their resources')}
               </span>

--- a/apps/app/src/components/screens/LandingScreen/Feed.tsx
+++ b/apps/app/src/components/screens/LandingScreen/Feed.tsx
@@ -96,7 +96,7 @@ const FeedContent = ({ limit = 10 }: { limit?: number }) => {
       )}
 
       {allPosts.length > 0 && !shouldShowTrigger && (
-        <p className="w-full p-4 text-center text-sm text-neutral-gray3">
+        <p className="w-full p-4 text-center text-sm text-muted-foreground">
           {t('No more updates.')}
         </p>
       )}

--- a/apps/app/src/components/screens/LandingScreen/index.tsx
+++ b/apps/app/src/components/screens/LandingScreen/index.tsx
@@ -156,7 +156,7 @@ const PostFeedSection = async ({
       <ErrorBoundary
         fallback={
           <div className="flex flex-col items-center justify-center py-8">
-            <span className="text-foreground">
+            <span>
               <TranslatedText text="Unable to load posts. Please try refreshing." />
             </span>
           </div>
@@ -217,7 +217,7 @@ const WelcomeSection = async () => {
   return (
     <div className="flex flex-col gap-2">
       <Welcome user={user} />
-      <span className="text-center text-foreground">
+      <span className="text-center">
         <TranslatedText text="Explore new connections and strengthen existing relationships." />
       </span>
     </div>

--- a/apps/app/src/components/screens/LandingScreen/index.tsx
+++ b/apps/app/src/components/screens/LandingScreen/index.tsx
@@ -156,7 +156,7 @@ const PostFeedSection = async ({
       <ErrorBoundary
         fallback={
           <div className="flex flex-col items-center justify-center py-8">
-            <span className="text-neutral-charcoal">
+            <span className="text-foreground">
               <TranslatedText text="Unable to load posts. Please try refreshing." />
             </span>
           </div>
@@ -217,7 +217,7 @@ const WelcomeSection = async () => {
   return (
     <div className="flex flex-col gap-2">
       <Welcome user={user} />
-      <span className="text-center text-neutral-charcoal">
+      <span className="text-center text-foreground">
         <TranslatedText text="Explore new connections and strengthen existing relationships." />
       </span>
     </div>

--- a/apps/app/src/components/screens/PlatformAdmin/AddUserToOrgModal.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/AddUserToOrgModal.tsx
@@ -150,7 +150,7 @@ const AddUserToOrgModalContent = ({
         {user.organizationUsers && user.organizationUsers.length > 0 ? (
           <>
             <div>
-              <div className="mb-2 text-sm font-medium text-foreground">
+              <div className="mb-2 text-sm font-medium">
                 {t('Current organizations')}
               </div>
               <div className="space-y-2">
@@ -356,9 +356,7 @@ const OrganizationAndRoleSelection = ({
                   return (
                     <ComboboxItem key={item.value} value={item}>
                       <div>
-                        <div className="leading-base text-foreground">
-                          {role.name}
-                        </div>
+                        <div className="leading-base">{role.name}</div>
                         {role.description ? (
                           <div className="text-xs text-muted-foreground">
                             {role.description}

--- a/apps/app/src/components/screens/PlatformAdmin/OrgMembersModal.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/OrgMembersModal.tsx
@@ -62,7 +62,7 @@ export const OrgMembersModal = ({
             </div>
           ) : (
             <div>
-              <div className="mb-2 text-sm font-medium text-foreground">
+              <div className="mb-2 text-sm font-medium">
                 {t('Members')} ({members.length})
               </div>
               <div className="space-y-2">

--- a/apps/app/src/components/screens/PlatformAdmin/PlatformStats.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/PlatformStats.tsx
@@ -77,7 +77,7 @@ const StatCard = ({
     >
       <div className="flex flex-col gap-2">
         <div className="text-muted-foreground">{label}</div>
-        <div className="font-serif text-title-xxl text-foreground">{value}</div>
+        <div className="font-serif text-title-xxl">{value}</div>
       </div>
     </Card>
   );

--- a/apps/app/src/components/screens/Profile/index.tsx
+++ b/apps/app/src/components/screens/Profile/index.tsx
@@ -145,7 +145,7 @@ export const Profile = ({
       {/* nav arrow */}
       <header className="absolute start-0 top-0 z-50 px-4 py-3 sm:hidden">
         <Link href="/">
-          <LuArrowLeft className="size-6 text-neutral-offWhite rtl:-scale-x-100" />
+          <LuArrowLeft className="size-6 text-background rtl:-scale-x-100" />
         </Link>
       </header>
       <div className="-mt-[3.05rem] flex w-full flex-col gap-3 border-offWhite border-b-transparent sm:mt-0 sm:min-h-[calc(100vh-3.5rem)] sm:gap-4 sm:border sm:border-offWhite">

--- a/apps/app/src/components/screens/Profile/index.tsx
+++ b/apps/app/src/components/screens/Profile/index.tsx
@@ -145,7 +145,7 @@ export const Profile = ({
       {/* nav arrow */}
       <header className="absolute start-0 top-0 z-50 px-4 py-3 sm:hidden">
         <Link href="/">
-          <LuArrowLeft className="size-6 text-background rtl:-scale-x-100" />
+          <LuArrowLeft className="size-6 text-white rtl:-scale-x-100" />
         </Link>
       </header>
       <div className="-mt-[3.05rem] flex w-full flex-col gap-3 border-offWhite border-b-transparent sm:mt-0 sm:min-h-[calc(100vh-3.5rem)] sm:gap-4 sm:border sm:border-offWhite">

--- a/apps/app/src/components/screens/ProfileOrganizations/index.tsx
+++ b/apps/app/src/components/screens/ProfileOrganizations/index.tsx
@@ -80,7 +80,7 @@ export const OrganizationNameSuspense = ({ slug }: { slug: string }) => {
       className="flex items-center gap-2"
     >
       <LuArrowLeft className="size-6 text-foreground rtl:-scale-x-100" />
-      <div className="flex items-center gap-1 text-sm font-semibold text-foreground">
+      <div className="flex items-center gap-1 text-sm font-semibold">
         <OrganizationAvatar profile={organization.profile} className="size-6" />
         {organization.profile.name}
       </div>

--- a/packages/sense/src/components/RichTextEditor/viewerStyles.ts
+++ b/packages/sense/src/components/RichTextEditor/viewerStyles.ts
@@ -15,7 +15,7 @@
  * `Header*` design-system components.
  */
 export const viewerProseStyles = [
-  'prose prose-lg !text-base text-neutral-black',
+  'prose prose-lg !text-base text-foreground',
   '[&_a:hover]:underline [&_a]:text-teal [&_a]:no-underline',
   '[&_li_p]:my-0',
   '[&_blockquote]:font-normal',
@@ -52,7 +52,7 @@ const placeholderStyles = [
   '[&_.is-editor-empty:first-child]:before:pointer-events-none',
   '[&_.is-editor-empty:first-child]:before:float-start',
   '[&_.is-editor-empty:first-child]:before:h-0',
-  '[&_.is-editor-empty:first-child]:before:text-neutral-gray3',
+  '[&_.is-editor-empty:first-child]:before:text-muted-foreground',
   '[&_.is-editor-empty:first-child]:before:content-[attr(data-placeholder)]',
 ].join(' ');
 
@@ -68,7 +68,7 @@ const detailsSummaryPlaceholderStyles = [
   // at the start of the summary, not after the placeholder text.
   '[&_summary.is-empty]:before:float-start',
   '[&_summary.is-empty]:before:h-0',
-  '[&_summary.is-empty]:before:text-neutral-gray3',
+  '[&_summary.is-empty]:before:text-muted-foreground',
   '[&_summary.is-empty]:before:content-[attr(data-placeholder)]',
   '[&_summary.is-empty]:before:font-serif',
 ].join(' ');
@@ -83,4 +83,4 @@ const detailsSummaryPlaceholderStyles = [
 // Without it Firefox takes the `requiresGeckoHackNode` path and appends a
 // trailing <br> to any block whose text ends in a space, which would match the
 // empty-block selector above and drop that paragraph out of per-line bidi.
-export const baseEditorStyles = `${viewerProseStyles} whitespace-pre-wrap rounded-lg outline-hidden focus-visible:ring-3 focus-visible:ring-ring/50 in-data-[slot=rich-text-editor-field]:focus-visible:ring-0 placeholder:text-neutral-gray2 ${placeholderStyles} ${detailsSummaryPlaceholderStyles}`;
+export const baseEditorStyles = `${viewerProseStyles} whitespace-pre-wrap rounded-lg outline-hidden focus-visible:ring-3 focus-visible:ring-ring/50 in-data-[slot=rich-text-editor-field]:focus-visible:ring-0 placeholder:text-muted-foreground ${placeholderStyles} ${detailsSummaryPlaceholderStyles}`;

--- a/packages/sense/src/components/ui/progress.tsx
+++ b/packages/sense/src/components/ui/progress.tsx
@@ -29,7 +29,10 @@ function ProgressTrack({ className, ...props }: ProgressPrimitive.Track.Props) {
   return (
     <ProgressPrimitive.Track
       className={cn(
-        'relative flex h-1 w-full items-center overflow-x-hidden rounded-full bg-accent',
+        // Figma `Progress` (296:4740) stacks two fills on the track: accent,
+        // then primary at 10%. Mixed in srgb to match how Figma composites the
+        // alpha — a plain bg-accent reads too light against the indicator.
+        'relative flex h-1 w-full items-center overflow-x-hidden rounded-full bg-[color-mix(in_srgb,var(--primary)_10%,var(--accent))]',
         className,
       )}
       data-slot="progress-track"

--- a/packages/styles/sense-theme.css
+++ b/packages/styles/sense-theme.css
@@ -26,6 +26,7 @@
   --color-card-foreground: var(--card-foreground);
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-muted: var(--muted);
@@ -45,101 +46,6 @@
   --color-success-muted: var(--success-muted);
   --color-success-muted-foreground: var(--success-muted-foreground);
   --color-input: var(--input);
-
-  /* Common Sense color scales (the "Colors Scale" Figma variables collection).
-   * These intentionally override Tailwind's default palette for these eight
-   * hues so `bg-teal-500`, `text-gray-600`, etc. resolve to brand ramps. */
-  --color-red-50: #fcf3f2;
-  --color-red-100: #fae2e0;
-  --color-red-200: #f6cbc8;
-  --color-red-300: #eea8a2;
-  --color-red-400: #e2766d;
-  --color-red-500: #cc3d31;
-  --color-red-600: #9d3b33;
-  --color-red-700: #86312a;
-  --color-red-800: #6e2c26;
-  --color-red-900: #5d2924;
-  --color-red-950: #33120f;
-  --color-orange-50: #fdf8ed;
-  --color-orange-100: #f8eacd;
-  --color-orange-200: #f0d497;
-  --color-orange-300: #e8b961;
-  --color-orange-400: #e2a23d;
-  --color-orange-500: #db862a;
-  --color-orange-600: #c1631e;
-  --color-orange-700: #a0481d;
-  --color-orange-800: #83391d;
-  --color-orange-900: #6c2f1b;
-  --color-orange-950: #3d170b;
-  --color-yellow-50: #fefce8;
-  --color-yellow-100: #fffac2;
-  --color-yellow-200: #fff088;
-  --color-yellow-300: #ffe145;
-  --color-yellow-400: #fdcd12;
-  --color-yellow-500: #f2b705;
-  --color-yellow-600: #cd8a01;
-  --color-yellow-700: #a36105;
-  --color-yellow-800: #874c0c;
-  --color-yellow-900: #723e11;
-  --color-yellow-950: #432005;
-  --color-green-50: #eefae4;
-  --color-green-100: #d6f3c4;
-  --color-green-200: #b0e790;
-  --color-green-300: #7ed64e;
-  --color-green-400: #58ab2d;
-  --color-green-500: #3f7f20;
-  --color-green-600: #2b5b15;
-  --color-green-700: #254e14;
-  --color-green-800: #203e14;
-  --color-green-900: #1b3513;
-  --color-green-950: #0c1d07;
-  --color-teal-50: #eff7f9;
-  --color-teal-100: #d7ebef;
-  --color-teal-200: #b5dade;
-  --color-teal-300: #81bcc8;
-  --color-teal-400: #4d96a3;
-  --color-teal-500: #387582;
-  --color-teal-600: #31606e;
-  --color-teal-700: #2d4f5a;
-  --color-teal-800: #2a434c;
-  --color-teal-900: #273941;
-  --color-teal-950: #16242b;
-  --color-blue-50: #eef1fc;
-  --color-blue-100: #dfe4fa;
-  --color-blue-200: #c5cdf5;
-  --color-blue-300: #a2acec;
-  --color-blue-400: #7d84e1;
-  --color-blue-500: #4444cc;
-  --color-blue-600: #473db3;
-  --color-blue-700: #514a90;
-  --color-blue-800: #413d6c;
-  --color-blue-900: #393755;
-  --color-blue-950: #212032;
-  --color-purple-50: #faf7fa;
-  --color-purple-100: #f5eef6;
-  --color-purple-200: #eadceb;
-  --color-purple-300: #dbbedb;
-  --color-purple-400: #c598c3;
-  --color-purple-500: #a1649f;
-  --color-purple-600: #845882;
-  --color-purple-700: #674464;
-  --color-purple-800: #553953;
-  --color-purple-900: #473145;
-  --color-purple-950: #2c1a2a;
-  --color-gray-50: #fafbfb;
-  /* Figma's Gray ramp says #f1f2f2, but adopting it washed out every border
-   * (`--border` and `--sidebar-border` both alias this step). Reverted pending a
-   * design answer — the ramp and our borders can't both be right. */
-  --color-gray-100: #edeeee;
-  --color-gray-200: #dee0e1;
-  --color-gray-300: #d0d3d4;
-  --color-gray-400: #aab0b1;
-  --color-gray-500: #858d8f;
-  --color-gray-600: #606a6c;
-  --color-gray-700: #3a4749;
-  --color-gray-800: #273638;
-  --color-gray-900: #142426;
-  --color-gray-950: #0a1517;
 
   /* Sidebar */
   --color-sidebar: var(--sidebar);
@@ -305,8 +211,11 @@
   --popover: var(--color-white);
   --popover-foreground: var(--color-gray-900);
 
-  /* Primary (teal-500 = the existing --color-primary value; the alias in
-   * shared-styles stays authoritative for `bg-primary` etc.) */
+  /* Primary. Defined here rather than inherited: `--color-primary` used to
+   * resolve through shared-styles' legacy alias (--op-primary-600), so the 57
+   * `bg-primary` / `text-primary` usages inside @op/sense depended on the
+   * package sense is replacing. Same value — teal-500 is #387582. */
+  --primary: var(--color-teal-500);
   --primary-foreground: var(--color-gray-50);
 
   /* Secondary (neutral). `--secondary` is defined here rather than inherited:

--- a/packages/styles/shared-styles.css
+++ b/packages/styles/shared-styles.css
@@ -251,7 +251,9 @@
    *   - functional-yellowWhite borrows the orange-50 tint
    *   - status-green / status-greenBg share the functional green scale
    * ============================================ */
-  --color-primary: var(--color-primary-600);
+  /* `--color-primary` is no longer aliased here — sense-theme.css owns it as a
+   * semantic (`--primary`), so `bg-primary` resolves through the Colors Scale
+   * instead of the legacy ramp. Same value either way. */
   --color-primary-teal: var(--color-primary-600);
   --color-primary-tealBlack: var(--color-primary-700);
   --color-primary-tealWhite: var(--color-primary-50);

--- a/packages/styles/tokens.css
+++ b/packages/styles/tokens.css
@@ -12,7 +12,118 @@
  *   - no separate status-green → uses functional-green-600 / -100
  */
 
+@theme {
+  /* ============================================
+   * Colors Scale — the current raw palette
+   *
+   * The Figma "Colors Scale" variables collection. This is the ramp the
+   * sense semantic tokens alias (see sense-theme.css) and the one new work
+   * should build on. Exposed to Tailwind by shared-styles.css, so it
+   * intentionally overrides Tailwind's default palette for these eight hues:
+   * `bg-teal-500`, `text-gray-600`, etc. resolve to brand ramps.
+   * ============================================ */
+  --color-red-50: #fcf3f2;
+  --color-red-100: #fae2e0;
+  --color-red-200: #f6cbc8;
+  --color-red-300: #eea8a2;
+  --color-red-400: #e2766d;
+  --color-red-500: #cc3d31;
+  --color-red-600: #9d3b33;
+  --color-red-700: #86312a;
+  --color-red-800: #6e2c26;
+  --color-red-900: #5d2924;
+  --color-red-950: #33120f;
+  --color-orange-50: #fdf8ed;
+  --color-orange-100: #f8eacd;
+  --color-orange-200: #f0d497;
+  --color-orange-300: #e8b961;
+  --color-orange-400: #e2a23d;
+  --color-orange-500: #db862a;
+  --color-orange-600: #c1631e;
+  --color-orange-700: #a0481d;
+  --color-orange-800: #83391d;
+  --color-orange-900: #6c2f1b;
+  --color-orange-950: #3d170b;
+  --color-yellow-50: #fefce8;
+  --color-yellow-100: #fffac2;
+  --color-yellow-200: #fff088;
+  --color-yellow-300: #ffe145;
+  --color-yellow-400: #fdcd12;
+  --color-yellow-500: #f2b705;
+  --color-yellow-600: #cd8a01;
+  --color-yellow-700: #a36105;
+  --color-yellow-800: #874c0c;
+  --color-yellow-900: #723e11;
+  --color-yellow-950: #432005;
+  --color-green-50: #eefae4;
+  --color-green-100: #d6f3c4;
+  --color-green-200: #b0e790;
+  --color-green-300: #7ed64e;
+  --color-green-400: #58ab2d;
+  --color-green-500: #3f7f20;
+  --color-green-600: #2b5b15;
+  --color-green-700: #254e14;
+  --color-green-800: #203e14;
+  --color-green-900: #1b3513;
+  --color-green-950: #0c1d07;
+  --color-teal-50: #eff7f9;
+  --color-teal-100: #d7ebef;
+  --color-teal-200: #b5dade;
+  --color-teal-300: #81bcc8;
+  --color-teal-400: #4d96a3;
+  --color-teal-500: #387582;
+  --color-teal-600: #31606e;
+  --color-teal-700: #2d4f5a;
+  --color-teal-800: #2a434c;
+  --color-teal-900: #273941;
+  --color-teal-950: #16242b;
+  --color-blue-50: #eef1fc;
+  --color-blue-100: #dfe4fa;
+  --color-blue-200: #c5cdf5;
+  --color-blue-300: #a2acec;
+  --color-blue-400: #7d84e1;
+  --color-blue-500: #4444cc;
+  --color-blue-600: #473db3;
+  --color-blue-700: #514a90;
+  --color-blue-800: #413d6c;
+  --color-blue-900: #393755;
+  --color-blue-950: #212032;
+  --color-purple-50: #faf7fa;
+  --color-purple-100: #f5eef6;
+  --color-purple-200: #eadceb;
+  --color-purple-300: #dbbedb;
+  --color-purple-400: #c598c3;
+  --color-purple-500: #a1649f;
+  --color-purple-600: #845882;
+  --color-purple-700: #674464;
+  --color-purple-800: #553953;
+  --color-purple-900: #473145;
+  --color-purple-950: #2c1a2a;
+  --color-gray-50: #fafbfb;
+  /* Figma's Gray ramp says #f1f2f2, but adopting it washed out every border
+   * (`--border` and `--sidebar-border` both alias this step). Reverted pending a
+   * design answer — the ramp and our borders can't both be right. */
+  --color-gray-100: #edeeee;
+  --color-gray-200: #dee0e1;
+  --color-gray-300: #d0d3d4;
+  --color-gray-400: #aab0b1;
+  --color-gray-500: #858d8f;
+  --color-gray-600: #606a6c;
+  --color-gray-700: #3a4749;
+  --color-gray-800: #273638;
+  --color-gray-900: #142426;
+  --color-gray-950: #0a1517;
+
+}
+
 :root {
+  /* ============================================
+   * Legacy @op/ui palette — retiring with @op/ui
+   *
+   * The pre-sense ramp. Only the stops above have a Colors Scale equivalent
+   * (those now alias it rather than repeat the literal); the rest are values
+   * the new scale does not carry. Nothing new should reference --op-*.
+   * ============================================ */
   /* ============================================
    * Primary (teal)
    * ============================================ */
@@ -22,7 +133,7 @@
   --op-primary-300: hsla(185.6, 40.5%, 69%, 1);   /* #90CAD0 */
   --op-primary-400: hsla(187.3, 37.8%, 53.3%, 1); /* #5BAAB5 */
   --op-primary-500: hsla(188, 41.7%, 42.4%, 1);   /* #3F8D99 */
-  --op-primary-600: hsla(191, 39.8%, 36.5%, 1);   /* #387582 */
+  --op-primary-600: var(--color-teal-500);   /* #387582 */
   --op-primary-700: hsla(192, 36.7%, 31%, 1);     /* #32606C */
   --op-primary-800: hsla(192.9, 30.4%, 27.1%, 1); /* #30515A */
   --op-primary-900: hsla(196.3, 27.3%, 23.7%, 1); /* #2C444D */
@@ -31,25 +142,25 @@
   /* ============================================
    * Primary - Yellow
    * ============================================ */
-  --op-primary-yellow-500: hsla(45, 96%, 48.4%, 1); /* #F2B705 */
+  --op-primary-yellow-500: var(--color-yellow-500); /* #F2B705 */
 
   /* ============================================
    * Primary - Orange
    * ============================================ */
-  --op-primary-orange-50: hsla(41, 80%, 96.1%, 1); /* #FDF8ED */
-  --op-primary-orange-500: hsla(31, 71.1%, 51.2%, 1); /* #DB862A */
+  --op-primary-orange-50: var(--color-orange-50); /* #FDF8ED */
+  --op-primary-orange-500: var(--color-orange-500); /* #DB862A */
 
   /* ============================================
    * Neutrals
    * ============================================ */
   --op-white: #ffffff;
-  --op-neutral-off-white: hsla(180, 11.1%, 98.2%, 1); /* #FAFBFB */
-  --op-neutral-gray-1: hsla(180, 2.9%, 93.1%, 1); /* #EDEEEE */
-  --op-neutral-gray-2: hsla(195, 4.4%, 82.4%, 1); /* #D0D3D4 */
-  --op-neutral-gray-3: hsla(189, 4.3%, 68%, 1); /* #AAB0B1 */
-  --op-neutral-gray-4: hsla(190, 5.9%, 40%, 1); /* #606A6C */
-  --op-neutral-charcoal: hsla(188, 11.5%, 25.7%, 1); /* #3A4749 */
-  --op-neutral-black: hsla(187, 31%, 11.4%, 1); /* #142426 */
+  --op-neutral-off-white: var(--color-gray-50); /* #FAFBFB */
+  --op-neutral-gray-1: var(--color-gray-100); /* #EDEEEE */
+  --op-neutral-gray-2: var(--color-gray-300); /* #D0D3D4 */
+  --op-neutral-gray-3: var(--color-gray-400); /* #AAB0B1 */
+  --op-neutral-gray-4: var(--color-gray-600); /* #606A6C */
+  --op-neutral-charcoal: var(--color-gray-700); /* #3A4749 */
+  --op-neutral-black: var(--color-gray-900); /* #142426 */
 
   /* ============================================
    * Functional
@@ -60,7 +171,7 @@
   --op-functional-red-300: hsla(4.9, 78.5%, 81.8%, 1); /* #F5B2AC */
   --op-functional-red-400: hsla(4.7, 77.2%, 70.8%, 1); /* #EE847B */
   --op-functional-red-500: hsla(4.6, 71.4%, 60.2%, 1); /* #E25C51 */
-  --op-functional-red-600: hsla(4.6, 61.3%, 49.6%, 1); /* #CC3D31 */
+  --op-functional-red-600: var(--color-red-500); /* #CC3D31 */
   --op-functional-red-700: hsla(4.5, 62.4%, 41.8%, 1); /* #AD3228 */
   --op-functional-red-800: hsla(5, 58.9%, 35.3%, 1);   /* #8F2D25 */
   --op-functional-red-900: hsla(5, 53.8%, 30.6%, 1);   /* #782B24 */
@@ -72,7 +183,7 @@
   --op-functional-green-300: hsla(97.8, 59.5%, 67.1%, 1);  /* #9EDD79 */
   --op-functional-green-400: hsla(98.4, 55.1%, 55.5%, 1);  /* #7CCC4F */
   --op-functional-green-500: hsla(99.4, 56.6%, 44.3%, 1);  /* #5DB131 */
-  --op-functional-green-600: hsla(100.4, 59.7%, 31.2%, 1); /* #3F7F20 */
+  --op-functional-green-600: var(--color-green-500); /* #3F7F20 */
   --op-functional-green-700: hsla(101.3, 55.4%, 27.3%, 1); /* #376C1F */
   --op-functional-green-800: hsla(101.8, 48.3%, 22.7%, 1); /* #2F561E */
   --op-functional-green-900: hsla(104, 43.7%, 20.2%, 1);   /* #294A1D */
@@ -86,6 +197,6 @@
   /* ============================================
    * Data Visualization
    * ============================================ */
-  --op-data-purple: hsla(302, 24.5%, 51.2%, 1); /* #A1649F */
-  --op-data-blue: hsla(240, 57.1%, 53.3%, 1); /* #4444CC */
+  --op-data-purple: var(--color-purple-500); /* #A1649F */
+  --op-data-blue: var(--color-blue-500); /* #4444CC */
 }


### PR DESCRIPTION
The last `neutral-*` bucket #1752 left behind. Unlike that PR, this one **is** a visual change and is meant to be.

`neutral-charcoal` is gray-700 `#3A4749`, and sense ships only two text semantics — `--foreground` gray-900 `#142426` and `--muted-foreground` gray-600 `#606A6C`. Charcoal sits between them, so there is no value-preserving target. Per the decision on the tracking task, it folds into `text-foreground`:

- `text-neutral-charcoal` → `text-foreground` (96 sites)
- `bg-neutral-charcoal` → `bg-foreground` (1 site)

Body text across the app darkens one step, and charcoal becomes byte-identical to the old `neutral-black`, collapsing the two-tone body text the `@op/ui` palette had.

Some files show a net line change: the shorter class name let the formatter re-wrap multi-line `className` / `cn()` calls. Those hunks have no content change.

**One thing worth a look:** 15 of the 97 replacements are in `RichTextEditor/RichTextEditorFloatingToolbar.tsx`, where the pattern was `isActive ? 'bg-gray-200 text-neutral-black' : 'text-neutral-charcoal'` — an active/inactive text contrast that this sweep flattens into `text-foreground` either way, leaving no-op ternaries. I left them rather than redesign the component, because the file has no remaining consumers: it is only re-exported from `RichTextEditor/index.ts`, and its own doc notes it went unused when the per-field bubble menu replaced the shared toolbar in #1725. It also styles itself with stock `bg-gray-100` / `bg-gray-200` rather than tokens. It should probably just be deleted — separate PR.

Targets `sense-migration`.

Asana: https://app.asana.com/0/1216361907129487/1217342864615638

---

**Second commit — dropping the now-redundant class.** `sense-theme` re-baselines `:root` to `var(--foreground)` and the root layout's `<body>` carries `text-foreground`, so the document default already *is* the foreground token. Once charcoal maps onto it, 142 call sites were setting the colour they would have inherited anyway.

Removed only where it provably cannot change rendering: the class sits on a lowercase HTML element (or `motion.*`), which has no styles of its own, and is not variant-prefixed or a ternary branch.

Kept, because these do change rendering:

- components that set their own colour — `EmptyDescription` / `DialogDescription` default to `muted-foreground`; `Button`, `FieldLabel`, `TableCell`, `Header1`, `StatusDot`, `ActionRow`, `AccordionTrigger`, `DialogTitle` carry variant colours
- `Link` (10 sites)
- react-icons (`Lu*`, `Icon`) — they paint from `currentColor` and frequently sit inside muted parents
- `hover:` / `group-hover:` variants, and ternaries where foreground is one branch of a choice
- `<body>` itself, which is the baseline everything above relies on
- the dead `RichTextEditorFloatingToolbar`

One incidental win: `ResourceCard` had `text-title-sm text-foreground` on the same element, which is the twMerge custom-token collision — a size class next to a colour class. Dropping the colour removes the hazard.

---

**Third commit — neutral finisher + `functional-red` → `destructive`.** After this the app *and* `@op/sense` are at zero legacy `neutral-*` classes.

Neutral finisher, 26 sites:

| From | To | Note |
| --- | --- | --- |
| `text-neutral-gray3`, `text-neutral-gray2` | `text-muted-foreground` | contrast fix — gray-400 on white is ~2.2:1 and gray-300 ~1.5:1, both under WCAG AA; gray-600 is ~5.7:1 |
| `border-neutral-gray3` | `border-input` | |
| `border-neutral-300` | `border-input` | was stock Tailwind, never our palette |
| `text-neutral-offWhite` | `text-background` | light text on dark/coloured fills |
| `bg-neutral-off-white` | `bg-muted` | hyphenated spelling is why #1752 missed it |
| `bg-neutral-gray2` | `bg-border` ×3, `bg-secondary` ×2 | 1px dividers vs the progress-bar track |

Includes `@op/sense`'s own `RichTextEditor/viewerStyles.ts`, which was still reaching into the legacy palette — that blocks dropping the `@op/ui` dependency.

`functional-red` → `destructive`, 21 sites: `--color-functional-red` resolves to `--op-functional-red-600` `#CC3D31`, and sense `--destructive` is `--color-red-500`, also `#CC3D31`. Exact match, no rendered change. Same for the bare `text-red` alias and the one `border-functional-red`.

---

**Fourth commit — one raw palette.** `tokens.css` and `sense-theme.css` each carried their own raw ramp, so most brand colours had two literals in the tree.

They were never two views of one palette. Diffing every stop: sense ships **88** raw stops to the legacy **47**; only **13** legacy values appear in the Colors Scale at all; and all 13 are renumbered (`neutral-charcoal` = `gray-700`, `functional-red-600` = `red-500`, `primary-600` = `teal-500`, `neutral-gray-1` = `gray-100`, …). Several nominally-equivalent stops differ outright — `primary-50` `#f1f9fa` vs `teal-50` `#eff7f9`, `functional-red-50` `#fdf4f3` vs `red-50` `#fcf3f2`, and the entire green ramp.

So:

- the Colors Scale moves into `tokens.css` as the raw layer, in **its own `@theme` block** — Tailwind v4 only mints utilities from `@theme`, so parking it in `:root` would have silently dropped `bg-teal-500`, `text-gray-600` and friends
- `sense-theme.css` keeps only the semantic aliases
- the 15 legacy `--op-*` stops byte-identical to a Colors Scale stop now reference it instead of repeating the literal; the rest keep their values and die with `@op/ui`
- **`--primary` is now defined.** It had been left to shared-styles' legacy alias (`--op-primary-600`), which meant the 57 `bg-primary` / `text-primary` / `border-primary` usages *inside `@op/sense`* resolved through the package sense is replacing. `teal-500` is the same `#387582`, so nothing moves

Verified value-identical two ways: all **318** custom properties resolve to the same literals before and after, and compiling `shared-styles.css` through the Tailwind pipeline gives identical output apart from the 33 token declarations that now indirect through a `var()`, plus the new `--primary`. **No utility rule changed.**
