### PR TITLE
feat(decisions): let admins review a proposal from the progress screen

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -57,9 +57,9 @@ interface ReviewFormState {
   handleValueChange: (key: string, value: unknown) => void;
   handleRationaleChange: (key: string, value: string) => void;
   handleOverallCommentChange: (value: string) => void;
-  handleSubmit: () => void;
+  handleSubmit: () => Promise<void>;
   startEditing: () => void;
-  handleUpdate: () => void;
+  handleUpdate: () => Promise<void>;
   requestRevision: (comment: string) => void;
   cancelRevisionRequest: () => void;
   isRequestingRevision: boolean;
@@ -76,10 +76,22 @@ export function useReviewForm(): ReviewFormState {
   return ctx;
 }
 
+/** What a host rendering the form's primary action outside it needs. */
+export interface ReviewFormStatus {
+  /** Resolves once the write settles, whether it succeeded or not. */
+  submit: () => Promise<void>;
+  canSubmit: boolean;
+}
+
 export function ReviewFormProvider(props: {
   assignmentId: string;
   decisionSlug: string;
   allowRevisions: boolean;
+  /** Runs after a submit or an update instead of leaving for the decision page. */
+  onCompleted?: () => void;
+  /** Lets a host render the primary action outside the form. */
+  onStatusChange?: (status: ReviewFormStatus) => void;
+  initiallyEditing?: boolean;
   children: ReactNode;
 }) {
   return (
@@ -93,11 +105,17 @@ function ReviewFormProviderInner({
   assignmentId,
   decisionSlug,
   allowRevisions,
+  onCompleted,
+  onStatusChange,
+  initiallyEditing = false,
   children,
 }: {
   assignmentId: string;
   decisionSlug: string;
   allowRevisions: boolean;
+  onCompleted?: () => void;
+  onStatusChange?: (status: ReviewFormStatus) => void;
+  initiallyEditing?: boolean;
   children: ReactNode;
 }) {
   const t = useTranslations();
@@ -160,11 +178,15 @@ function ReviewFormProviderInner({
     allowRevisions && !isSubmitted && !hasAnyOpenRevisionRequest;
 
   // Local: unsaved until "Update review", so navigating away discards edits.
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(initiallyEditing);
 
   const submitReview = trpc.decision.submitReview.useMutation({
     onSuccess: () => {
       toast.success(t('Review submitted successfully'));
+      if (onCompleted) {
+        onCompleted();
+        return;
+      }
       router.push(`/decisions/${decisionSlug}/current`);
     },
     onError: (error) => {
@@ -178,6 +200,7 @@ function ReviewFormProviderInner({
       // refreshing the read-only view in place (as requestRevision does).
       setIsEditing(false);
       toast.success(t('Review updated successfully'));
+      onCompleted?.();
     },
     onError: (error) => {
       toast.error(error.message || t('Failed to update review'));
@@ -242,58 +265,81 @@ function ReviewFormProviderInner({
     [scheduleAutosave],
   );
 
-  const handleSubmit = useCallback(() => {
-    submitReview.mutate({
+  // `.mutate` is stable; the mutation object is a new snapshot every render and
+  // would give every handler, and the context value, a new identity each time.
+  const submitMutate = submitReview.mutateAsync;
+  const updateMutate = updateReview.mutateAsync;
+  const requestRevisionMutate = requestRevisionMutation.mutate;
+  const cancelRevisionMutate = cancelRevisionMutation.mutate;
+
+  // Rejections are swallowed: the mutation's onError owns the message, and
+  // callers only await settlement.
+  const handleSubmit = useCallback(async () => {
+    await submitMutate({
       assignmentId,
       reviewData: { answers: values, rationales },
       overallComment: overallComment.trim() ? overallComment : null,
-    });
-  }, [assignmentId, values, rationales, overallComment, submitReview]);
+    }).catch(() => {});
+  }, [assignmentId, values, rationales, overallComment, submitMutate]);
 
   const startEditing = useCallback(() => {
     setIsEditing(true);
   }, []);
 
-  const handleUpdate = useCallback(() => {
-    updateReview.mutate({
+  const handleUpdate = useCallback(async () => {
+    await updateMutate({
       assignmentId,
       reviewData: { answers: values, rationales },
       overallComment: overallComment.trim() ? overallComment : null,
-    });
-  }, [assignmentId, values, rationales, overallComment, updateReview]);
+    }).catch(() => {});
+  }, [assignmentId, values, rationales, overallComment, updateMutate]);
 
   const handleRequestRevision = useCallback(
     (comment: string) => {
-      requestRevisionMutation.mutate({
+      requestRevisionMutate({
         assignmentId,
         requestComment: comment,
       });
     },
-    [assignmentId, requestRevisionMutation],
+    [assignmentId, requestRevisionMutate],
   );
 
   const handleCancelRevision = useCallback(() => {
     if (!ownRevisionRequest) {
       return;
     }
-    cancelRevisionMutation.mutate({
+    cancelRevisionMutate({
       assignmentId,
       revisionRequestId: ownRevisionRequest.id,
     });
-  }, [assignmentId, ownRevisionRequest, cancelRevisionMutation]);
+  }, [assignmentId, ownRevisionRequest, cancelRevisionMutate]);
+
+  const canSubmit = isRubricValid && !isSubmitted && !isPausedForRevision;
+  const canUpdate = isRubricValid && isEditing;
+
+  // What a host outside the form needs to drive its primary action.
+  const primaryAction = isEditing ? handleUpdate : handleSubmit;
+  const primaryActionEnabled = isEditing ? canUpdate : canSubmit;
+
+  useEffect(() => {
+    onStatusChange?.({
+      submit: primaryAction,
+      canSubmit: primaryActionEnabled,
+    });
+  }, [onStatusChange, primaryAction, primaryActionEnabled]);
 
   const state = useMemo<ReviewFormState>(
     () => ({
       values,
       rationales,
       overallComment,
-      canSubmit: isRubricValid && !isSubmitted && !isPausedForRevision,
+      canSubmit,
       isSubmitting: submitReview.isPending,
       isSubmitted,
       canEditReview,
       isEditing,
       isUpdating: updateReview.isPending,
-      canUpdate: isRubricValid && isEditing,
+      canUpdate,
       isPausedForRevision,
       revisionRequest: effectiveRevisionRequest,
       isOwnRevisionRequest,
@@ -316,7 +362,8 @@ function ReviewFormProviderInner({
       values,
       rationales,
       overallComment,
-      isRubricValid,
+      canSubmit,
+      canUpdate,
       isSubmitted,
       canEditReview,
       isEditing,

--- a/apps/app/src/components/decisions/ReviewSummary/OwnReviewPanel.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/OwnReviewPanel.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
+import { Skeleton, SkeletonText } from '@op/sense/Skeleton';
+import { Suspense } from 'react';
+
+import { useTranslations } from '@/lib/i18n';
+
+import {
+  ReviewFormProvider,
+  type ReviewFormStatus,
+} from '../Review/ReviewFormContext';
+import { ReviewRubricForm } from '../Review/ReviewRubricForm';
+import { BackToReviewers } from '../ReviewsPanel/BackToReviewers';
+
+interface OwnReviewPanelProps {
+  decisionSlug: string;
+  assignmentId: string;
+  onBack: () => void;
+  /** Runs after a submit or an update; the host closes the panel. */
+  onCompleted: () => void;
+  initiallyEditing?: boolean;
+  /** Hands the form's primary action up; the host's top bar renders it. */
+  onStatusChange: (status: ReviewFormStatus) => void;
+}
+
+/**
+ * The viewer's own review form as a state of the Review Progress panel.
+ *
+ * Loading stays inside this boundary so opening the form never blanks the
+ * proposal pane beside it, and the primary action is reported to the host
+ * rather than rendered here — its top bar owns that button.
+ */
+export function OwnReviewPanel({
+  decisionSlug,
+  assignmentId,
+  onBack,
+  onCompleted,
+  initiallyEditing,
+  onStatusChange,
+}: OwnReviewPanelProps) {
+  return (
+    <APIErrorBoundary fallbacks={{ default: () => <OwnReviewPanelError /> }}>
+      <Suspense fallback={<OwnReviewPanelSkeleton />}>
+        <ReviewFormProvider
+          assignmentId={assignmentId}
+          decisionSlug={decisionSlug}
+          // Revisions belong to the reviewer surface.
+          allowRevisions={false}
+          onCompleted={onCompleted}
+          onStatusChange={onStatusChange}
+          initiallyEditing={initiallyEditing}
+        >
+          <div className="flex flex-col gap-6">
+            <BackToReviewers onClick={onBack} />
+            <ReviewRubricForm openReviews={false} previousReviewPhases={[]} />
+          </div>
+        </ReviewFormProvider>
+      </Suspense>
+    </APIErrorBoundary>
+  );
+}
+
+const OwnReviewPanelSkeleton = () => (
+  <div className="flex flex-col gap-6">
+    <Skeleton className="h-5 w-40" />
+    <Skeleton className="h-8 w-48" />
+    <SkeletonText lines={4} />
+  </div>
+);
+
+const OwnReviewPanelError = () => {
+  const t = useTranslations();
+
+  return (
+    <p className="text-base text-muted-foreground">
+      {t('Something went wrong on our end. Please try again')}
+    </p>
+  );
+};

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryLayout.tsx
@@ -88,11 +88,21 @@ export async function ReviewSummaryLayout({
     phaseId === instance.currentStateId &&
     isReviewPhase(assertInstancePhase({ instance, phaseId }));
 
-  await utils.decision.getProposalWithReviewAggregates.prefetch({
-    processInstanceId: instanceId,
-    proposalId,
-    phaseId,
-  });
+  await Promise.all([
+    utils.decision.getProposalWithReviewAggregates.prefetch({
+      processInstanceId: instanceId,
+      proposalId,
+      phaseId,
+    }),
+    // Same key as the query in ReviewSummaryView, `sort` included, or the
+    // client refetches on mount.
+    utils.decision.listReviewAssignments.prefetch({
+      processInstanceId: instanceId,
+      proposalProfileId,
+      phaseId,
+      sort: 'newest',
+    }),
+  ]);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
+++ b/apps/app/src/components/decisions/ReviewSummary/ReviewSummaryView.tsx
@@ -1,9 +1,14 @@
 'use client';
 
+import { useRequiredUser } from '@/utils/UserProvider';
 import { trpc } from '@op/api/client';
+import { ProposalReviewState } from '@op/common/client';
+import { Button } from '@op/sense/Button';
 import { SplitPane } from '@op/sense/SplitPane';
 import { cn } from '@op/sense/lib/utils';
 import { useQueryState } from 'nuqs';
+import { useCallback, useState } from 'react';
+import { LuCheck, LuPencil } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
@@ -11,7 +16,10 @@ import { TranslatedText } from '@/components/TranslatedText';
 
 import { DecisionSubpageHeader } from '../DecisionSubpageHeader';
 import { ProposalPreview } from '../ProposalPreview';
+import type { ReviewFormStatus } from '../Review/ReviewFormContext';
+import type { OwnReviewEntry } from '../ReviewsPanel/ReviewsPanel';
 import { ReviewsPanel } from '../ReviewsPanel/ReviewsPanel';
+import { OwnReviewPanel } from './OwnReviewPanel';
 import { ReviewSummaryAdvanceFooter } from './ReviewSummaryAdvanceFooter';
 
 interface ReviewSummaryViewProps {
@@ -32,21 +40,104 @@ export function ReviewSummaryView({
   isPhaseInProgress = false,
 }: ReviewSummaryViewProps) {
   const t = useTranslations();
-  const [[proposalWithReviews, proposal]] = trpc.useSuspenseQueries((t) => [
-    t.decision.getProposalWithReviewAggregates({
-      processInstanceId: instanceId,
-      proposalId,
-      phaseId,
-    }),
-    t.decision.getProposal({ profileId: proposalProfileId }),
-  ]);
+  const { user } = useRequiredUser();
+  const utils = trpc.useUtils();
+
+  const [[proposalWithReviews, proposal, ownAssignments]] =
+    trpc.useSuspenseQueries((t) => [
+      t.decision.getProposalWithReviewAggregates({
+        processInstanceId: instanceId,
+        proposalId,
+        phaseId,
+      }),
+      t.decision.getProposal({ profileId: proposalProfileId }),
+      // Self-scoped, and scoped to the phase this screen describes — the same
+      // one the aggregates above use.
+      t.decision.listReviewAssignments(
+        {
+          processInstanceId: instanceId,
+          proposalProfileId,
+          phaseId,
+          sort: 'newest',
+        },
+        // Force a client-side fetch so the query registers its invalidation
+        // channel via the client link; the SSR prefetch cannot.
+        { refetchOnMount: 'always' },
+      ),
+    ]);
 
   const rubricTemplate = proposalWithReviews.rubricTemplate;
+
+  // 'newest' orders by assignedAt in SQL, as ProposalReviewsLayout does.
+  const ownAssignment = ownAssignments.assignments[0];
 
   const [selectedAssignmentId, setSelectedAssignmentId] = useQueryState(
     'assignment',
     { history: 'push' },
   );
+
+  // Never the URL: opening the form is not a navigation.
+  const [isOwnFormOpen, setIsOwnFormOpen] = useState(false);
+  const [ownFormStatus, setOwnFormStatus] = useState<ReviewFormStatus | null>(
+    null,
+  );
+  const [isSavingOwnReview, setIsSavingOwnReview] = useState(false);
+
+  const openOwnForm = useCallback(() => {
+    // Guarded: writing this unconditionally pushes a history entry for the
+    // same URL when the form opens from the list.
+    if (selectedAssignmentId) {
+      setSelectedAssignmentId(null);
+    }
+    setOwnFormStatus(null);
+    setIsOwnFormOpen(true);
+  }, [selectedAssignmentId, setSelectedAssignmentId]);
+
+  const closeOwnForm = useCallback(() => {
+    setOwnFormStatus(null);
+    setIsOwnFormOpen(false);
+  }, []);
+
+  // The assignment list refreshes itself through its review channel; the
+  // aggregates router registers none, so only that one needs a nudge.
+  const handleOwnReviewCompleted = useCallback(() => {
+    setOwnFormStatus(null);
+    setIsOwnFormOpen(false);
+    void utils.decision.getProposalWithReviewAggregates.invalidate({
+      processInstanceId: instanceId,
+      proposalId,
+      phaseId,
+    });
+  }, [utils, instanceId, proposalId, phaseId]);
+
+  const currentProfileId = user.currentProfile?.id;
+
+  const ownReviewIsSubmitted =
+    ownAssignment?.review?.state === ProposalReviewState.SUBMITTED;
+
+  const ownReview: OwnReviewEntry | undefined =
+    ownAssignment && currentProfileId
+      ? {
+          profileId: currentProfileId,
+          hasSubmitted: ownReviewIsSubmitted,
+          onOpenForm: openOwnForm,
+        }
+      : undefined;
+
+  const saveOwnReview = async () => {
+    if (!ownFormStatus) {
+      return;
+    }
+    setIsSavingOwnReview(true);
+    await ownFormStatus.submit();
+    setIsSavingOwnReview(false);
+  };
+
+  // `canEditReview` already implies a submitted review, and only a submitted
+  // review has a row to drill into.
+  const isOwnDetailOpen =
+    !!ownAssignment && selectedAssignmentId === ownAssignment.assignment.id;
+  const canEditOwnReview = !!ownAssignment?.canEditReview;
 
   return (
     <div
@@ -58,7 +149,31 @@ export function ReviewSummaryView({
       <DecisionSubpageHeader
         backHref={`/decisions/${decisionSlug}/current`}
         backLabel={t('Back')}
-      />
+      >
+        {/* Swaps without a navigation. */}
+        <div className="flex items-center gap-4" aria-live="polite">
+          {isOwnFormOpen
+            ? ownFormStatus && (
+                <Button
+                  onClick={saveOwnReview}
+                  disabled={!ownFormStatus.canSubmit}
+                  loading={isSavingOwnReview}
+                >
+                  <LuCheck className="size-4" />
+                  {ownReviewIsSubmitted
+                    ? t('Update review')
+                    : t('Submit review')}
+                </Button>
+              )
+            : isOwnDetailOpen &&
+              canEditOwnReview && (
+                <Button variant="outline" onClick={openOwnForm}>
+                  <LuPencil className="size-4" />
+                  {t('Edit review')}
+                </Button>
+              )}
+        </div>
+      </DecisionSubpageHeader>
 
       <SplitPane className="mx-auto max-w-6xl" defaultMobileTabId="summary">
         <SplitPane.Pane
@@ -77,13 +192,31 @@ export function ReviewSummaryView({
             )
           }
         >
-          <ReviewsPanel
-            proposalWithReviews={proposalWithReviews}
-            rubricTemplate={rubricTemplate}
-            selectedAssignmentId={selectedAssignmentId}
-            onSelectAssignment={setSelectedAssignmentId}
-            title={isPhaseInProgress ? t('Review Progress') : undefined}
-          />
+          {/* Outside the panel: a live region around the form would announce
+              every keystroke. */}
+          <span role="status" className="sr-only">
+            {isOwnFormOpen ? t('Review Proposal') : t('Review Progress')}
+          </span>
+
+          {isOwnFormOpen && ownAssignment ? (
+            <OwnReviewPanel
+              decisionSlug={decisionSlug}
+              assignmentId={ownAssignment.assignment.id}
+              onBack={closeOwnForm}
+              onCompleted={handleOwnReviewCompleted}
+              initiallyEditing={ownReviewIsSubmitted}
+              onStatusChange={setOwnFormStatus}
+            />
+          ) : (
+            <ReviewsPanel
+              proposalWithReviews={proposalWithReviews}
+              rubricTemplate={rubricTemplate}
+              selectedAssignmentId={selectedAssignmentId}
+              onSelectAssignment={setSelectedAssignmentId}
+              title={isPhaseInProgress ? t('Review Progress') : undefined}
+              ownReview={ownReview}
+            />
+          )}
         </SplitPane.Pane>
       </SplitPane>
 

--- a/apps/app/src/components/decisions/ReviewsPanel/BackToReviewers.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/BackToReviewers.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Button } from '@op/sense/Button';
+import { LuArrowLeft } from 'react-icons/lu';
+
+import { useTranslations } from '@/lib/i18n';
+
+/** Returns any panel state that replaced the reviewer list back to it. */
+export function BackToReviewers({ onClick }: { onClick: () => void }) {
+  const t = useTranslations();
+
+  return (
+    <Button
+      variant="link"
+      size="inline"
+      onClick={onClick}
+      className="self-start text-base"
+    >
+      <LuArrowLeft className="size-4 rtl:-scale-x-100" />
+      {t('Back to all reviewers')}
+    </Button>
+  );
+}

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerDetail.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerDetail.tsx
@@ -6,15 +6,12 @@ import {
   type SubmittedReviewItem,
   findSchemaOption,
 } from '@op/common/client';
-import { Button } from '@op/sense/Button';
 import { Header3 } from '@op/sense/Header';
 import { StatusDot } from '@op/sense/StatusDot';
-import { LuArrowLeft } from 'react-icons/lu';
-
-import { useTranslations } from '@/lib/i18n';
 
 import { ProfileAvatar } from '../../ProfileAvatar';
 import { SubmittedReviewView } from '../Review/SubmittedReviewView';
+import { BackToReviewers } from './BackToReviewers';
 import type { RubricSummary } from './ReviewsPanel';
 import { recommendationIntent } from './recommendationIntent';
 
@@ -31,7 +28,6 @@ export function ReviewerDetail({
   rubricSummary,
   onBack,
 }: ReviewerDetailProps) {
-  const t = useTranslations();
   const { hasOverallRecommendation, hasScoring, totalPoints } = rubricSummary;
 
   const recommendationLabel = (() => {
@@ -47,15 +43,7 @@ export function ReviewerDetail({
 
   return (
     <div className="flex flex-col gap-6">
-      <Button
-        variant="link"
-        size="inline"
-        onClick={onBack}
-        className="self-start text-base"
-      >
-        <LuArrowLeft className="size-4 rtl:-scale-x-100" />
-        {t('Back to all reviewers')}
-      </Button>
+      <BackToReviewers onClick={onBack} />
 
       <div className="flex items-center justify-between border-b border-border pb-4">
         <div className="flex items-center gap-2">

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewerList.tsx
@@ -17,7 +17,7 @@ import { useTranslations } from '@/lib/i18n';
 
 import { ProfileAvatar } from '../../ProfileAvatar';
 import { AverageScoreBar } from './AverageScoreBar';
-import type { RubricSummary } from './ReviewsPanel';
+import type { OwnReviewEntry, RubricSummary } from './ReviewsPanel';
 import { recommendationIntent } from './recommendationIntent';
 
 interface ReviewerListProps {
@@ -28,6 +28,7 @@ interface ReviewerListProps {
   onSelectAssignment: (assignmentId: string) => void;
   hideSummaryHeader?: boolean;
   title?: string;
+  ownReview?: OwnReviewEntry;
 }
 
 export function ReviewerList({
@@ -38,6 +39,7 @@ export function ReviewerList({
   onSelectAssignment,
   hideSummaryHeader,
   title,
+  ownReview,
 }: ReviewerListProps) {
   const t = useTranslations();
   const { reviewsSubmittedCount, assignmentsCount, averageScore } =
@@ -75,7 +77,7 @@ export function ReviewerList({
         </header>
       )}
 
-      {hasScoring && (
+      {hasScoring && reviewsSubmittedCount > 0 && (
         <AverageScoreBar
           averageScore={averageScore}
           totalPoints={totalPoints}
@@ -98,6 +100,7 @@ export function ReviewerList({
                   showScore={hasScoring}
                   totalPoints={totalPoints}
                   onSelect={onSelectAssignment}
+                  isOwn={item.reviewer.id === ownReview?.profileId}
                 />
               ))}
             </RecommendationGroup>
@@ -114,10 +117,22 @@ export function ReviewerList({
                 showScore={hasScoring}
                 totalPoints={totalPoints}
                 onSelect={onSelectAssignment}
+                isOwn={item.reviewer.id === ownReview?.profileId}
               />
             ))}
           </div>
         </div>
+      )}
+
+      {ownReview && !ownReview.hasSubmitted && (
+        <Button
+          variant="link"
+          size="inline"
+          onClick={ownReview.onOpenForm}
+          className="self-start text-base"
+        >
+          {t('+ Add review')}
+        </Button>
       )}
     </div>
   );
@@ -186,13 +201,20 @@ function ReviewerRow({
   showScore,
   totalPoints,
   onSelect,
+  isOwn,
 }: {
   item: SubmittedReviewItem;
   showScore: boolean;
   totalPoints: number;
   onSelect: (assignmentId: string) => void;
+  isOwn?: boolean;
 }) {
   const t = useTranslations();
+  const reviewerName = item.reviewer.name ?? item.reviewer.slug;
+  const rowLabel = isOwn
+    ? t('{name} (You)', { name: reviewerName })
+    : reviewerName;
+
   return (
     // `bare`: the row keeps its card look and picks up the sense focus ring,
     // which the hand-rolled outline it used to carry never matched.
@@ -200,9 +222,7 @@ function ReviewerRow({
       variant="bare"
       onClick={() => onSelect(item.review.assignmentId)}
       className="flex h-14 w-full items-center justify-between rounded-lg border border-border bg-white px-3 py-2 text-start transition-colors duration-200 hover:bg-muted"
-      aria-label={t('View review by {name}', {
-        name: item.reviewer.name ?? item.reviewer.slug,
-      })}
+      aria-label={t('View review by {name}', { name: rowLabel })}
     >
       <div className="flex items-center gap-2">
         <ProfileAvatar
@@ -211,9 +231,7 @@ function ReviewerRow({
           className="size-6"
         />
         <div className="flex flex-col">
-          <span className="text-base">
-            {item.reviewer.name ?? item.reviewer.slug}
-          </span>
+          <span className="text-base">{rowLabel}</span>
           {showScore && (
             <span className="text-sm">
               {item.score}

--- a/apps/app/src/components/decisions/ReviewsPanel/ReviewsPanel.tsx
+++ b/apps/app/src/components/decisions/ReviewsPanel/ReviewsPanel.tsx
@@ -18,6 +18,14 @@ export interface RubricSummary {
   hasOverallRecommendation: boolean;
 }
 
+/** The viewer's own assignment for this proposal, when they hold one. */
+export interface OwnReviewEntry {
+  /** Matched against each row's reviewer to mark it "(You)". */
+  profileId: string;
+  hasSubmitted: boolean;
+  onOpenForm: () => void;
+}
+
 interface ReviewsPanelProps {
   proposalWithReviews: ProposalWithSubmittedReviews;
   rubricTemplate: RubricTemplateSchema | null;
@@ -29,6 +37,7 @@ interface ReviewsPanelProps {
   hideSummaryHeader?: boolean;
   /** Header text; defaults to "Review Summary". */
   title?: string;
+  ownReview?: OwnReviewEntry;
 }
 
 export function ReviewsPanel({
@@ -39,6 +48,7 @@ export function ReviewsPanel({
   excludeProfileId,
   hideSummaryHeader,
   title,
+  ownReview,
 }: ReviewsPanelProps) {
   const rubricSummary = useMemo<RubricSummary>(() => {
     if (!rubricTemplate) {
@@ -95,6 +105,7 @@ export function ReviewsPanel({
       onSelectAssignment={onSelectAssignment}
       hideSummaryHeader={hideSummaryHeader}
       title={title}
+      ownReview={ownReview}
     />
   );
 }

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1534,5 +1534,7 @@
   "No invitations were sent": "لم يتم إرسال أي دعوات",
   "Some invitations could not be sent": "تعذّر إرسال بعض الدعوات",
   "Select an organization": "اختر مؤسسة",
-  "You can only invite people to organizations you administer.": "يمكنك دعوة أشخاص فقط إلى المؤسسات التي تديرها."
+  "You can only invite people to organizations you administer.": "يمكنك دعوة أشخاص فقط إلى المؤسسات التي تديرها.",
+  "+ Add review": "+ إضافة مراجعة",
+  "{name} (You)": "{name} (أنت)"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1537,5 +1537,7 @@
   "No invitations were sent": "কোনো আমন্ত্রণ পাঠানো হয়নি",
   "Some invitations could not be sent": "কিছু আমন্ত্রণ পাঠানো যায়নি",
   "Select an organization": "একটি সংস্থা নির্বাচন করুন",
-  "You can only invite people to organizations you administer.": "আপনি শুধু সেই সংস্থাগুলিতে মানুষকে আমন্ত্রণ জানাতে পারেন যেগুলি আপনি পরিচালনা করেন।"
+  "You can only invite people to organizations you administer.": "আপনি শুধু সেই সংস্থাগুলিতে মানুষকে আমন্ত্রণ জানাতে পারেন যেগুলি আপনি পরিচালনা করেন।",
+  "+ Add review": "+ পর্যালোচনা যোগ করুন",
+  "{name} (You)": "{name} (আপনি)"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1599,5 +1599,7 @@
   "No invitations were sent": "No invitations were sent",
   "Some invitations could not be sent": "Some invitations could not be sent",
   "Select an organization": "Select an organization",
-  "You can only invite people to organizations you administer.": "You can only invite people to organizations you administer."
+  "You can only invite people to organizations you administer.": "You can only invite people to organizations you administer.",
+  "+ Add review": "+ Add review",
+  "{name} (You)": "{name} (You)"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1534,5 +1534,7 @@
   "No invitations were sent": "No se envió ninguna invitación",
   "Some invitations could not be sent": "No se pudieron enviar algunas invitaciones",
   "Select an organization": "Selecciona una organización",
-  "You can only invite people to organizations you administer.": "Solo puedes invitar personas a organizaciones que administras."
+  "You can only invite people to organizations you administer.": "Solo puedes invitar personas a organizaciones que administras.",
+  "+ Add review": "+ Agregar revisión",
+  "{name} (You)": "{name} (Tú)"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1534,5 +1534,7 @@
   "No invitations were sent": "Aucune invitation n'a été envoyée",
   "Some invitations could not be sent": "Certaines invitations n'ont pas pu être envoyées",
   "Select an organization": "Sélectionnez une organisation",
-  "You can only invite people to organizations you administer.": "Vous pouvez uniquement inviter des personnes dans les organisations que vous administrez."
+  "You can only invite people to organizations you administer.": "Vous pouvez uniquement inviter des personnes dans les organisations que vous administrez.",
+  "+ Add review": "+ Ajouter une évaluation",
+  "{name} (You)": "{name} (Vous)"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1534,5 +1534,7 @@
   "No invitations were sent": "Nenhum convite foi enviado",
   "Some invitations could not be sent": "Não foi possível enviar alguns convites",
   "Select an organization": "Selecione uma organização",
-  "You can only invite people to organizations you administer.": "Você só pode convidar pessoas para organizações que administra."
+  "You can only invite people to organizations you administer.": "Você só pode convidar pessoas para organizações que administra.",
+  "+ Add review": "+ Adicionar avaliação",
+  "{name} (You)": "{name} (Você)"
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1536,5 +1536,7 @@
   "No invitations were sent": "Casuumaad lama dirin",
   "Some invitations could not be sent": "Casuumaadaha qaarkood lama diri karin",
   "Select an organization": "Dooro urur",
-  "You can only invite people to organizations you administer.": "Waxaad dad ku casuumi kartaa oo keliya ururrada aad maamusho."
+  "You can only invite people to organizations you administer.": "Waxaad dad ku casuumi kartaa oo keliya ururrada aad maamusho.",
+  "+ Add review": "+ Ku dar dib-u-eegis",
+  "{name} (You)": "{name} (Adiga)"
 }

--- a/tests/e2e/tests/review-submit.spec.ts
+++ b/tests/e2e/tests/review-submit.spec.ts
@@ -281,6 +281,18 @@ test.describe('Review Submit', () => {
       page.getByRole('heading', { name: 'Review Progress' }),
     ).toBeVisible({ timeout: 36_000 });
 
+    // Being the assignee too, they get "+ Add review" below the reviewer list.
+    // It swaps their own form into the panel without leaving the screen.
+    const progressUrl = page.url();
+    await page.getByRole('button', { name: '+ Add review' }).click();
+    await expect(
+      page.getByText('Review Proposal', { exact: true }).first(),
+    ).toBeVisible({ timeout: 10_000 });
+    expect(page.url()).toBe(progressUrl);
+
+    // Revisions belong to the reviewer surface, so the rest of the journey runs
+    // on the standalone review screen.
+    await page.getByRole('button', { name: 'Back to all reviewers' }).click();
     await openReview();
     await expect(
       page.getByText('Review Proposal', { exact: true }).first(),

--- a/tests/e2e/tests/review-summary.spec.ts
+++ b/tests/e2e/tests/review-summary.spec.ts
@@ -12,6 +12,7 @@ import {
   createReviewScenario,
   getSeededTemplate,
 } from '@op/test';
+import type { Locator, Page } from '@playwright/test';
 
 import {
   TEST_USER_DEFAULT_PASSWORD,
@@ -124,6 +125,21 @@ const RUBRIC_TEMPLATE = {
 } as const satisfies RubricTemplateSchema;
 
 const PROPOSAL_TITLE = 'Community Solar Initiative';
+
+/**
+ * Keyboard, not a click: headless, Base UI's inert node over the open popup is
+ * hit-tested as intercepting the option (a real browser hits the option).
+ */
+async function answerCriterion(page: Page, pane: Locator, criterion: string) {
+  const combobox = pane.getByRole('combobox', { name: criterion });
+
+  await combobox.focus();
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+
+  await expect(combobox).not.toHaveText(/Select an option/);
+}
 
 test.describe('Review Summary page', () => {
   test('admin sees aggregated reviews grouped by recommendation, deep-link round-trips', async ({
@@ -306,6 +322,11 @@ test.describe('Review Summary page', () => {
     });
     await expect(reviewerRows).toHaveCount(3);
 
+    // This admin reviews nothing here, so no own-review entry point.
+    await expect(
+      page.getByRole('button', { name: '+ Add review' }),
+    ).toHaveCount(0);
+
     // ====================================================================
     // Step 3: Click the top-scoring row (Yes1, 8/8) → ReviewerDetail mounts
     //          and the assignment ID is pushed into the URL
@@ -367,6 +388,308 @@ test.describe('Review Summary page', () => {
     await expect(page).toHaveURL(
       new RegExp(`/decisions/${instance.slug}/current$`),
       { timeout: 10_000 },
+    );
+  });
+
+  test('admin reviews the proposal in place: + Add review swaps the panel, submit returns the list with a (You) row', async ({
+    authenticatedPage: page,
+    org,
+  }) => {
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: REVIEW_SCHEMA,
+    });
+
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...(instance.instance.instanceData as Record<string, unknown>),
+          rubricTemplate: RUBRIC_TEMPLATE,
+        },
+        currentStateId: 'review',
+      })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    // Reviewer == the org admin: the proposal-keyed URL resolves to Review
+    // Progress for them, so this panel is their only way to their own form.
+    const { proposal } = await createReviewScenario({
+      instance: { id: instance.instance.id },
+      author: {
+        profileId: org.organizationProfile.id,
+        authUserId: org.adminUser.authUserId,
+        email: org.adminUser.email,
+      },
+      reviewer: { profileId: org.adminUser.profileId },
+      proposalData: {
+        title: PROPOSAL_TITLE,
+        collaborationDocId: 'test-proposal-view-doc',
+      },
+    });
+
+    const summaryUrl = `/en/decisions/${instance.slug}/proposal/${proposal.profileId}/reviews`;
+
+    await page.goto(summaryUrl, { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', { name: 'Review Progress' }),
+    ).toBeVisible({ timeout: 36_000 });
+
+    // Every later step must leave this URL untouched — the form is a panel
+    // state, not a route.
+    const urlOnArrival = page.url();
+
+    // ====================================================================
+    // Step 1: "+ Add review" (below the reviewer list) swaps the panel to the
+    //          form, in place: proposal still on the left, URL unchanged
+    // ====================================================================
+
+    const addReview = page.getByRole('button', { name: '+ Add review' });
+    await expect(addReview).toBeVisible();
+
+    // Nothing submitted yet, so no average to show — but the counts line stays.
+    await expect(page.getByText('Average Score')).toHaveCount(0);
+    await expect(
+      page
+        .getByText('0 out of 1 reviewers submitted a review for this proposal')
+        .first(),
+    ).toBeVisible();
+
+    await addReview.click();
+
+    await expect(
+      page.getByText('Review Proposal', { exact: true }).first(),
+    ).toBeVisible({ timeout: 10_000 });
+    expect(page.url()).toBe(urlOnArrival);
+
+    // The proposal pane stayed put beside the form.
+    await expect(
+      page.getByRole('heading', { name: PROPOSAL_TITLE }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Back to all reviewers' }),
+    ).toBeVisible();
+
+    // ====================================================================
+    // Step 2: Fill the rubric and submit — same machinery, and the same top-bar
+    //          action placement, as the standalone review screen
+    // ====================================================================
+
+    const topBar = page.locator('header').first();
+    const submitButton = topBar.getByRole('button', { name: 'Submit review' });
+    await expect(submitButton).toBeDisabled();
+    // In the top bar only — never inline in the panel.
+    await expect(
+      page.getByRole('button', { name: 'Submit review' }),
+    ).toHaveCount(1);
+
+    // SplitPane keeps both panes mounted (the mobile tab copy included), so
+    // scope the form controls to the pane on screen — the other copy's
+    // controls match by name but don't respond.
+    const formPane = page
+      .getByRole('tabpanel')
+      .filter({ hasText: 'Review Proposal' })
+      .last();
+
+    // Both scored criteria are sense Selects — the trigger is a combobox.
+    await answerCriterion(page, formPane, 'Innovation');
+    await answerCriterion(page, formPane, 'Feasibility');
+
+    // The radio inputs are sr-only, so click the visible label text.
+    await formPane
+      .getByRole('radiogroup', { name: 'Overall Recommendation' })
+      .getByText('Yes', { exact: true })
+      .click();
+
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(
+      page
+        .locator('[data-slot="toast"]')
+        .filter({ hasText: 'Review submitted successfully' }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // ====================================================================
+    // Step 3: The panel returns to the progress list with their own row
+    //          marked "(You)" — still without navigating
+    // ====================================================================
+
+    await expect(
+      page.getByRole('heading', { name: 'Review Progress' }),
+    ).toBeVisible({ timeout: 10_000 });
+    expect(page.url()).toBe(urlOnArrival);
+
+    const ownRow = page.getByRole('button', { name: /\(You\)$/ });
+    await expect(ownRow).toHaveCount(1);
+    // Their review is grouped under the "Yes" recommendation they picked, and
+    // an average exists now that one review is in.
+    await expect(page.getByText('Yes (1)').first()).toBeVisible();
+    await expect(page.getByText('Average Score').first()).toBeVisible();
+
+    // Submitted, so the button below the list is gone — the row is the entry.
+    await expect(
+      page.getByRole('button', { name: '+ Add review' }),
+    ).toHaveCount(0);
+
+    // The form's actions left the top bar with it.
+    await expect(
+      topBar.getByRole('button', { name: /^(Submit|Update|Edit) review$/ }),
+    ).toHaveCount(0);
+
+    // ====================================================================
+    // Step 4: Their own row drills in and, while the review phase is current,
+    //          re-opens the form through "Edit review"
+    // ====================================================================
+
+    await ownRow.click();
+
+    // The detail's edit affordance also lives in the top bar — the panel never
+    // carries review actions itself.
+    const editReview = topBar.getByRole('button', { name: 'Edit review' });
+    await expect(editReview).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('button', { name: 'Edit review' })).toHaveCount(
+      1,
+    );
+
+    await editReview.click();
+
+    await expect(
+      page.getByText('Review Proposal', { exact: true }).first(),
+    ).toBeVisible({ timeout: 10_000 });
+    // Opened straight in edit mode — no second "Edit review" step — and the
+    // action is back in the top bar.
+    await expect(
+      topBar.getByRole('button', { name: 'Update review' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Update review' }),
+    ).toHaveCount(1);
+    // The drill-in's ?assignment param is dropped with it.
+    await expect(page).toHaveURL(urlOnArrival);
+
+    // ====================================================================
+    // Step 5: Updating completes the panel the same way submitting does —
+    //          back to the list, empty top bar, new answers on the row
+    // ====================================================================
+
+    await formPane
+      .getByRole('radiogroup', { name: 'Overall Recommendation' })
+      .getByText('Maybe', { exact: true })
+      .click();
+
+    await topBar.getByRole('button', { name: 'Update review' }).click();
+
+    await expect(
+      page
+        .locator('[data-slot="toast"]')
+        .filter({ hasText: 'Review updated successfully' }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await expect(
+      page.getByRole('heading', { name: 'Review Progress' }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page).toHaveURL(urlOnArrival);
+    await expect(
+      topBar.getByRole('button', { name: /^(Submit|Update|Edit) review$/ }),
+    ).toHaveCount(0);
+
+    // The refreshed aggregates regroup their row under the new answer.
+    await expect(page.getByText('Maybe (1)').first()).toBeVisible();
+    await expect(page.getByText('Yes (1)')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /\(You\)$/ })).toHaveCount(1);
+  });
+
+  test('own submitted review is view-only once the review phase has passed', async ({
+    authenticatedPage: page,
+    org,
+  }) => {
+    const template = await getSeededTemplate();
+
+    const instance = await createDecisionInstance({
+      processId: template.id,
+      ownerProfileId: org.organizationProfile.id,
+      authUserId: org.adminUser.authUserId,
+      email: org.adminUser.email,
+      schema: REVIEW_SCHEMA,
+    });
+
+    // The instance has moved on to results while the assignment stays pinned to
+    // the review phase — `canEditReview` is false, so the review is read-only.
+    // Set before the first page load: `getInstance` is cached, so a mid-test
+    // phase change would not be seen (see getInstance L1 cache staleness).
+    //
+    // This also covers the screen's phase scoping: the own-assignment lookup
+    // names the phase `resolveReviewPhaseId` walks back to, so the "(You)" row
+    // below only appears if that walk-back lands on 'review' — the phase the
+    // assignment is pinned to. A lookup scoped to the current phase ('results')
+    // would find nothing and the row would render unlabelled.
+    await db
+      .update(processInstances)
+      .set({
+        instanceData: {
+          ...(instance.instance.instanceData as Record<string, unknown>),
+          rubricTemplate: RUBRIC_TEMPLATE,
+        },
+        currentStateId: 'results',
+      })
+      .where(eq(processInstances.id, instance.instance.id));
+
+    const { proposal, assignment } = await createReviewScenario({
+      instance: { id: instance.instance.id },
+      author: {
+        profileId: org.organizationProfile.id,
+        authUserId: org.adminUser.authUserId,
+        email: org.adminUser.email,
+      },
+      reviewer: { profileId: org.adminUser.profileId },
+      phaseId: 'review',
+      proposalData: {
+        title: PROPOSAL_TITLE,
+        collaborationDocId: 'test-proposal-view-doc',
+      },
+    });
+
+    await createProposalReview({
+      assignmentId: assignment.id,
+      state: ProposalReviewState.SUBMITTED,
+      reviewData: {
+        answers: {
+          innovation: 3,
+          feasibility: 3,
+          [OVERALL_RECOMMENDATION_KEY]: 'maybe',
+        },
+        rationales: {},
+      },
+      submittedAt: new Date().toISOString(),
+    });
+
+    await page.goto(
+      `/en/decisions/${instance.slug}/proposal/${proposal.profileId}/reviews`,
+      { waitUntil: 'domcontentloaded' },
+    );
+
+    // Submitted, so no "+ Add review"; their own row carries the review.
+    const ownRow = page.getByRole('button', { name: /\(You\)$/ });
+    await expect(ownRow).toHaveCount(1, { timeout: 36_000 });
+    await expect(
+      page.getByRole('button', { name: '+ Add review' }),
+    ).toHaveCount(0);
+
+    // Drilling in shows the submitted review read-only: the phase has passed,
+    // so `canEditReview` is false and no edit affordance is offered.
+    await ownRow.click();
+
+    await expect(
+      page.getByRole('button', { name: 'Back to all reviewers' }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('button', { name: 'Edit review' })).toHaveCount(
+      0,
     );
   });
 


### PR DESCRIPTION
An instance admin who is also an assigned reviewer had no way to reach their own review form: the proposal-keyed reviews URL resolves to Review Progress for them. Their review now happens on that screen, without a navigation.

fix(decisions): return the panel to the reviewer list after an update, not only after a submit
fix(decisions): hide the average score until at least one review is submitted
fix(decisions): register the assignment list's realtime channel so it refreshes itself
