### PR TITLE
feat(decision): rubric template sections, render-only

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
@@ -1,7 +1,11 @@
 'use client';
 
-import type { XFormatPropertySchema } from '@op/common/client';
+import type {
+  RubricTemplateSchema,
+  XFormatPropertySchema,
+} from '@op/common/client';
 import {
+  groupFieldsBySection,
   isOverallRecommendationField,
   parseSchemaOptions,
 } from '@op/common/client';
@@ -155,20 +159,45 @@ function RubricField({ field }: { field: FieldDescriptor }) {
  * Static read-only preview of rubric fields.
  * Shows field labels and placeholder inputs — no interactivity.
  * Rationale placeholder is rendered under every criterion.
+ *
+ * Sections are previewed as a heading above their members — enough for the
+ * admin to see the grouping; editing sections is not supported here.
  */
 export function RubricFormPreviewRenderer({
+  template,
   fields,
 }: {
+  template: RubricTemplateSchema;
   fields: FieldDescriptor[];
 }) {
+  const blocks = groupFieldsBySection(template, fields);
+
   return (
     <div className="pointer-events-none flex flex-col gap-6">
-      {fields.map((field) => (
-        <div key={field.key} className="flex flex-col gap-4">
-          <RubricField field={field} />
-          <RationalePlaceholder />
-        </div>
-      ))}
+      {blocks.map((block) =>
+        block.kind === 'field' ? (
+          <div key={block.field.key} className="flex flex-col gap-4">
+            <RubricField field={block.field} />
+            <RationalePlaceholder />
+          </div>
+        ) : (
+          <div
+            key={`section:${block.section.id}`}
+            className="flex flex-col gap-4"
+          >
+            <FieldHeader
+              title={block.section.title}
+              description={block.section.description}
+            />
+            {block.fields.map((field) => (
+              <div key={field.key} className="flex flex-col gap-4">
+                <RubricField field={field} />
+                <RationalePlaceholder />
+              </div>
+            ))}
+          </div>
+        ),
+      )}
     </div>
   );
 }

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricParticipantPreview.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricParticipantPreview.tsx
@@ -42,7 +42,7 @@ export function RubricParticipantPreview({
           {t('Review Proposal')}
         </Header2>
 
-        <RubricFormPreviewRenderer fields={fields} />
+        <RubricFormPreviewRenderer template={template} fields={fields} />
       </div>
     </aside>
   );

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -3,7 +3,9 @@
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import {
   ProposalReviewState,
+  type TemplateSectionBlock,
   type XFormatPropertySchema,
+  groupFieldsBySection,
   isOverallRecommendationField,
   parseSchemaOptions,
 } from '@op/common/client';
@@ -13,7 +15,7 @@ import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { Select, SelectItem } from '@op/ui/Select';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
-import type { Key } from 'react';
+import type { Key, ReactNode } from 'react';
 import { useState } from 'react';
 import { LuCircleAlert, LuPlus } from 'react-icons/lu';
 
@@ -26,6 +28,7 @@ import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
 import { useReviewForm } from './ReviewFormContext';
 import { FormShell, TotalScoreCard } from './ReviewFormShell';
 import { type PreviousReviewPhase, ReviewTabs } from './ReviewTabs';
+import { RubricSectionShell } from './RubricSection';
 import { SubmittedReviewView } from './SubmittedReviewView';
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
@@ -84,11 +87,29 @@ function MyReviewForm() {
     review,
   } = useReviewForm();
   const fields = compileRubricSchema(template);
+  const blocks = groupFieldsBySection(template, fields);
 
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(
     overallComment.length > 0,
   );
   const [isViewModalOpen, setIsViewModalOpen] = useState(false);
+
+  const renderCriterion = (field: FieldDescriptor) => (
+    <RubricCriterionSection
+      key={field.key}
+      field={field}
+      maxPoints={getCriterionMaxPoints(template, field.key) ?? 0}
+      value={values[field.key]}
+      onChange={(value) => handleValueChange(field.key, value)}
+      rationaleValue={rationales[field.key] ?? ''}
+      onRationaleChange={(value) => handleRationaleChange(field.key, value)}
+      rationalePlaceholder={
+        isOverallRecommendationField(field.key)
+          ? t('Add overall notes...')
+          : t('Add reasons or insights...')
+      }
+    />
+  );
 
   // A submitted review shows the read-only result unless the reviewer has
   // switched it back into the form via "Edit review".
@@ -137,22 +158,11 @@ function MyReviewForm() {
         }
       >
         <div className="flex flex-col gap-6">
-          {fields.map((field) => (
-            <RubricCriterionSection
-              key={field.key}
-              field={field}
-              maxPoints={getCriterionMaxPoints(template, field.key) ?? 0}
-              value={values[field.key]}
-              onChange={(value) => handleValueChange(field.key, value)}
-              rationaleValue={rationales[field.key] ?? ''}
-              onRationaleChange={(value) =>
-                handleRationaleChange(field.key, value)
-              }
-              rationalePlaceholder={
-                isOverallRecommendationField(field.key)
-                  ? t('Add overall notes...')
-                  : t('Add reasons or insights...')
-              }
+          {blocks.map((block) => (
+            <RubricBlock
+              key={blockKey(block)}
+              block={block}
+              renderCriterion={renderCriterion}
             />
           ))}
 
@@ -191,6 +201,38 @@ function MyReviewForm() {
       </div>
     </>
   );
+}
+
+/**
+ * Render one grouping block: either a bare criterion or a section wrapper
+ * with its members.
+ */
+function RubricBlock({
+  block,
+  renderCriterion,
+}: {
+  block: TemplateSectionBlock<FieldDescriptor>;
+  renderCriterion: (field: FieldDescriptor) => ReactNode;
+}) {
+  if (block.kind === 'field') {
+    return renderCriterion(block.field);
+  }
+
+  return (
+    <RubricSectionShell section={block.section}>
+      {block.fields.map(renderCriterion)}
+    </RubricSectionShell>
+  );
+}
+
+/**
+ * Keyed on a field key rather than the section id: a legacy template with a
+ * split section yields one block per run, so the section id alone is not unique.
+ */
+function blockKey(block: TemplateSectionBlock<FieldDescriptor>): string {
+  return block.kind === 'field'
+    ? `field:${block.field.key}`
+    : `section:${block.section.id}:${block.fields[0]?.key ?? ''}`;
 }
 
 /**

--- a/apps/app/src/components/decisions/Review/RubricSection.tsx
+++ b/apps/app/src/components/decisions/Review/RubricSection.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import type { TemplateSection } from '@op/common/client';
+import type { ReactNode } from 'react';
+
+import { FieldHeader } from '../forms/FieldHeader';
+
+/**
+ * A presentational criterion group: the section title in the serif heading
+ * style (the same treatment as a criterion title such as "Overall
+ * Recommendation"), its optional description, then its members rendered
+ * exactly as they would be ungrouped.
+ */
+export function RubricSectionShell({
+  section,
+  children,
+}: {
+  section: TemplateSection;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-4">
+      <FieldHeader title={section.title} description={section.description} />
+      {children}
+    </section>
+  );
+}

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -1,7 +1,9 @@
 import {
   type ProposalReview,
   type RubricTemplateSchema,
+  type TemplateSectionBlock,
   findSchemaOption,
+  groupFieldsBySection,
   isOverallRecommendationField,
 } from '@op/common/client';
 import type { ReactNode } from 'react';
@@ -12,6 +14,7 @@ import { FieldHeader } from '../forms/FieldHeader';
 import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
 import { inferCriterionType } from '../rubricTemplate';
+import { RubricSectionShell } from './RubricSection';
 
 export function SubmittedReviewView({
   rubricTemplate,
@@ -22,23 +25,32 @@ export function SubmittedReviewView({
 }) {
   const t = useTranslations();
   const fields = compileRubricSchema(rubricTemplate);
+  const blocks = groupFieldsBySection(rubricTemplate, fields);
   const { answers, rationales } = review.reviewData;
+
+  const renderField = (field: FieldDescriptor) => (
+    <ResultSection
+      key={field.key}
+      title={field.schema.title}
+      description={field.schema.description}
+      required={field.required}
+    >
+      <RubricFieldResult
+        field={field}
+        value={answers[field.key]}
+        rationale={rationales[field.key]?.trim() || undefined}
+      />
+    </ResultSection>
+  );
 
   return (
     <div className="flex flex-col gap-6">
-      {fields.map((field) => (
-        <ResultSection
-          key={field.key}
-          title={field.schema.title}
-          description={field.schema.description}
-          required={field.required}
-        >
-          <RubricFieldResult
-            field={field}
-            value={answers[field.key]}
-            rationale={rationales[field.key]?.trim() || undefined}
-          />
-        </ResultSection>
+      {blocks.map((block) => (
+        <ResultBlock
+          key={blockKey(block)}
+          block={block}
+          renderField={renderField}
+        />
       ))}
 
       {review.overallComment && (
@@ -48,6 +60,38 @@ export function SubmittedReviewView({
       )}
     </div>
   );
+}
+
+/**
+ * One grouping block of a submitted review: a bare criterion result, or a
+ * section wrapper with its members.
+ */
+function ResultBlock({
+  block,
+  renderField,
+}: {
+  block: TemplateSectionBlock<FieldDescriptor>;
+  renderField: (field: FieldDescriptor) => ReactNode;
+}) {
+  if (block.kind === 'field') {
+    return renderField(block.field);
+  }
+
+  return (
+    <RubricSectionShell section={block.section}>
+      {block.fields.map(renderField)}
+    </RubricSectionShell>
+  );
+}
+
+/**
+ * Keyed on a field key rather than the section id: a legacy template with a
+ * split section yields one block per run, so the section id alone is not unique.
+ */
+function blockKey(block: TemplateSectionBlock<FieldDescriptor>): string {
+  return block.kind === 'field'
+    ? `field:${block.field.key}`
+    : `section:${block.section.id}:${block.fields[0]?.key ?? ''}`;
 }
 
 function ResultSection({

--- a/apps/app/src/components/decisions/rubricTemplate.test.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.test.ts
@@ -17,6 +17,7 @@ import {
   setCriterionRequired,
   setSelectOptions,
   updateCriterionDescription,
+  updateCriterionJsonSchema,
 } from './rubricTemplate';
 
 const ALL_TYPES: RubricCriterionType[] = [
@@ -274,5 +275,31 @@ describe('getCriteria', () => {
     expect(single?.criterionType).toBe('single_select');
     expect(single?.options).toHaveLength(2);
     expect(single?.options[0]?.title).toBe('Parks');
+  });
+});
+
+describe('section membership under type changes', () => {
+  it('keeps x-section when a criterion changes type', () => {
+    let template = createEmptyRubricTemplate();
+    template = addCriterion(template, 'crit1', 'scored', 'Impact');
+    template = updateCriterionJsonSchema(template, 'crit1', {
+      'x-section': 'cost',
+    });
+
+    const updated = changeCriterionType(template, 'crit1', 'long_text');
+
+    expect(getCriterionType(updated, 'crit1')).toBe('long_text');
+    // Sections are presentation only: any type can live in any section, so
+    // switching the type must not silently regroup the criterion.
+    expect(updated.properties?.crit1).toMatchObject({ 'x-section': 'cost' });
+  });
+
+  it('leaves an unsectioned criterion unsectioned', () => {
+    let template = createEmptyRubricTemplate();
+    template = addCriterion(template, 'crit1', 'scored', 'Impact');
+
+    const updated = changeCriterionType(template, 'crit1', 'yes_no');
+
+    expect(updated.properties?.crit1).not.toHaveProperty('x-section');
   });
 });

--- a/apps/app/src/components/decisions/rubricTemplate.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.ts
@@ -449,6 +449,13 @@ export function changeCriterionType(
     if (existing.description) {
       newSchema.description = existing.description;
     }
+    // Section membership is presentation, independent of the criterion's type:
+    // any type can sit in any section, so changing the type must not silently
+    // pull the criterion out of its group.
+    const sectionId = existing['x-section'];
+    if (sectionId !== undefined) {
+      newSchema['x-section'] = sectionId;
+    }
     return newSchema;
   });
 }

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -122,6 +122,21 @@ export {
   templateCollectsLocation,
   getLocationFieldMapView,
 } from './services/decision/templateLocation';
+// Presentational field grouping. Template-level concepts (not rubric-specific)
+// so proposal templates can adopt them later.
+export {
+  TEMPLATE_SECTIONS_KEY,
+  TEMPLATE_SECTION_KEY,
+  getTemplateSections,
+  getFieldSectionId,
+  getOrderedFieldKeys,
+  groupFieldsBySection,
+  assertContiguousTemplateSections,
+  type TemplateSection,
+  type TemplateSectionBlock,
+  type SectionableField,
+} from './services/decision/templateSections';
+export { assertRubricTemplateAuthoring } from './services/decision/templateAuthoring';
 export { assembleProposalData } from './services/decision/assembleProposalData';
 export { relaxLocationCategoryRequirement } from './services/decision/relaxLocationCategoryRequirement';
 export {

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -115,6 +115,8 @@ export * from './resolveBoundary';
 export * from './listBoundaryShapes';
 export * from './reverseGeocode';
 export * from './templateLocation';
+export * from './templateSections';
+export * from './templateAuthoring';
 export * from './extractProposalText';
 export * from './resolveProposalTemplate';
 export * from './getProposalTemplateFieldOrder';

--- a/packages/common/src/services/decision/schemaValidator.ts
+++ b/packages/common/src/services/decision/schemaValidator.ts
@@ -34,6 +34,10 @@ export class SchemaValidator {
     this.ajv.addKeyword('x-map-default');
     // Phase designation on custom forms (see CustomFormDefinitionSchema).
     this.ajv.addKeyword('x-phase');
+    // Purely presentational field grouping (see templateSections.ts): the
+    // top-level section list and the per-property membership marker.
+    this.ajv.addKeyword('x-sections');
+    this.ajv.addKeyword('x-section');
   }
 
   /**

--- a/packages/common/src/services/decision/templateAuthoring.ts
+++ b/packages/common/src/services/decision/templateAuthoring.ts
@@ -1,0 +1,31 @@
+/**
+ * Template-authoring guards — the semantic checks AJV cannot express.
+ *
+ * AJV answers "is this a compilable JSON Schema, and does this data satisfy
+ * it". It cannot answer "will the form this schema describes actually work".
+ * Vendor keys carry no shape schema of their own, so anything a client sends
+ * under `x-sections` / `x-section` would otherwise persist unchecked and
+ * surface as a broken form.
+ *
+ * These run at the persistence boundary, next to `validateJsonSchema`.
+ */
+import type { SectionableTemplate } from './templateSections';
+import { assertContiguousTemplateSections } from './templateSections';
+import type { XFormatPropertySchema } from './types';
+
+/** A template shape these guards can read. */
+type AuthorableTemplate = SectionableTemplate & {
+  properties?: Record<string, XFormatPropertySchema | boolean>;
+  'x-field-order'?: string[];
+};
+
+/**
+ * Assert a rubric template is safely authored.
+ *
+ * @throws ValidationError describing the first problem found.
+ */
+export function assertRubricTemplateAuthoring(
+  template: AuthorableTemplate,
+): void {
+  assertContiguousTemplateSections(template);
+}

--- a/packages/common/src/services/decision/templateSections.test.ts
+++ b/packages/common/src/services/decision/templateSections.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+
+import { ValidationError } from '../../utils';
+import { SchemaValidator } from './schemaValidator';
+import {
+  assertContiguousTemplateSections,
+  getFieldSectionId,
+  getOrderedFieldKeys,
+  getTemplateSections,
+  groupFieldsBySection,
+} from './templateSections';
+import type { RubricTemplateSchema, XFormatPropertySchema } from './types';
+
+/** Compiled-field stand-in: what the app's schema compilers produce. */
+function field(key: string, schema: XFormatPropertySchema = {}) {
+  return { key, schema };
+}
+
+const sections = [
+  { id: 's1', title: 'Total Estimated Cost', description: 'All-in cost' },
+  { id: 's2', title: 'Community Impact' },
+];
+
+describe('getTemplateSections', () => {
+  it('returns declared sections in declaration order', () => {
+    expect(getTemplateSections({ 'x-sections': sections })).toEqual([
+      { id: 's1', title: 'Total Estimated Cost', description: 'All-in cost' },
+      { id: 's2', title: 'Community Impact' },
+    ]);
+  });
+
+  it('returns an empty list when the key is missing or not an array', () => {
+    expect(getTemplateSections({})).toEqual([]);
+    expect(getTemplateSections({ 'x-sections': 'nope' })).toEqual([]);
+  });
+
+  it('drops malformed and duplicate entries instead of throwing', () => {
+    const result = getTemplateSections({
+      'x-sections': [
+        null,
+        'string',
+        { title: 'No id' },
+        { id: '   ', title: 'Blank id' },
+        { id: 'ok', title: 'Kept' },
+        { id: 'ok', title: 'Duplicate' },
+        // A section with no usable title would render as a blank heading, so
+        // it is dropped and its members degrade to ungrouped.
+        { id: 'untitled' },
+        { id: 'blank-title', title: '   ' },
+        { id: 'numeric-title', title: 7 },
+      ],
+    });
+
+    expect(result).toEqual([{ id: 'ok', title: 'Kept' }]);
+  });
+
+  it('degrades members of a title-less section to ungrouped', () => {
+    const orphan = field('orphan', { 'x-section': 'untitled' });
+
+    expect(
+      groupFieldsBySection({ 'x-sections': [{ id: 'untitled' }] }, [orphan]),
+    ).toEqual([{ kind: 'field', field: orphan }]);
+  });
+});
+
+describe('getFieldSectionId', () => {
+  it('reads the declared section id', () => {
+    expect(getFieldSectionId({ 'x-section': 's1' })).toBe('s1');
+  });
+
+  it('ignores absent and blank values', () => {
+    expect(getFieldSectionId({})).toBeUndefined();
+    expect(getFieldSectionId({ 'x-section': '  ' })).toBeUndefined();
+  });
+});
+
+describe('groupFieldsBySection', () => {
+  it('leaves every field ungrouped when no sections are declared', () => {
+    const fields = [field('a'), field('b')];
+
+    expect(groupFieldsBySection({}, fields)).toEqual([
+      { kind: 'field', field: fields[0] },
+      { kind: 'field', field: fields[1] },
+    ]);
+  });
+
+  it('places a section block at the position of its first member', () => {
+    const before = field('before');
+    const m1 = field('m1', { 'x-section': 's1' });
+    const m2 = field('m2', { 'x-section': 's1' });
+    const after = field('after');
+
+    const blocks = groupFieldsBySection({ 'x-sections': sections }, [
+      before,
+      m1,
+      m2,
+      after,
+    ]);
+
+    expect(blocks).toEqual([
+      { kind: 'field', field: before },
+      { kind: 'section', section: sections[0], fields: [m1, m2] },
+      { kind: 'field', field: after },
+    ]);
+  });
+
+  it('never moves a field past another when members are non-contiguous', () => {
+    // Non-contiguous membership is rejected at the persistence boundary (see
+    // assertContiguousTemplateSections). Should one reach the renderer from a
+    // template persisted before that guard, field order must still win: each
+    // run becomes its own block rather than the section swallowing `middle`.
+    const m1 = field('m1', { 'x-section': 's1' });
+    const middle = field('middle');
+    const m2 = field('m2', { 'x-section': 's1' });
+
+    const blocks = groupFieldsBySection({ 'x-sections': sections }, [
+      m1,
+      middle,
+      m2,
+    ]);
+
+    expect(blocks).toEqual([
+      { kind: 'section', section: sections[0], fields: [m1] },
+      { kind: 'field', field: middle },
+      { kind: 'section', section: sections[0], fields: [m2] },
+    ]);
+  });
+
+  it('keeps member order from the incoming (x-field-order) field list', () => {
+    const m2 = field('m2', { 'x-section': 's1' });
+    const m1 = field('m1', { 'x-section': 's1' });
+
+    const blocks = groupFieldsBySection({ 'x-sections': sections }, [m2, m1]);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.kind === 'section' && blocks[0].fields).toEqual([m2, m1]);
+  });
+
+  it('renders a dangling x-section ungrouped rather than hiding it', () => {
+    const orphan = field('orphan', { 'x-section': 'does-not-exist' });
+
+    expect(groupFieldsBySection({ 'x-sections': sections }, [orphan])).toEqual([
+      { kind: 'field', field: orphan },
+    ]);
+  });
+
+  it('emits no block for a section with no members', () => {
+    const blocks = groupFieldsBySection({ 'x-sections': sections }, [
+      field('a'),
+    ]);
+
+    expect(blocks.every((block) => block.kind === 'field')).toBe(true);
+  });
+});
+
+describe('AJV registration of the section vendor keys', () => {
+  it('compiles a template using x-sections and x-section', () => {
+    const validator = new SchemaValidator();
+    const template: RubricTemplateSchema = {
+      type: 'object',
+      'x-sections': [{ id: 's1', title: 'Total Estimated Cost' }],
+      'x-field-order': ['crit'],
+      properties: {
+        crit: { type: 'string', 'x-format': 'long-text', 'x-section': 's1' },
+      },
+    };
+
+    expect(() => validator.validateJsonSchema(template)).not.toThrow();
+    expect(validator.validate(template, { crit: 'hello' }).valid).toBe(true);
+  });
+});
+
+describe('getOrderedFieldKeys', () => {
+  it('follows x-field-order and appends properties it forgot', () => {
+    expect(
+      getOrderedFieldKeys({
+        'x-field-order': ['b', 'a', 'gone'],
+        properties: { a: {}, b: {}, c: {} },
+      }),
+    ).toEqual(['b', 'a', 'c']);
+  });
+});
+
+describe('assertContiguousTemplateSections', () => {
+  const cost = { 'x-sections': [{ id: 'cost', title: 'Cost' }] };
+
+  it('accepts a contiguous section', () => {
+    expect(() =>
+      assertContiguousTemplateSections({
+        ...cost,
+        'x-field-order': ['before', 'm1', 'm2', 'after'],
+        properties: {
+          before: {},
+          m1: { 'x-section': 'cost' },
+          m2: { 'x-section': 'cost' },
+          after: {},
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects a section split by another criterion', () => {
+    expect(() =>
+      assertContiguousTemplateSections({
+        ...cost,
+        'x-field-order': ['m1', 'middle', 'm2'],
+        properties: {
+          m1: { 'x-section': 'cost' },
+          middle: {},
+          m2: { 'x-section': 'cost' },
+        },
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  it('rejects a section split by a member of another section', () => {
+    expect(() =>
+      assertContiguousTemplateSections({
+        'x-sections': [
+          { id: 'cost', title: 'Cost' },
+          { id: 'impact', title: 'Impact' },
+        ],
+        'x-field-order': ['m1', 'other', 'm2'],
+        properties: {
+          m1: { 'x-section': 'cost' },
+          other: { 'x-section': 'impact' },
+          m2: { 'x-section': 'cost' },
+        },
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  it('is a no-op when no sections are declared', () => {
+    expect(() =>
+      assertContiguousTemplateSections({
+        'x-field-order': ['a', 'b'],
+        properties: { a: { 'x-section': 'ghost' }, b: {} },
+      }),
+    ).not.toThrow();
+  });
+
+  it('treats a dangling section id as ungrouped, so it splits a real run', () => {
+    expect(() =>
+      assertContiguousTemplateSections({
+        ...cost,
+        'x-field-order': ['m1', 'ghost', 'm2'],
+        properties: {
+          m1: { 'x-section': 'cost' },
+          ghost: { 'x-section': 'not-declared' },
+          m2: { 'x-section': 'cost' },
+        },
+      }),
+    ).toThrow(ValidationError);
+  });
+});

--- a/packages/common/src/services/decision/templateSections.ts
+++ b/packages/common/src/services/decision/templateSections.ts
@@ -1,0 +1,279 @@
+/**
+ * Template sections — pure presentational grouping for JSON Schema templates.
+ *
+ * Both proposal templates and rubric templates are flat JSON Schema objects
+ * with one property per field, ordered by `x-field-order`. Sections add
+ * *layout only* on top of that, via two vendor keys:
+ *
+ * - top-level `x-sections: [{ id, title, description? }]`
+ * - per-property `x-section: <sectionId>`
+ *
+ * Nothing else changes: answers stay keyed by the property id, `required`
+ * stays top-level, validation and scoring keep iterating the flat property
+ * map. Moving a field between sections therefore never moves its answer.
+ *
+ * These helpers are deliberately template-agnostic (no "rubric" in any name)
+ * so proposal templates can adopt the same keys later. Only rubric rendering
+ * consumes them today.
+ */
+import { ValidationError } from '../../utils';
+import type { XFormatPropertySchema } from './types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Top-level vendor key holding the section list. */
+export const TEMPLATE_SECTIONS_KEY = 'x-sections';
+
+/** Per-property vendor key naming the section a field belongs to. */
+export const TEMPLATE_SECTION_KEY = 'x-section';
+
+/** One declared section. `id` is opaque — never derived from the title. */
+export interface TemplateSection {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+/**
+ * A render block: either a standalone field or a section with its members.
+ * Produced by {@link groupFieldsBySection}; the only thing sections do.
+ */
+export type TemplateSectionBlock<TField> =
+  | { kind: 'field'; field: TField }
+  | { kind: 'section'; section: TemplateSection; fields: TField[] };
+
+/** Minimal shape {@link groupFieldsBySection} needs from a compiled field. */
+export interface SectionableField {
+  key: string;
+  schema: XFormatPropertySchema;
+}
+
+/** Minimal shape the section readers need from a template. */
+export interface SectionableTemplate {
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Readers
+// ---------------------------------------------------------------------------
+
+/** Narrows unknown stored JSON to a plain (non-array) object. */
+function isPlainObject(value: unknown): value is { [key: string]: unknown } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** A non-blank string, the requirement for both section ids and titles. */
+function readNonBlankString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+/**
+ * Declared sections of a template, in declaration order.
+ *
+ * Malformed entries — not an object, blank/missing/non-string id **or title**,
+ * or a duplicate id — are dropped rather than thrown on. Templates are stored
+ * JSON that no schema constrains (custom AJV keywords carry no shape), so a bad
+ * section must degrade to "no section": its members then render ungrouped,
+ * which is strictly better than wrapping them in a blank heading.
+ */
+export function getTemplateSections(
+  template: SectionableTemplate,
+): TemplateSection[] {
+  const raw = template[TEMPLATE_SECTIONS_KEY];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const sections: TemplateSection[] = [];
+  const seenIds = new Set<string>();
+
+  for (const entry of raw) {
+    if (!isPlainObject(entry)) {
+      continue;
+    }
+    const id = readNonBlankString(entry.id);
+    const title = readNonBlankString(entry.title);
+    if (id === undefined || title === undefined || seenIds.has(id)) {
+      continue;
+    }
+    seenIds.add(id);
+    sections.push({
+      id,
+      title,
+      ...(typeof entry.description === 'string'
+        ? { description: entry.description }
+        : {}),
+    });
+  }
+
+  return sections;
+}
+
+/** The section id declared on a property, if any. */
+export function getFieldSectionId(
+  schema: XFormatPropertySchema,
+): string | undefined {
+  const value = schema[TEMPLATE_SECTION_KEY];
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Grouping
+// ---------------------------------------------------------------------------
+
+/**
+ * Group compiled fields into render blocks.
+ *
+ * - `x-field-order` (already applied to `fields` by the caller's compiler)
+ *   remains the single source of field order, inside and outside sections.
+ *   Grouping never moves a field past another field: a section's members are
+ *   required to be one contiguous run, enforced at the persistence boundary by
+ *   {@link assertContiguousTemplateSections}.
+ * - A field whose `x-section` names an unknown section renders ungrouped, as
+ *   if the key were absent. Nothing is hidden and nothing throws.
+ * - Sections with no members produce no block.
+ * - A non-contiguous section can still reach this renderer from a template
+ *   persisted before the guard existed. Rather than reorder, each run becomes
+ *   its own block, so field order survives and the heading simply repeats.
+ */
+export function groupFieldsBySection<TField extends SectionableField>(
+  template: SectionableTemplate,
+  fields: TField[],
+): TemplateSectionBlock<TField>[] {
+  const sectionsById = new Map(
+    getTemplateSections(template).map((section) => [section.id, section]),
+  );
+
+  if (sectionsById.size === 0) {
+    return fields.map(
+      (field): TemplateSectionBlock<TField> => ({ kind: 'field', field }),
+    );
+  }
+
+  const blocks: TemplateSectionBlock<TField>[] = [];
+  let openBlock:
+    | { kind: 'section'; section: TemplateSection; fields: TField[] }
+    | undefined;
+
+  for (const field of fields) {
+    const sectionId = getFieldSectionId(field.schema);
+    const section = sectionId ? sectionsById.get(sectionId) : undefined;
+
+    if (!section) {
+      openBlock = undefined;
+      blocks.push({ kind: 'field', field });
+      continue;
+    }
+
+    if (openBlock?.section.id === section.id) {
+      openBlock.fields.push(field);
+      continue;
+    }
+
+    const block: {
+      kind: 'section';
+      section: TemplateSection;
+      fields: TField[];
+    } = {
+      kind: 'section',
+      section,
+      fields: [field],
+    };
+    openBlock = block;
+    blocks.push(block);
+  }
+
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Ordering + authoring guard
+// ---------------------------------------------------------------------------
+
+/**
+ * The order fields are rendered in: `x-field-order` first, then any property
+ * the order array forgot, appended. Mirrors what the app's schema compilers do,
+ * so the authoring guard below reasons about the order users actually see.
+ */
+export function getOrderedFieldKeys(
+  template: SectionableTemplate & {
+    properties?: Record<string, XFormatPropertySchema | boolean>;
+    'x-field-order'?: string[];
+  },
+): string[] {
+  const properties = template.properties ?? {};
+  const declaredOrder = Array.isArray(template['x-field-order'])
+    ? template['x-field-order']
+    : [];
+
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+
+  for (const key of [...declaredOrder, ...Object.keys(properties)]) {
+    if (!seen.has(key) && key in properties) {
+      seen.add(key);
+      ordered.push(key);
+    }
+  }
+
+  return ordered;
+}
+
+/**
+ * A section's members must form one contiguous run in the field order.
+ *
+ * Sections are pure layout, so grouping must never change which field comes
+ * before which. If members were allowed to interleave with non-members, the
+ * renderer would have to choose between reordering fields (breaking
+ * `x-field-order` as the ordering authority) and repeating the section heading.
+ * Neither is a state worth persisting, so it is rejected at the boundary and
+ * the renderer stays simple.
+ *
+ * @throws ValidationError naming the section that is split.
+ */
+export function assertContiguousTemplateSections(
+  template: SectionableTemplate & {
+    properties?: Record<string, XFormatPropertySchema | boolean>;
+    'x-field-order'?: string[];
+  },
+): void {
+  const sectionIds = new Set(
+    getTemplateSections(template).map((section) => section.id),
+  );
+  if (sectionIds.size === 0) {
+    return;
+  }
+
+  const properties = template.properties ?? {};
+  const closedSectionIds = new Set<string>();
+  let openSectionId: string | undefined;
+
+  for (const key of getOrderedFieldKeys(template)) {
+    const definition = properties[key];
+    const declared =
+      typeof definition === 'object' && definition !== null
+        ? getFieldSectionId(definition)
+        : undefined;
+    // An unknown section id degrades to ungrouped, so it also closes a run.
+    const sectionId =
+      declared !== undefined && sectionIds.has(declared) ? declared : undefined;
+
+    if (sectionId === openSectionId) {
+      continue;
+    }
+
+    if (sectionId !== undefined && closedSectionIds.has(sectionId)) {
+      throw new ValidationError(
+        `Section "${sectionId}" is split by other criteria; a section's members must be consecutive in x-field-order`,
+        { [`x-sections.${sectionId}`]: 'Section members must be consecutive' },
+      );
+    }
+
+    if (openSectionId !== undefined) {
+      closedSectionIds.add(openSectionId);
+    }
+    openSectionId = sectionId;
+  }
+}

--- a/packages/common/src/services/decision/types.ts
+++ b/packages/common/src/services/decision/types.ts
@@ -3,6 +3,7 @@ import type { JSONSchema7 } from 'json-schema';
 
 import type { PhaseDefinition } from './schemas/types';
 import type { SelectionPipeline } from './selectionPipeline/types';
+import type { TemplateSection } from './templateSections';
 
 // Base JSON Schema type (more specific than any)
 export type JsonSchema = JSONSchema7;
@@ -42,6 +43,11 @@ export interface XFormatPropertySchema extends JSONSchema7 {
   'x-format'?: XFormat;
   /** Default map camera for `location` fields (see {@link MapDefaultView}). */
   'x-map-default'?: MapDefaultView;
+  /**
+   * Id of the `x-sections` entry this field is displayed under. Purely
+   * presentational — see `templateSections.ts`.
+   */
+  'x-section'?: string;
 }
 
 /** JSON Schema 7 extended with proposal template vendor extensions. */
@@ -49,6 +55,8 @@ export interface ProposalTemplateSchema extends JSONSchema7 {
   [key: string]: unknown;
   properties?: Record<string, XFormatPropertySchema>;
   'x-field-order'?: string[];
+  /** Presentational field groups (see `templateSections.ts`). */
+  'x-sections'?: TemplateSection[];
 }
 
 // ---------------------------------------------------------------------------
@@ -60,6 +68,8 @@ export interface RubricTemplateSchema extends JSONSchema7 {
   [key: string]: unknown;
   properties?: Record<string, XFormatPropertySchema>;
   'x-field-order'?: string[];
+  /** Presentational criterion groups (see `templateSections.ts`). */
+  'x-sections'?: TemplateSection[];
 }
 
 // Process Schema Structure

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -24,6 +24,7 @@ import type {
   PhaseOverride,
 } from './schemas/instanceData';
 import type { ProcessConfig } from './schemas/types';
+import { assertRubricTemplateAuthoring } from './templateAuthoring';
 import type { RubricTemplateSchema } from './types';
 import { updateTransitionsForProcess } from './updateTransitionsForProcess';
 
@@ -96,15 +97,19 @@ export const updateDecisionInstance = async ({
     newEndDate: string;
   }> = [];
 
-  // Validate rubricTemplate is a structurally valid JSON Schema before persisting
+  // Validate rubricTemplate is a structurally valid JSON Schema before
+  // persisting, plus the semantic checks AJV can't express (contiguous
+  // sections).
   if (rubricTemplate !== undefined) {
     schemaValidator.validateJsonSchema(rubricTemplate);
+    assertRubricTemplateAuthoring(rubricTemplate);
   }
 
   // Same validation for phase-level rubric templates (null = clear, skipped)
   for (const phase of phases ?? []) {
     if (phase.rubricTemplate != null) {
       schemaValidator.validateJsonSchema(phase.rubricTemplate);
+      assertRubricTemplateAuthoring(phase.rubricTemplate);
     }
   }
 

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -1,6 +1,7 @@
 import {
   type DecisionInstanceData,
   type RubricTemplateSchema,
+  type XFormatPropertySchema,
 } from '@op/common';
 import { db, eq } from '@op/db/client';
 import { ProcessStatus, processInstances } from '@op/db/schema';
@@ -25,6 +26,47 @@ const createCaller = createCallerFactory(appRouter);
 async function createAuthenticatedCaller(email: string) {
   const { session } = await createIsolatedSession(email);
   return createCaller(await createTestContextWithSession(session));
+}
+
+/** A plain long-text criterion, optionally in a section. */
+function sectionedCriterion(
+  title: string,
+  sectionId?: string,
+): XFormatPropertySchema {
+  return {
+    type: 'string',
+    title,
+    'x-format': 'long-text',
+    ...(sectionId ? { 'x-section': sectionId } : {}),
+  };
+}
+
+/** Rubric with one presentational section holding two criteria. */
+function sectionedRubric(): RubricTemplateSchema {
+  return {
+    type: 'object',
+    'x-sections': [{ id: 'cost', title: 'Total Estimated Cost' }],
+    'x-field-order': ['design', 'construction'],
+    properties: {
+      design: sectionedCriterion('Design & Engineering Cost', 'cost'),
+      construction: sectionedCriterion('Construction', 'cost'),
+    },
+    required: ['design', 'construction'],
+  };
+}
+
+/** Rubric whose one section is split by a non-member criterion. */
+function splitSectionRubric(): RubricTemplateSchema {
+  return {
+    type: 'object',
+    'x-sections': [{ id: 'cost', title: 'Total Estimated Cost' }],
+    'x-field-order': ['design', 'impact', 'construction'],
+    properties: {
+      design: sectionedCriterion('Design', 'cost'),
+      impact: sectionedCriterion('Impact'),
+      construction: sectionedCriterion('Construction', 'cost'),
+    },
+  };
 }
 
 describe.concurrent('updateDecisionInstance', () => {
@@ -898,6 +940,94 @@ describe.concurrent('updateDecisionInstance', () => {
     });
     const afterData = afterInstance!.instanceData as DecisionInstanceData;
     expect(afterData.rubricTemplate).toEqual(beforeData.rubricTemplate);
+  });
+
+  it('accepts a sectioned rubric and persists its x-sections', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.updateDecisionInstance({
+        instanceId: setup.instance.instance.id,
+        rubricTemplate: sectionedRubric(),
+      }),
+    ).resolves.toBeDefined();
+
+    const dbInstance = await db.query.processInstances.findFirst({
+      where: { id: setup.instance.instance.id },
+    });
+    const instanceData = dbInstance!.instanceData as DecisionInstanceData;
+    expect(instanceData.rubricTemplate?.['x-sections']).toEqual([
+      { id: 'cost', title: 'Total Estimated Cost' },
+    ]);
+  });
+
+  it('rejects a section split by another criterion', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const before = await db.query.processInstances.findFirst({
+      where: { id: setup.instance.instance.id },
+    });
+
+    await expect(
+      caller.decision.updateDecisionInstance({
+        instanceId: setup.instance.instance.id,
+        rubricTemplate: splitSectionRubric(),
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
+
+    const after = await db.query.processInstances.findFirst({
+      where: { id: setup.instance.instance.id },
+    });
+    expect(
+      (after!.instanceData as DecisionInstanceData).rubricTemplate,
+    ).toEqual((before!.instanceData as DecisionInstanceData).rubricTemplate);
+  });
+
+  it('applies the same section guard to a per-phase rubric template', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const phases = (
+      (setup.instance.instance.instanceData as DecisionInstanceData).phases ??
+      []
+    ).map((phase) => ({ phaseId: phase.phaseId }));
+    const targetPhaseId = phases[0]?.phaseId;
+    expect(targetPhaseId).toBeDefined();
+
+    await expect(
+      caller.decision.updateDecisionInstance({
+        instanceId: setup.instance.instance.id,
+        phases: [
+          {
+            phaseId: targetPhaseId!,
+            rubricTemplate: splitSectionRubric(),
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
   });
 
   it('should update phases on a published instance when some phases have no dates', async ({


### PR DESCRIPTION
PR B — bottom of the rubric-money-sections stack (split of #1768; B → C → D). PR A (CurrencyField) was cancelled: no new @op/ui components without design approval — the money input in PR C reuses NumberField + prefix.

## What

The pure-presentation grouping mechanism, zero money content:

- `templateSections.ts`: `getTemplateSections`, `getFieldSectionId`, `groupFieldsBySection`, `getOrderedFieldKeys`, `assertContiguousTemplateSections` (+19 unit tests)
- `x-sections` / `x-section` AJV keywords, `TemplateSection` type (no `showTotal` — that's PR D)
- `assertRubricTemplateAuthoring` persistence guard wired into `updateDecisionInstance`, calling only the contiguity assert for now (money + currency asserts arrive in C and D)
- Section grouping rendered in `ReviewRubricForm`, `SubmittedReviewView`, `RubricFormPreviewRenderer` via a shell-only `RubricSection`
- `changeCriterionType` preserves `x-section`

## Invariants

- Sections are layout only: answers, `required`, validation, scoring untouched
- Malformed section entries degrade to ungrouped rendering, never throw
- A split section from a pre-guard template renders one block per run; the guard rejects new persists
- `x-field-order` stays the single ordering authority

## Verification

`pnpm typecheck` green; `templateSections.test.ts` (19) and `rubricTemplate.test.ts` (19) pass; `updateDecisionInstance.test.ts` additions run in CI (supabase harness).