### PR TITLE
feat(ui): add locale-aware CurrencyField

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,7 @@
     "./EmptyState": "./src/components/EmptyState.tsx",
     "./Field": "./src/components/Field.tsx",
     "./CollapsibleConfigCard": "./src/components/CollapsibleConfigCard.tsx",
+    "./CurrencyField": "./src/components/CurrencyField.tsx",
     "./FileDropZone": "./src/components/FileDropZone.tsx",
     "./FooterBar": "./src/components/FooterBar.tsx",
     "./Form": "./src/components/Form.tsx",

--- a/packages/ui/src/components/CurrencyField.tsx
+++ b/packages/ui/src/components/CurrencyField.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import {
+  NumberField as AriaNumberField,
+  type NumberFieldProps as AriaNumberFieldProps,
+  type ValidationResult,
+} from 'react-aria-components';
+
+import { cn } from '../lib/utils';
+import { composeTailwindRenderProps } from '../utils';
+import { Description, FieldError, FieldGroup, Input, Label } from './Field';
+import type { InputWithVariantsProps } from './Field';
+import { RequiredAsterisk } from './RequiredAsterisk';
+
+export interface CurrencyFieldProps extends Omit<
+  AriaNumberFieldProps,
+  'formatOptions' | 'value'
+> {
+  /** ISO 4217 code (e.g. "USD"). Drives the symbol, grouping and decimals. */
+  currency: string;
+  label?: string;
+  description?: string;
+  /** External error message. Takes precedence over built-in validation. */
+  errorMessage?: string | ((validation: ValidationResult) => string);
+  inputProps?: InputWithVariantsProps & { className?: string };
+  fieldClassName?: string;
+  labelClassName?: string;
+  /** `null` means "no amount", which is what an unanswered money field is. */
+  value?: number | null;
+}
+
+/**
+ * Locale-aware currency input.
+ *
+ * Wraps React Aria's `NumberField` with `formatOptions: { style: 'currency' }`,
+ * so parsing *and* formatting follow the locale from the surrounding
+ * `I18nProvider`. That matters: in `es`/`fr`/`pt` the natural way to type one
+ * euro fifty is `1,50`, and a parser that only knows `.` would read it as 150.
+ * React Aria owns the locale's decimal and grouping separators in both
+ * directions, and supplies its own translated validation messages.
+ *
+ * This is deliberately separate from `NumberField`, which is a plain ASCII
+ * numeric text input with a decorative `prefixText`: mixing a locale-derived
+ * currency symbol with an ASCII-only parser is the bug this component exists to
+ * avoid. Use `NumberField` for locale-neutral counts (max points, limits) and
+ * this for money.
+ *
+ * React Aria renders the currency symbol inside the formatted value, so no
+ * separate prefix adornment is needed.
+ */
+export const CurrencyField = ({
+  currency,
+  label,
+  description,
+  errorMessage,
+  inputProps,
+  fieldClassName,
+  labelClassName,
+  value,
+  isRequired,
+  ...props
+}: CurrencyFieldProps) => {
+  return (
+    <AriaNumberField
+      {...props}
+      // `aria` rather than the default `native`: these fields live outside a
+      // <form> and are gated by schema validation, so required/min should be
+      // announced without the browser's own submit-blocking bubbles.
+      validationBehavior="aria"
+      isRequired={isRequired}
+      // React Aria's NumberField takes NaN, not null, for "empty".
+      value={value ?? Number.NaN}
+      formatOptions={{ style: 'currency', currency }}
+      className={composeTailwindRenderProps(
+        props.className,
+        'group flex flex-col gap-1',
+      )}
+    >
+      {label && (
+        <Label
+          className={cn(
+            labelClassName,
+            'group-data-[invalid=true]:text-functional-red',
+          )}
+        >
+          {label}
+          {isRequired && <RequiredAsterisk />}
+        </Label>
+      )}
+      <FieldGroup className={fieldClassName}>
+        <Input
+          {...inputProps}
+          className={cn(
+            inputProps?.className,
+            'group-data-[invalid=true]:outline-1 group-data-[invalid=true]:outline-functional-red',
+          )}
+        />
+      </FieldGroup>
+      {description && <Description>{description}</Description>}
+      <FieldError>{errorMessage}</FieldError>
+    </AriaNumberField>
+  );
+};

--- a/packages/ui/stories/CurrencyField.stories.tsx
+++ b/packages/ui/stories/CurrencyField.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta } from '@storybook/react-vite';
+import { useState } from 'react';
+import { I18nProvider } from 'react-aria';
+
+import { CurrencyField } from '../src/components/CurrencyField';
+
+const meta: Meta<typeof CurrencyField> = {
+  title: 'Legacy/CurrencyField',
+  component: CurrencyField,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: {
+    label: 'Design & Engineering Cost',
+    currency: 'USD',
+  },
+};
+
+export default meta;
+
+export const Example = () => (
+  <div className="flex w-96 flex-col gap-8">
+    <CurrencyField
+      label="Empty state"
+      currency="USD"
+      inputProps={{ placeholder: '$0.00' }}
+    />
+    <CurrencyField label="With value" currency="USD" value={42000} />
+    <CurrencyField
+      label="Required"
+      currency="USD"
+      isRequired
+      description="Helper text"
+    />
+    <CurrencyField
+      label="With a minimum"
+      currency="USD"
+      minValue={0}
+      value={-5}
+    />
+    <CurrencyField label="Disabled" currency="USD" value={1250.5} isDisabled />
+  </div>
+);
+
+/**
+ * Parsing and formatting both follow the locale, so a comma-decimal locale
+ * reads `1,50` as one and a half rather than one hundred and fifty.
+ */
+export const Locales = () => (
+  <div className="flex w-96 flex-col gap-8">
+    {(
+      [
+        ['en-US', 'USD'],
+        ['es-ES', 'EUR'],
+        ['fr-FR', 'EUR'],
+        ['pt-BR', 'BRL'],
+        ['ar-EG', 'EGP'],
+      ] as const
+    ).map(([locale, currency]) => (
+      <I18nProvider key={locale} locale={locale}>
+        <CurrencyField
+          label={`${locale} — ${currency}`}
+          currency={currency}
+          value={1234.5}
+        />
+      </I18nProvider>
+    ))}
+  </div>
+);
+
+export const Controlled = () => {
+  const [amount, setAmount] = useState<number | null>(null);
+
+  return (
+    <div className="flex w-96 flex-col gap-4">
+      <CurrencyField
+        label="Construction / Materials / Labor"
+        currency="USD"
+        value={amount}
+        onChange={(next) => setAmount(Number.isNaN(next) ? null : next)}
+        inputProps={{ placeholder: '$0.00' }}
+      />
+      <pre className="text-sm">{JSON.stringify({ amount })}</pre>
+    </div>
+  );
+};


### PR DESCRIPTION
PR A of the rubric-money-sections stack (split of #1768 — see the comparison verdict; #1768's model won over #1763).

## What

A new `@op/ui` CurrencyField component + stories, extracted verbatim from `feat/rubric-section-grouping`:

- `packages/ui/src/components/CurrencyField.tsx`
- `packages/ui/stories/CurrencyField.stories.tsx`
- one-line `packages/ui/package.json` export entry

## Why it stands alone

This fixes a real pre-existing locale bug independent of the rubric work: `NumberField` is an ASCII-only numeric input with a decorative `prefixText`, so in comma-decimal locales (es/fr/pt) typing `1,50` parses as **150**. CurrencyField wraps React Aria's NumberField with `formatOptions: { style: 'currency' }` so parsing AND formatting follow the `I18nProvider` locale in both directions.

`NumberField` stays for locale-neutral counts (max points, limits). `validationBehavior="aria"` and the `value ?? Number.NaN` empty-state mapping are deliberate.

## Stack

A (this) → B sections render-only → C flat money criteria → D summed sections. Next PRs will be linked as a GitHub stack.