### PR TITLE
fix(decision): default review aggregates to the current phase when phaseId is omitted

### DIFF
--- a/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
+++ b/packages/common/src/services/decision/getProposalWithReviewAggregates.ts
@@ -33,25 +33,29 @@ export type GetProposalWithReviewAggregatesInput = z.infer<
  * `aggregates.assignmentsCount` but are not surfaced in `reviews[]`.
  *
  * `phaseId` scopes the review set to assignments pinned to that phase, so all
- * derived values (reviews[], aggregates) are per-source-phase. Omitted means
- * all phases — admin-only; reviewers must always name a phase.
+ * derived values (reviews[], aggregates) are per-source-phase. Omitted
+ * defaults to the instance's current phase — admin-only; reviewers must
+ * always name a phase.
  */
 export async function getProposalWithReviewAggregates(
   input: GetProposalWithReviewAggregatesInput & { user: User },
 ): Promise<ProposalWithSubmittedReviews> {
-  const { user, processInstanceId, proposalId, phaseId } = input;
+  const { user, processInstanceId, proposalId } = input;
 
   const instance = await getInstance({ instanceId: processInstanceId, user });
 
   // Read gate: admin, or the process-wide reviewer grant on an open phase at
   // or before the current one — see `canReadPhaseReviews` for the semantics.
-  assertCanReadPhaseReviews(instance, phaseId);
+  // Gated on the caller's raw phaseId so reviewers must always name a phase.
+  assertCanReadPhaseReviews(instance, input.phaseId);
 
-  // Resolved by the requested phase so each phase's reviews are scored (and
-  // rendered by clients) against that phase's rubric. When an admin omits
-  // `phaseId` (all phases) this falls back to the instance-level rubric —
-  // aggregates blended across phases with different rubrics are inherently
-  // approximate.
+  // Effective phase: explicit `phaseId`, else the instance's current phase —
+  // mirrors `listProposalsWithReviewAggregates`, so there is no cross-phase
+  // blended mode.
+  const phaseId = input.phaseId ?? instance.currentStateId ?? undefined;
+
+  // Resolved by the effective phase so each phase's reviews are scored (and
+  // rendered by clients) against that phase's rubric.
   const rubricTemplate = getPhaseRubricTemplate(instance.instanceData, phaseId);
   const scoredCriterionKeys = rubricTemplate
     ? getRubricScoringInfo(rubricTemplate)

--- a/packages/common/src/services/decision/reviewHelpers.ts
+++ b/packages/common/src/services/decision/reviewHelpers.ts
@@ -133,11 +133,11 @@ export interface PhaseReviewsReadContext {
 
 /**
  * Whether the caller may read a phase's submitted review set on this
- * instance. Admins always can — any phase, or all phases when `phaseId` is
- * omitted — and return before any phase-settings resolution (which throws
- * NotFound on a phase the instance doesn't have). Reviewers (`access.review`)
- * must name a phase — without one the caller would read reviews blended
- * across ALL phases — and that phase's resolved `openReviews` must be on. An
+ * instance. Admins always can — any phase, or the caller's default when
+ * `phaseId` is omitted — and return before any phase-settings resolution
+ * (which throws NotFound on a phase the instance doesn't have). Reviewers
+ * (`access.review`) must name a phase, and that phase's resolved
+ * `openReviews` must be on. An
  * open phase stays readable after it ends (later-phase reviewers read the
  * earlier phase's reviews), but phases after the current one are never
  * readable. The reviewer grant is deliberately process-wide: ANY reviewer of

--- a/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
+++ b/services/api/src/routers/decision/proposals/getProposalWithReviewAggregates.test.ts
@@ -716,7 +716,7 @@ describe.concurrent('getProposalWithReviewAggregates', () => {
 // delegates reading feasibility reviews) without exposing any closed phase.
 
 describe.concurrent('getProposalWithReviewAggregates phase scoping', () => {
-  it('admin without phaseId reads submitted reviews across all phases', async ({
+  it('admin without phaseId defaults to the current phase', async ({
     task,
     onTestFinished,
   }) => {
@@ -727,18 +727,17 @@ describe.concurrent('getProposalWithReviewAggregates phase scoping', () => {
       seeded.context.defaultReviewer.email,
     );
 
+    // The instance sits on the community phase, so the earlier feasibility
+    // review must not appear.
     const result = await adminCaller.decision.getProposalWithReviewAggregates({
       processInstanceId: seeded.context.instance.instance.id,
       proposalId: seeded.proposal.id,
     });
 
-    expect(result.aggregates.assignmentsCount).toBe(2);
-    expect(result.reviews).toHaveLength(2);
-    expect(result.reviews.map((r) => r.reviewer.id).sort()).toEqual(
-      [
-        seeded.feasibilityReviewerProfileId,
-        seeded.communityReviewerProfileId,
-      ].sort(),
+    expect(result.aggregates.assignmentsCount).toBe(1);
+    expect(result.reviews).toHaveLength(1);
+    expect(result.reviews[0]!.reviewer.id).toBe(
+      seeded.communityReviewerProfileId,
     );
   });
 
@@ -879,8 +878,9 @@ describe.concurrent('getProposalWithReviewAggregates phase scoping', () => {
     );
     const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
 
-    // No phaseId would blend reviews across ALL phases — reviewer-tier callers
-    // are rejected outright.
+    // The read gate uses the caller's raw phaseId, so reviewer-tier callers
+    // must always name a phase — omitting it is rejected outright even
+    // though admins get the current-phase default.
     await expect(
       reviewerCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: seeded.context.instance.instance.id,

--- a/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
+++ b/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
@@ -318,18 +318,36 @@ describe.concurrent('per-phase rubric templates', () => {
     expect(communityResult.aggregates.averageScore).toBe(11);
     expect(communityResult.reviews[0]!.overallRecommendation).toBe('yes');
 
-    // Admin omitting phaseId blends phases; the documented behavior is the
-    // instance-level rubric, so the feasibility review scores 0 against it.
-    const blendedResult =
+    // Admin omitting phaseId defaults to the current (community) phase:
+    // its rubric (instance fallback) and only its review — never a blend
+    // across phases.
+    const defaultPhaseResult =
       await adminCaller.decision.getProposalWithReviewAggregates({
         processInstanceId: instanceId,
         proposalId: feasibilityScenario.proposal.id,
       });
-    expect(blendedResult.rubricTemplate).toMatchObject({
+    expect(defaultPhaseResult.rubricTemplate).toMatchObject({
       properties: { impact: { title: 'Impact' } },
     });
-    expect(blendedResult.aggregates.reviewsSubmittedCount).toBe(2);
-    expect(blendedResult.aggregates.averageScore).toBe(5.5);
+    expect(defaultPhaseResult.aggregates.reviewsSubmittedCount).toBe(1);
+    expect(defaultPhaseResult.aggregates.averageScore).toBe(11);
+    expect(defaultPhaseResult.reviews).toHaveLength(1);
+
+    // Wind back to feasibility: the omitted-phase default follows the
+    // current phase, picking up its rubric override.
+    await testData.setCurrentPhase(instanceId, FEASIBILITY_PHASE);
+    const feasibilityDefaultResult =
+      await adminCaller.decision.getProposalWithReviewAggregates({
+        processInstanceId: instanceId,
+        proposalId: feasibilityScenario.proposal.id,
+      });
+    expect(feasibilityDefaultResult.rubricTemplate).toMatchObject({
+      properties: { viability: { title: 'Viability' } },
+    });
+    expect(feasibilityDefaultResult.aggregates.reviewsSubmittedCount).toBe(1);
+    expect(feasibilityDefaultResult.aggregates.averageScore).toBe(3);
+    // Restore the current phase for the list-endpoint assertions below.
+    await testData.setCurrentPhase(instanceId, COMMUNITY_PHASE);
 
     // The list endpoint carries the same phase-resolved rubric, so clients
     // never resolve one themselves (e.g. shortlist total points).


### PR DESCRIPTION
Omitting phaseId on getProposalWithReviewAggregates used to blend reviews from all phases against the instance-level rubric — an unused mode where aggregates mixed answers scored on different rubrics. It now defaults to the instance's current phase, matching listProposalsWithReviewAggregates. The read gate still checks the raw input phaseId, so reviewers must name a phase; only admins get the default.