### PR TITLE
feat(decisions): optimistic like/follow counts with click coalescing

### DIFF
--- a/apps/app/src/components/decisions/ProposalPreview.tsx
+++ b/apps/app/src/components/decisions/ProposalPreview.tsx
@@ -325,7 +325,6 @@ function EngagementRow({
         noun={likesNoun}
         pressed={engagement?.isLiked}
         onPressedChange={engagement?.onLike}
-        isPending={engagement?.isPending}
       />
       <EngagementToggle
         icon={LuBookmark}
@@ -333,7 +332,6 @@ function EngagementRow({
         noun={followersNoun}
         pressed={engagement?.isFollowing}
         onPressedChange={engagement?.onFollow}
-        isPending={engagement?.isPending}
       />
       {/* A link, not a toggle: jumping to the comments works for any viewer,
           signed in or not. `px-2` matches the ghost toggles' inset. */}
@@ -366,14 +364,12 @@ function EngagementToggle({
   noun,
   pressed,
   onPressedChange,
-  isPending,
 }: {
   icon: IconType;
   count: number;
   noun: string;
   pressed?: boolean;
   onPressedChange?: () => void;
-  isPending?: boolean;
 }) {
   const isInteractive = Boolean(onPressedChange);
   const iconClassName = cn(pressed && 'fill-current');
@@ -391,12 +387,15 @@ function EngagementToggle({
   return (
     // The visible count is the accessible name; on/off comes from aria-pressed,
     // which base-ui sets from `pressed`.
+    //
+    // Not disabled while the mutation runs: the count and the pressed state are
+    // already optimistic, and disabling the button you just pressed drops focus
+    // to the body — mid-interaction, for a keyboard or screen reader user.
     <Toggle
       size="sm"
       variant="ghost"
       pressed={pressed ?? false}
       onPressedChange={onPressedChange}
-      disabled={isPending}
     >
       <Icon className={iconClassName} aria-hidden />
       <AnimatedCount value={count} /> {noun}

--- a/apps/app/src/components/decisions/ProposalView.tsx
+++ b/apps/app/src/components/decisions/ProposalView.tsx
@@ -245,7 +245,6 @@ export function ProposalView({
                 isFollowing: engagement.isFollowed,
                 onLike: engagement.onLike,
                 onFollow: engagement.onFollow,
-                isPending: engagement.isPending,
               }
             : undefined
         }

--- a/apps/app/src/hooks/optimisticProposalCounts.test.ts
+++ b/apps/app/src/hooks/optimisticProposalCounts.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import { bumpProposalCount } from './optimisticProposalCounts';
+
+const flat = (likes: number) => ({
+  items: [
+    { profileId: 'p1', likesCount: likes, followersCount: 3 },
+    { profileId: 'p2', likesCount: 99, followersCount: 0 },
+  ],
+});
+
+const infinite = (likes: number) => ({
+  pageParams: [undefined],
+  pages: [flat(likes)],
+});
+
+// listProposals — what the current-phase grid reads — names the array
+// `proposals`, not `items`. Getting this wrong is invisible: the patch simply
+// finds nothing and the count sits still.
+const proposalsShape = (likes: number) => ({
+  pageParams: [undefined],
+  pages: [
+    {
+      total: 2,
+      proposals: [
+        { profileId: 'p1', likesCount: likes, followersCount: 3 },
+        { profileId: 'p2', likesCount: 99, followersCount: 0 },
+      ],
+    },
+  ],
+});
+
+describe('bumpProposalCount', () => {
+  it('moves the matching row in a flat list and leaves the others alone', () => {
+    const next = bumpProposalCount(
+      flat(4),
+      'p1',
+      'likesCount',
+      1,
+    ) as ReturnType<typeof flat>;
+
+    expect(next.items[0]).toMatchObject({ likesCount: 5, followersCount: 3 });
+    expect(next.items[1]).toMatchObject({ likesCount: 99 });
+  });
+
+  it('walks the pages of an infinite list', () => {
+    const next = bumpProposalCount(
+      infinite(4),
+      'p1',
+      'likesCount',
+      -1,
+    ) as ReturnType<typeof infinite>;
+
+    expect(next.pages[0]!.items[0]).toMatchObject({ likesCount: 3 });
+  });
+
+  it('moves followersCount independently of likesCount', () => {
+    const next = bumpProposalCount(
+      flat(4),
+      'p1',
+      'followersCount',
+      1,
+    ) as ReturnType<typeof flat>;
+
+    expect(next.items[0]).toMatchObject({ likesCount: 4, followersCount: 4 });
+  });
+
+  it('never renders a negative count', () => {
+    const next = bumpProposalCount(
+      flat(0),
+      'p1',
+      'likesCount',
+      -1,
+    ) as ReturnType<typeof flat>;
+
+    expect(next.items[0]!.likesCount).toBe(0);
+  });
+
+  it('walks pages that name the array `proposals` (listProposals)', () => {
+    const next = bumpProposalCount(
+      proposalsShape(4),
+      'p1',
+      'likesCount',
+      1,
+    ) as ReturnType<typeof proposalsShape>;
+
+    expect(next.pages[0]!.proposals[0]).toMatchObject({ likesCount: 5 });
+    expect(next.pages[0]!.proposals[1]).toMatchObject({ likesCount: 99 });
+  });
+
+  it('walks a flat `proposals` result (the ballot)', () => {
+    const ballot = {
+      proposals: [{ profileId: 'p1', likesCount: 4, followersCount: 3 }],
+    };
+    const next = bumpProposalCount(
+      ballot,
+      'p1',
+      'followersCount',
+      1,
+    ) as typeof ballot;
+
+    expect(next.proposals[0]).toMatchObject({ followersCount: 4 });
+  });
+
+  it('moves a bare proposal, the shape getProposal caches', () => {
+    const single = { profileId: 'p1', likesCount: 4, followersCount: 3 };
+    const next = bumpProposalCount(
+      single,
+      'p1',
+      'likesCount',
+      1,
+    ) as typeof single;
+
+    expect(next).toMatchObject({ likesCount: 5, followersCount: 3 });
+    expect(single.likesCount).toBe(4);
+  });
+
+  it('leaves a bare proposal for someone else alone', () => {
+    const single = { profileId: 'p2', likesCount: 4 };
+
+    expect(bumpProposalCount(single, 'p1', 'likesCount', 1)).toBe(single);
+  });
+
+  it('leaves unrecognised cache shapes untouched', () => {
+    const odd = { somethingElse: true };
+
+    expect(bumpProposalCount(odd, 'p1', 'likesCount', 1)).toBe(odd);
+    expect(bumpProposalCount(undefined, 'p1', 'likesCount', 1)).toBeUndefined();
+  });
+
+  it('does not mutate the cached object', () => {
+    const before = flat(4);
+    bumpProposalCount(before, 'p1', 'likesCount', 1);
+
+    expect(before.items[0]!.likesCount).toBe(4);
+  });
+});

--- a/apps/app/src/hooks/optimisticProposalCounts.test.ts
+++ b/apps/app/src/hooks/optimisticProposalCounts.test.ts
@@ -31,87 +31,62 @@ const proposalsShape = (likes: number) => ({
 });
 
 describe('bumpProposalCount', () => {
+  // Asserted against the whole returned shape rather than a drilled-in
+  // property: the function's return is `unknown` by design, and matching
+  // structurally keeps that honest instead of asserting a type back onto it.
   it('moves the matching row in a flat list and leaves the others alone', () => {
-    const next = bumpProposalCount(
-      flat(4),
-      'p1',
-      'likesCount',
-      1,
-    ) as ReturnType<typeof flat>;
-
-    expect(next.items[0]).toMatchObject({ likesCount: 5, followersCount: 3 });
-    expect(next.items[1]).toMatchObject({ likesCount: 99 });
+    expect(bumpProposalCount(flat(4), 'p1', 'likesCount', 1)).toMatchObject({
+      items: [{ likesCount: 5, followersCount: 3 }, { likesCount: 99 }],
+    });
   });
 
   it('walks the pages of an infinite list', () => {
-    const next = bumpProposalCount(
-      infinite(4),
-      'p1',
-      'likesCount',
-      -1,
-    ) as ReturnType<typeof infinite>;
-
-    expect(next.pages[0]!.items[0]).toMatchObject({ likesCount: 3 });
+    expect(
+      bumpProposalCount(infinite(4), 'p1', 'likesCount', -1),
+    ).toMatchObject({
+      pages: [{ items: [{ likesCount: 3 }, { likesCount: 99 }] }],
+    });
   });
 
   it('moves followersCount independently of likesCount', () => {
-    const next = bumpProposalCount(
-      flat(4),
-      'p1',
-      'followersCount',
-      1,
-    ) as ReturnType<typeof flat>;
-
-    expect(next.items[0]).toMatchObject({ likesCount: 4, followersCount: 4 });
+    expect(bumpProposalCount(flat(4), 'p1', 'followersCount', 1)).toMatchObject(
+      {
+        items: [{ likesCount: 4, followersCount: 4 }, { followersCount: 0 }],
+      },
+    );
   });
 
   it('never renders a negative count', () => {
-    const next = bumpProposalCount(
-      flat(0),
-      'p1',
-      'likesCount',
-      -1,
-    ) as ReturnType<typeof flat>;
-
-    expect(next.items[0]!.likesCount).toBe(0);
+    expect(bumpProposalCount(flat(0), 'p1', 'likesCount', -1)).toMatchObject({
+      items: [{ likesCount: 0 }, { likesCount: 99 }],
+    });
   });
 
   it('walks pages that name the array `proposals` (listProposals)', () => {
-    const next = bumpProposalCount(
-      proposalsShape(4),
-      'p1',
-      'likesCount',
-      1,
-    ) as ReturnType<typeof proposalsShape>;
-
-    expect(next.pages[0]!.proposals[0]).toMatchObject({ likesCount: 5 });
-    expect(next.pages[0]!.proposals[1]).toMatchObject({ likesCount: 99 });
+    expect(
+      bumpProposalCount(proposalsShape(4), 'p1', 'likesCount', 1),
+    ).toMatchObject({
+      pages: [{ proposals: [{ likesCount: 5 }, { likesCount: 99 }] }],
+    });
   });
 
   it('walks a flat `proposals` result (the ballot)', () => {
     const ballot = {
       proposals: [{ profileId: 'p1', likesCount: 4, followersCount: 3 }],
     };
-    const next = bumpProposalCount(
-      ballot,
-      'p1',
-      'followersCount',
-      1,
-    ) as typeof ballot;
 
-    expect(next.proposals[0]).toMatchObject({ followersCount: 4 });
+    expect(bumpProposalCount(ballot, 'p1', 'followersCount', 1)).toMatchObject({
+      proposals: [{ followersCount: 4 }],
+    });
   });
 
   it('moves a bare proposal, the shape getProposal caches', () => {
     const single = { profileId: 'p1', likesCount: 4, followersCount: 3 };
-    const next = bumpProposalCount(
-      single,
-      'p1',
-      'likesCount',
-      1,
-    ) as typeof single;
 
-    expect(next).toMatchObject({ likesCount: 5, followersCount: 3 });
+    expect(bumpProposalCount(single, 'p1', 'likesCount', 1)).toMatchObject({
+      likesCount: 5,
+      followersCount: 3,
+    });
     expect(single.likesCount).toBe(4);
   });
 

--- a/apps/app/src/hooks/optimisticProposalCounts.ts
+++ b/apps/app/src/hooks/optimisticProposalCounts.ts
@@ -24,6 +24,13 @@ export type ProposalCountField = 'likesCount' | 'followersCount';
 
 type ProposalRow = Record<string, unknown> & { profileId?: unknown };
 
+/**
+ * Narrows cache data structurally instead of asserting: `typeof x === 'object'`
+ * alone leaves TypeScript with `object`, which can't be indexed.
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
 function bumpRow(
   row: ProposalRow,
   profileId: string,
@@ -34,7 +41,8 @@ function bumpRow(
     return row;
   }
 
-  const current = typeof row[field] === 'number' ? (row[field] as number) : 0;
+  const value = row[field];
+  const current = typeof value === 'number' ? value : 0;
 
   // Clamp at zero: a stale row can already read 0 while the viewer's
   // relationship cache still says "liked", and a negative count would render.
@@ -52,9 +60,7 @@ function bumpItems(
   }
 
   return items.map((item) =>
-    item && typeof item === 'object'
-      ? bumpRow(item as ProposalRow, profileId, field, delta)
-      : item,
+    isRecord(item) ? bumpRow(item, profileId, field, delta) : item,
   );
 }
 
@@ -88,35 +94,26 @@ export function bumpProposalCount(
   field: ProposalCountField,
   delta: number,
 ): unknown {
-  if (!data || typeof data !== 'object') {
+  if (!isRecord(data)) {
     return data;
   }
 
-  const record = data as Record<string, unknown>;
-
-  if (Array.isArray(record.pages)) {
+  if (Array.isArray(data.pages)) {
     return {
-      ...record,
-      pages: record.pages.map((page) =>
-        page && typeof page === 'object'
-          ? bumpRowArrays(
-              page as Record<string, unknown>,
-              profileId,
-              field,
-              delta,
-            )
-          : page,
+      ...data,
+      pages: data.pages.map((page) =>
+        isRecord(page) ? bumpRowArrays(page, profileId, field, delta) : page,
       ),
     };
   }
 
-  if (ROW_ARRAY_KEYS.some((key) => Array.isArray(record[key]))) {
-    return bumpRowArrays(record, profileId, field, delta);
+  if (ROW_ARRAY_KEYS.some((key) => Array.isArray(data[key]))) {
+    return bumpRowArrays(data, profileId, field, delta);
   }
 
   // A bare proposal — what `decision.getProposal` caches for the detail view.
-  if ('profileId' in record) {
-    return bumpRow(record as ProposalRow, profileId, field, delta);
+  if ('profileId' in data) {
+    return bumpRow(data, profileId, field, delta);
   }
 
   return data;

--- a/apps/app/src/hooks/optimisticProposalCounts.ts
+++ b/apps/app/src/hooks/optimisticProposalCounts.ts
@@ -1,0 +1,123 @@
+/**
+ * Optimistic count bumps for cached `decision.listProposals` data.
+ *
+ * The relationship mutations already patch `profile.getRelationships`, which is
+ * what flips a toggle's pressed state. The count next to it lives on the
+ * proposal rows in the list cache, so without this the number sits still until
+ * the post-mutation refetch lands.
+ *
+ * Kept as a pure function over `unknown` because the same proposal can sit in
+ * several cached lists at once (different filters, sorts, or the ballot's
+ * non-infinite query). The caller matches every `listProposals` entry by path
+ * and lets this walk whatever shape it finds.
+ */
+
+/**
+ * The routers disagree on what the array is called: `listProposals` pages carry
+ * `proposals` (and so does the ballot's flat result), while `listAllProposals`
+ * carries `items`. Both are walked rather than picking one.
+ */
+const ROW_ARRAY_KEYS = ['proposals', 'items'] as const;
+
+/** Count fields a relationship can move. */
+export type ProposalCountField = 'likesCount' | 'followersCount';
+
+type ProposalRow = Record<string, unknown> & { profileId?: unknown };
+
+function bumpRow(
+  row: ProposalRow,
+  profileId: string,
+  field: ProposalCountField,
+  delta: number,
+): ProposalRow {
+  if (row.profileId !== profileId) {
+    return row;
+  }
+
+  const current = typeof row[field] === 'number' ? (row[field] as number) : 0;
+
+  // Clamp at zero: a stale row can already read 0 while the viewer's
+  // relationship cache still says "liked", and a negative count would render.
+  return { ...row, [field]: Math.max(0, current + delta) };
+}
+
+function bumpItems(
+  items: unknown,
+  profileId: string,
+  field: ProposalCountField,
+  delta: number,
+): unknown {
+  if (!Array.isArray(items)) {
+    return items;
+  }
+
+  return items.map((item) =>
+    item && typeof item === 'object'
+      ? bumpRow(item as ProposalRow, profileId, field, delta)
+      : item,
+  );
+}
+
+/** Rewrites whichever row array(s) the container happens to use. */
+function bumpRowArrays(
+  container: Record<string, unknown>,
+  profileId: string,
+  field: ProposalCountField,
+  delta: number,
+): Record<string, unknown> {
+  let next = container;
+
+  for (const key of ROW_ARRAY_KEYS) {
+    if (Array.isArray(next[key])) {
+      next = { ...next, [key]: bumpItems(next[key], profileId, field, delta) };
+    }
+  }
+
+  return next;
+}
+
+/**
+ * Returns `data` with the matching proposal's count moved by `delta`. Handles
+ * both the flat result and the infinite `{ pages: [...] }` one, whichever row
+ * array the router uses, and returns the input untouched for anything it
+ * doesn't recognise.
+ */
+export function bumpProposalCount(
+  data: unknown,
+  profileId: string,
+  field: ProposalCountField,
+  delta: number,
+): unknown {
+  if (!data || typeof data !== 'object') {
+    return data;
+  }
+
+  const record = data as Record<string, unknown>;
+
+  if (Array.isArray(record.pages)) {
+    return {
+      ...record,
+      pages: record.pages.map((page) =>
+        page && typeof page === 'object'
+          ? bumpRowArrays(
+              page as Record<string, unknown>,
+              profileId,
+              field,
+              delta,
+            )
+          : page,
+      ),
+    };
+  }
+
+  if (ROW_ARRAY_KEYS.some((key) => Array.isArray(record[key]))) {
+    return bumpRowArrays(record, profileId, field, delta);
+  }
+
+  // A bare proposal — what `decision.getProposal` caches for the detail view.
+  if ('profileId' in record) {
+    return bumpRow(record as ProposalRow, profileId, field, delta);
+  }
+
+  return data;
+}

--- a/apps/app/src/hooks/relationshipDrain.test.ts
+++ b/apps/app/src/hooks/relationshipDrain.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type RelationshipDrainIo,
+  requestRelationship,
+} from './relationshipDrain';
+
+/** A promise plus the handle to settle it, so a test can hold a call in flight. */
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
+/** Runs every pending microtask, so the loop lands on its next await. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * An `io` that records what the drain did.
+ *
+ * `overlaps` is the load-bearing one: nothing the loop calls may run
+ * concurrently with anything else it calls. An entry there means the lease was
+ * dropped somewhere and a second drain started racing the first.
+ */
+function createIo(
+  options: {
+    send?: (next: boolean) => Promise<void>;
+    reconcile?: () => Promise<void>;
+  } = {},
+) {
+  const sends: boolean[] = [];
+  const errors: unknown[] = [];
+  const overlaps: string[] = [];
+  const counts = { reconcile: 0 };
+  let active: string | null = null;
+
+  const exclusive = async (label: string, run: () => Promise<void>) => {
+    if (active) {
+      overlaps.push(`${active} during ${label}`);
+    }
+
+    active = label;
+
+    try {
+      await run();
+    } finally {
+      active = null;
+    }
+  };
+
+  const io: RelationshipDrainIo = {
+    send: (next) =>
+      exclusive('send', async () => {
+        sends.push(next);
+        await (options.send?.(next) ?? Promise.resolve());
+      }),
+    reconcile: () =>
+      exclusive('reconcile', async () => {
+        counts.reconcile += 1;
+        await (options.reconcile?.() ?? Promise.resolve());
+      }),
+    onError: (error) => errors.push(error),
+  };
+
+  return { io, sends, errors, overlaps, counts };
+}
+
+describe('requestRelationship', () => {
+  it('sends on the first press, with no prior state', async () => {
+    const { io, sends, counts, overlaps } = createIo();
+
+    await requestRelationship('cold:likes', true, io);
+
+    expect(sends).toEqual([true]);
+    expect(counts.reconcile).toBe(1);
+    expect(overlaps).toEqual([]);
+  });
+
+  it('collapses a burst that ends where it started to one request', async () => {
+    const inFlight = deferred();
+    const { io, sends, counts } = createIo({ send: () => inFlight.promise });
+
+    const drain = requestRelationship('odd:likes', true, io);
+
+    // Two more presses while the first request is still in the air.
+    void requestRelationship('odd:likes', false, io);
+    void requestRelationship('odd:likes', true, io);
+
+    inFlight.resolve();
+    await drain;
+
+    expect(sends).toEqual([true]);
+    expect(counts.reconcile).toBe(1);
+  });
+
+  it('sends one correction when a burst ends on the opposite state', async () => {
+    const inFlight = deferred();
+    const gates = [inFlight.promise];
+    const { io, sends } = createIo({
+      send: () => gates.shift() ?? Promise.resolve(),
+    });
+
+    const drain = requestRelationship('even:likes', true, io);
+
+    void requestRelationship('even:likes', false, io);
+
+    inFlight.resolve();
+    await drain;
+
+    // The sequence, not just the count: it's what proves the loop re-read the
+    // intent rather than queueing a request per press.
+    expect(sends).toEqual([true, false]);
+  });
+
+  it('picks up a press that lands during the reconcile', async () => {
+    const inFlight = deferred();
+    const gates = [inFlight.promise];
+    const { io, sends, counts, overlaps } = createIo({
+      reconcile: () => gates.shift() ?? Promise.resolve(),
+    });
+
+    const drain = requestRelationship('mid:likes', true, io);
+
+    await flush();
+
+    expect(sends).toEqual([true]);
+    expect(counts.reconcile).toBe(1);
+
+    void requestRelationship('mid:likes', false, io);
+
+    inFlight.resolve();
+    await drain;
+
+    expect(sends).toEqual([true, false]);
+    expect(overlaps).toEqual([]);
+  });
+
+  it('ends the burst on a failed write instead of retrying', async () => {
+    const boom = new Error('write failed');
+    let fail = true;
+    const { io, sends, errors, counts } = createIo({
+      send: () => (fail ? Promise.reject(boom) : Promise.resolve()),
+    });
+
+    await requestRelationship('fail:likes', true, io);
+
+    expect(sends).toEqual([true]);
+    expect(errors).toEqual([boom]);
+    expect(counts.reconcile).toBe(1);
+
+    // The lease survived the failure, so the next press starts a fresh drain
+    // rather than finding the button dead for the rest of the session.
+    fail = false;
+    await requestRelationship('fail:likes', true, io);
+
+    expect(sends).toEqual([true, true]);
+  });
+
+  it('still sends a press that lands during the reconcile after a failure', async () => {
+    const boom = new Error('write failed');
+    const inFlight = deferred();
+    const gates = [inFlight.promise];
+    let fail = true;
+    const { io, sends, errors } = createIo({
+      send: () => {
+        const result = fail ? Promise.reject(boom) : Promise.resolve();
+
+        fail = false;
+
+        return result;
+      },
+      reconcile: () => gates.shift() ?? Promise.resolve(),
+    });
+
+    const drain = requestRelationship('failmid:likes', true, io);
+
+    await flush();
+
+    void requestRelationship('failmid:likes', false, io);
+
+    inFlight.resolve();
+    await drain;
+
+    // The press was made while the error's reconcile was in flight. Discarding
+    // it leaves the cache flipped against the server for the next press to read.
+    expect(sends).toEqual([true, false]);
+    expect(errors).toEqual([boom]);
+  });
+
+  it('drains each key independently', async () => {
+    const inFlight = deferred();
+    const likes = createIo({ send: () => inFlight.promise });
+    const follows = createIo();
+
+    const likesDrain = requestRelationship('split:likes', true, likes.io);
+
+    await requestRelationship('split:following', true, follows.io);
+
+    expect(follows.sends).toEqual([true]);
+
+    inFlight.resolve();
+    await likesDrain;
+
+    expect(likes.sends).toEqual([true]);
+  });
+
+  it('shares one drain between two mounts of the same proposal', async () => {
+    const inFlight = deferred();
+    const cardA = createIo({ send: () => inFlight.promise });
+    const cardB = createIo();
+
+    const drain = requestRelationship('shared:likes', true, cardA.io);
+
+    // The same proposal, mounted a second time — a card in the list and the
+    // detail view, say.
+    void requestRelationship('shared:likes', false, cardB.io);
+
+    inFlight.resolve();
+    await drain;
+
+    // One drain, two requests: B reversed the target instead of opening a
+    // second loop, and the correction went through B's callbacks — the newest.
+    expect(cardA.sends).toEqual([true]);
+    expect(cardB.sends).toEqual([false]);
+    expect(cardA.counts.reconcile).toBe(0);
+    expect(cardB.counts.reconcile).toBe(1);
+  });
+});

--- a/apps/app/src/hooks/relationshipDrain.ts
+++ b/apps/app/src/hooks/relationshipDrain.ts
@@ -1,0 +1,112 @@
+/**
+ * Click coalescing for the proposal like/follow toggles.
+ *
+ * A burst of presses has to move the UI on every press while sending far fewer
+ * requests than there were presses. This keeps, per target, what the user wants
+ * and what was last sent, and runs one request at a time — re-reading the
+ * intent after each one rather than queueing a request per click. Ten taps are
+ * at most two requests: the one already going, and one to correct it.
+ *
+ * The state is module-scoped and keyed, not per hook instance: the same
+ * proposal can be mounted twice at once (a card in the list and the detail
+ * view), and two drains for one relationship would double the requests against
+ * a 20-per-10s limit and race each other's reconciles.
+ *
+ * No React and no tRPC in here on purpose — everything it touches arrives
+ * through `io`, so the loop is testable on its own.
+ */
+
+/** The outside world, re-supplied on every request so it can't go stale. */
+export interface RelationshipDrainIo {
+  /** Write `next` to the server. Rejecting ends the burst. */
+  send: (next: boolean) => Promise<void>;
+  /** Drop the optimistic state and refetch the truth. */
+  reconcile: () => Promise<void>;
+  onError: (error: unknown) => void;
+}
+
+interface DrainState {
+  /** What the user wants. `undefined` once the burst has been settled. */
+  desired?: boolean;
+  /** What was last written to the server during this burst. */
+  sent?: boolean;
+  /** Held for the whole loop, reconciles included. */
+  draining: boolean;
+  io: RelationshipDrainIo;
+}
+
+const drains = new Map<string, DrainState>();
+
+/**
+ * Record what the user wants for `key` and make sure a drain is running.
+ *
+ * Returns when the drain this call belongs to has finished — immediately if one
+ * was already running, since that loop will pick the new intent up itself.
+ */
+export function requestRelationship(
+  key: string,
+  next: boolean,
+  io: RelationshipDrainIo,
+): Promise<void> {
+  const state = drains.get(key) ?? { draining: false, io };
+
+  // Newest callbacks win: a running loop re-reads them each pass, so it sends
+  // through the latest render's mutations rather than the ones it started with.
+  state.io = io;
+  state.desired = next;
+  drains.set(key, state);
+
+  return runDrain(key, state);
+}
+
+async function runDrain(key: string, state: DrainState): Promise<void> {
+  if (state.draining) {
+    return;
+  }
+
+  state.draining = true;
+
+  // Forget this burst and pull the truth back in. Stays inside the loop so a
+  // click that lands during the refetch is picked up here rather than by a
+  // second drain racing the queries this one just kicked off.
+  const settle = async () => {
+    state.desired = undefined;
+    state.sent = undefined;
+    await state.io.reconcile();
+  };
+
+  try {
+    while (state.desired !== undefined) {
+      const target = state.desired;
+
+      if (target === state.sent) {
+        await settle();
+        continue;
+      }
+
+      try {
+        await state.io.send(target);
+        state.sent = target;
+      } catch (error) {
+        state.io.onError(error);
+
+        // `continue`, not `break`: settle() cleared the burst, so with no
+        // further press the loop condition ends it here anyway — there is no
+        // retry. A click that landed during the reconcile is the case `break`
+        // got wrong; it couldn't start its own drain (the lease is still held)
+        // and was dropped silently, leaving the cache flipped against the
+        // server for the next press to read.
+        await settle();
+        continue;
+      }
+    }
+  } finally {
+    state.draining = false;
+
+    // Idle and empty — settle() cleared both fields — so drop it rather than
+    // keep an entry per proposal the viewer has ever touched.
+    if (state.desired === undefined && drains.get(key) === state) {
+      drains.delete(key);
+    }
+  }
+}

--- a/apps/app/src/hooks/useProposalEngagement.ts
+++ b/apps/app/src/hooks/useProposalEngagement.ts
@@ -23,7 +23,6 @@ export const canEngageWithProposals = (
 export interface ProposalEngagement {
   isLiked: boolean;
   isFollowed: boolean;
-  isPending: boolean;
   onLike: () => void;
   /** Absent for a proposal's own author — see {@link useProposalEngagement}. */
   onFollow?: () => void;
@@ -58,7 +57,7 @@ export function useProposalEngagement({
   const { user } = useUser();
   const canToggle = userCanInteract(user) && canEngage;
 
-  const { isLiked, isFollowed, isLoading, handleLike, handleFollow } =
+  const { isLiked, isFollowed, handleLike, handleFollow } =
     useRelationshipMutations({
       targetProfileId: proposal.profileId,
       enabled: canToggle,
@@ -79,7 +78,6 @@ export function useProposalEngagement({
   return {
     isLiked,
     isFollowed,
-    isPending: isLoading,
     onLike: handleLike,
     // Keep the toggle for an author who already follows, or they'd be stuck
     // following with no way to undo it.

--- a/apps/app/src/hooks/useProposalEngagement.ts
+++ b/apps/app/src/hooks/useProposalEngagement.ts
@@ -32,9 +32,10 @@ export interface ProposalEngagement {
  * Like/follow for a proposal, shared by the card's metric toggles and the
  * detail view's engagement row so the two can't drift.
  *
- * Returns `undefined` when the viewer can't act — anonymous visitors, and roles
- * without engagement access on the parent decision. Callers render the counts
- * as plain numbers in that case rather than dead controls.
+ * Returns `undefined` when the viewer can't act — anonymous visitors, roles
+ * without engagement access on the parent decision, and a relationship list
+ * that failed to load. Callers render the counts as plain numbers in that case
+ * rather than dead controls.
  *
  * An author gets no `onFollow`: they're the proposal's audience by definition.
  * Nothing writes that follow for them, so their own follower count doesn't
@@ -57,14 +58,16 @@ export function useProposalEngagement({
   const { user } = useUser();
   const canToggle = userCanInteract(user) && canEngage;
 
-  const { isLiked, isFollowed, handleLike, handleFollow } =
+  const { isLiked, isFollowed, error, handleLike, handleFollow } =
     useRelationshipMutations({
       targetProfileId: proposal.profileId,
       enabled: canToggle,
       invalidateQueries: [{ processInstanceId: proposal.processInstanceId }],
     });
 
-  if (!canToggle) {
+  // A failed load leaves both flags false for want of data, which would render
+  // every toggle unpressed and turn the next click into a redundant add.
+  if (!canToggle || error) {
     return undefined;
   }
 

--- a/apps/app/src/hooks/useProposalEngagement.ts
+++ b/apps/app/src/hooks/useProposalEngagement.ts
@@ -34,7 +34,7 @@ export interface ProposalEngagement {
  *
  * Returns `undefined` when the viewer can't act — anonymous visitors, roles
  * without engagement access on the parent decision, and a relationship list
- * that failed to load. Callers render the counts as plain numbers in that case
+ * that never loaded. Callers render the counts as plain numbers in that case
  * rather than dead controls.
  *
  * An author gets no `onFollow`: they're the proposal's audience by definition.
@@ -58,16 +58,16 @@ export function useProposalEngagement({
   const { user } = useUser();
   const canToggle = userCanInteract(user) && canEngage;
 
-  const { isLiked, isFollowed, error, handleLike, handleFollow } =
+  const { isLiked, isFollowed, stateUnknown, handleLike, handleFollow } =
     useRelationshipMutations({
       targetProfileId: proposal.profileId,
       enabled: canToggle,
       invalidateQueries: [{ processInstanceId: proposal.processInstanceId }],
     });
 
-  // A failed load leaves both flags false for want of data, which would render
-  // every toggle unpressed and turn the next click into a redundant add.
-  if (!canToggle || error) {
+  // With nothing loaded both flags read false for want of data, which would
+  // render every toggle unpressed and turn the next click into a redundant add.
+  if (!canToggle || stateUnknown) {
     return undefined;
   }
 

--- a/apps/app/src/hooks/useRelationshipMutations.ts
+++ b/apps/app/src/hooks/useRelationshipMutations.ts
@@ -93,6 +93,19 @@ export function useRelationshipMutations({
     ),
   );
 
+  /**
+   * There is no answer to `isLiked` / `isFollowed`, as opposed to the answer
+   * being no.
+   *
+   * Deliberately not `Boolean(error)`. A failed *refetch* keeps the cached list
+   * and still answers correctly, and `reconcile` invalidates this query after
+   * every burst — so with `retry` and `refetchOnWindowFocus` both off app-wide,
+   * treating any error as fatal would let one dropped response strip the
+   * controls from every proposal on the page with nothing left to restore them.
+   */
+  const stateUnknown =
+    Boolean(relationshipsError) && userRelationships === undefined;
+
   // The raw client rather than `utils`: the count caches are matched by a
   // predicate on the tRPC path, which the typed helpers can't express.
   const queryClient = useQueryClient();
@@ -170,13 +183,13 @@ export function useRelationshipMutations({
   const reconcile = async () => {
     await Promise.all([
       utils.profile.getRelationships.invalidate(relationshipQueryKey),
-      // `refetchType: 'all'`, not the default 'active': `setQueriesData` wrote
-      // every matching entry, so an unmounted `getProposal` or an off-screen
-      // filter would otherwise keep the optimistic delta and serve it on mount.
-      queryClient.invalidateQueries({
-        ...countQueryFilter,
-        refetchType: 'all',
-      }),
+      // Default `refetchType`, deliberately. `setQueriesData` wrote every
+      // matching entry including inactive ones, but invalidation marks all of
+      // them stale whatever gets refetched now, and there's no app-wide
+      // `staleTime`, so an off-screen filter refetches when it next mounts.
+      // `'all'` would instead fan out over every persisted proposal query —
+      // hydrated entries carry no queryFn and fail — on every single press.
+      queryClient.invalidateQueries(countQueryFilter),
       ...invalidateQueries.flatMap((query) =>
         query.processInstanceId
           ? [
@@ -283,12 +296,11 @@ export function useRelationshipMutations({
     isLiked,
     isFollowed,
     /**
-     * The relationship list failed to load, so `isLiked` / `isFollowed` are
-     * both reading false for want of data rather than because they're false.
-     * Callers should fall back to read-only counts instead of offering a
-     * toggle that would send a redundant write.
+     * `isLiked` / `isFollowed` are reading false for want of data rather than
+     * because they're false. Callers should fall back to read-only counts
+     * instead of offering a toggle that would send a redundant write.
      */
-    error: relationshipsError,
+    stateUnknown,
 
     handleLike: () =>
       toggleRelationship(

--- a/apps/app/src/hooks/useRelationshipMutations.ts
+++ b/apps/app/src/hooks/useRelationshipMutations.ts
@@ -96,77 +96,35 @@ export function useRelationshipMutations({
     ),
   );
 
-  // Shared by both mutations' onSettled: always refetch relationship data
-  // after error or success. The proposal detail view refreshes via the
-  // realtime channel the mutation registers (Channels.decisionProposal), so
-  // it isn't invalidated here; the proposal list deliberately isn't
-  // channel-invalidated, so callers pass processInstanceId to refresh their
-  // own list counts.
+  // The raw client rather than `utils`: the count caches are matched by a
+  // predicate on the tRPC path, which the typed helpers can't express.
   const queryClient = useQueryClient();
 
-  /**
-   * Move the proposal's like/follow count everywhere it is cached.
-   *
-   * Matched with a predicate on the tRPC path rather than a built query key:
-   * the same proposal sits in several caches at once — any number of
-   * `listProposals` / `listAllProposals` results (different filters or sorts,
-   * plus the ballot's non-infinite query) and the `getProposal` entry — and
-   * a predicate matches all of them without depending on how tRPC happens to
-   * encode inputs in the key.
-   *
-   * Rolling back applies the opposite delta rather than restoring a snapshot.
-   * Every card on the page writes to these same caches, so a snapshot taken
-   * before this mutation would also undo whatever another card did in the
-   * meantime.
-   */
-  const countQueryFilter = {
-    predicate: (query: { queryKey: readonly unknown[] }) => {
-      const [path] = query.queryKey;
-
-      return (
-        Array.isArray(path) &&
-        path[0] === 'decision' &&
-        (path[1] === 'listProposals' ||
-          path[1] === 'listAllProposals' ||
-          path[1] === 'getProposal')
-      );
-    },
-  };
-
-  const patchCachedCounts = (relationshipType: string, delta: number) => {
+  /** Move the proposal's like/follow count everywhere it is cached. */
+  const patchCachedCounts = (
+    relationshipType: ProfileRelationshipType,
+    delta: number,
+  ) => {
     if (!targetProfileId) {
       return;
     }
 
-    const field: ProposalCountField =
-      relationshipType === ProfileRelationshipType.LIKES
-        ? 'likesCount'
-        : 'followersCount';
-
-    queryClient.setQueriesData(
-      {
-        predicate: (query: { queryKey: readonly unknown[] }) => {
-          const [path] = query.queryKey;
-
-          return (
-            Array.isArray(path) &&
-            path[0] === 'decision' &&
-            (path[1] === 'listProposals' ||
-              path[1] === 'listAllProposals' ||
-              path[1] === 'getProposal')
-          );
-        },
-      },
-      (old: unknown) => bumpProposalCount(old, targetProfileId, field, delta),
+    queryClient.setQueriesData(countQueryFilter, (old: unknown) =>
+      bumpProposalCount(
+        old,
+        targetProfileId,
+        COUNT_FIELD[relationshipType],
+        delta,
+      ),
     );
   };
 
   /**
-   * Add or drop this proposal in the viewer's relationship list.
+   * Add or drop this proposal in the viewer's relationship list — the cache the
+   * pressed state is read from.
    *
-   * Same reasoning as the counts: one cache entry (`{ types: [...] }`) is
-   * shared by every card on the page, so rollback removes exactly what this
-   * mutation added rather than reinstating a stale copy of the whole list.
+   * The row written is a stub with an empty name and slug, safe only because
+   * this key has exactly one reader and it touches `targetProfile.id` alone.
    */
   const patchCachedRelationship = (
     relationshipType: ProfileRelationshipType,
@@ -215,7 +173,13 @@ export function useRelationshipMutations({
   const reconcile = async () => {
     await Promise.all([
       utils.profile.getRelationships.invalidate(relationshipQueryKey),
-      queryClient.invalidateQueries(countQueryFilter),
+      // `refetchType: 'all'`, not the default 'active': `setQueriesData` wrote
+      // every matching entry, so an unmounted `getProposal` or an off-screen
+      // filter would otherwise keep the optimistic delta and serve it on mount.
+      queryClient.invalidateQueries({
+        ...countQueryFilter,
+        refetchType: 'all',
+      }),
       ...invalidateQueries.flatMap((query) =>
         query.processInstanceId
           ? [
@@ -234,12 +198,9 @@ export function useRelationshipMutations({
   const addRelationshipMutation =
     trpc.decision.addProposalRelationship.useMutation({
       onSuccess: () => onSuccess?.(),
-      onError: (error, variables) => {
-        logger.error('Failed to add relationship', {
-          error,
-          context: 'useRelationshipMutations.add',
-        });
-
+      // Failures are logged once, in the drain's catch — it has the burst
+      // context, and logging here too splits the PostHog issue group.
+      onError: (_error, variables) => {
         // Four whole sentences rather than a verb slotted into one template:
         // the pieces don't reassemble into a sentence in every language.
         toast.error(
@@ -253,12 +214,7 @@ export function useRelationshipMutations({
   const removeRelationshipMutation =
     trpc.decision.removeProposalRelationship.useMutation({
       onSuccess: () => onSuccess?.(),
-      onError: (error, variables) => {
-        logger.error('Failed to remove relationship', {
-          error,
-          context: 'useRelationshipMutations.remove',
-        });
-
+      onError: (_error, variables) => {
         toast.error(
           variables.relationshipType === ProfileRelationshipType.LIKES
             ? t("Couldn't remove your like. Please try again.")
@@ -328,14 +284,20 @@ export function useRelationshipMutations({
           await mutation.mutateAsync({ targetProfileId, relationshipType });
           sent.current[relationshipType] = target;
         } catch (error) {
-          // Logged and toasted in onError; the reconcile puts the cache back to
-          // whatever the server actually has.
+          // Toasted in onError; the reconcile puts the cache back to whatever
+          // the server actually has.
           logger.error('Relationship write failed', {
             error,
             context: `useRelationshipMutations.${relationshipType}`,
           });
+
+          // `continue`, not `break`: settle() cleared the burst, so with no
+          // further press the loop condition ends it here anyway. A click that
+          // landed during the reconcile is the one case `break` got wrong — it
+          // couldn't start its own drain (lease still held) and was dropped
+          // silently, leaving the cache flipped against the server.
           await settle();
-          break;
+          continue;
         }
       }
     } finally {
@@ -412,3 +374,34 @@ export function useRelationshipMutations({
     removeRelationshipMutation,
   };
 }
+
+/** Which proposal count each relationship type moves. */
+const COUNT_FIELD: Record<ProfileRelationshipType, ProposalCountField> = {
+  [ProfileRelationshipType.LIKES]: 'likesCount',
+  [ProfileRelationshipType.FOLLOWING]: 'followersCount',
+};
+
+/**
+ * Every cache an optimistic count is written to.
+ *
+ * A predicate on the tRPC path rather than a built query key: the same proposal
+ * sits in several caches at once — any number of `listProposals` /
+ * `listAllProposals` results (different filters or sorts, plus the ballot's
+ * non-infinite query) and the `getProposal` entry. One definition, used for the
+ * cancel, the write and the invalidate alike; drift between them means writing
+ * to a cache nothing invalidates, which is the frozen-count bug this file
+ * already fixed once.
+ */
+const countQueryFilter = {
+  predicate: (query: { queryKey: readonly unknown[] }) => {
+    const [path] = query.queryKey;
+
+    return (
+      Array.isArray(path) &&
+      path[0] === 'decision' &&
+      (path[1] === 'listProposals' ||
+        path[1] === 'listAllProposals' ||
+        path[1] === 'getProposal')
+    );
+  },
+};

--- a/apps/app/src/hooks/useRelationshipMutations.ts
+++ b/apps/app/src/hooks/useRelationshipMutations.ts
@@ -4,7 +4,6 @@ import { ProfileRelationshipType } from '@op/api/encoders';
 import { logger } from '@op/logging/client';
 import { toast } from '@op/sense/Toast';
 import { useQueryClient } from '@tanstack/react-query';
-import { useRef } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -12,6 +11,7 @@ import {
   type ProposalCountField,
   bumpProposalCount,
 } from './optimisticProposalCounts';
+import { requestRelationship } from './relationshipDrain';
 
 interface UseRelationshipMutationsOptions {
   targetProfileId?: string | null;
@@ -218,13 +218,6 @@ export function useRelationshipMutations({
       },
     });
 
-  /** What the user wants, and what we last managed to send, per type. */
-  const desired = useRef<Partial<Record<ProfileRelationshipType, boolean>>>({});
-  const sent = useRef<Partial<Record<ProfileRelationshipType, boolean>>>({});
-  const draining = useRef<Partial<Record<ProfileRelationshipType, boolean>>>(
-    {},
-  );
-
   const isLikedInCache = (relationshipType: ProfileRelationshipType) =>
     Boolean(
       utils.profile.getRelationships
@@ -233,66 +226,6 @@ export function useRelationshipMutations({
           (rel) => rel.targetProfile?.id === targetProfileId,
         ),
     );
-
-  /**
-   * Send whatever the user has settled on, one request at a time, re-reading
-   * their intent after each one. Clicks that arrive mid-flight change the
-   * target rather than queueing behind it, so ten taps are at most two
-   * requests: the one already going, and one to correct it.
-   */
-  const drain = async (relationshipType: ProfileRelationshipType) => {
-    if (!targetProfileId || draining.current[relationshipType]) {
-      return;
-    }
-
-    draining.current[relationshipType] = true;
-
-    // Forget this burst and pull the truth back in. Stays inside the loop so a
-    // click that lands during the refetch is picked up here rather than by a
-    // second drain racing the queries this one just kicked off.
-    const settle = async () => {
-      delete desired.current[relationshipType];
-      delete sent.current[relationshipType];
-      await reconcile();
-    };
-
-    try {
-      while (desired.current[relationshipType] !== undefined) {
-        const target = desired.current[relationshipType];
-
-        if (target === sent.current[relationshipType]) {
-          await settle();
-          continue;
-        }
-
-        const mutation = target
-          ? addRelationshipMutation
-          : removeRelationshipMutation;
-
-        try {
-          await mutation.mutateAsync({ targetProfileId, relationshipType });
-          sent.current[relationshipType] = target;
-        } catch (error) {
-          // Toasted in onError; the reconcile puts the cache back to whatever
-          // the server actually has.
-          logger.error('Relationship write failed', {
-            error,
-            context: `useRelationshipMutations.${relationshipType}`,
-          });
-
-          // `continue`, not `break`: settle() cleared the burst, so with no
-          // further press the loop condition ends it here anyway. A click that
-          // landed during the reconcile is the one case `break` got wrong — it
-          // couldn't start its own drain (lease still held) and was dropped
-          // silently, leaving the cache flipped against the server.
-          await settle();
-          continue;
-        }
-      }
-    } finally {
-      draining.current[relationshipType] = false;
-    }
-  };
 
   // Not wrapped in useCallback: it closes over every helper above, all of them
   // rebuilt each render, so an honest dependency array would invalidate on
@@ -321,11 +254,29 @@ export function useRelationshipMutations({
     // an earlier one is still in the air.
     const next = !isLikedInCache(relationshipType);
 
-    desired.current[relationshipType] = next;
     patchCachedRelationship(relationshipType, next);
     patchCachedCounts(relationshipType, next ? 1 : -1);
 
-    void drain(relationshipType);
+    // Keyed by proposal and type rather than held per instance: the same
+    // proposal can be mounted twice at once, and both toggles must feed the
+    // one drain.
+    void requestRelationship(`${targetProfileId}:${relationshipType}`, next, {
+      send: async (target) => {
+        const mutation = target
+          ? addRelationshipMutation
+          : removeRelationshipMutation;
+
+        await mutation.mutateAsync({ targetProfileId, relationshipType });
+      },
+      reconcile,
+      // Toasted in the mutation's onError; the reconcile puts the cache back to
+      // whatever the server actually has.
+      onError: (error) =>
+        logger.error('Relationship write failed', {
+          error,
+          context: `useRelationshipMutations.${relationshipType}`,
+        }),
+    });
   };
 
   return {

--- a/apps/app/src/hooks/useRelationshipMutations.ts
+++ b/apps/app/src/hooks/useRelationshipMutations.ts
@@ -75,10 +75,12 @@ export function useRelationshipMutations({
   };
 
   // Get user's likes and follows
-  const { data: userRelationships, error: relationshipsError } =
-    trpc.profile.getRelationships.useQuery(relationshipQueryKey, {
+  const { data: userRelationships } = trpc.profile.getRelationships.useQuery(
+    relationshipQueryKey,
+    {
       enabled: !!user && enabled,
-    });
+    },
+  );
 
   // Check if current user has liked/followed this profile
   const isLiked = Boolean(
@@ -95,16 +97,17 @@ export function useRelationshipMutations({
 
   /**
    * There is no answer to `isLiked` / `isFollowed`, as opposed to the answer
-   * being no.
+   * being no. Covers both the first fetch still being in flight and one that
+   * failed outright — either way the flags below read false for want of data,
+   * and a press decided on that would bump a count the server won't move.
    *
-   * Deliberately not `Boolean(error)`. A failed *refetch* keeps the cached list
-   * and still answers correctly, and `reconcile` invalidates this query after
-   * every burst — so with `retry` and `refetchOnWindowFocus` both off app-wide,
-   * treating any error as fatal would let one dropped response strip the
-   * controls from every proposal on the page with nothing left to restore them.
+   * A failed *refetch* is deliberately not unknown: it keeps the cached list, so
+   * the flags still answer correctly. `reconcile` invalidates this query after
+   * every burst and `retry` is off app-wide, so treating any error as fatal
+   * would let one dropped response strip the controls from every proposal on the
+   * page with nothing left to restore them.
    */
-  const stateUnknown =
-    Boolean(relationshipsError) && userRelationships === undefined;
+  const stateUnknown = userRelationships === undefined;
 
   // The raw client rather than `utils`: the count caches are matched by a
   // predicate on the tRPC path, which the typed helpers can't express.

--- a/apps/app/src/hooks/useRelationshipMutations.ts
+++ b/apps/app/src/hooks/useRelationshipMutations.ts
@@ -3,9 +3,15 @@ import { trpc } from '@op/api/client';
 import { ProfileRelationshipType } from '@op/api/encoders';
 import { logger } from '@op/logging/client';
 import { toast } from '@op/sense/Toast';
-import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useRef } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
+
+import {
+  type ProposalCountField,
+  bumpProposalCount,
+} from './optimisticProposalCounts';
 
 interface UseRelationshipMutationsOptions {
   targetProfileId?: string | null;
@@ -96,9 +102,120 @@ export function useRelationshipMutations({
   // it isn't invalidated here; the proposal list deliberately isn't
   // channel-invalidated, so callers pass processInstanceId to refresh their
   // own list counts.
-  const invalidateAfterMutation = async () => {
+  const queryClient = useQueryClient();
+
+  /**
+   * Move the proposal's like/follow count everywhere it is cached.
+   *
+   * Matched with a predicate on the tRPC path rather than a built query key:
+   * the same proposal sits in several caches at once — any number of
+   * `listProposals` / `listAllProposals` results (different filters or sorts,
+   * plus the ballot's non-infinite query) and the `getProposal` entry — and
+   * a predicate matches all of them without depending on how tRPC happens to
+   * encode inputs in the key.
+   *
+   * Rolling back applies the opposite delta rather than restoring a snapshot.
+   * Every card on the page writes to these same caches, so a snapshot taken
+   * before this mutation would also undo whatever another card did in the
+   * meantime.
+   */
+  const countQueryFilter = {
+    predicate: (query: { queryKey: readonly unknown[] }) => {
+      const [path] = query.queryKey;
+
+      return (
+        Array.isArray(path) &&
+        path[0] === 'decision' &&
+        (path[1] === 'listProposals' ||
+          path[1] === 'listAllProposals' ||
+          path[1] === 'getProposal')
+      );
+    },
+  };
+
+  const patchCachedCounts = (relationshipType: string, delta: number) => {
+    if (!targetProfileId) {
+      return;
+    }
+
+    const field: ProposalCountField =
+      relationshipType === ProfileRelationshipType.LIKES
+        ? 'likesCount'
+        : 'followersCount';
+
+    queryClient.setQueriesData(
+      {
+        predicate: (query: { queryKey: readonly unknown[] }) => {
+          const [path] = query.queryKey;
+
+          return (
+            Array.isArray(path) &&
+            path[0] === 'decision' &&
+            (path[1] === 'listProposals' ||
+              path[1] === 'listAllProposals' ||
+              path[1] === 'getProposal')
+          );
+        },
+      },
+      (old: unknown) => bumpProposalCount(old, targetProfileId, field, delta),
+    );
+  };
+
+  /**
+   * Add or drop this proposal in the viewer's relationship list.
+   *
+   * Same reasoning as the counts: one cache entry (`{ types: [...] }`) is
+   * shared by every card on the page, so rollback removes exactly what this
+   * mutation added rather than reinstating a stale copy of the whole list.
+   */
+  const patchCachedRelationship = (
+    relationshipType: ProfileRelationshipType,
+    present: boolean,
+  ) => {
+    if (!targetProfileId) {
+      return;
+    }
+
+    utils.profile.getRelationships.setData(relationshipQueryKey, (old) => {
+      const base = old ?? {};
+      const without = (base[relationshipType] ?? []).filter(
+        (rel) => rel.targetProfile?.id !== targetProfileId,
+      );
+
+      return {
+        ...base,
+        [relationshipType]: present
+          ? [
+              ...without,
+              {
+                relationshipType,
+                pending: false,
+                createdAt: new Date().toISOString(),
+                targetProfile: {
+                  id: targetProfileId,
+                  name: '',
+                  slug: '',
+                  bio: null,
+                  avatarImage: null,
+                  type: 'proposal',
+                },
+              },
+            ]
+          : without,
+      };
+    });
+  };
+
+  /**
+   * Pull the truth back in once the writes stop. Invalidates everything the
+   * optimistic patches touched — including `listAllProposals` and
+   * `getProposal`, which the counts are written to but nothing else refetches,
+   * so a count that drifted had no way back.
+   */
+  const reconcile = async () => {
     await Promise.all([
       utils.profile.getRelationships.invalidate(relationshipQueryKey),
+      queryClient.invalidateQueries(countQueryFilter),
       ...invalidateQueries.flatMap((query) =>
         query.processInstanceId
           ? [
@@ -111,69 +228,13 @@ export function useRelationshipMutations({
     ]);
   };
 
-  // Add relationship mutation with optimistic updates
+  // The cache writes live in `toggleRelationship`, not in `onMutate`: a burst
+  // of clicks has to move the UI on every press, while sending far fewer
+  // requests than there were presses.
   const addRelationshipMutation =
     trpc.decision.addProposalRelationship.useMutation({
-      onMutate: async (variables) => {
-        // Cancel outgoing refetches for the relationship queries
-        await utils.profile.getRelationships.cancel(relationshipQueryKey);
-
-        // Snapshot the previous value
-        const previousData =
-          utils.profile.getRelationships.getData(relationshipQueryKey);
-
-        // Optimistically update the cache
-        if (
-          previousData &&
-          variables.targetProfileId &&
-          typeof previousData === 'object' &&
-          !Array.isArray(previousData)
-        ) {
-          // Create a minimal relationship object for optimistic update
-          const optimisticRelationship = {
-            relationshipType: variables.relationshipType,
-            pending: false,
-            createdAt: new Date().toISOString(),
-            targetProfile: {
-              id: variables.targetProfileId,
-              name: '',
-              slug: '',
-              bio: null,
-              avatarImage: null,
-              type: 'proposal',
-            },
-          };
-
-          const optimisticData = { ...previousData };
-          const existingRelationships =
-            optimisticData[variables.relationshipType] || [];
-          optimisticData[variables.relationshipType] = [
-            ...existingRelationships,
-            optimisticRelationship,
-          ];
-
-          utils.profile.getRelationships.setData(
-            relationshipQueryKey,
-            optimisticData,
-          );
-        }
-
-        return { previousData };
-      },
-      onSuccess: () => {
-        // Call user-provided onSuccess callback
-        if (onSuccess) {
-          onSuccess();
-        }
-      },
-      onError: (error, variables, context) => {
-        // Rollback on error
-        if (context?.previousData) {
-          utils.profile.getRelationships.setData(
-            relationshipQueryKey,
-            context.previousData,
-          );
-        }
+      onSuccess: () => onSuccess?.(),
+      onError: (error, variables) => {
         logger.error('Failed to add relationship', {
           error,
           context: 'useRelationshipMutations.add',
@@ -187,57 +248,12 @@ export function useRelationshipMutations({
             : t("Couldn't follow this proposal. Please try again."),
         );
       },
-      onSettled: invalidateAfterMutation,
     });
 
-  // Remove relationship mutation with optimistic updates
   const removeRelationshipMutation =
     trpc.decision.removeProposalRelationship.useMutation({
-      onMutate: async (variables) => {
-        // Cancel outgoing refetches for the relationship queries
-        await utils.profile.getRelationships.cancel(relationshipQueryKey);
-
-        // Snapshot the previous value
-        const previousData =
-          utils.profile.getRelationships.getData(relationshipQueryKey);
-
-        // Optimistically update the cache
-        if (
-          previousData &&
-          variables.targetProfileId &&
-          typeof previousData === 'object' &&
-          !Array.isArray(previousData)
-        ) {
-          const optimisticData = { ...previousData };
-          const existingRelationships =
-            optimisticData[variables.relationshipType] || [];
-          optimisticData[variables.relationshipType] =
-            existingRelationships.filter(
-              (rel) => rel.targetProfile?.id !== variables.targetProfileId,
-            );
-
-          utils.profile.getRelationships.setData(
-            relationshipQueryKey,
-            optimisticData,
-          );
-        }
-
-        return { previousData };
-      },
-      onSuccess: () => {
-        // Call user-provided onSuccess callback
-        if (onSuccess) {
-          onSuccess();
-        }
-      },
-      onError: (error, variables, context) => {
-        // Rollback on error
-        if (context?.previousData) {
-          utils.profile.getRelationships.setData(
-            relationshipQueryKey,
-            context.previousData,
-          );
-        }
+      onSuccess: () => onSuccess?.(),
+      onError: (error, variables) => {
         logger.error('Failed to remove relationship', {
           error,
           context: 'useRelationshipMutations.remove',
@@ -249,7 +265,6 @@ export function useRelationshipMutations({
             : t("Couldn't unfollow this proposal. Please try again."),
         );
       },
-      onSettled: invalidateAfterMutation,
     });
 
   // Combined loading state (includes initial query loading)
@@ -258,83 +273,129 @@ export function useRelationshipMutations({
     removeRelationshipMutation.isPending ||
     isLoadingRelationships;
 
-  // Handler for like/unlike
-  const handleLike = useCallback(async () => {
-    if (!targetProfileId) {
-      logger.error('No targetProfileId provided for like action', {
-        context: 'useRelationshipMutations.like',
-      });
+  /** What the user wants, and what we last managed to send, per type. */
+  const desired = useRef<Partial<Record<ProfileRelationshipType, boolean>>>({});
+  const sent = useRef<Partial<Record<ProfileRelationshipType, boolean>>>({});
+  const draining = useRef<Partial<Record<ProfileRelationshipType, boolean>>>(
+    {},
+  );
+
+  const isLikedInCache = (relationshipType: ProfileRelationshipType) =>
+    Boolean(
+      utils.profile.getRelationships
+        .getData(relationshipQueryKey)
+        ?.[relationshipType]?.some(
+          (rel) => rel.targetProfile?.id === targetProfileId,
+        ),
+    );
+
+  /**
+   * Send whatever the user has settled on, one request at a time, re-reading
+   * their intent after each one. Clicks that arrive mid-flight change the
+   * target rather than queueing behind it, so ten taps are at most two
+   * requests: the one already going, and one to correct it.
+   */
+  const drain = async (relationshipType: ProfileRelationshipType) => {
+    if (!targetProfileId || draining.current[relationshipType]) {
       return;
     }
 
-    try {
-      if (isLiked) {
-        // Unlike
-        await removeRelationshipMutation.mutateAsync({
-          targetProfileId,
-          relationshipType: ProfileRelationshipType.LIKES,
-        });
-      } else {
-        // Like
-        await addRelationshipMutation.mutateAsync({
-          targetProfileId,
-          relationshipType: ProfileRelationshipType.LIKES,
-        });
-      }
-    } catch (error) {
-      // Mutation errors are rolled back and toasted in onError; mutateAsync
-      // also rejects when onSuccess/onSettled throw (onError doesn't run for
-      // those), so log here instead of swallowing silently.
-      logger.error('Like mutation post-processing failed', {
-        error,
-        context: 'useRelationshipMutations.like',
-      });
-    }
-  }, [
-    targetProfileId,
-    isLiked,
-    addRelationshipMutation,
-    removeRelationshipMutation,
-  ]);
+    draining.current[relationshipType] = true;
 
-  // Handler for follow/unfollow
-  const handleFollow = useCallback(async () => {
-    if (!targetProfileId) {
-      logger.error('No targetProfileId provided for follow action', {
-        context: 'useRelationshipMutations.follow',
-      });
-      return;
-    }
+    // Forget this burst and pull the truth back in. Stays inside the loop so a
+    // click that lands during the refetch is picked up here rather than by a
+    // second drain racing the queries this one just kicked off.
+    const settle = async () => {
+      delete desired.current[relationshipType];
+      delete sent.current[relationshipType];
+      await reconcile();
+    };
 
     try {
-      if (isFollowed) {
-        // Unfollow
-        await removeRelationshipMutation.mutateAsync({
-          targetProfileId,
-          relationshipType: ProfileRelationshipType.FOLLOWING,
-        });
-      } else {
-        // Follow
-        await addRelationshipMutation.mutateAsync({
-          targetProfileId,
-          relationshipType: ProfileRelationshipType.FOLLOWING,
-        });
+      while (desired.current[relationshipType] !== undefined) {
+        const target = desired.current[relationshipType];
+
+        if (target === sent.current[relationshipType]) {
+          await settle();
+          continue;
+        }
+
+        const mutation = target
+          ? addRelationshipMutation
+          : removeRelationshipMutation;
+
+        try {
+          await mutation.mutateAsync({ targetProfileId, relationshipType });
+          sent.current[relationshipType] = target;
+        } catch (error) {
+          // Logged and toasted in onError; the reconcile puts the cache back to
+          // whatever the server actually has.
+          logger.error('Relationship write failed', {
+            error,
+            context: `useRelationshipMutations.${relationshipType}`,
+          });
+          await settle();
+          break;
+        }
       }
-    } catch (error) {
-      // Mutation errors are rolled back and toasted in onError; mutateAsync
-      // also rejects when onSuccess/onSettled throw (onError doesn't run for
-      // those), so log here instead of swallowing silently.
-      logger.error('Follow mutation post-processing failed', {
-        error,
-        context: 'useRelationshipMutations.follow',
-      });
+    } finally {
+      draining.current[relationshipType] = false;
     }
-  }, [
-    targetProfileId,
-    isFollowed,
-    addRelationshipMutation,
-    removeRelationshipMutation,
-  ]);
+  };
+
+  const toggleRelationship = useCallback(
+    (relationshipType: ProfileRelationshipType, context: string) => {
+      if (!targetProfileId) {
+        logger.error('No targetProfileId provided for relationship action', {
+          context,
+        });
+
+        return;
+      }
+
+      // Anything in flight would land on top of the writes below and undo the
+      // press — including the refetches `reconcile` kicks off. Both caches, not
+      // just the relationship one: a stale list result resets the count while
+      // the button stays pressed, and the next click then counts the same like
+      // twice.
+      void utils.profile.getRelationships.cancel(relationshipQueryKey);
+      void queryClient.cancelQueries(countQueryFilter);
+
+      // Flip the cache first, every time: the press has to register even while
+      // an earlier one is still in the air.
+      const next = !isLikedInCache(relationshipType);
+
+      desired.current[relationshipType] = next;
+      patchCachedRelationship(relationshipType, next);
+      patchCachedCounts(relationshipType, next ? 1 : -1);
+
+      void drain(relationshipType);
+    },
+    [
+      targetProfileId,
+      utils,
+      addRelationshipMutation,
+      removeRelationshipMutation,
+    ],
+  );
+
+  const handleLike = useCallback(
+    () =>
+      toggleRelationship(
+        ProfileRelationshipType.LIKES,
+        'useRelationshipMutations.like',
+      ),
+    [toggleRelationship],
+  );
+
+  const handleFollow = useCallback(
+    () =>
+      toggleRelationship(
+        ProfileRelationshipType.FOLLOWING,
+        'useRelationshipMutations.follow',
+      ),
+    [toggleRelationship],
+  );
 
   return {
     // State

--- a/apps/app/src/hooks/useRelationshipMutations.ts
+++ b/apps/app/src/hooks/useRelationshipMutations.ts
@@ -4,7 +4,7 @@ import { ProfileRelationshipType } from '@op/api/encoders';
 import { logger } from '@op/logging/client';
 import { toast } from '@op/sense/Toast';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useRef } from 'react';
+import { useRef } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -21,7 +21,6 @@ interface UseRelationshipMutationsOptions {
    * don't subscribe to a list they'll never use.
    */
   enabled?: boolean;
-  onSuccess?: () => void;
   invalidateQueries?: Array<{
     processInstanceId?: string;
   }>;
@@ -53,18 +52,16 @@ type UserRelationships = Partial<
 >;
 
 /**
- * Hook to manage profile relationship mutations (likes and follows) with optimistic updates
+ * Like/follow a proposal's profile, with optimistic cache updates and one
+ * request per burst of clicks rather than one per click.
  *
  * @param targetProfileId - The profile ID to create relationships with
- * @param onSuccess - Optional callback to run on successful mutations
- * @param invalidateQueries - Optional array of additional queries to invalidate (e.g., proposal or list queries)
- *
- * @returns Object containing handlers, state, and mutation utilities
+ * @param enabled - Whether to subscribe to the viewer's relationship list
+ * @param invalidateQueries - Extra proposal lists to refresh once the writes settle
  */
 export function useRelationshipMutations({
   targetProfileId,
   enabled = true,
-  onSuccess,
   invalidateQueries = [],
 }: UseRelationshipMutationsOptions) {
   const t = useTranslations();
@@ -78,7 +75,7 @@ export function useRelationshipMutations({
   };
 
   // Get user's likes and follows
-  const { data: userRelationships, isLoading: isLoadingRelationships } =
+  const { data: userRelationships, error: relationshipsError } =
     trpc.profile.getRelationships.useQuery(relationshipQueryKey, {
       enabled: !!user && enabled,
     });
@@ -197,7 +194,6 @@ export function useRelationshipMutations({
   // requests than there were presses.
   const addRelationshipMutation =
     trpc.decision.addProposalRelationship.useMutation({
-      onSuccess: () => onSuccess?.(),
       // Failures are logged once, in the drain's catch — it has the burst
       // context, and logging here too splits the PostHog issue group.
       onError: (_error, variables) => {
@@ -213,7 +209,6 @@ export function useRelationshipMutations({
 
   const removeRelationshipMutation =
     trpc.decision.removeProposalRelationship.useMutation({
-      onSuccess: () => onSuccess?.(),
       onError: (_error, variables) => {
         toast.error(
           variables.relationshipType === ProfileRelationshipType.LIKES
@@ -222,12 +217,6 @@ export function useRelationshipMutations({
         );
       },
     });
-
-  // Combined loading state (includes initial query loading)
-  const isLoading =
-    addRelationshipMutation.isPending ||
-    removeRelationshipMutation.isPending ||
-    isLoadingRelationships;
 
   /** What the user wants, and what we last managed to send, per type. */
   const desired = useRef<Partial<Record<ProfileRelationshipType, boolean>>>({});
@@ -305,73 +294,61 @@ export function useRelationshipMutations({
     }
   };
 
-  const toggleRelationship = useCallback(
-    (relationshipType: ProfileRelationshipType, context: string) => {
-      if (!targetProfileId) {
-        logger.error('No targetProfileId provided for relationship action', {
-          context,
-        });
+  // Not wrapped in useCallback: it closes over every helper above, all of them
+  // rebuilt each render, so an honest dependency array would invalidate on
+  // every render anyway. Nothing downstream is memoised.
+  const toggleRelationship = (
+    relationshipType: ProfileRelationshipType,
+    context: string,
+  ) => {
+    if (!targetProfileId) {
+      logger.error('No targetProfileId provided for relationship action', {
+        context,
+      });
 
-        return;
-      }
+      return;
+    }
 
-      // Anything in flight would land on top of the writes below and undo the
-      // press — including the refetches `reconcile` kicks off. Both caches, not
-      // just the relationship one: a stale list result resets the count while
-      // the button stays pressed, and the next click then counts the same like
-      // twice.
-      void utils.profile.getRelationships.cancel(relationshipQueryKey);
-      void queryClient.cancelQueries(countQueryFilter);
+    // Anything in flight would land on top of the writes below and undo the
+    // press — including the refetches `reconcile` kicks off. Both caches, not
+    // just the relationship one: a stale list result resets the count while
+    // the button stays pressed, and the next click then counts the same like
+    // twice.
+    void utils.profile.getRelationships.cancel(relationshipQueryKey);
+    void queryClient.cancelQueries(countQueryFilter);
 
-      // Flip the cache first, every time: the press has to register even while
-      // an earlier one is still in the air.
-      const next = !isLikedInCache(relationshipType);
+    // Flip the cache first, every time: the press has to register even while
+    // an earlier one is still in the air.
+    const next = !isLikedInCache(relationshipType);
 
-      desired.current[relationshipType] = next;
-      patchCachedRelationship(relationshipType, next);
-      patchCachedCounts(relationshipType, next ? 1 : -1);
+    desired.current[relationshipType] = next;
+    patchCachedRelationship(relationshipType, next);
+    patchCachedCounts(relationshipType, next ? 1 : -1);
 
-      void drain(relationshipType);
-    },
-    [
-      targetProfileId,
-      utils,
-      addRelationshipMutation,
-      removeRelationshipMutation,
-    ],
-  );
+    void drain(relationshipType);
+  };
 
-  const handleLike = useCallback(
-    () =>
+  return {
+    isLiked,
+    isFollowed,
+    /**
+     * The relationship list failed to load, so `isLiked` / `isFollowed` are
+     * both reading false for want of data rather than because they're false.
+     * Callers should fall back to read-only counts instead of offering a
+     * toggle that would send a redundant write.
+     */
+    error: relationshipsError,
+
+    handleLike: () =>
       toggleRelationship(
         ProfileRelationshipType.LIKES,
         'useRelationshipMutations.like',
       ),
-    [toggleRelationship],
-  );
-
-  const handleFollow = useCallback(
-    () =>
+    handleFollow: () =>
       toggleRelationship(
         ProfileRelationshipType.FOLLOWING,
         'useRelationshipMutations.follow',
       ),
-    [toggleRelationship],
-  );
-
-  return {
-    // State
-    isLiked,
-    isFollowed,
-    isLoading,
-
-    // Handlers
-    handleLike,
-    handleFollow,
-
-    // Raw mutations (for advanced use cases)
-    addRelationshipMutation,
-    removeRelationshipMutation,
   };
 }
 


### PR DESCRIPTION
Stacked on #1760. Split out of it because the card work is a design-system change and this is the concurrent part underneath: it has been wrong twice, and can't be reverted independently once it's inside a twenty-file migration.

- Optimistic like/follow — patches the pressed state and the count together across `listProposals` / `listAllProposals` / `getProposal`, matched by a predicate on the tRPC path since one proposal sits in several caches at once, then reconciles once the writes stop.
- Click coalescing in `relationshipDrain.ts`. A burst moves the UI on every press but sends at most two requests, and a press landing mid-flight changes the target rather than queueing behind it. Pure — `send` / `reconcile` / `onError` injected — with 8 unit tests.
- Drain state is keyed by proposal + relationship type, so two mounts of the same proposal share one drain instead of racing each other's reconciles against a 20-per-10s limit.
- Engagement controls fall back to plain counts only when the relationship list never loaded — not on a failed refetch over good cached data, which would otherwise strip the toggles from every proposal on the page with nothing left to restore them.
