### PR TITLE
feat(decisions): resolve proposal review screens from one proposal-keyed URL

### DIFF
--- a/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/reviews/page.tsx
+++ b/apps/app/src/app/[locale]/(no-header)/decisions/[slug]/proposal/[profileId]/reviews/page.tsx
@@ -2,7 +2,7 @@ import { createClient } from '@op/api/serverClient';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
-import { ReviewSummaryLayout } from '@/components/decisions/ReviewSummary/ReviewSummaryLayout';
+import { ProposalReviewsLayout } from '@/components/decisions/ProposalReviews/ProposalReviewsLayout';
 
 export async function generateMetadata({
   params,
@@ -28,7 +28,7 @@ export async function generateMetadata({
   }
 }
 
-export default async function ReviewSummaryPage({
+export default async function ProposalReviewsPage({
   params,
 }: {
   params: Promise<{ slug: string; profileId: string }>;
@@ -36,7 +36,7 @@ export default async function ReviewSummaryPage({
   const { slug, profileId: proposalProfileId } = await params;
 
   return (
-    <ReviewSummaryLayout
+    <ProposalReviewsLayout
       decisionSlug={slug}
       proposalProfileId={proposalProfileId}
     />

--- a/apps/app/src/components/decisions/ProposalReviews/ProposalReviewsLayout.tsx
+++ b/apps/app/src/components/decisions/ProposalReviews/ProposalReviewsLayout.tsx
@@ -1,0 +1,101 @@
+import { createClient } from '@op/api/serverClient';
+import { CommonError } from '@op/common';
+import { forbidden, notFound } from 'next/navigation';
+
+import { ReviewLayout } from '@/components/decisions/Review/ReviewLayout';
+import { ReviewSummaryLayout } from '@/components/decisions/ReviewSummary/ReviewSummaryLayout';
+
+interface ProposalReviewsLayoutProps {
+  decisionSlug: string;
+  proposalProfileId: string;
+}
+
+/**
+ * Resolves the proposal-keyed reviews URL per viewer:
+ *   1. instance admin        → the "Review Progress" summary screen
+ *   2. reviewer assigned in the current phase → their own review screen
+ *   3. anyone else           → forbidden()
+ *
+ * Once the instance advances past the review phase, a reviewer's own review is
+ * reachable through its `/reviews/[assignmentId]` link, and this URL belongs to
+ * the admin summary (which walks back to the last review phase).
+ */
+export async function ProposalReviewsLayout({
+  decisionSlug,
+  proposalProfileId,
+}: ProposalReviewsLayoutProps) {
+  const client = await createClient();
+
+  let decisionProfile;
+  try {
+    decisionProfile = await client.decision.getDecisionBySlug({
+      slug: decisionSlug,
+    });
+  } catch (error) {
+    interruptForCommonError(error);
+    throw error;
+  }
+
+  if (!decisionProfile?.processInstance) {
+    notFound();
+  }
+
+  if (decisionProfile.processInstance.access?.admin) {
+    return (
+      <ReviewSummaryLayout
+        decisionSlug={decisionSlug}
+        proposalProfileId={proposalProfileId}
+      />
+    );
+  }
+
+  // The reviewer branch means "review now", so it is scoped to the current
+  // phase — a stateless instance has no phase to review in.
+  const phaseId = decisionProfile.processInstance.currentStateId;
+  if (!phaseId) {
+    forbidden();
+  }
+
+  let assignmentId: string | undefined;
+  try {
+    // 'newest' orders by assignedAt (id tie-break) in SQL, so the first row is
+    // the latest of this phase's assignments.
+    const { assignments } = await client.decision.listReviewAssignments({
+      processInstanceId: decisionProfile.processInstance.id,
+      proposalProfileId,
+      phaseId,
+      sort: 'newest',
+    });
+
+    assignmentId = assignments[0]?.assignment.id;
+  } catch (error) {
+    interruptForCommonError(error);
+    throw error;
+  }
+
+  // Neither admin nor a reviewer of this proposal.
+  if (!assignmentId) {
+    forbidden();
+  }
+
+  return (
+    <ReviewLayout decisionSlug={decisionSlug} assignmentId={assignmentId} />
+  );
+}
+
+/**
+ * Maps a tRPC failure to the interrupt both review layouts use. 401 joins 403 so
+ * an anonymous SSR pass renders the forbidden screen instead of a 500.
+ */
+function interruptForCommonError(error: unknown): void {
+  const cause = error instanceof Error ? error.cause : null;
+  if (!(cause instanceof CommonError)) {
+    return;
+  }
+  if (cause.statusCode === 401 || cause.statusCode === 403) {
+    forbidden();
+  }
+  if (cause.statusCode === 404 || cause.statusCode === 400) {
+    notFound();
+  }
+}

--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -69,8 +69,19 @@ export function ReviewAssignmentsList({
     parseAsStringLiteral(REVIEW_ASSIGNMENT_SORTS).withDefault('leastReviewed'),
   );
 
+  // cached from the page-level suspense query — no extra request
+  const [instance] = trpc.decision.getInstance.useSuspenseQuery({
+    instanceId: processInstanceId,
+  });
+  const phases = instance.instanceData?.phases ?? [];
+  const currentPhase = phases.find(
+    (phase) => phase.phaseId === instance.currentStateId,
+  );
+
   const { data, isLoading } = trpc.decision.listReviewAssignments.useQuery({
     processInstanceId,
+    // The queue is this phase's work; omitting phaseId would list every phase.
+    ...(instance.currentStateId && { phaseId: instance.currentStateId }),
     ...(statusFilter && {
       status: statusFilter as ProposalReviewAssignmentStatus,
     }),
@@ -90,15 +101,6 @@ export function ReviewAssignmentsList({
         enabled: canViewReviewers && proposalIds.length > 0,
       },
     );
-
-  // cached from the page-level suspense query — no extra request
-  const [instance] = trpc.decision.getInstance.useSuspenseQuery({
-    instanceId: processInstanceId,
-  });
-  const phases = instance.instanceData?.phases ?? [];
-  const currentPhase = phases.find(
-    (phase) => phase.phaseId === instance.currentStateId,
-  );
   const isByCategory =
     !!currentPhase &&
     getPhaseReviewSettings({ phases }, currentPhase.phaseId).scope ===
@@ -257,7 +259,9 @@ export function ReviewAssignmentsList({
             <ReviewAssignmentCard
               key={item.assignment.id}
               assignment={item}
-              viewHref={`/decisions/${decisionSlug}/reviews/${item.assignment.id}`}
+              // The proposal-keyed URL resolves per viewer (own review screen
+              // for a reviewer, review progress for an admin).
+              viewHref={`/decisions/${decisionSlug}/proposal/${item.assignment.proposal.profileId}/reviews`}
               reviewers={
                 aggregatesData?.items.find(
                   (i) => i.proposal.id === item.assignment.proposal.id,

--- a/packages/common/src/services/decision/listReviewAssignments.ts
+++ b/packages/common/src/services/decision/listReviewAssignments.ts
@@ -41,23 +41,26 @@ const STATUS_SORT_RANK: Record<string, number> = {
 const UNKNOWN_STATUS_RANK = Object.keys(STATUS_SORT_RANK).length;
 
 /**
- * Returns the reviewer's authorized review assignments for a single phase — the
- * requested `phaseId`, else the current one.
+ * Returns the reviewer's authorized review assignments — scoped to `phaseId`
+ * when given, across every phase when it is omitted.
  */
 export async function listReviewAssignments({
   processInstanceId,
-  phaseId: requestedPhaseId,
+  phaseId,
   status,
   categoryIds,
+  proposalProfileId,
   sort = 'leastReviewed',
   user,
 }: {
   processInstanceId: string;
-  /** Defaults to the instance's current phase. */
+  /** Omit for every phase. */
   phaseId?: string;
   status?: string;
   /** Taxonomy term ids — limits results to assignments whose proposal is in any of the categories. */
   categoryIds?: string[];
+  /** Profile id of a single proposal — limits results to that proposal's assignments. */
+  proposalProfileId?: string;
   sort?: ReviewAssignmentSort;
   user: User;
 }): Promise<ReviewAssignmentList> {
@@ -73,10 +76,6 @@ export async function listReviewAssignments({
   if (!instance.access.review && !instance.access.admin) {
     throw new UnauthorizedError("You don't have access to review proposals");
   }
-
-  // Same resolution as listProposalsWithReviewAggregates. Assignment rows are
-  // never unphased, so only a phase-less instance skips the filter.
-  const phaseId = requestedPhaseId ?? instance.currentStateId ?? undefined;
 
   // Resolve the categories' proposal IDs up front (same approach as
   // resolveProposalListScope): assignments have no category column, so the
@@ -140,16 +139,23 @@ export async function listReviewAssignments({
       ...(categoryProposalIds && {
         proposalId: { in: categoryProposalIds },
       }),
+      ...(proposalProfileId && {
+        proposal: { profileId: proposalProfileId },
+      }),
     },
     with: reviewAssignmentWithConfig,
     // The `id` tie-break gives a deterministic order when the primary keys are
     // equal (e.g. same `assignedAt`, or same coverage before the shuffle).
     orderBy: (table, { asc, desc }) => {
+      // `assignedAt` is nullable, and Postgres puts NULLs first on DESC — which
+      // would let an undated assignment lead the "newest" list (the single-
+      // proposal resolver reads the first row as the latest one). NULLS LAST on
+      // both directions keeps an undated assignment from ever winning.
       if (sort === 'newest') {
-        return [desc(table.assignedAt), desc(table.id)];
+        return [sql`${table.assignedAt} DESC NULLS LAST`, desc(table.id)];
       }
       if (sort === 'oldest') {
-        return [asc(table.assignedAt), asc(table.id)];
+        return [sql`${table.assignedAt} ASC NULLS LAST`, asc(table.id)];
       }
       // 'leastReviewed': fewest completed reviews, then status priority, then
       // the stable per-reviewer shuffle.

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.test.ts
@@ -150,6 +150,24 @@ function seedMockCollab(collaborationDocId: string) {
   });
 }
 
+/**
+ * Seeds the mock collab doc for a created proposal, narrowing `proposalData`
+ * instead of asserting its shape.
+ */
+function seedProposalCollab(proposal: { proposalData: unknown }) {
+  const data = proposal.proposalData;
+  if (
+    typeof data !== 'object' ||
+    data === null ||
+    !('collaborationDocId' in data) ||
+    typeof data.collaborationDocId !== 'string'
+  ) {
+    throw new Error('proposal has no collaborationDocId');
+  }
+
+  seedMockCollab(data.collaborationDocId);
+}
+
 describe.concurrent('listReviewAssignments', () => {
   it('returns the assignment using the live proposal when no history snapshot exists', async ({
     task,
@@ -429,7 +447,7 @@ describe.concurrent('listReviewAssignments', () => {
     );
   });
 
-  it('scopes the queue to the current phase and honors an explicit phase', async ({
+  it('lists every phase when phaseId is omitted and scopes to an explicit one', async ({
     task,
     onTestFinished,
   }) => {
@@ -459,20 +477,30 @@ describe.concurrent('listReviewAssignments', () => {
       feasibility.reviewer.email,
     );
 
-    const current = await reviewerCaller.decision.listReviewAssignments({
+    // No phaseId — the instance sits on the community phase, but both
+    // assignments come back.
+    const everyPhase = await reviewerCaller.decision.listReviewAssignments({
       processInstanceId: context.instance.instance.id,
     });
-    expect(current.assignments.map((a) => a.assignment.id)).toEqual([
-      communityAssignment.id,
-    ]);
+    expect(everyPhase.assignments.map((a) => a.assignment.id).sort()).toEqual(
+      [communityAssignment.id, feasibility.assignment.id].sort(),
+    );
 
-    // The past phase stays reachable when asked for explicitly.
+    // Each phase resolves on its own when asked for explicitly.
     const past = await reviewerCaller.decision.listReviewAssignments({
       processInstanceId: context.instance.instance.id,
       phaseId: FEASIBILITY_PHASE,
     });
     expect(past.assignments.map((a) => a.assignment.id)).toEqual([
       feasibility.assignment.id,
+    ]);
+
+    const current = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+      phaseId: COMMUNITY_PHASE,
+    });
+    expect(current.assignments.map((a) => a.assignment.id)).toEqual([
+      communityAssignment.id,
     ]);
   });
 
@@ -531,6 +559,7 @@ describe.concurrent('listReviewAssignments', () => {
     const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
     const result = await reviewerCaller.decision.listReviewAssignments({
       processInstanceId: instanceId,
+      phaseId: COMMUNITY_PHASE,
       sort: 'leastReviewed',
     });
 
@@ -633,6 +662,192 @@ describe.concurrent('listReviewAssignments', () => {
     const result = await reviewerCaller.decision.listReviewAssignments({
       processInstanceId: created.context.instance.instance.id,
       categoryIds: [crypto.randomUUID()],
+    });
+
+    expect(result.assignments).toHaveLength(0);
+  });
+
+  it('filters assignments to a single proposal by its profile id', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const target = await testData.createReviewAssignment({
+      context: await createReviewPhaseContext(testData),
+      title: 'The proposal under review',
+    });
+    const context = target.context;
+    const reviewer = target.reviewer;
+    const other = await testData.createReviewAssignment({
+      context,
+      reviewer,
+      title: 'Another proposal',
+    });
+
+    for (const created of [target, other]) {
+      seedProposalCollab(created.proposal);
+    }
+
+    // A second reviewer on the same proposal — their assignment must stay out.
+    const otherReviewer = await testData.createReviewer(context);
+    await createReviewAssignmentRow({
+      processInstanceId: context.instance.instance.id,
+      proposalId: target.proposal.id,
+      reviewerProfileId: otherReviewer.profileId,
+      phaseId: REVIEW_PHASE,
+    });
+
+    const reviewerCaller = await createAuthenticatedCaller(reviewer.email);
+    const result = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+      proposalProfileId: target.proposal.profileId,
+    });
+
+    expect(result.assignments.map((a) => a.assignment.id)).toEqual([
+      target.assignment.id,
+    ]);
+  });
+
+  it('includes an earlier phase’s assignments for a proposal when phaseId is omitted', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoReviewPhaseContext(testData);
+
+    // The instance sits on the community phase; the assignment is pinned to the
+    // feasibility phase it was created in.
+    const feasibility = await testData.createReviewAssignment({
+      context,
+      title: 'Reviewed in the earlier phase',
+      phaseId: FEASIBILITY_PHASE,
+    });
+
+    seedProposalCollab(feasibility.proposal);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      feasibility.reviewer.email,
+    );
+
+    const everyPhase = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+      proposalProfileId: feasibility.proposal.profileId,
+    });
+    expect(everyPhase.assignments.map((a) => a.assignment.id)).toEqual([
+      feasibility.assignment.id,
+    ]);
+
+    // The proposal filter composes with an explicit phase, which scopes it out.
+    const otherPhase = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+      proposalProfileId: feasibility.proposal.profileId,
+      phaseId: COMMUNITY_PHASE,
+    });
+    expect(otherPhase.assignments).toHaveLength(0);
+  });
+
+  it('orders a proposal’s assignments newest first, so the latest one leads', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoReviewPhaseContext(testData);
+
+    // Same reviewer, same proposal, one assignment per review phase — what the
+    // proposal-keyed review screen resolves against.
+    const feasibility = await testData.createReviewAssignment({
+      context,
+      title: 'Reviewed in both phases',
+      phaseId: FEASIBILITY_PHASE,
+      assignedAt: '2026-01-01T00:00:00.000Z',
+    });
+    const community = await createReviewAssignmentRow({
+      processInstanceId: context.instance.instance.id,
+      proposalId: feasibility.proposal.id,
+      reviewerProfileId: feasibility.reviewer.profileId,
+      phaseId: COMMUNITY_PHASE,
+      assignedAt: '2026-02-01T00:00:00.000Z',
+    });
+
+    seedProposalCollab(feasibility.proposal);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      feasibility.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+      proposalProfileId: feasibility.proposal.profileId,
+      sort: 'newest',
+    });
+
+    expect(result.assignments.map((a) => a.assignment.id)).toEqual([
+      community.id,
+      feasibility.assignment.id,
+    ]);
+  });
+
+  it('breaks an assignedAt tie by id, keeping the newest sort deterministic', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createTwoReviewPhaseContext(testData);
+
+    // A single batch insert stamps the same `assignedAt` on every row, so the
+    // tie-break is what keeps the "latest" pick stable across refetches.
+    const assignedAt = '2026-03-01T00:00:00.000Z';
+    const feasibility = await testData.createReviewAssignment({
+      context,
+      title: 'Assigned in one batch',
+      phaseId: FEASIBILITY_PHASE,
+      assignedAt,
+    });
+    const community = await createReviewAssignmentRow({
+      processInstanceId: context.instance.instance.id,
+      proposalId: feasibility.proposal.id,
+      reviewerProfileId: feasibility.reviewer.profileId,
+      phaseId: COMMUNITY_PHASE,
+      assignedAt,
+    });
+
+    seedProposalCollab(feasibility.proposal);
+
+    const reviewerCaller = await createAuthenticatedCaller(
+      feasibility.reviewer.email,
+    );
+    const result = await reviewerCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+      proposalProfileId: feasibility.proposal.profileId,
+      sort: 'newest',
+    });
+
+    expect(result.assignments.map((a) => a.assignment.id)).toEqual(
+      [community.id, feasibility.assignment.id].sort().reverse(),
+    );
+  });
+
+  it('returns an empty list for an admin with no assignments on the proposal', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const context = await createReviewPhaseContext(testData);
+    const reviewer = await testData.createReviewer(context);
+    const created = await testData.createReviewAssignment({
+      context,
+      reviewer,
+      title: 'Someone else’s assignment',
+    });
+
+    seedProposalCollab(created.proposal);
+
+    // The context's default user is an instance admin, not the assignee.
+    const adminCaller = await createAuthenticatedCaller(
+      context.defaultReviewer.email,
+    );
+    const result = await adminCaller.decision.listReviewAssignments({
+      processInstanceId: context.instance.instance.id,
+      proposalProfileId: created.proposal.profileId,
     });
 
     expect(result.assignments).toHaveLength(0);

--- a/services/api/src/routers/decision/reviews/listReviewAssignments.ts
+++ b/services/api/src/routers/decision/reviews/listReviewAssignments.ts
@@ -14,10 +14,12 @@ export const listReviewAssignmentsRouter = router({
     .input(
       z.object({
         processInstanceId: z.uuid(),
-        /** Defaults to the current phase. */
+        /** Omit for all phases. */
         phaseId: z.string().optional(),
         status: z.enum(ProposalReviewAssignmentStatus).optional(),
         categoryIds: z.array(z.string()).optional(),
+        /** Limits results to one proposal's assignments. */
+        proposalProfileId: z.uuid().optional(),
         sort: z.enum(REVIEW_ASSIGNMENT_SORTS).optional(),
       }),
     )
@@ -32,6 +34,7 @@ export const listReviewAssignmentsRouter = router({
         phaseId: input.phaseId,
         status: input.status,
         categoryIds: input.categoryIds,
+        proposalProfileId: input.proposalProfileId,
         sort: input.sort,
         user: ctx.user,
       });

--- a/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
+++ b/services/api/src/routers/decision/reviews/phaseRubricTemplates.test.ts
@@ -231,9 +231,9 @@ describe.concurrent('per-phase rubric templates', () => {
       properties: { viability: { title: 'Viability' } },
     });
 
-    // Community is current, so the default scope lands there.
     const communityList = await reviewerCaller.decision.listReviewAssignments({
       processInstanceId: context.instance.instance.id,
+      phaseId: COMMUNITY_PHASE,
     });
     expect(communityList.assignments.map((a) => a.assignment.id)).toEqual([
       communityAssignment.id,

--- a/services/api/src/test/helpers/TestReviewsDataManager.ts
+++ b/services/api/src/test/helpers/TestReviewsDataManager.ts
@@ -54,6 +54,8 @@ interface CreateReviewAssignmentOptions {
   status?: ProposalReviewAssignmentStatus;
   /** Phase the assignment is pinned to (defaults to `'review'`). */
   phaseId?: string;
+  /** Assignment timestamp (defaults to `now()`) — pin it to control ordering. */
+  assignedAt?: string;
 }
 
 /** Creates review-focused test fixtures on top of the decision test setup. */
@@ -365,6 +367,7 @@ export class TestReviewsDataManager {
       },
       assignmentStatus: opts.status,
       phaseId: opts.phaseId,
+      assignedAt: opts.assignedAt,
     });
 
     this.decisions.trackProfileForCleanup(proposal.profileId);

--- a/tests/core/src/review-data.ts
+++ b/tests/core/src/review-data.ts
@@ -93,6 +93,11 @@ export interface CreateReviewAssignmentOptions {
   phaseId?: string;
   assignedProposalHistoryId?: string | null;
   status?: ProposalReviewAssignmentStatus;
+  /**
+   * Defaults to `now()`. Set it explicitly to pin the ordering — e.g. two rows
+   * sharing a timestamp, as a single batch insert produces.
+   */
+  assignedAt?: string;
 }
 
 export interface CreateProposalReviewOptions {
@@ -122,6 +127,7 @@ export async function createReviewAssignment(
     phaseId = 'review',
     assignedProposalHistoryId = null,
     status = ProposalReviewAssignmentStatus.PENDING,
+    assignedAt,
   } = opts;
 
   const [assignment] = await db
@@ -133,6 +139,7 @@ export async function createReviewAssignment(
       phaseId,
       assignedProposalHistoryId,
       status,
+      ...(assignedAt !== undefined && { assignedAt }),
     })
     .returning();
 
@@ -194,6 +201,8 @@ export interface CreateReviewScenarioOptions {
   assignmentStatus?: ProposalReviewAssignmentStatus;
   /** Phase ID the assignment belongs to (defaults to 'review') */
   phaseId?: string;
+  /** Assignment timestamp (defaults to `now()`) — pin it to control ordering */
+  assignedAt?: string;
   /**
    * If provided, also create a revision request on the assignment.
    * Mirrors `CreateRevisionRequestOptions` minus assignmentId.
@@ -248,6 +257,7 @@ export async function createReviewScenario(
     phaseId: opts.phaseId,
     assignedProposalHistoryId,
     status: opts.assignmentStatus ?? ProposalReviewAssignmentStatus.PENDING,
+    assignedAt: opts.assignedAt,
   });
 
   const revisionRequest = opts.revisionRequest

--- a/tests/e2e/tests/review-submit.spec.ts
+++ b/tests/e2e/tests/review-submit.spec.ts
@@ -183,6 +183,14 @@ const RUBRIC_TEMPLATE = {
  */
 const PROPOSAL_TITLE = 'Community Solar Initiative';
 
+/**
+ * Queue cards open the proposal-keyed review URL, which resolves per viewer —
+ * the assignee's own review screen here, the review-progress screen for an
+ * instance admin. (The assignment-keyed `/reviews/[assignmentId]` URL still
+ * exists for email links; it is just no longer what a card links to.)
+ */
+const PROPOSAL_REVIEWS_URL = /\/proposal\/[^/]+\/reviews$/;
+
 test.describe('Review Submit', () => {
   test('full review journey: request revision → cancel → submit review → edit review', async ({
     authenticatedPage: page,
@@ -229,6 +237,20 @@ test.describe('Review Submit', () => {
     await new Promise((resolve) => setTimeout(resolve, 600));
 
     const decisionUrl = `/en/decisions/${instance.slug}/current`;
+    // The fixture's reviewer is also the instance admin, so the proposal-keyed
+    // URL a queue card links to resolves to Review Progress for them (asserted
+    // in step 2). The assignment-keyed URL is the reviewer surface, so the
+    // review-form steps below enter through it.
+    const reviewUrl = `/en/decisions/${instance.slug}/reviews/${assignment.id}`;
+    // Each entry is a cold load, so drop the persisted React Query cache first —
+    // otherwise the form can initialise from the pre-mutation snapshot written
+    // earlier in this session (an empty rubric after the review was submitted).
+    const openReview = async () => {
+      await page.evaluate(() =>
+        window.localStorage.removeItem('REACT_QUERY_OFFLINE_CACHE'),
+      );
+      await page.goto(reviewUrl, { waitUntil: 'domcontentloaded' });
+    };
 
     /** Locate the status badge <span> on the assignments list. */
     const statusBadge = page.locator('span').filter({
@@ -249,11 +271,17 @@ test.describe('Review Submit', () => {
     await expect(statusBadge).toHaveText('Not Started');
 
     // ========================================================================
-    // Step 2: Click into review and request a revision
+    // Step 2: Card opens the proposal-keyed URL; request a revision
     // ========================================================================
 
     await page.getByText(PROPOSAL_TITLE).first().click();
-    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
+    await expect(page).toHaveURL(PROPOSAL_REVIEWS_URL, { timeout: 10_000 });
+    // Admin resolution of that URL.
+    await expect(
+      page.getByRole('heading', { name: 'Review Progress' }),
+    ).toBeVisible({ timeout: 36_000 });
+
+    await openReview();
     await expect(
       page.getByText('Review Proposal', { exact: true }).first(),
     ).toBeVisible({ timeout: 36_000 });
@@ -292,11 +320,10 @@ test.describe('Review Submit', () => {
     await expect(statusBadge).toHaveText('Revision Requested');
 
     // ========================================================================
-    // Step 4: Click back into review and cancel the revision
+    // Step 4: Back into the review and cancel the revision
     // ========================================================================
 
-    await page.getByText(PROPOSAL_TITLE).first().click();
-    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
+    await openReview();
     await expect(
       page.getByText('Review Proposal', { exact: true }).first(),
     ).toBeVisible({ timeout: 36_000 });
@@ -337,11 +364,10 @@ test.describe('Review Submit', () => {
     await expect(statusBadge).toHaveText('In Progress');
 
     // ========================================================================
-    // Step 6: Click back into review, fill rubric, and submit
+    // Step 6: Back into the review, fill rubric, and submit
     // ========================================================================
 
-    await page.getByText(PROPOSAL_TITLE).first().click();
-    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
+    await openReview();
     await expect(
       page.getByText('Review Proposal', { exact: true }).first(),
     ).toBeVisible({ timeout: 36_000 });
@@ -452,8 +478,7 @@ test.describe('Review Submit', () => {
     // Step 8: Re-open the completed review, edit it, and update in place
     // ========================================================================
 
-    await page.getByText(PROPOSAL_TITLE).first().click();
-    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
+    await openReview();
     await expect(
       page.getByText('Review Proposal', { exact: true }).first(),
     ).toBeVisible({ timeout: 36_000 });
@@ -524,7 +549,7 @@ test.describe('Review Submit', () => {
       })
       .where(eq(processInstances.id, instance.instance.id));
 
-    await createReviewScenario({
+    const { assignment } = await createReviewScenario({
       instance: { id: instance.instance.id },
       author: {
         profileId: org.organizationProfile.id,
@@ -540,14 +565,11 @@ test.describe('Review Submit', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 600));
 
-    await page.goto(`/en/decisions/${instance.slug}/current`, {
+    // Straight to the reviewer surface — the queue card's link target is
+    // covered by the full-journey test above.
+    await page.goto(`/en/decisions/${instance.slug}/reviews/${assignment.id}`, {
       waitUntil: 'domcontentloaded',
     });
-    await expect(page.getByText('Proposals to review').first()).toBeVisible({
-      timeout: 36_000,
-    });
-    await page.getByText(PROPOSAL_TITLE).first().click();
-    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
     await expect(
       page.getByText('Review Proposal', { exact: true }).first(),
     ).toBeVisible({ timeout: 36_000 });
@@ -558,7 +580,11 @@ test.describe('Review Submit', () => {
     await expect(
       page.getByRole('heading', { name: /^Comments \(\d+\)$/ }),
     ).toBeVisible();
-    await expect(page.getByText('No comments yet.')).toBeVisible();
+    // A cold page load leaves the streamed server copy of the proposal pane in
+    // the DOM (hidden) alongside the hydrated one, so target the visible copy.
+    await expect(
+      page.getByText('No comments yet.').filter({ visible: true }),
+    ).toBeVisible();
     await expect(page.getByText('Be the first to comment')).toHaveCount(0);
     await expect(page.getByPlaceholder(/^Comment( as |\.\.\.)/)).toHaveCount(0);
   });
@@ -591,7 +617,7 @@ test.describe('Review Submit', () => {
       })
       .where(eq(processInstances.id, instance.instance.id));
 
-    await createReviewScenario({
+    const { assignment } = await createReviewScenario({
       instance: { id: instance.instance.id },
       author: {
         profileId: org.organizationProfile.id,
@@ -607,15 +633,11 @@ test.describe('Review Submit', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 600));
 
-    const decisionUrl = `/en/decisions/${instance.slug}/current`;
-
-    await page.goto(decisionUrl, { waitUntil: 'domcontentloaded' });
-
-    await expect(page.getByText('Proposals to review').first()).toBeVisible({
-      timeout: 36_000,
+    // Straight to the reviewer surface — the queue card's link target is
+    // covered by the full-journey test above.
+    await page.goto(`/en/decisions/${instance.slug}/reviews/${assignment.id}`, {
+      waitUntil: 'domcontentloaded',
     });
-    await page.getByText(PROPOSAL_TITLE).first().click();
-    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
     await expect(
       page.getByText('Review Proposal', { exact: true }).first(),
     ).toBeVisible({ timeout: 36_000 });
@@ -655,7 +677,7 @@ test.describe('Review Submit', () => {
       })
       .where(eq(processInstances.id, instance.instance.id));
 
-    await createReviewScenario({
+    const { assignment } = await createReviewScenario({
       instance: { id: instance.instance.id },
       author: {
         profileId: org.organizationProfile.id,
@@ -673,14 +695,11 @@ test.describe('Review Submit', () => {
 
     await page.setViewportSize({ width: 390, height: 844 });
 
-    await page.goto(`/en/decisions/${instance.slug}/current`, {
+    // Straight to the reviewer surface — the queue card's link target is
+    // covered by the full-journey test above.
+    await page.goto(`/en/decisions/${instance.slug}/reviews/${assignment.id}`, {
       waitUntil: 'domcontentloaded',
     });
-    await expect(page.getByText('Proposals to review').first()).toBeVisible({
-      timeout: 36_000,
-    });
-    await page.getByText(PROPOSAL_TITLE).first().click();
-    await expect(page).toHaveURL(/\/reviews\//, { timeout: 10_000 });
     await expect(
       page.getByRole('button', { name: 'Submit review' }),
     ).toBeVisible({ timeout: 36_000 });


### PR DESCRIPTION
Clicking a review card's title and its reviewer count opened two different screens behind two different URL keys with opposite auth: reviewers could only open `/decisions/[slug]/reviews/[assignmentId]`, admins only `/decisions/[slug]/proposal/[profileId]/reviews`. This makes the proposal-keyed URL the one canonical screen, resolved per viewer: instance admins get the Review Progress summary, assigned reviewers get their own review (the latest assignment when several phases assigned one), everyone else gets `forbidden()` — anonymous SSR included, mapped to forbidden rather than a 500. The lookup is an optional `proposalProfileId` filter on the existing `listReviewAssignments`; with no explicit `phaseId` it skips the current-phase default so assignments pinned to earlier phases still resolve, ordered `assignedAt DESC NULLS LAST` in SQL. `/decisions/[slug]/reviews/[reviewId]` stays untouched for stable email links.
