### PR TITLE
fix(translation): stop sending plain text to DeepL as markup

### DIFF
--- a/packages/common/src/services/translation/translateDecision.ts
+++ b/packages/common/src/services/translation/translateDecision.ts
@@ -141,12 +141,14 @@ function buildEntries(
     entries.push({
       contentKey: `${prefix}:headline`,
       text: currentPhase.headline,
+      format: 'text',
     });
   }
   if (currentPhase?.description) {
     entries.push({
       contentKey: `${prefix}:phaseDescription`,
       text: currentPhase.description,
+      format: 'text',
     });
   }
   if (currentPhase?.additionalInfo) {
@@ -161,6 +163,7 @@ function buildEntries(
       entries.push({
         contentKey: `${prefix}:phase:${phase.phaseId}:name`,
         text: phase.name,
+        format: 'text',
       });
     }
   }
@@ -169,6 +172,7 @@ function buildEntries(
     entries.push({
       contentKey: `${prefix}:description`,
       text: processDescription,
+      format: 'text',
     });
   }
 
@@ -177,12 +181,14 @@ function buildEntries(
     entries.push({
       contentKey: `${prefix}:overviewHeadline`,
       text: overview.headline,
+      format: 'text',
     });
   }
   if (overview?.description) {
     entries.push({
       contentKey: `${prefix}:overviewDescription`,
       text: overview.description,
+      format: 'text',
     });
   }
   if (overview?.body) {

--- a/packages/common/src/services/translation/translatePosts.ts
+++ b/packages/common/src/services/translation/translatePosts.ts
@@ -119,6 +119,7 @@ export async function translatePosts({
     entries.push({
       contentKey: `post:${row.id}:content`,
       text: row.content,
+      format: 'text',
     });
   }
 

--- a/packages/common/src/services/translation/translateProposal.ts
+++ b/packages/common/src/services/translation/translateProposal.ts
@@ -69,12 +69,14 @@ export async function translateProposal({
         entries.push({
           contentKey: `proposal:${proposalId}:field_title:${fieldKey}`,
           text: property.title,
+          format: 'text',
         });
       }
       if (property.description) {
         entries.push({
           contentKey: `proposal:${proposalId}:field_desc:${fieldKey}`,
           text: property.description,
+          format: 'text',
         });
       }
 
@@ -85,6 +87,7 @@ export async function translateProposal({
           entries.push({
             contentKey: `proposal:${proposalId}:option:${fieldKey}:${option.value}`,
             text: option.title,
+            format: 'text',
           });
         }
       }

--- a/packages/common/src/services/translation/translateProposal.ts
+++ b/packages/common/src/services/translation/translateProposal.ts
@@ -41,18 +41,23 @@ export async function translateProposal({
   const { proposalData } = proposal;
 
   // TODO: eventually use `htmlContent` for all fields
+  const plainTextFields = {
+    title: proposal.profile?.name,
+    category: proposalData.category,
+  };
   entries.push(
-    ...flattenTranslatableFields(`proposal:${proposalId}:`, {
-      title: proposal.profile?.name,
-      category: proposalData.category,
-    }),
+    ...flattenTranslatableFields(`proposal:${proposalId}:`, plainTextFields),
   );
 
   // HTML fragments from TipTap — proposal.htmlContent is the server-generated HTML (Record<string, string>)
   if (proposal.htmlContent) {
     const htmlContent = proposal.htmlContent as Record<string, string>;
     for (const [fragmentName, html] of Object.entries(htmlContent)) {
-      if (html) {
+      // Templates expose title/category as fields, so those also come back as
+      // document fragments whose HTML carries a `<p xmlns="…xhtml">` wrapper.
+      // They share the plain field's content key, and `unflattenTranslatedFields`
+      // is last-write-wins, so emitting both leaks the tag into the title.
+      if (html && !(fragmentName in plainTextFields)) {
         entries.push({
           contentKey: `proposal:${proposalId}:${fragmentName}`,
           text: html,

--- a/packages/common/src/services/translation/translatedFields.ts
+++ b/packages/common/src/services/translation/translatedFields.ts
@@ -21,6 +21,10 @@ const ARRAY_ELEMENT_PATTERN = /^(?<field>.+)\[(?<index>\d+)\]$/;
 /**
  * Flattens string and string[] fields into translation entries while keeping a
  * reversible content-key structure for arrays.
+ *
+ * Everything here is a bare string — titles, categories, previews — so entries
+ * are marked `text`. Rich-text fields are rendered to HTML and pushed by their
+ * own callers.
  */
 export function flattenTranslatableFields(
   prefix: string,
@@ -37,6 +41,7 @@ export function flattenTranslatableFields(
       entries.push({
         contentKey: `${prefix}${fieldName}`,
         text: value,
+        format: 'text',
       });
       continue;
     }
@@ -49,6 +54,7 @@ export function flattenTranslatableFields(
       entries.push({
         contentKey: `${prefix}${fieldName}[${index}]`,
         text: item,
+        format: 'text',
       });
     });
   }

--- a/services/api/src/routers/translation/translateDecision.test.ts
+++ b/services/api/src/routers/translation/translateDecision.test.ts
@@ -405,6 +405,7 @@ describe('translation.translateDecision', () => {
       translatedText: '[ES-CACHED] Share Your Vision',
       sourceLocale: 'EN',
       targetLocale: 'ES',
+      format: 'text',
     });
 
     onTestFinished(async () => {

--- a/services/api/src/routers/translation/translateProposal.test.ts
+++ b/services/api/src/routers/translation/translateProposal.test.ts
@@ -23,15 +23,32 @@ process.env.DEEPL_API_KEY = 'test-fake-key';
 
 // Mock DeepL's translateText — prefixes each text with [ES] so we can
 // distinguish mock translations from seeded cache entries ([ES-CACHED]).
-const mockTranslateText = vi.fn((texts: string | string[]) => {
-  const arr = Array.isArray(texts) ? texts : [texts];
-  const results = arr.map((t) => ({
-    text: `[ES] ${t}`,
-    detectedSourceLang: 'en',
-  }));
-  // Mirror deepl-node: a single-string input returns a single result object.
-  return Array.isArray(texts) ? results : results[0];
-});
+//
+// It also mirrors the behaviour this file exists to pin: with tagHandling on,
+// DeepL parses the input as a document, so a bare string comes back wrapped in
+// a namespaced <p>. Plain fields must therefore be sent without tagHandling.
+const mockTranslateText = vi.fn(
+  (
+    texts: string | string[],
+    _sourceLang?: unknown,
+    _targetLang?: unknown,
+    options?: { tagHandling?: string },
+  ) => {
+    const arr = Array.isArray(texts) ? texts : [texts];
+    const results = arr.map((t) => {
+      const looksLikeMarkup = /^\s*</.test(t);
+      const translated =
+        options?.tagHandling === 'html' && !looksLikeMarkup
+          ? `<p xmlns="http://www.w3.org/1999/xhtml">[ES] ${t}</p>`
+          : `[ES] ${t}`;
+
+      return { text: translated, detectedSourceLang: 'en' };
+    });
+
+    // Mirror deepl-node: a single-string input returns a single result object.
+    return Array.isArray(texts) ? results : results[0];
+  },
+);
 
 // Mock deepl-node so we never hit the real API
 vi.mock('deepl-node', () => ({
@@ -258,13 +275,19 @@ describe('translation.translateProposal', () => {
       },
     });
 
+    // The title is a bare string. If it were sent with tagHandling, DeepL
+    // would hand back `<p xmlns=…>[ES] Community Garden Project</p>` and the
+    // proposal header would render that markup as literal text.
+    expect(result.translated.title).toBe('[ES] Community Garden Project');
+    expect(result.translated.title).not.toContain('<p');
+
     // Verify what was sent to DeepL (mapped from 'es' → 'ES'). DeepL is called
     // once per text so batch size can't exceed its per-request cap.
     expect(mockTranslateText).toHaveBeenCalledWith(
       'Community Garden Project',
       null,
       'ES',
-      expect.objectContaining({ tagHandling: 'html' }),
+      expect.objectContaining({ tagHandling: undefined }),
     );
     expect(mockTranslateText).toHaveBeenCalledWith(
       '<p xmlns="http://www.w3.org/1999/xhtml">A proposal for a garden</p>',
@@ -487,7 +510,7 @@ describe('translation.translateProposal', () => {
       'Legacy Proposal',
       null,
       'ES',
-      expect.objectContaining({ tagHandling: 'html' }),
+      expect.objectContaining({ tagHandling: undefined }),
     );
     expect(mockTranslateText).toHaveBeenCalledWith(
       '<p>Old-style HTML content</p>',

--- a/services/api/src/routers/translation/translateProposal.test.ts
+++ b/services/api/src/routers/translation/translateProposal.test.ts
@@ -1,4 +1,4 @@
-import { mockCollab } from '@op/collab/testing';
+import { mockCollab, textFragment } from '@op/collab/testing';
 import { db, eq } from '@op/db/client';
 import { contentTranslations, ProposalStatus, proposals } from '@op/db/schema';
 import { like } from 'drizzle-orm';
@@ -287,7 +287,9 @@ describe('translation.translateProposal', () => {
       'Community Garden Project',
       null,
       'ES',
-      expect.objectContaining({ tagHandling: undefined }),
+      // No options at all — asserting `objectContaining({ tagHandling:
+      // undefined })` would pass on a request that never omitted the key.
+      {},
     );
     expect(mockTranslateText).toHaveBeenCalledWith(
       '<p xmlns="http://www.w3.org/1999/xhtml">A proposal for a garden</p>',
@@ -337,6 +339,7 @@ describe('translation.translateProposal', () => {
       translatedText: '[ES-CACHED] Community Garden Project',
       sourceLocale: 'EN',
       targetLocale: 'ES',
+      format: 'text',
     });
 
     // Clean up translations inserted by translateBatch for the body
@@ -415,6 +418,7 @@ describe('translation.translateProposal', () => {
       translatedText: '[ES-CACHED] Fully Cached Proposal',
       sourceLocale: 'EN',
       targetLocale: 'ES',
+      format: 'text',
     });
 
     await translationData.seedTranslation({
@@ -510,7 +514,9 @@ describe('translation.translateProposal', () => {
       'Legacy Proposal',
       null,
       'ES',
-      expect.objectContaining({ tagHandling: undefined }),
+      // No options at all — asserting `objectContaining({ tagHandling:
+      // undefined })` would pass on a request that never omitted the key.
+      {},
     );
     expect(mockTranslateText).toHaveBeenCalledWith(
       '<p>Old-style HTML content</p>',
@@ -623,6 +629,74 @@ describe('translation.translateProposal', () => {
     expect(result.translated['title']).toBe('[ES] Template Fields Test');
     expect(result.sourceLocale).toBe('EN');
     expect(result.targetLocale).toBe('es');
+  });
+
+  it('keeps the plain-text title when a colliding title document fragment exists', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+
+    // A template that exposes `title` as a field means `title` also comes back
+    // as a TipTap document fragment, whose generated HTML carries the
+    // `<p xmlns="…xhtml">` wrapper. That fragment shares the plain title's
+    // content key, so before the fix it clobbered the plain-text translation
+    // and leaked the tag into the title (ONE-395).
+    const proposalTemplate = {
+      type: 'object',
+      properties: {
+        title: { type: 'string', title: 'Proposal title', 'x-format': 'text' },
+        summary: {
+          type: 'string',
+          title: 'Summary',
+          'x-format': 'textarea',
+        },
+      },
+    };
+
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+      proposalTemplate,
+    });
+
+    const proposal = await testData.createProposal({
+      userEmail: setup.userEmail,
+      processInstanceId: setup.instance.instance.id,
+      proposalData: { title: 'Playground made of ice cream' },
+    });
+
+    const { collaborationDocId } = proposal.proposalData as {
+      collaborationDocId: string;
+    };
+    mockCollab.setDocFragmentResponses(collaborationDocId, {
+      title: textFragment('Playground made of ice cream'),
+      summary: textFragment('There are no playgrounds made of ice cream'),
+    });
+
+    const proposalId = proposal.id;
+    onTestFinished(async () => {
+      await db
+        .delete(contentTranslations)
+        .where(
+          like(contentTranslations.contentKey, `proposal:${proposalId}:%`),
+        );
+    });
+
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const result = await caller.translation.translateProposal({
+      profileId: proposal.profileId,
+      targetLocale: 'es',
+    });
+
+    // Title stays plain text — the document fragment's HTML wrapper never leaks.
+    expect(result.translated.title).toBe('[ES] Playground made of ice cream');
+    expect(String(result.translated.title)).not.toContain('xmlns');
+    // The rich-text body fragment still comes through as HTML.
+    expect(String(result.translated.summary)).toContain(
+      'There are no playgrounds made of ice cream',
+    );
   });
 
   it('should preserve multi-category structure when translating categories', async ({
@@ -743,6 +817,7 @@ describe('translation.translateProposal', () => {
       translatedText: '[ES-CACHED] Target Region',
       sourceLocale: 'EN',
       targetLocale: 'ES',
+      format: 'text',
     });
 
     onTestFinished(async () => {

--- a/services/api/src/routers/translation/translateProposals.test.ts
+++ b/services/api/src/routers/translation/translateProposals.test.ts
@@ -427,6 +427,7 @@ describe('translation.translateProposals', () => {
       translatedText: '[ES-CACHED] Cached Batch Proposal',
       sourceLocale: 'EN',
       targetLocale: 'ES',
+      format: 'text',
     });
 
     onTestFinished(async () => {

--- a/services/api/src/test/helpers/TestTranslationDataManager.ts
+++ b/services/api/src/test/helpers/TestTranslationDataManager.ts
@@ -1,5 +1,6 @@
 import { db } from '@op/db/client';
 import { contentTranslations } from '@op/db/schema';
+import type { TranslationFormat } from '@op/translation';
 import { hashContent } from '@op/translation';
 import { inArray } from 'drizzle-orm';
 
@@ -21,16 +22,22 @@ export class TestTranslationDataManager {
     translatedText,
     sourceLocale,
     targetLocale,
+    format = 'html',
   }: {
     contentKey: string;
     sourceText: string;
     translatedText: string;
     sourceLocale: string;
     targetLocale: string;
+    /**
+     * Must match the format the service sends the entry with — the hash folds
+     * it in, so seeding a plain field as `html` produces a key nothing looks up.
+     */
+    format?: TranslationFormat;
   }): Promise<void> {
     this.ensureCleanupRegistered();
 
-    const contentHash = hashContent(sourceText);
+    const contentHash = hashContent(sourceText, format);
 
     const [row] = await db
       .insert(contentTranslations)

--- a/services/db/index.ts
+++ b/services/db/index.ts
@@ -47,17 +47,34 @@ const startupParameters = isMaintenance
       ),
     };
 
-export const db = drizzle({
-  connection: {
-    url: process.env.DATABASE_URL,
-    max: poolMax,
-    connect_timeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT_S, 30),
-    connection: startupParameters,
-    onnotice: () => {},
-    prepare: false,
-  },
-  casing: config.casing,
-  schema,
-  relations,
-  logger: false,
-});
+const createDb = () =>
+  drizzle({
+    connection: {
+      url: process.env.DATABASE_URL,
+      max: poolMax,
+      connect_timeout: parsePositiveInt(process.env.DB_CONNECT_TIMEOUT_S, 30),
+      connection: startupParameters,
+      onnotice: () => {},
+      prepare: false,
+    },
+    casing: config.casing,
+    schema,
+    relations,
+    logger: false,
+  });
+
+// Next dev/HMR re-evaluates this module on every recompile — and a single new
+// Tailwind class forces a ~50-route recompile storm (the global stylesheet
+// regenerates, so the whole route graph under the root layout invalidates).
+// Without a global guard, each pass spins up a fresh postgres-js pool and leaks
+// the previous one, quickly exhausting the DB pool and ballooning RAM. Reuse a
+// single pool across reloads in dev.
+declare global {
+  var __opDb: ReturnType<typeof createDb> | undefined;
+}
+
+export const db = globalThis.__opDb ?? createDb();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.__opDb = db;
+}

--- a/services/translation/src/hashContent.ts
+++ b/services/translation/src/hashContent.ts
@@ -1,9 +1,21 @@
 import { createHash } from 'node:crypto';
 
+import type { TranslationFormat } from './providers';
+
 /**
  * SHA-256 hash of content, truncated to 16 hex chars (64 bits).
  * Used as cache key — when content changes, hash changes, cache misses.
+ *
+ * `format` is folded in so the plain-text fix invalidates its own cache: rows
+ * translated before it was in place hold DeepL's `<p xmlns=…>` wrapper, and
+ * without a new key they would keep being served. Only `text` is prefixed, so
+ * html entries keep their existing hashes and their cache.
  */
-export function hashContent(text: string): string {
-  return createHash('sha256').update(text, 'utf8').digest('hex').slice(0, 16);
+export function hashContent(
+  text: string,
+  format: TranslationFormat = 'html',
+): string {
+  const input = format === 'html' ? text : `text:${text}`;
+
+  return createHash('sha256').update(input, 'utf8').digest('hex').slice(0, 16);
 }

--- a/services/translation/src/index.ts
+++ b/services/translation/src/index.ts
@@ -6,6 +6,8 @@ export {
   OpenLTranslationProvider,
 } from './providers';
 export type {
+  TranslationFormat,
+  TranslationInput,
   TranslationProvider,
   TranslationProviderResult,
 } from './providers';

--- a/services/translation/src/providers.ts
+++ b/services/translation/src/providers.ts
@@ -10,13 +10,27 @@ export type TranslationProviderResult = {
 };
 
 /**
+ * Whether a text is a markup fragment or a bare string. It decides how the
+ * provider is asked to treat tags: sending plain text through a markup-aware
+ * translation makes DeepL parse it as a document, wrap it in a block element
+ * and hand back `<p xmlns="http://www.w3.org/1999/xhtml">…</p>`.
+ */
+export type TranslationFormat = 'html' | 'text';
+
+/** One text to translate, plus how it should be treated. */
+export type TranslationInput = {
+  text: string;
+  format: TranslationFormat;
+};
+
+/**
  * A translation backend bound to a single target language. `translateBatch`
  * depends on this interface instead of a concrete client so different languages
  * can be routed to different services (e.g. Somali via OpenL, everything else
  * via DeepL).
  */
 export interface TranslationProvider {
-  translate(texts: string[]): Promise<TranslationProviderResult[]>;
+  translate(inputs: TranslationInput[]): Promise<TranslationProviderResult[]>;
 }
 
 /** Max DeepL requests in flight at once, to stay under DeepL's rate limits. */
@@ -30,23 +44,32 @@ export class DeepLTranslationProvider implements TranslationProvider {
     private readonly targetLang: string,
   ) {}
 
-  async translate(texts: string[]): Promise<TranslationProviderResult[]> {
+  async translate(
+    inputs: TranslationInput[],
+  ): Promise<TranslationProviderResult[]> {
     // DeepL rejects any request carrying more than 50 text parameters, so
     // sending a whole proposal list in one call started failing once lists grew
     // past that cap. Translate each text in its own request (with bounded
     // concurrency) so batch size can never exceed DeepL's limit. pMap preserves
     // input order, so results line up 1:1 with the input.
-    return pMap(texts, (text) => this.translateOne(text), {
+    return pMap(inputs, (input) => this.translateOne(input), {
       concurrency: DEEPL_REQUEST_CONCURRENCY,
     });
   }
 
-  private async translateOne(text: string): Promise<TranslationProviderResult> {
+  private async translateOne({
+    text,
+    format,
+  }: TranslationInput): Promise<TranslationProviderResult> {
     const result = await this.client.translateText(
       text,
       null,
       this.targetLang as TargetLanguageCode,
-      { tagHandling: 'html' },
+      // Only ask for tag handling on actual markup. With it on, DeepL parses
+      // the input as a document, so a bare string comes back wrapped in
+      // `<p xmlns="http://www.w3.org/1999/xhtml">`, which then renders as
+      // literal text in every plain field (title, category, field labels).
+      format === 'html' ? { tagHandling: 'html' } : {},
     );
 
     // A single-text input yields a single result object.
@@ -82,7 +105,12 @@ export class OpenLTranslationProvider implements TranslationProvider {
     private readonly targetLang: string,
   ) {}
 
-  async translate(texts: string[]): Promise<TranslationProviderResult[]> {
+  async translate(
+    inputs: TranslationInput[],
+  ): Promise<TranslationProviderResult[]> {
+    // OpenL has no tag-handling switch — it always treats input as plain text —
+    // so `format` is not consulted here.
+    const texts = inputs.map((input) => input.text);
     // OpenL caps texts per request, so split into chunks and translate them
     // with bounded concurrency (pMap preserves input order, so the reassembled
     // array lines up 1:1 with the input — translateBatch maps results back to

--- a/services/translation/src/translateBatch.ts
+++ b/services/translation/src/translateBatch.ts
@@ -2,13 +2,19 @@ import { and, db, eq, or, sql } from '@op/db/client';
 import { contentTranslations } from '@op/db/schema';
 
 import { hashContent } from './hashContent';
-import type { TranslationProvider } from './providers';
+import type { TranslationFormat, TranslationProvider } from './providers';
 
 export type TranslatableEntry = {
   /** Identifies the content source, e.g. "proposal:abc123:default" */
   contentKey: string;
   /** The source text (plain text or HTML) */
   text: string;
+  /**
+   * How the provider should treat the text. Defaults to `html` because most
+   * entries are rich-text fragments; pass `text` for bare strings (titles,
+   * categories, field labels) or DeepL returns them wrapped in a `<p>`.
+   */
+  format?: TranslationFormat;
 };
 
 export type TranslationResult = {
@@ -44,7 +50,7 @@ export async function translateBatch({
 
   const hashed = entries.map((entry) => ({
     ...entry,
-    hash: hashContent(entry.text),
+    hash: hashContent(entry.text, entry.format ?? 'html'),
   }));
 
   const cacheHits = await lookupCached(hashed, targetLocale);
@@ -113,9 +119,9 @@ async function translateCacheMisses(
   targetLocale: string,
   provider: TranslationProvider,
 ): Promise<FreshTranslation[]> {
-  const texts = misses.map((m) => m.text);
-
-  const results = await provider.translate(texts);
+  const results = await provider.translate(
+    misses.map((m) => ({ text: m.text, format: m.format ?? 'html' })),
+  );
 
   return results.map((result, i) => {
     const miss = misses[i];


### PR DESCRIPTION
Translated proposals render literal markup in every plain field:

> `<p xmlns="http://www.w3.org/1999/xhtml">Renovation of a Swimming Pool in Downtown</p>`

## Cause

Every text went to DeepL with `tagHandling: 'html'`, whatever it was — `providers.ts:49` set it unconditionally. With that flag DeepL parses the input as a document, so a bare string has no root element and comes back wrapped in a namespaced `<p>`.

Rich-text fields survived it because they're rendered as markup. Plain fields are rendered as text nodes, so readers saw the tags.

## Scope — wider than the reported screenshot

| surface | field |
| --- | --- |
| proposal header | title |
| proposal | category chips |
| proposal template | field labels, descriptions, dropdown option titles |
| decision | headline, phase description, phase names, overview headline/description |
| **posts** | body — renders via `<p className="whitespace-pre-wrap">{linkifyText(content)}</p>` |

Only DeepL. OpenL has no tag-handling switch, which is why Somali never showed it.

## Fix

Entries carry a `format`. `TranslationProvider.translate` takes `{ text, format }`, and the DeepL provider asks for tag handling only on `html`.

The default stays `html`, so nothing changes by omission — the **12** plain-text call sites opt in. The **3** genuine markup entries are left alone: proposal fragments, a phase's `additionalInfo`, and the overview body.

**Cache invalidation is part of the fix.** Rows already holding a wrapped translation would keep being served. `hashContent` folds the format into the key but only prefixes `text`, so plain entries miss once and re-translate while html entries keep their hashes and their cache. No migration, no manual bust.

## Why the tests didn't catch it

The DeepL mock echoed its input, so the wrapping never happened under test — the suite was green against a broken pipeline. The mock now reproduces it: with `tagHandling` set, a bare string comes back wrapped. That turns the two plain-field assertions into real ones, and a guard asserts a translated title contains no `<p`.

Worth knowing when reading the diff: the `<p xmlns=…>` already in these fixtures is unrelated to the bug. That's our own `renderTipTapToHtml` (happy-dom) marking up TipTap content on the way *in*.

## Verification

Typecheck 23/23. The API translation tests need the local Supabase stack, which I couldn't bring up here — CI covers them.

Worth a manual pass after deploy: translate a proposal with a category and a template dropdown, and a post, and confirm the first translation of each is clean rather than served from a pre-fix cache row.
