### PR TITLE
fix(decision): hide proposal like/follow from callers without engagement access

### DIFF
--- a/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
+++ b/apps/app/src/components/decisions/ProposalCard/ProposalCardActions.tsx
@@ -15,12 +15,15 @@ import { LuBookmark, LuHeart, LuPencil, LuTrash2 } from 'react-icons/lu';
 import { useTranslations } from '@/lib/i18n';
 
 /**
- * Like/Follow actions for viewing other users' proposals
+ * Like/Follow actions for viewing other users' proposals. `canEngage` mirrors
+ * the server-side engagement gate on the parent decision.
  */
 export function ProposalCardActions({
   proposal: initialProposal,
+  canEngage,
 }: {
   proposal: Proposal;
+  canEngage: boolean;
 }) {
   const t = useTranslations();
   const { user } = useUser();
@@ -52,7 +55,7 @@ export function ProposalCardActions({
 
   // Like/Follow are user-scoped writes gated at the API — anonymous visitors
   // can read the proposal but aren't offered these actions.
-  if (!userCanInteract(user)) {
+  if (!userCanInteract(user) || !canEngage) {
     return null;
   }
 

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -273,6 +273,7 @@ export function ProposalView({
       // so the Join button, the modal mount, and the prompt can't diverge —
       // on any route that renders a proposal, including the legacy one.
       canJoin={currentProposal.access?.submitProposals === true}
+      canEngage={currentProposal.access?.submitProposals === true}
       revisionToggle={
         firstRevisionRequestId
           ? {

--- a/apps/app/src/components/decisions/ProposalViewLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalViewLayout.tsx
@@ -31,6 +31,7 @@ export function ProposalViewLayout({
   isLoading = false,
   editHref,
   canEdit = false,
+  canEngage = false,
   canJoin = false,
   reportProposalId,
   revisionToggle,
@@ -45,6 +46,8 @@ export function ProposalViewLayout({
   isLoading?: boolean;
   editHref?: string;
   canEdit?: boolean;
+  /** Mirrors the server-side engagement gate — hides Like/Follow otherwise. */
+  canEngage?: boolean;
   /**
    * Public process (viewer can submit proposals without an account): the
    * header offers "Join" (account claim, see JoinAccountModal) instead of
@@ -104,8 +107,9 @@ export function ProposalViewLayout({
             <ReportProposalDialog proposalId={reportProposalId} />
           )}
           {/* Like/Follow are user-scoped writes gated at the API — only offer
-              them to a signed-in, non-anonymous member. */}
-          {userCanInteract(user) ? (
+              them to a signed-in, non-anonymous member with engagement
+              access. */}
+          {userCanInteract(user) && canEngage ? (
             <>
               <Button
                 surface="outline"

--- a/apps/app/src/components/decisions/ProposalsGrid.tsx
+++ b/apps/app/src/components/decisions/ProposalsGrid.tsx
@@ -498,6 +498,10 @@ const ViewProposalsList = ({
   revisionRequestIdByProposalId?: Map<string, string>;
 }) => {
   const canManageProposals = permissions?.admin ?? false;
+  // Like/Follow require SUBMIT_PROPOSALS (or admin) on the parent decision —
+  // don't offer buttons the API would reject (e.g. reviewer-only roles).
+  const canEngage =
+    (permissions?.submitProposals ?? false) || canManageProposals;
   if (!proposals || proposals.length === 0) {
     if (proposalsHidden && !hasFilter) {
       return <HiddenProposalsEmptyState />;
@@ -577,7 +581,10 @@ const ViewProposalsList = ({
                 ) : (
                   <>
                     <ProposalCardMetrics proposal={proposal} />
-                    <ProposalCardActions proposal={proposal} />
+                    <ProposalCardActions
+                      proposal={proposal}
+                      canEngage={canEngage}
+                    />
                   </>
                 )}
               </ProposalCardFooter>

--- a/services/api/src/routers/decision/proposals/addRelationship.test.ts
+++ b/services/api/src/routers/decision/proposals/addRelationship.test.ts
@@ -1,8 +1,10 @@
+import { createDecisionRole } from '@op/common';
 import { db } from '@op/db/client';
 import {
   ProfileRelationshipType,
   ProposalStatus,
   profileRelationships,
+  profileUsers,
   proposals,
 } from '@op/db/schema';
 import { and, eq } from 'drizzle-orm';
@@ -145,6 +147,76 @@ describe.concurrent('proposal relationship engagement access', () => {
     expect(await relationshipRows(ProfileRelationshipType.LIKES)).toHaveLength(
       1,
     );
+  });
+
+  it('rejects a reviewer-only caller — engagement stays gated on SUBMIT_PROPOSALS', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: setup.instance.instance.id,
+      proposalData: { title: 'Reviewed proposal' },
+    });
+    await db
+      .update(proposals)
+      .set({ status: ProposalStatus.SUBMITTED })
+      .where(eq(proposals.id, proposal.id));
+
+    // An external reviewer: only a READ+REVIEW grant on the decision, from an
+    // unrelated org (the owning org's Member role carries SUBMIT_PROPOSALS
+    // and would admit them via the org fallback).
+    const reviewerHome = await new TestDecisionsDataManager(
+      `${task.id}-reviewer-home`,
+      onTestFinished,
+    ).createDecisionSetup({ instanceCount: 0, grantAccess: true });
+    const reviewer = await testData.createMemberUser({
+      organization: reviewerHome.organization,
+    });
+
+    const reviewerRole = await createDecisionRole({
+      name: `Reviewer-${task.id}`,
+      profileId: setup.instance.profileId,
+      permissions: {
+        decisions: {
+          type: 'decision',
+          value: {
+            create: false,
+            read: true,
+            update: false,
+            delete: false,
+            admin: false,
+            inviteMembers: false,
+            review: true,
+            submitProposals: false,
+            vote: false,
+          },
+        },
+      },
+    });
+    await db.insert(profileUsers).values({
+      profileId: setup.instance.profileId,
+      authUserId: reviewer.authUserId,
+      email: reviewer.email,
+    });
+    await testData.assignRole(
+      reviewer.authUserId,
+      setup.instance.profileId,
+      reviewerRole.id,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+    await expect(
+      reviewerCaller.decision.addProposalRelationship({
+        targetProfileId: proposal.profileId,
+        relationshipType: 'likes',
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'UnauthorizedError' } });
   });
 
   it('rejects a confirmed account with no standing on the decision', async ({


### PR DESCRIPTION
Reviewer-only roles were shown Like/Follow buttons the API rejects with an error toast. Engagement stays gated on SUBMIT_PROPOSALS; the UI now mirrors that gate instead of offering unusable actions, and a test pins the reviewer rejection.