### PR TITLE
feat(decision): add budget add-up rubric criterion

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -21,6 +21,7 @@ import type { TranslationKey } from '@/lib/i18n/routing';
 
 import type {
   CriterionView,
+  EditableRubricCriterionType,
   RubricCriterionType,
   SelectOption,
 } from '@/components/decisions/rubricTemplate';
@@ -44,7 +45,10 @@ interface RubricCriterionCardProps {
   onBlur?: (criterionId: string) => void;
   onUpdateLabel?: (criterionId: string, label: string) => void;
   onUpdateDescription?: (criterionId: string, description: string) => void;
-  onChangeType?: (criterionId: string, newType: RubricCriterionType) => void;
+  onChangeType?: (
+    criterionId: string,
+    newType: EditableRubricCriterionType,
+  ) => void;
   onUpdateMaxPoints?: (criterionId: string, maxPoints: number) => void;
   onUpdateScoreLabel?: (
     criterionId: string,
@@ -129,107 +133,152 @@ export function RubricCriterionCard({
           errors.length > 0 && 'border-functional-red',
         )}
       >
-        <div className="space-y-2.5 px-8">
-          {/* Field name */}
-          <TextField
-            label={t('Field name')}
-            isRequired
-            value={criterion.label}
-            onChange={(value) => onUpdateLabel?.(criterion.id, value)}
-            maxLength={50}
-            inputProps={{
-              className: 'bg-white',
-            }}
-            className="min-w-0 flex-1"
-          />
+        {criterion.criterionType === 'budget_addup' ? (
+          <BudgetAddUpCriterionSummary criterion={criterion} />
+        ) : (
+          <div className="space-y-2.5 px-8">
+            {/* Field name */}
+            <TextField
+              label={t('Field name')}
+              isRequired
+              value={criterion.label}
+              onChange={(value) => onUpdateLabel?.(criterion.id, value)}
+              maxLength={50}
+              inputProps={{
+                className: 'bg-white',
+              }}
+              className="min-w-0 flex-1"
+            />
 
-          {/* Description */}
-          <TextField
-            label={t('Description')}
-            useTextArea
-            value={criterion.description ?? ''}
-            onChange={(value) => onUpdateDescription?.(criterion.id, value)}
-            textareaProps={{
-              placeholder: t('Provide additional guidance for participants...'),
-              className: 'min-h-24 resize-none bg-white',
-            }}
-          />
+            {/* Description */}
+            <TextField
+              label={t('Description')}
+              useTextArea
+              value={criterion.description ?? ''}
+              onChange={(value) => onUpdateDescription?.(criterion.id, value)}
+              textareaProps={{
+                placeholder: t(
+                  'Provide additional guidance for participants...',
+                ),
+                className: 'min-h-24 resize-none bg-white',
+              }}
+            />
 
-          <hr />
+            <hr />
 
-          {/* Criterion type radio selector */}
-          <CriterionTypeSelector
-            value={criterion.criterionType}
-            onChange={(newType) => onChangeType?.(criterion.id, newType)}
-          />
+            {/* Criterion type radio selector */}
+            <CriterionTypeSelector
+              value={criterion.criterionType}
+              onChange={(newType) => onChangeType?.(criterion.id, newType)}
+            />
 
-          {/* Type-specific configuration */}
-          {criterion.criterionType === 'scored' && (
-            <>
-              <hr />
-              <ScoredCriterionConfig
-                criterion={criterion}
-                onUpdateMaxPoints={(max) =>
-                  onUpdateMaxPoints?.(criterion.id, max)
-                }
-                onUpdateScoreLabel={(scoreValue, label) =>
-                  onUpdateScoreLabel?.(criterion.id, scoreValue, label)
-                }
-              />
-            </>
-          )}
-
-          {criterion.criterionType === 'single_select' && (
-            <>
-              <hr />
-              <SingleSelectCriterionConfig
-                criterion={criterion}
-                onUpdateOptions={(options) =>
-                  onUpdateOptions?.(criterion.id, options)
-                }
-              />
-            </>
-          )}
-
-          {/* Validation errors */}
-          {errors.length > 0 && (
-            <div className="space-y-1">
-              {errors.map((error) => (
-                <p key={error} className="text-sm text-functional-red">
-                  {t(error)}
-                </p>
-              ))}
-            </div>
-          )}
-
-          {/* Footer: Required toggle + Delete button */}
-          <div className="flex items-center justify-between border-t pt-4">
-            <div className="flex items-center gap-2">
-              <span className="text-neutral-charcoal">{t('Required?')}</span>
-              <ToggleButton
-                size="small"
-                isSelected={criterion.required}
-                onChange={(isSelected) =>
-                  onUpdateRequired(criterion.id, isSelected)
-                }
-                aria-label={t('Required')}
-              />
-            </div>
-            {onRemove && (
-              <Button
-                color="ghost"
-                size="small"
-                onPress={() => onRemove(criterion.id)}
-                aria-label={t('Delete')}
-                className="text-neutral-charcoal hover:text-functional-red"
-              >
-                <LuTrash2 className="size-4" />
-                {t('Delete')}
-              </Button>
+            {/* Type-specific configuration */}
+            {criterion.criterionType === 'scored' && (
+              <>
+                <hr />
+                <ScoredCriterionConfig
+                  criterion={criterion}
+                  onUpdateMaxPoints={(max) =>
+                    onUpdateMaxPoints?.(criterion.id, max)
+                  }
+                  onUpdateScoreLabel={(scoreValue, label) =>
+                    onUpdateScoreLabel?.(criterion.id, scoreValue, label)
+                  }
+                />
+              </>
             )}
+
+            {criterion.criterionType === 'single_select' && (
+              <>
+                <hr />
+                <SingleSelectCriterionConfig
+                  criterion={criterion}
+                  onUpdateOptions={(options) =>
+                    onUpdateOptions?.(criterion.id, options)
+                  }
+                />
+              </>
+            )}
+
+            {/* Validation errors */}
+            {errors.length > 0 && (
+              <div className="space-y-1">
+                {errors.map((error) => (
+                  <p key={error} className="text-sm text-functional-red">
+                    {t(error)}
+                  </p>
+                ))}
+              </div>
+            )}
+
+            {/* Footer: Required toggle + Delete button */}
+            <div className="flex items-center justify-between border-t pt-4">
+              <div className="flex items-center gap-2">
+                <span className="text-neutral-charcoal">{t('Required?')}</span>
+                <ToggleButton
+                  size="small"
+                  isSelected={criterion.required}
+                  onChange={(isSelected) =>
+                    onUpdateRequired(criterion.id, isSelected)
+                  }
+                  aria-label={t('Required')}
+                />
+              </div>
+              {onRemove && (
+                <Button
+                  color="ghost"
+                  size="small"
+                  onPress={() => onRemove(criterion.id)}
+                  aria-label={t('Delete')}
+                  className="text-neutral-charcoal hover:text-functional-red"
+                >
+                  <LuTrash2 className="size-4" />
+                  {t('Delete')}
+                </Button>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </CollapsibleConfigCard>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Budget add-up (read-only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only body for a budget add-up criterion. The builder cannot yet create
+ * or edit one — templates seed them — but the card must exist so the criterion
+ * stays visible and keeps its place when other criteria are reordered.
+ */
+function BudgetAddUpCriterionSummary({
+  criterion,
+}: {
+  criterion: CriterionView;
+}) {
+  const t = useTranslations();
+
+  return (
+    <div className="space-y-2.5 px-8">
+      <p className="text-sm text-neutral-charcoal">
+        {t(
+          'This criterion is set up in the template and cannot be edited here.',
+        )}
+      </p>
+
+      {criterion.description && (
+        <p className="text-sm text-neutral-gray4">{criterion.description}</p>
+      )}
+
+      <ul className="space-y-1">
+        {criterion.lineItems.map((lineItem) => (
+          <li key={lineItem.id} className="text-base text-neutral-black">
+            {lineItem.title}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -243,7 +292,7 @@ function CriterionTypeSelector({
   onChange,
 }: {
   value: RubricCriterionType;
-  onChange: (type: RubricCriterionType) => void;
+  onChange: (type: EditableRubricCriterionType) => void;
 }) {
   const t = useTranslations();
 
@@ -251,7 +300,7 @@ function CriterionTypeSelector({
     <RadioGroup
       label={t('How should reviewers score this?')}
       value={value}
-      onChange={(newValue) => onChange(newValue as RubricCriterionType)}
+      onChange={(newValue) => onChange(newValue as EditableRubricCriterionType)}
       orientation="vertical"
       labelClassName="text-base"
     >

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -24,7 +24,7 @@ import type { SectionProps } from '@/components/decisions/ProcessBuilder/content
 import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import type {
   CriterionView,
-  RubricCriterionType,
+  EditableRubricCriterionType,
   SelectOption,
 } from '@/components/decisions/rubricTemplate';
 import {
@@ -198,7 +198,7 @@ export function RubricEditorContent({
   );
 
   const handleChangeType = useCallback(
-    (criterionId: string, newType: RubricCriterionType) => {
+    (criterionId: string, newType: EditableRubricCriterionType) => {
       setTemplate((prev) => {
         // Stash scored config before switching away from scored
         if (getCriterionType(prev, criterionId) === 'scored') {

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/rubricCriterionRegistry.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/rubricCriterionRegistry.tsx
@@ -1,6 +1,9 @@
 import type { TranslationKey } from '@/lib/i18n/routing';
 
-import type { RubricCriterionType } from '@/components/decisions/rubricTemplate';
+import type {
+  EditableRubricCriterionType,
+  RubricCriterionType,
+} from '@/components/decisions/rubricTemplate';
 
 /**
  * Display metadata for each rubric criterion type.
@@ -33,12 +36,18 @@ export const CRITERION_TYPE_REGISTRY: Record<
     labelKey: 'Text response only',
     descriptionKey: 'No score, just written feedback',
   },
+  budget_addup: {
+    labelKey: 'Budget add-up',
+    descriptionKey: 'Reviewers enter amounts that add up to a total',
+  },
 };
 
 /**
- * Ordered list of criterion types for the radio selector.
+ * Ordered list of criterion types for the radio selector. Budget add-ups are
+ * omitted: they are seeded through the template, not built here, and the card
+ * renders them read-only.
  */
-export const CRITERION_TYPES: RubricCriterionType[] = [
+export const CRITERION_TYPES: EditableRubricCriterionType[] = [
   'scored',
   'yes_no',
   'single_select',

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/BudgetFieldConfig.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/template/BudgetFieldConfig.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { CURRENCIES, getCurrencySymbol } from '@/utils/currency';
 import { ProposalTemplateSchema } from '@op/common';
 import { CollapsibleConfigCard } from '@op/ui/CollapsibleConfigCard';
 import { NumberField } from '@op/ui/NumberField';
@@ -17,28 +18,6 @@ import {
   setFieldRequired,
 } from '../../../proposalTemplate';
 
-const CURRENCIES = [
-  { code: 'USD', symbol: '$' },
-  { code: 'EUR', symbol: '€' },
-  { code: 'GBP', symbol: '£' },
-  { code: 'JPY', symbol: '¥' },
-  { code: 'CAD', symbol: 'CA$' },
-  { code: 'AUD', symbol: 'A$' },
-  { code: 'CHF', symbol: 'CHF' },
-  { code: 'CNY', symbol: '¥' },
-  { code: 'INR', symbol: '₹' },
-  { code: 'BRL', symbol: 'R$' },
-  { code: 'KRW', symbol: '₩' },
-  { code: 'SGD', symbol: 'S$' },
-  { code: 'MXN', symbol: 'MX$' },
-  { code: 'AED', symbol: 'د.إ' },
-  { code: 'SAR', symbol: '﷼' },
-] as const;
-
-const CURRENCY_SYMBOL_MAP = new Map<string, string>(
-  CURRENCIES.map((c) => [c.code, c.symbol]),
-);
-
 export function BudgetFieldConfig({
   template,
   onTemplateChange,
@@ -55,7 +34,7 @@ export function BudgetFieldConfig({
   const budgetCurrency =
     (budgetSchema?.properties?.currency as { default?: string } | undefined)
       ?.default ?? 'USD';
-  const budgetCurrencySymbol = CURRENCY_SYMBOL_MAP.get(budgetCurrency) ?? '$';
+  const budgetCurrencySymbol = getCurrencySymbol(budgetCurrency);
   const budgetMaxAmount = budgetSchema?.maximum as number | undefined;
   const budgetRequired = isFieldRequired(template, 'budget');
 

--- a/apps/app/src/components/decisions/Review/MoneyTotalRow.tsx
+++ b/apps/app/src/components/decisions/Review/MoneyTotalRow.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { formatCurrency } from '@/utils/formatting';
+import { Surface } from '@op/ui/Surface';
+
+import { useTranslations } from '@/lib/i18n';
+
+/**
+ * Derived total of a budget add-up: the filled row under its money line
+ * items, shown live in the reviewer form and again on the submitted review.
+ * Totals are never stored — every caller passes a freshly summed value.
+ */
+export function MoneyTotalRow({
+  total,
+  currency,
+}: {
+  total: number;
+  currency: string;
+}) {
+  const t = useTranslations();
+
+  return (
+    <Surface
+      variant="filled"
+      className="flex items-center justify-between rounded-lg border-neutral-gray1 p-4"
+    >
+      <span className="text-base text-neutral-charcoal">{t('Total')}</span>
+      <span className="font-serif text-title-base text-neutral-black">
+        {formatCurrency(total, undefined, currency, {
+          minimumFractionDigits: 2,
+        })}
+      </span>
+    </Surface>
+  );
+}

--- a/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
@@ -32,6 +32,12 @@ export function TotalScoreCard({
   const { totalPoints } = getRubricScoringInfo(rubricTemplate);
 
   const totalScore = criteria.reduce<number | null>((total, criterion) => {
+    // Only scored criteria contribute; a numeric answer of any other type
+    // (e.g. a budget add-up amount) must never reach the displayed score.
+    if (criterion.criterionType !== 'scored') {
+      return total;
+    }
+
     const value = values[criterion.id];
 
     if (typeof value !== 'number') {

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -1,14 +1,21 @@
 'use client';
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { getCurrencySymbol } from '@/utils/currency';
 import {
   ProposalReviewState,
   type XFormatPropertySchema,
+  getMoneyGroupCurrency,
+  getMoneyGroupLineItems,
+  getMoneyLineItemAmount,
   isOverallRecommendationField,
   parseSchemaOptions,
+  setMoneyLineItemAmount,
+  sumMoneyGroupTotal,
 } from '@op/common/client';
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Button } from '@op/ui/Button';
+import { NumberField } from '@op/ui/NumberField';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { Select, SelectItem } from '@op/ui/Select';
 import { TextField } from '@op/ui/TextField';
@@ -23,6 +30,7 @@ import { FieldHeader } from '../forms/FieldHeader';
 import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
 import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
+import { MoneyTotalRow } from './MoneyTotalRow';
 import { useReviewForm } from './ReviewFormContext';
 import { FormShell, TotalScoreCard } from './ReviewFormShell';
 import { type PreviousReviewPhase, ReviewTabs } from './ReviewTabs';
@@ -465,9 +473,60 @@ function RubricFieldInput({
         />
       );
 
+    case 'money-group':
+      return (
+        <BudgetAddUpField field={field} value={value} onChange={onChange} />
+      );
+
     default:
       return null;
   }
+}
+
+/**
+ * Budget add-up: one money input per line item plus the derived total. The
+ * total is never stored — it is summed from the line items on every render.
+ * The group's currency is materialized into the stored answer on each edit,
+ * so reviewers never pick one.
+ */
+function BudgetAddUpField({
+  field,
+  value,
+  onChange,
+}: {
+  field: FieldDescriptor;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const lineItems = getMoneyGroupLineItems(field.schema);
+  const currency = getMoneyGroupCurrency(field.schema, value);
+  const currencySymbol = getCurrencySymbol(currency);
+  const total = sumMoneyGroupTotal(field.schema, value);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {lineItems.map((lineItem) => (
+        <NumberField
+          key={lineItem.id}
+          label={lineItem.title}
+          isRequired={lineItem.required}
+          labelClassName="text-base font-bold text-neutral-black"
+          value={getMoneyLineItemAmount(value, lineItem.id)}
+          onChange={(amount) =>
+            onChange(
+              setMoneyLineItemAmount(field.schema, value, lineItem.id, amount),
+            )
+          }
+          prefixText={currencySymbol}
+          minValue={0}
+          inputProps={{ placeholder: '0.00' }}
+          className="w-full"
+        />
+      ))}
+
+      <MoneyTotalRow total={total} currency={currency} />
+    </div>
+  );
 }
 
 /**

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -1,8 +1,13 @@
+import { formatCurrency } from '@/utils/formatting';
 import {
   type ProposalReview,
   type RubricTemplateSchema,
   findSchemaOption,
+  getMoneyGroupCurrency,
+  getMoneyGroupLineItems,
+  getMoneyLineItemAmount,
   isOverallRecommendationField,
+  sumMoneyGroupTotal,
 } from '@op/common/client';
 import type { ReactNode } from 'react';
 
@@ -12,6 +17,7 @@ import { FieldHeader } from '../forms/FieldHeader';
 import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
 import { inferCriterionType } from '../rubricTemplate';
+import { MoneyTotalRow } from './MoneyTotalRow';
 
 export function SubmittedReviewView({
   rubricTemplate,
@@ -163,10 +169,64 @@ function RubricFieldResult({
     );
   }
 
+  if (field.format === 'money-group') {
+    return (
+      <BudgetAddUpResult field={field} value={value} rationale={rationale} />
+    );
+  }
+
   if (field.format === 'long-text' || field.format === 'short-text') {
     const text = typeof value === 'string' ? value.trim() : '';
     return <ResultCard description={text || '—'} />;
   }
 
   return null;
+}
+
+/**
+ * Submitted budget add-up: each line item's amount plus the total, re-summed
+ * here rather than read from the answer (totals are never stored).
+ */
+function BudgetAddUpResult({
+  field,
+  value,
+  rationale,
+}: {
+  field: FieldDescriptor;
+  value: unknown;
+  rationale?: string;
+}) {
+  const currency = getMoneyGroupCurrency(field.schema, value);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {getMoneyGroupLineItems(field.schema).map((lineItem) => {
+        const amount = getMoneyLineItemAmount(value, lineItem.id);
+        return (
+          <div
+            key={lineItem.id}
+            className="flex items-baseline justify-between gap-4"
+          >
+            <span className="text-base font-bold text-neutral-black">
+              {lineItem.title}
+            </span>
+            <span className="text-base text-neutral-charcoal">
+              {amount === null
+                ? '—'
+                : formatCurrency(amount, undefined, currency, {
+                    minimumFractionDigits: 2,
+                  })}
+            </span>
+          </div>
+        );
+      })}
+
+      <MoneyTotalRow
+        total={sumMoneyGroupTotal(field.schema, value)}
+        currency={currency}
+      />
+
+      {rationale && <ResultCard rationale={rationale} />}
+    </div>
+  );
 }

--- a/apps/app/src/components/decisions/rubricTemplate.test.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type {
-  RubricCriterionType,
+  EditableRubricCriterionType,
   RubricTemplateSchema,
 } from './rubricTemplate';
 import {
@@ -14,27 +14,50 @@ import {
   getCriterionOptions,
   getCriterionType,
   inferCriterionType,
+  reorderCriteria,
   setCriterionRequired,
   setSelectOptions,
   updateCriterionDescription,
 } from './rubricTemplate';
 
-const ALL_TYPES: RubricCriterionType[] = [
+const EDITABLE_TYPES: EditableRubricCriterionType[] = [
   'scored',
   'yes_no',
   'single_select',
   'long_text',
 ];
 
+/** Seeded budget add-up — the builder cannot create one. */
+const budgetAddUpTemplate: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': ['b7e41c93'],
+  properties: {
+    b7e41c93: {
+      type: 'object',
+      title: 'Total Estimated Cost',
+      'x-format': 'money-group',
+      properties: {
+        a1b2c3d4: { type: 'number', title: 'Design', minimum: 0 },
+        e5f6a7b8: { type: 'number', title: 'Build', minimum: 0 },
+        currency: { type: 'string', const: 'USD', default: 'USD' },
+      },
+      additionalProperties: false,
+      required: ['a1b2c3d4', 'e5f6a7b8', 'currency'],
+      'x-field-order': ['a1b2c3d4', 'e5f6a7b8'],
+    },
+  },
+  required: ['b7e41c93'],
+};
+
 function templateWithCriterion(
-  type: RubricCriterionType,
+  type: EditableRubricCriterionType,
   criterionId = 'crit1',
 ): RubricTemplateSchema {
   return addCriterion(createEmptyRubricTemplate(), criterionId, type, 'Label');
 }
 
 describe('createCriterionJsonSchema / inferCriterionType round-trip', () => {
-  it.each(ALL_TYPES)('round-trips %s', (type) => {
+  it.each(EDITABLE_TYPES)('round-trips %s', (type) => {
     const schema = createCriterionJsonSchema(type);
     expect(inferCriterionType(schema)).toBe(type);
   });
@@ -274,5 +297,34 @@ describe('getCriteria', () => {
     expect(single?.criterionType).toBe('single_select');
     expect(single?.options).toHaveLength(2);
     expect(single?.options[0]?.title).toBe('Parks');
+  });
+});
+
+describe('budget add-up criteria', () => {
+  it('reads a seeded budget add-up with its line items, excluding currency', () => {
+    const criteria = getCriteria(budgetAddUpTemplate);
+
+    expect(criteria).toHaveLength(1);
+    expect(criteria[0]?.criterionType).toBe('budget_addup');
+    expect(criteria[0]?.label).toBe('Total Estimated Cost');
+    expect(criteria[0]?.lineItems).toEqual([
+      { id: 'a1b2c3d4', title: 'Design', required: true },
+      { id: 'e5f6a7b8', title: 'Build', required: true },
+    ]);
+  });
+
+  it('keeps the add-up when other criteria are reordered', () => {
+    let template = addCriterion(
+      budgetAddUpTemplate,
+      'notes',
+      'long_text',
+      'Notes',
+    );
+    template = reorderCriteria(template, ['notes', 'b7e41c93']);
+
+    expect(getCriteria(template).map((c) => c.id)).toEqual([
+      'notes',
+      'b7e41c93',
+    ]);
   });
 });

--- a/apps/app/src/components/decisions/rubricTemplate.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.ts
@@ -10,12 +10,15 @@
  * type inference from schema shape.
  */
 import type {
+  MoneyLineItem,
   RubricTemplateSchema,
   XFormatPropertySchema,
 } from '@op/common/client';
 import {
   OVERALL_RECOMMENDATION_KEY,
   RECOMMENDATION_OPTION,
+  getMoneyGroupLineItems,
+  isMoneyGroupSchema,
   isOverallRecommendationField,
 } from '@op/common/client';
 import type { JSONSchema7 } from 'json-schema';
@@ -48,7 +51,23 @@ export type RubricCriterionType =
   | 'scored'
   | 'yes_no'
   | 'single_select'
-  | 'long_text';
+  | 'long_text'
+  /**
+   * Budget add-up: one composite criterion holding money line items whose
+   * total is derived at render time, never stored. Read-only here — templates
+   * seed it (see `kb/adr/0003-budget-addup-derived-totals`), so it is excluded
+   * from {@link EditableRubricCriterionType}.
+   */
+  | 'budget_addup';
+
+/**
+ * The criterion types the builder can create or switch between. Budget add-ups
+ * are rendered and inferred but never authored here.
+ */
+export type EditableRubricCriterionType = Exclude<
+  RubricCriterionType,
+  'budget_addup'
+>;
 
 /** A single admin-defined option on a single-select criterion. */
 export interface SelectOption {
@@ -80,6 +99,8 @@ export interface CriterionView {
   scoreLabels: string[];
   /** Admin-defined options. Single-select criteria only (empty for other types). */
   options: SelectOption[];
+  /** Money line items. Budget add-ups only (empty for other types). */
+  lineItems: MoneyLineItem[];
 }
 
 // ---------------------------------------------------------------------------
@@ -130,7 +151,7 @@ function getSelectOptionEntries(schema: XFormatPropertySchema): SelectOption[] {
  * Callers with i18n access pass translated labels (e.g. Yes/Maybe/No).
  */
 export function createCriterionJsonSchema(
-  type: RubricCriterionType,
+  type: EditableRubricCriterionType,
   selectOptionLabels?: string[],
 ): XFormatPropertySchema {
   switch (type) {
@@ -187,6 +208,10 @@ export function inferCriterionType(
   schema: XFormatPropertySchema,
 ): RubricCriterionType | undefined {
   const xFormat = schema['x-format'];
+
+  if (isMoneyGroupSchema(schema)) {
+    return 'budget_addup';
+  }
 
   if (xFormat === 'long-text') {
     return 'long_text';
@@ -310,6 +335,21 @@ export function getCriterionOptions(
   return getSelectOptionEntries(schema);
 }
 
+/**
+ * Money line items of a budget add-up, in stored order.
+ * Empty for other criterion types.
+ */
+export function getCriterionLineItems(
+  template: RubricTemplateSchema,
+  criterionId: string,
+): MoneyLineItem[] {
+  const schema = getCriterionSchema(template, criterionId);
+  if (!schema || !isMoneyGroupSchema(schema)) {
+    return [];
+  }
+  return getMoneyGroupLineItems(schema);
+}
+
 // ---------------------------------------------------------------------------
 // Composite readers
 // ---------------------------------------------------------------------------
@@ -332,6 +372,7 @@ export function getCriterion(
     maxPoints: getCriterionMaxPoints(template, criterionId),
     scoreLabels: getCriterionScoreLabels(template, criterionId),
     options: getCriterionOptions(template, criterionId),
+    lineItems: getCriterionLineItems(template, criterionId),
   };
 }
 
@@ -382,7 +423,7 @@ export function getCriterionErrors(criterion: CriterionView): TranslationKey[] {
 export function addCriterion(
   template: RubricTemplateSchema,
   criterionId: string,
-  type: RubricCriterionType,
+  type: EditableRubricCriterionType,
   label: string,
   selectOptionLabels?: string[],
 ): RubricTemplateSchema {
@@ -438,7 +479,7 @@ export function setCriterionRequired(
 export function changeCriterionType(
   template: RubricTemplateSchema,
   criterionId: string,
-  newType: RubricCriterionType,
+  newType: EditableRubricCriterionType,
   selectOptionLabels?: string[],
 ): RubricTemplateSchema {
   return updateProperty(template, criterionId, (existing) => {

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1430,5 +1430,9 @@
   "Reviewers can see each other's reviews on a proposal": "يمكن للمراجعين رؤية مراجعات بعضهم البعض على المقترح",
   "Turn on Open Reviews?": "تفعيل المراجعات المفتوحة؟",
   "This can lead reviewers to agree with each other more than they would independently.": "قد يؤدي ذلك إلى اتفاق المراجعين مع بعضهم البعض أكثر مما لو كانوا مستقلين.",
-  "Enable": "تفعيل"
+  "Enable": "تفعيل",
+  "Total": "الإجمالي",
+  "Budget add-up": "مجموع الميزانية",
+  "Reviewers enter amounts that add up to a total": "يُدخل المراجعون مبالغ تُجمع في إجمالي",
+  "This criterion is set up in the template and cannot be edited here.": "يُضبط هذا المعيار في القالب ولا يمكن تعديله هنا."
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1433,5 +1433,9 @@
   "Reviewers can see each other's reviews on a proposal": "পর্যালোচকরা একটি প্রস্তাবে একে অপরের পর্যালোচনা দেখতে পারেন",
   "Turn on Open Reviews?": "উন্মুক্ত পর্যালোচনা চালু করবেন?",
   "This can lead reviewers to agree with each other more than they would independently.": "এটি পর্যালোচকদের স্বাধীনভাবে যতটা একমত হতেন তার চেয়ে বেশি একে অপরের সাথে একমত হতে পরিচালিত করতে পারে।",
-  "Enable": "চালু করুন"
+  "Enable": "চালু করুন",
+  "Total": "মোট",
+  "Budget add-up": "বাজেট যোগফল",
+  "Reviewers enter amounts that add up to a total": "পর্যালোচকরা এমন পরিমাণ লেখেন যা যোগ হয়ে মোট হয়",
+  "This criterion is set up in the template and cannot be edited here.": "এই মানদণ্ডটি টেমপ্লেটে নির্ধারিত এবং এখানে সম্পাদনা করা যায় না।"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1496,5 +1496,9 @@
   "Voting (max {count} per member)": "Voting (max {count} per member)",
   "Vote editing": "Vote editing",
   "Advances manually": "Advances manually",
-  "Advances by date": "Advances by date"
+  "Advances by date": "Advances by date",
+  "Total": "Total",
+  "Budget add-up": "Budget add-up",
+  "Reviewers enter amounts that add up to a total": "Reviewers enter amounts that add up to a total",
+  "This criterion is set up in the template and cannot be edited here.": "This criterion is set up in the template and cannot be edited here."
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1430,5 +1430,9 @@
   "Reviewers can see each other's reviews on a proposal": "Las personas revisoras pueden ver las revisiones de las demás en una propuesta",
   "Turn on Open Reviews?": "¿Activar las revisiones abiertas?",
   "This can lead reviewers to agree with each other more than they would independently.": "Esto puede llevar a que las personas revisoras estén de acuerdo entre sí más de lo que lo harían de forma independiente.",
-  "Enable": "Activar"
+  "Enable": "Activar",
+  "Total": "Total",
+  "Budget add-up": "Suma de presupuesto",
+  "Reviewers enter amounts that add up to a total": "Los revisores ingresan montos que suman un total",
+  "This criterion is set up in the template and cannot be edited here.": "Este criterio se configura en la plantilla y no se puede editar aquí."
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1430,5 +1430,9 @@
   "Reviewers can see each other's reviews on a proposal": "Les évaluateurs peuvent voir les évaluations des autres sur une proposition",
   "Turn on Open Reviews?": "Activer les évaluations ouvertes ?",
   "This can lead reviewers to agree with each other more than they would independently.": "Cela peut amener les évaluateurs à être davantage d’accord entre eux qu’ils ne le seraient de manière indépendante.",
-  "Enable": "Activer"
+  "Enable": "Activer",
+  "Total": "Total",
+  "Budget add-up": "Total du budget",
+  "Reviewers enter amounts that add up to a total": "Les évaluateurs saisissent des montants qui forment un total",
+  "This criterion is set up in the template and cannot be edited here.": "Ce critère est défini dans le modèle et ne peut pas être modifié ici."
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1430,5 +1430,9 @@
   "Reviewers can see each other's reviews on a proposal": "Os avaliadores podem ver as avaliações uns dos outros em uma proposta",
   "Turn on Open Reviews?": "Ativar avaliações abertas?",
   "This can lead reviewers to agree with each other more than they would independently.": "Isso pode levar os avaliadores a concordarem mais uns com os outros do que fariam de forma independente.",
-  "Enable": "Ativar"
+  "Enable": "Ativar",
+  "Total": "Total",
+  "Budget add-up": "Soma do orçamento",
+  "Reviewers enter amounts that add up to a total": "Os revisores inserem valores que somam um total",
+  "This criterion is set up in the template and cannot be edited here.": "Este critério é definido no modelo e não pode ser editado aqui."
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1432,5 +1432,9 @@
   "Reviewers can see each other's reviews on a proposal": "Dib-u-eegayaashu waxay ku arki karaan dib-u-eegisyada midba midka kale ee soo jeedin",
   "Turn on Open Reviews?": "Shid dib-u-eegisyada furan?",
   "This can lead reviewers to agree with each other more than they would independently.": "Tani waxay u horseedi kartaa in dib-u-eegayaashu isku raacaan midba midka kale in ka badan intii ay si madax-bannaan u samayn lahaayeen.",
-  "Enable": "Shid"
+  "Enable": "Shid",
+  "Total": "Wadarta",
+  "Budget add-up": "Isku-darka miisaaniyadda",
+  "Reviewers enter amounts that add up to a total": "Dib-u-eegayaashu waxay geliyaan qaddaro isku darsama wadar",
+  "This criterion is set up in the template and cannot be edited here.": "Shuruudkan waxaa lagu dejiyaa qaabka, halkanna lagama beddeli karo."
 }

--- a/apps/app/src/utils/currency.ts
+++ b/apps/app/src/utils/currency.ts
@@ -1,0 +1,31 @@
+/**
+ * Currencies offered wherever an admin picks one (proposal budget field,
+ * rubric budget add-ups) and the symbols used to prefix money inputs.
+ */
+
+export const CURRENCIES = [
+  { code: 'USD', symbol: '$' },
+  { code: 'EUR', symbol: '€' },
+  { code: 'GBP', symbol: '£' },
+  { code: 'JPY', symbol: '¥' },
+  { code: 'CAD', symbol: 'CA$' },
+  { code: 'AUD', symbol: 'A$' },
+  { code: 'CHF', symbol: 'CHF' },
+  { code: 'CNY', symbol: '¥' },
+  { code: 'INR', symbol: '₹' },
+  { code: 'BRL', symbol: 'R$' },
+  { code: 'KRW', symbol: '₩' },
+  { code: 'SGD', symbol: 'S$' },
+  { code: 'MXN', symbol: 'MX$' },
+  { code: 'AED', symbol: 'د.إ' },
+  { code: 'SAR', symbol: '﷼' },
+] as const;
+
+export const CURRENCY_SYMBOL_MAP = new Map<string, string>(
+  CURRENCIES.map((c) => [c.code, c.symbol]),
+);
+
+/** Symbol for an ISO 4217 code, falling back to `$` for unknown codes. */
+export function getCurrencySymbol(currencyCode: string): string {
+  return CURRENCY_SYMBOL_MAP.get(currencyCode) ?? '$';
+}

--- a/apps/app/src/utils/formatting.ts
+++ b/apps/app/src/utils/formatting.ts
@@ -7,17 +7,21 @@ import {
 } from '@op/ui/utils/formatting';
 
 /**
- * Format currency amount using locale-aware formatting
+ * Format currency amount using locale-aware formatting.
+ *
+ * Whole amounts by default; pass `minimumFractionDigits: 2` where cents
+ * matter (e.g. rubric budget add-up totals).
  */
 export function formatCurrency(
   amount: number,
   locale: string = 'en-US',
   currency: string = 'USD',
+  options: { minimumFractionDigits?: number } = {},
 ): string {
   return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency,
-    minimumFractionDigits: 0,
+    minimumFractionDigits: options.minimumFractionDigits ?? 0,
   }).format(amount);
 }
 

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -155,6 +155,17 @@ export {
   isOverallRecommendationField,
 } from './services/decision/getRubricScoringInfo';
 export {
+  MONEY_GROUP_CURRENCY_KEY,
+  DEFAULT_MONEY_GROUP_CURRENCY,
+  isMoneyGroupSchema,
+  getMoneyGroupLineItems,
+  getMoneyGroupCurrency,
+  getMoneyLineItemAmount,
+  setMoneyLineItemAmount,
+  sumMoneyGroupTotal,
+  type MoneyLineItem,
+} from './services/decision/moneyGroup';
+export {
   REVIEWS_POLICIES,
   REVIEWS_SCOPES,
   phaseReviewSettingsSchema,

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -116,6 +116,7 @@ export * from './extractProposalText';
 export * from './resolveProposalTemplate';
 export * from './getProposalTemplateFieldOrder';
 export * from './getRubricScoringInfo';
+export * from './moneyGroup';
 export * from './tiptapExtensions';
 
 // Proposal attachments

--- a/packages/common/src/services/decision/moneyGroup.test.ts
+++ b/packages/common/src/services/decision/moneyGroup.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getMoneyGroupCurrency,
+  getMoneyGroupLineItems,
+  getMoneyLineItemAmount,
+  isMoneyGroupSchema,
+  setMoneyLineItemAmount,
+  sumMoneyGroupTotal,
+} from './moneyGroup';
+import type { XFormatPropertySchema } from './types';
+
+/** Two required line items + one optional, currency pinned to USD. */
+const schema: XFormatPropertySchema = {
+  type: 'object',
+  title: 'Total Estimated Cost',
+  'x-format': 'money-group',
+  properties: {
+    a1b2c3d4: { type: 'number', title: 'Design', minimum: 0 },
+    e5f6a7b8: { type: 'number', title: 'Construction', minimum: 0 },
+    c9d0e1f2: { type: 'number', title: 'Contingency', minimum: 0 },
+    currency: { type: 'string', const: 'USD', default: 'USD' },
+  },
+  additionalProperties: false,
+  required: ['a1b2c3d4', 'e5f6a7b8', 'currency'],
+  'x-field-order': ['a1b2c3d4', 'e5f6a7b8', 'c9d0e1f2'],
+};
+
+describe('isMoneyGroupSchema', () => {
+  it('accepts a declared money group and rejects look-alikes', () => {
+    expect(isMoneyGroupSchema(schema)).toBe(true);
+    // The proposal budget field is an object with a currency too, but its
+    // x-format is `money`, not `money-group`.
+    expect(
+      isMoneyGroupSchema({
+        type: 'object',
+        'x-format': 'money',
+        properties: { amount: { type: 'number' } },
+      }),
+    ).toBe(false);
+    expect(
+      isMoneyGroupSchema({ type: 'string', 'x-format': 'long-text' }),
+    ).toBe(false);
+  });
+});
+
+describe('getMoneyGroupLineItems', () => {
+  it('orders by x-field-order and flags required items, excluding currency', () => {
+    expect(getMoneyGroupLineItems(schema)).toEqual([
+      { id: 'a1b2c3d4', title: 'Design', required: true },
+      { id: 'e5f6a7b8', title: 'Construction', required: true },
+      { id: 'c9d0e1f2', title: 'Contingency', required: false },
+    ]);
+  });
+
+  it('appends properties missing from x-field-order', () => {
+    const items = getMoneyGroupLineItems({
+      ...schema,
+      'x-field-order': ['c9d0e1f2'],
+    });
+
+    expect(items.map((item) => item.id)).toEqual([
+      'c9d0e1f2',
+      'a1b2c3d4',
+      'e5f6a7b8',
+    ]);
+  });
+});
+
+describe('getMoneyLineItemAmount', () => {
+  it.each([
+    ['a filled item', { a1b2c3d4: 1200, currency: 'USD' }, 1200],
+    ['an unanswered item', { currency: 'USD' }, null],
+    ['a non-numeric value', { a1b2c3d4: '1200', currency: 'USD' }, null],
+    ['NaN', { a1b2c3d4: Number.NaN, currency: 'USD' }, null],
+    ['an undefined answer', undefined, null],
+    ['a non-object answer', 'nope', null],
+  ])('reads %s', (_label, value, expected) => {
+    expect(getMoneyLineItemAmount(value, 'a1b2c3d4')).toBe(expected);
+  });
+});
+
+describe('sumMoneyGroupTotal', () => {
+  it('sums only schema-declared line items, ignoring currency and stale keys', () => {
+    const value = {
+      a1b2c3d4: 100,
+      e5f6a7b8: 200,
+      currency: 'USD',
+      // A line item removed from the template since this answer was saved.
+      stale9999: 5000,
+    };
+
+    expect(sumMoneyGroupTotal(schema, value)).toBe(300);
+  });
+
+  it('sums decimals and treats unanswered items as zero', () => {
+    expect(
+      sumMoneyGroupTotal(schema, {
+        a1b2c3d4: 19750.25,
+        e5f6a7b8: 0.75,
+        currency: 'USD',
+      }),
+    ).toBe(19751);
+  });
+
+  it('totals an untouched or partial group without throwing', () => {
+    expect(sumMoneyGroupTotal(schema, undefined)).toBe(0);
+    expect(sumMoneyGroupTotal(schema, {})).toBe(0);
+    expect(sumMoneyGroupTotal(schema, { a1b2c3d4: 50 })).toBe(50);
+  });
+});
+
+describe('getMoneyGroupCurrency', () => {
+  it('prefers the stored currency so submitted reviews stay self-describing', () => {
+    expect(getMoneyGroupCurrency(schema, { currency: 'EUR' })).toBe('EUR');
+  });
+
+  it('falls back to the template currency when the answer has none', () => {
+    expect(getMoneyGroupCurrency(schema, { a1b2c3d4: 10 })).toBe('USD');
+    expect(getMoneyGroupCurrency(schema)).toBe('USD');
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['not-a-code', 'malformed'],
+    ['US', 'too short'],
+    [42, 'non-string'],
+  ])('ignores a stored %s currency (%s) — drafts are unvalidated', (stored) => {
+    expect(getMoneyGroupCurrency(schema, { currency: stored })).toBe('USD');
+  });
+
+  it('falls back to USD when the template declares no currency', () => {
+    expect(
+      getMoneyGroupCurrency({
+        type: 'object',
+        'x-format': 'money-group',
+        properties: { a1b2c3d4: { type: 'number' } },
+      }),
+    ).toBe('USD');
+  });
+});
+
+describe('setMoneyLineItemAmount', () => {
+  it('materializes the currency on the first edit', () => {
+    expect(setMoneyLineItemAmount(schema, undefined, 'a1b2c3d4', 1200)).toEqual(
+      {
+        a1b2c3d4: 1200,
+        currency: 'USD',
+      },
+    );
+  });
+
+  it('keeps other line items and never writes a total', () => {
+    const value = { a1b2c3d4: 100, currency: 'USD' };
+
+    expect(setMoneyLineItemAmount(schema, value, 'e5f6a7b8', 250)).toEqual({
+      a1b2c3d4: 100,
+      e5f6a7b8: 250,
+      currency: 'USD',
+    });
+  });
+
+  it('drops the key when the reviewer clears the field', () => {
+    const value = { a1b2c3d4: 100, e5f6a7b8: 250, currency: 'USD' };
+
+    expect(setMoneyLineItemAmount(schema, value, 'e5f6a7b8', null)).toEqual({
+      a1b2c3d4: 100,
+      currency: 'USD',
+    });
+  });
+
+  it('repairs a malformed stored currency on the next edit', () => {
+    expect(
+      setMoneyLineItemAmount(schema, { currency: 'nope' }, 'a1b2c3d4', 5),
+    ).toEqual({ a1b2c3d4: 5, currency: 'USD' });
+  });
+});

--- a/packages/common/src/services/decision/moneyGroup.ts
+++ b/packages/common/src/services/decision/moneyGroup.ts
@@ -1,0 +1,187 @@
+/**
+ * Budget add-up (`x-format: 'money-group'`) readers.
+ *
+ * A budget add-up is **one** composite rubric criterion: an object-typed schema
+ * property whose sub-properties are money line items plus a group-level
+ * `currency` string carrying the template-set default. The stored answer is a
+ * valid instance of that schema — line-item amounts plus the currency
+ * materialized at fill time:
+ *
+ * ```json
+ * { "a1b2c3": 12000, "d4e5f6": 3000, "currency": "USD" }
+ * ```
+ *
+ * The **Total is never stored** — it is summed at render/read time, the same
+ * philosophy as review scores. See `kb/adr/0003-budget-addup-derived-totals`.
+ *
+ * Every reader here excludes the reserved `currency` key when iterating line
+ * items; callers should use these helpers rather than walking the object.
+ */
+import type { JSONSchema7 } from 'json-schema';
+
+import type { XFormatPropertySchema } from './types';
+
+/**
+ * Reserved sub-property of a money group holding its ISO 4217 currency code.
+ * Never a line item — mirrors the proposal budget field's shape.
+ */
+export const MONEY_GROUP_CURRENCY_KEY = 'currency';
+
+/** Fallback when neither the answer nor the template declares a currency. */
+export const DEFAULT_MONEY_GROUP_CURRENCY = 'USD';
+
+/** One money line item of a budget add-up, in stored order. */
+export interface MoneyLineItem {
+  /** Opaque generated id — the key under which the amount is stored. */
+  id: string;
+  /** Admin-editable display label. */
+  title: string;
+  /** Listed in the group's nested `required` array. */
+  required: boolean;
+}
+
+/** Narrows a JSON Schema definition to its object form. */
+function isSchemaObject(
+  definition: JSONSchema7 | boolean | undefined,
+): definition is JSONSchema7 {
+  return typeof definition === 'object' && definition !== null;
+}
+
+/** `true` when the property schema describes a budget add-up criterion. */
+export function isMoneyGroupSchema(schema: XFormatPropertySchema): boolean {
+  return schema['x-format'] === 'money-group' && schema.type === 'object';
+}
+
+/**
+ * Money line items of a budget add-up, ordered by the group's nested
+ * `x-field-order` with any unlisted properties appended. The reserved
+ * `currency` property is never a line item.
+ */
+export function getMoneyGroupLineItems(
+  schema: XFormatPropertySchema,
+): MoneyLineItem[] {
+  const properties = schema.properties ?? {};
+  const declaredOrder = schema['x-field-order'] ?? [];
+
+  const orderedIds: string[] = [];
+  for (const id of [...declaredOrder, ...Object.keys(properties)]) {
+    if (id === MONEY_GROUP_CURRENCY_KEY) continue;
+    if (orderedIds.includes(id)) continue;
+    if (!isSchemaObject(properties[id])) continue;
+    orderedIds.push(id);
+  }
+
+  const required = new Set(schema.required ?? []);
+
+  return orderedIds.map((id) => {
+    const itemSchema = properties[id];
+    const title =
+      isSchemaObject(itemSchema) && typeof itemSchema.title === 'string'
+        ? itemSchema.title
+        : id;
+    return { id, title, required: required.has(id) };
+  });
+}
+
+/**
+ * Currency of a budget add-up. The stored answer wins (each submitted review
+ * stays self-describing even if the template's currency is later edited), then
+ * the template default, then USD.
+ *
+ * Drafts are never schema-validated, so a stored currency is trusted only when
+ * it is a well-formed ISO 4217 code — anything else falls back to the template
+ * default rather than reaching `Intl.NumberFormat`, which throws on a malformed
+ * code.
+ */
+export function getMoneyGroupCurrency(
+  schema: XFormatPropertySchema,
+  value?: unknown,
+): string {
+  const answerCurrency =
+    readMoneyGroupObject(value)?.[MONEY_GROUP_CURRENCY_KEY];
+  if (isCurrencyCode(answerCurrency)) {
+    return answerCurrency;
+  }
+
+  const currencySchema = schema.properties?.[MONEY_GROUP_CURRENCY_KEY];
+  if (isSchemaObject(currencySchema)) {
+    // `const` pins the group to one currency; `default` is what the reviewer
+    // form materializes into the answer.
+    const declared = currencySchema.const ?? currencySchema.default;
+    if (isCurrencyCode(declared)) {
+      return declared;
+    }
+  }
+
+  return DEFAULT_MONEY_GROUP_CURRENCY;
+}
+
+/** A well-formed ISO 4217 code — three letters, the shape `Intl` accepts. */
+function isCurrencyCode(value: unknown): value is string {
+  return typeof value === 'string' && /^[A-Za-z]{3}$/.test(value);
+}
+
+/**
+ * Amount stored for one line item, or `null` when unanswered. Anything
+ * non-finite (string, null, NaN) reads as unanswered.
+ */
+export function getMoneyLineItemAmount(
+  value: unknown,
+  lineItemId: string,
+): number | null {
+  const amount = readMoneyGroupObject(value)?.[lineItemId];
+  return typeof amount === 'number' && Number.isFinite(amount) ? amount : null;
+}
+
+/**
+ * Derived total of a budget add-up: the sum of the amounts of the line items
+ * **declared by the schema**, which structurally excludes the `currency` key
+ * and any stale ids. Unanswered line items contribute 0, so an untouched group
+ * totals 0.
+ */
+export function sumMoneyGroupTotal(
+  schema: XFormatPropertySchema,
+  value: unknown,
+): number {
+  return getMoneyGroupLineItems(schema).reduce((total, lineItem) => {
+    return total + (getMoneyLineItemAmount(value, lineItem.id) ?? 0);
+  }, 0);
+}
+
+/**
+ * Stored answer with one line item set to `amount` (or cleared when `null`),
+ * materializing the group's `currency` alongside it — the answer stays a valid
+ * instance of the group schema, and each submitted review keeps describing its
+ * own currency. Reviewers never pick the currency; it comes from the template.
+ */
+export function setMoneyLineItemAmount(
+  schema: XFormatPropertySchema,
+  value: unknown,
+  lineItemId: string,
+  amount: number | null,
+): Record<string, unknown> {
+  const current = readMoneyGroupObject(value) ?? {};
+  const next: Record<string, unknown> = {
+    ...current,
+    [MONEY_GROUP_CURRENCY_KEY]: getMoneyGroupCurrency(schema, value),
+  };
+
+  if (amount === null) {
+    delete next[lineItemId];
+  } else {
+    next[lineItemId] = amount;
+  }
+
+  return next;
+}
+
+/** Narrows a stored answer to its object form. */
+function readMoneyGroupObject(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/common/src/services/decision/schemaValidator.test.ts
+++ b/packages/common/src/services/decision/schemaValidator.test.ts
@@ -27,4 +27,28 @@ describe('SchemaValidator.validateJsonSchema', () => {
 
     expect(() => schemaValidator.validateJsonSchema(template)).not.toThrow();
   });
+
+  it('accepts a budget add-up criterion with a nested x-field-order', () => {
+    const template = {
+      type: 'object',
+      properties: {
+        cost: {
+          type: 'object',
+          title: 'Total Estimated Cost',
+          'x-format': 'money-group',
+          properties: {
+            design: { type: 'number', title: 'Design', minimum: 0 },
+            currency: { type: 'string', const: 'USD', default: 'USD' },
+          },
+          additionalProperties: false,
+          required: ['design', 'currency'],
+          'x-field-order': ['design'],
+        },
+      },
+      'x-field-order': ['cost'],
+      required: ['cost'],
+    };
+
+    expect(() => schemaValidator.validateJsonSchema(template)).not.toThrow();
+  });
 });

--- a/packages/common/src/services/decision/types.ts
+++ b/packages/common/src/services/decision/types.ts
@@ -18,11 +18,17 @@ export type JsonSchema = JSONSchema7;
  *
  * `radio` renders an enum as a horizontal radio row (the NPS-style control)
  * instead of a dropdown; used by custom form scale questions.
+ *
+ * `money-group` marks a **budget add-up**: one composite rubric criterion whose
+ * nested `properties` are money line items plus a group-level `currency`. Its
+ * total is always derived at render/read time, never stored (see
+ * `kb/adr/0003-budget-addup-derived-totals`).
  */
 export type XFormat =
   | 'short-text'
   | 'long-text'
   | 'money'
+  | 'money-group'
   | 'dropdown'
   | 'radio'
   | 'location';
@@ -42,6 +48,11 @@ export interface XFormatPropertySchema extends JSONSchema7 {
   'x-format'?: XFormat;
   /** Default map camera for `location` fields (see {@link MapDefaultView}). */
   'x-map-default'?: MapDefaultView;
+  /**
+   * Ordering of a composite property's own sub-properties. Used by
+   * `money-group` criteria to order their money line items.
+   */
+  'x-field-order'?: string[];
 }
 
 /** JSON Schema 7 extended with proposal template vendor extensions. */

--- a/services/api/src/routers/decision/proposals/listWithReviewAggregates.test.ts
+++ b/services/api/src/routers/decision/proposals/listWithReviewAggregates.test.ts
@@ -372,6 +372,68 @@ describe.concurrent('listWithReviewAggregates', () => {
     });
     expect(result.items[0]?.aggregates.reviewers.length).toBeGreaterThan(0);
   });
+
+  it('leaves the score untouched by budget add-up amounts', async ({
+    task,
+    onTestFinished,
+  }) => {
+    // The add-up is score-less: only `impact` (7) counts, never the dollar
+    // line items or their derived total.
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await testData.createContext();
+    await testData.setRubricTemplate(context, {
+      type: 'object',
+      required: ['impact'],
+      'x-field-order': ['impact', 'b7e41c93'],
+      properties: {
+        impact: { type: 'integer', title: 'Impact', minimum: 0, maximum: 10 },
+        b7e41c93: {
+          type: 'object',
+          title: 'Total Estimated Cost',
+          'x-format': 'money-group',
+          properties: {
+            a1b2c3d4: { type: 'number', title: 'Design', minimum: 0 },
+            currency: { type: 'string', const: 'USD', default: 'USD' },
+          },
+          additionalProperties: false,
+          required: ['a1b2c3d4', 'currency'],
+          'x-field-order': ['a1b2c3d4'],
+        },
+      },
+    });
+    await testData.setCurrentPhase(context.instance.instance.id, 'review');
+
+    const created = await testData.createReviewAssignment({
+      context,
+      title: 'Proposal With Cost Estimate',
+    });
+
+    await createProposalReview({
+      assignmentId: created.assignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          impact: 7,
+          b7e41c93: { a1b2c3d4: 250000, currency: 'USD' },
+        },
+        rationales: {},
+      },
+      submittedAt: new Date().toISOString(),
+    });
+
+    const adminCaller = await createAuthenticatedCaller(
+      context.defaultReviewer.email,
+    );
+    const result = await adminCaller.decision.listWithReviewAggregates({
+      processInstanceId: context.instance.instance.id,
+      proposalIds: [created.proposal.id],
+    });
+
+    expect(result.items[0]?.aggregates).toMatchObject({
+      reviewsSubmittedCount: 1,
+      averageScore: 7,
+    });
+  });
 });
 
 describeDecisionAccessTierGating('listWithReviewAggregates', {

--- a/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
+++ b/services/api/src/routers/decision/reviews/saveReviewDraft.test.ts
@@ -41,6 +41,30 @@ const rubricTemplate: RubricTemplateSchema = {
   required: ['impact'],
 };
 
+/** Budget add-up criterion: money line items plus the group currency. */
+const budgetAddUpRubricTemplate: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': ['b7e41c93'],
+  properties: {
+    b7e41c93: {
+      type: 'object',
+      title: 'Total Estimated Cost',
+      'x-format': 'money-group',
+      properties: {
+        a1b2c3d4: { type: 'number', title: 'Design & Engineering', minimum: 0 },
+        e5f6a7b8: { type: 'number', title: 'Construction', minimum: 0 },
+        currency: { type: 'string', const: 'USD', default: 'USD' },
+      },
+      // Nothing beyond the line items and the currency may be stored — this
+      // is what keeps the derived total from ever being persisted.
+      additionalProperties: false,
+      required: ['a1b2c3d4', 'e5f6a7b8', 'currency'],
+      'x-field-order': ['a1b2c3d4', 'e5f6a7b8'],
+    },
+  },
+  required: ['b7e41c93'],
+};
+
 async function createAuthenticatedCaller(email: string) {
   const { session } = await createIsolatedSession(email);
   return createCaller(await createTestContextWithSession(session));
@@ -84,6 +108,36 @@ describe.concurrent('saveReviewDraft', () => {
     expect(assignment?.completedAt).toBeNull();
     expect(assignment?.reviews[0]?.state).toBe(ProposalReviewState.DRAFT);
     expect(assignment?.reviews[0]?.submittedAt).toBeNull();
+  });
+
+  it('saves a budget add-up draft with only some line items filled', async ({
+    task,
+    onTestFinished,
+  }) => {
+    // Drafts are unvalidated, so a partially filled add-up — one line item
+    // plus the materialized currency — persists as-is.
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      budgetAddUpRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { b7e41c93: { a1b2c3d4: 500, currency: 'USD' } },
+        rationales: {},
+      },
+    });
+
+    expect(result.state).toBe(ProposalReviewState.DRAFT);
+    expect(result.reviewData.answers).toEqual({
+      b7e41c93: { a1b2c3d4: 500, currency: 'USD' },
+    });
   });
 
   it('upserts a single draft row per assignment — last write wins', async ({

--- a/services/api/src/routers/decision/reviews/submitReview.test.ts
+++ b/services/api/src/routers/decision/reviews/submitReview.test.ts
@@ -59,6 +59,33 @@ const singleSelectRubricTemplate: RubricTemplateSchema = {
   required: ['department'],
 };
 
+/**
+ * Budget add-up: one composite criterion whose nested properties are money
+ * line items plus the group currency. The total is never stored.
+ */
+const budgetAddUpRubricTemplate: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': ['b7e41c93'],
+  properties: {
+    b7e41c93: {
+      type: 'object',
+      title: 'Total Estimated Cost',
+      'x-format': 'money-group',
+      properties: {
+        a1b2c3d4: { type: 'number', title: 'Design & Engineering', minimum: 0 },
+        e5f6a7b8: { type: 'number', title: 'Construction', minimum: 0 },
+        currency: { type: 'string', const: 'USD', default: 'USD' },
+      },
+      // Nothing beyond the line items and the currency may be stored — this
+      // is what keeps the derived total from ever being persisted.
+      additionalProperties: false,
+      required: ['a1b2c3d4', 'e5f6a7b8', 'currency'],
+      'x-field-order': ['a1b2c3d4', 'e5f6a7b8'],
+    },
+  },
+  required: ['b7e41c93'],
+};
+
 async function createAuthenticatedCaller(email: string) {
   const { session } = await createIsolatedSession(email);
   return createCaller(await createTestContextWithSession(session));
@@ -212,6 +239,215 @@ describe.concurrent('submitReview', () => {
 
     expect(result.state).toBe(ProposalReviewState.SUBMITTED);
     expect(result.reviewData.answers).toEqual({ department: ['e5f6a7b8'] });
+  });
+
+  it('stores a budget add-up answer verbatim, currency included', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      budgetAddUpRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.submitReview({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: {
+          b7e41c93: {
+            a1b2c3d4: 12000.5,
+            e5f6a7b8: 3000,
+            currency: 'USD',
+          },
+        },
+        rationales: { b7e41c93: 'Costs are conservative' },
+      },
+    });
+
+    expect(result.state).toBe(ProposalReviewState.SUBMITTED);
+    // No `total` key: totals are derived at read time, never stored.
+    expect(result.reviewData.answers).toEqual({
+      b7e41c93: {
+        a1b2c3d4: 12000.5,
+        e5f6a7b8: 3000,
+        currency: 'USD',
+      },
+    });
+
+    const assignment = await db.query.proposalReviewAssignments.findFirst({
+      where: { id: created.assignment.id },
+      with: { reviews: true },
+    });
+
+    expect(assignment?.reviews[0]?.reviewData).toMatchObject({
+      answers: {
+        b7e41c93: {
+          a1b2c3d4: 12000.5,
+          e5f6a7b8: 3000,
+          currency: 'USD',
+        },
+      },
+    });
+  });
+
+  it('rejects a budget add-up missing a required line item', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      budgetAddUpRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: {
+            b7e41c93: { a1b2c3d4: 12000, currency: 'USD' },
+          },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+  });
+
+  it('rejects a budget add-up carrying a derived total', async ({
+    task,
+    onTestFinished,
+  }) => {
+    // The total is derived at read time and must never be persisted;
+    // `additionalProperties: false` is what enforces that server-side.
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      budgetAddUpRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: {
+            b7e41c93: {
+              a1b2c3d4: 12000,
+              e5f6a7b8: 3000,
+              currency: 'USD',
+              total: 15000,
+            },
+          },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+  });
+
+  it('rejects a budget add-up whose currency is not the group currency', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      budgetAddUpRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: {
+            b7e41c93: { a1b2c3d4: 12000, e5f6a7b8: 3000, currency: 'EUR' },
+          },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+  });
+
+  it('rejects a budget add-up with a malformed currency code', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      budgetAddUpRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: {
+            b7e41c93: {
+              a1b2c3d4: 12000,
+              e5f6a7b8: 3000,
+              currency: 'not-a-code',
+            },
+          },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+  });
+
+  it('rejects a negative budget add-up amount', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment();
+    await testData.setRubricTemplate(
+      created.context,
+      budgetAddUpRubricTemplate,
+    );
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      created.reviewer.email,
+    );
+
+    await expect(
+      reviewerCaller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: {
+            b7e41c93: {
+              a1b2c3d4: -1,
+              e5f6a7b8: 3000,
+              currency: 'USD',
+            },
+          },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
   });
 
   it('rejects invalid rubric submissions', async ({ task, onTestFinished }) => {


### PR DESCRIPTION
Feasibility reviewers need to estimate a proposal's cost from named line items and see the running total. The group is one composite criterion — one answer, one rationale — and the total is derived at render/read time rather than stored, so it can never drift from the line items or the template.