### PR TITLE
feat(decision): flat money rubric criteria

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricCriterionCard.tsx
@@ -21,13 +21,14 @@ import type { TranslationKey } from '@/lib/i18n/routing';
 
 import type {
   CriterionView,
-  RubricCriterionType,
+  EditableRubricCriterionType,
   SelectOption,
 } from '@/components/decisions/rubricTemplate';
 
 import {
   CRITERION_TYPES,
   CRITERION_TYPE_REGISTRY,
+  isEditableRubricCriterionType,
 } from './rubricCriterionRegistry';
 
 // ---------------------------------------------------------------------------
@@ -44,7 +45,10 @@ interface RubricCriterionCardProps {
   onBlur?: (criterionId: string) => void;
   onUpdateLabel?: (criterionId: string, label: string) => void;
   onUpdateDescription?: (criterionId: string, description: string) => void;
-  onChangeType?: (criterionId: string, newType: RubricCriterionType) => void;
+  onChangeType?: (
+    criterionId: string,
+    newType: EditableRubricCriterionType,
+  ) => void;
   onUpdateMaxPoints?: (criterionId: string, maxPoints: number) => void;
   onUpdateScoreLabel?: (
     criterionId: string,
@@ -90,6 +94,14 @@ export function RubricCriterionCard({
   const cardRef = useRef<HTMLDivElement>(null);
 
   const displayLabel = criterion.label || t('Untitled field');
+
+  // Money criteria come from the process template, not this editor. Show them
+  // as an inert card so they stay visible (and keep their slot in
+  // `x-field-order` when other criteria are reordered) without pretending to
+  // be editable.
+  if (criterion.criterionType === 'money') {
+    return <MoneyCriterionCard criterion={criterion} label={displayLabel} />;
+  }
 
   const badgeLabel =
     criterion.criterionType === 'scored' && criterion.maxPoints
@@ -235,6 +247,40 @@ export function RubricCriterionCard({
 }
 
 // ---------------------------------------------------------------------------
+// Money criterion (read-only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Inert card for a template-authored money criterion: label, currency, and a
+ * note that it is set by the process template. No type selector, no delete,
+ * no required toggle — editing money criteria is not supported in the builder.
+ */
+function MoneyCriterionCard({
+  criterion,
+  label,
+}: {
+  criterion: CriterionView;
+  label: string;
+}) {
+  const t = useTranslations();
+
+  return (
+    <CollapsibleConfigCard
+      label={label}
+      badgeLabel={t(CRITERION_TYPE_REGISTRY.money.labelKey)}
+      locked
+    >
+      <div className="space-y-1 px-8 text-sm text-neutral-gray4">
+        <p>{t('Set by the process template and cannot be edited here.')}</p>
+        {criterion.currency && (
+          <p>{t('Currency: {code}', { code: criterion.currency })}</p>
+        )}
+      </div>
+    </CollapsibleConfigCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Criterion type radio selector
 // ---------------------------------------------------------------------------
 
@@ -242,8 +288,8 @@ function CriterionTypeSelector({
   value,
   onChange,
 }: {
-  value: RubricCriterionType;
-  onChange: (type: RubricCriterionType) => void;
+  value: string;
+  onChange: (type: EditableRubricCriterionType) => void;
 }) {
   const t = useTranslations();
 
@@ -251,7 +297,12 @@ function CriterionTypeSelector({
     <RadioGroup
       label={t('How should reviewers score this?')}
       value={value}
-      onChange={(newValue) => onChange(newValue as RubricCriterionType)}
+      onChange={(newValue) => {
+        // The radio's value is a string; only forward one the model accepts.
+        if (isEditableRubricCriterionType(newValue)) {
+          onChange(newValue);
+        }
+      }}
       orientation="vertical"
       labelClassName="text-base"
     >

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricEditorContent.tsx
@@ -24,7 +24,7 @@ import type { SectionProps } from '@/components/decisions/ProcessBuilder/content
 import { useProcessBuilderStore } from '@/components/decisions/ProcessBuilder/stores/useProcessBuilderStore';
 import type {
   CriterionView,
-  RubricCriterionType,
+  EditableRubricCriterionType,
   SelectOption,
 } from '@/components/decisions/rubricTemplate';
 import {
@@ -198,7 +198,7 @@ export function RubricEditorContent({
   );
 
   const handleChangeType = useCallback(
-    (criterionId: string, newType: RubricCriterionType) => {
+    (criterionId: string, newType: EditableRubricCriterionType) => {
       setTemplate((prev) => {
         // Stash scored config before switching away from scored
         if (getCriterionType(prev, criterionId) === 'scored') {

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/RubricFormPreviewRenderer.tsx
@@ -131,6 +131,22 @@ function RubricField({ field }: { field: FieldDescriptor }) {
       );
     }
 
+    case 'money': {
+      // Template-authored (not editable in the builder); shown so the criterion
+      // never silently vanishes from the participant preview.
+      return (
+        <div className="flex flex-col gap-3">
+          <FieldHeader
+            title={schema.title}
+            description={schema.description}
+            required={field.required}
+            className="gap-1"
+          />
+          <div className="min-h-8 text-neutral-gray3">{t('Amount')}</div>
+        </div>
+      );
+    }
+
     case 'short-text':
     case 'long-text': {
       return (

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/rubricCriterionRegistry.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/rubricCriterionRegistry.tsx
@@ -1,6 +1,9 @@
 import type { TranslationKey } from '@/lib/i18n/routing';
 
-import type { RubricCriterionType } from '@/components/decisions/rubricTemplate';
+import type {
+  EditableRubricCriterionType,
+  RubricCriterionType,
+} from '@/components/decisions/rubricTemplate';
 
 /**
  * Display metadata for each rubric criterion type.
@@ -33,14 +36,27 @@ export const CRITERION_TYPE_REGISTRY: Record<
     labelKey: 'Text response only',
     descriptionKey: 'No score, just written feedback',
   },
+  money: {
+    labelKey: 'Cost estimate',
+    descriptionKey: 'Reviewers enter an amount',
+  },
 };
 
 /**
- * Ordered list of criterion types for the radio selector.
+ * Ordered list of criterion types offered in the radio selector. Money
+ * criteria are template-authored, so they are not offered here — see
+ * {@link EditableRubricCriterionType}.
  */
-export const CRITERION_TYPES: RubricCriterionType[] = [
+export const CRITERION_TYPES: EditableRubricCriterionType[] = [
   'scored',
   'yes_no',
   'single_select',
   'long_text',
 ];
+
+/** Runtime predicate for the types the builder is allowed to assign. */
+export function isEditableRubricCriterionType(
+  value: string,
+): value is EditableRubricCriterionType {
+  return CRITERION_TYPES.some((type) => type === value);
+}

--- a/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormContext.tsx
@@ -228,7 +228,15 @@ function ReviewFormProviderInner({
 
   const handleValueChange = useCallback(
     (key: string, value: unknown) => {
-      setValues((current) => ({ ...current, [key]: value }));
+      setValues((current) => {
+        // `undefined` means "unanswered": drop the key so an optional
+        // criterion validates as absent rather than as a malformed value.
+        if (value === undefined) {
+          const { [key]: _cleared, ...rest } = current;
+          return rest;
+        }
+        return { ...current, [key]: value };
+      });
       scheduleAutosave();
     },
     [scheduleAutosave],

--- a/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewFormShell.tsx
@@ -31,7 +31,15 @@ export function TotalScoreCard({
   const criteria = getCriteria(rubricTemplate);
   const { totalPoints } = getRubricScoringInfo(rubricTemplate);
 
+  // Only scored criteria contribute points. Gating on `criterionType` rather
+  // than "is the answer a number" keeps non-scored numeric answers (money
+  // amounts) out of the displayed score, matching the backend, which sums
+  // over `scoredCriterionKeys`.
   const totalScore = criteria.reduce<number | null>((total, criterion) => {
+    if (criterion.criterionType !== 'scored') {
+      return total;
+    }
+
     const value = values[criterion.id];
 
     if (typeof value !== 'number') {

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -2,21 +2,27 @@
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import {
+  DEFAULT_MONEY_CURRENCY,
   ProposalReviewState,
   type TemplateSectionBlock,
   type XFormatPropertySchema,
+  buildMoneyFieldAnswer,
+  getMoneyAnswerAmount,
+  getMoneyFieldCurrency,
   groupFieldsBySection,
   isOverallRecommendationField,
+  isSchemaObjectDefinition,
   parseSchemaOptions,
 } from '@op/common/client';
 import { AlertBanner } from '@op/ui/AlertBanner';
 import { Button } from '@op/ui/Button';
+import { NumberField } from '@op/ui/NumberField';
 import { Radio, RadioGroup } from '@op/ui/RadioGroup';
 import { Select, SelectItem } from '@op/ui/Select';
 import { TextField } from '@op/ui/TextField';
 import { ToggleButton } from '@op/ui/ToggleButton';
 import type { Key, ReactNode } from 'react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { LuCircleAlert, LuPlus } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
@@ -262,7 +268,16 @@ function RubricCriterionSection({
 
   return (
     <section className="flex flex-col gap-4 border-b border-neutral-gray1 pb-6">
-      {criterionType === 'yes_no' ? (
+      {criterionType === 'money' ? (
+        // The money label carries its own required marker, so it uses the
+        // input's label slot instead of the serif FieldHeader.
+        <MoneyFieldInput
+          field={field}
+          value={value}
+          onChange={onChange}
+          isRequired={field.required ?? false}
+        />
+      ) : criterionType === 'yes_no' ? (
         <>
           <FieldHeader
             title={field.schema.title}
@@ -345,6 +360,52 @@ function RubricRationaleField({
         textareaProps={{ placeholder, rows: 3, className: 'min-h-20' }}
       />
     </div>
+  );
+}
+
+/**
+ * Amount input for a money criterion. The currency comes from the template
+ * (never from the reviewer) and is materialized into the stored answer at fill
+ * time, so a submitted review stays self-describing. Clearing the input drops
+ * the answer key entirely rather than storing a currency-only object.
+ *
+ * The input is `@op/ui` NumberField with the currency symbol as a decorative
+ * prefix — the same pattern as proposal budget entry
+ * (`CollaborativeBudgetField`), including its ASCII-only parsing.
+ */
+function MoneyFieldInput({
+  field,
+  value,
+  onChange,
+  isRequired,
+}: {
+  field: FieldDescriptor;
+  value: unknown;
+  onChange: (value: unknown) => void;
+  isRequired: boolean;
+}) {
+  // The field shows the currency that *will be stored*, i.e. the template's,
+  // not whatever a stale draft happens to carry.
+  const currency =
+    getMoneyFieldCurrency(field.schema) ?? DEFAULT_MONEY_CURRENCY;
+  const currencySymbol = useMemo(() => getCurrencySymbol(currency), [currency]);
+
+  return (
+    <NumberField
+      label={field.schema.title}
+      description={field.schema.description}
+      isRequired={isRequired}
+      prefixText={currencySymbol}
+      value={getMoneyAnswerAmount(value)}
+      minValue={getMoneyFieldMinimum(field.schema)}
+      onChange={(next) =>
+        onChange(
+          next === null ? undefined : buildMoneyFieldAnswer(next, field.schema),
+        )
+      }
+      labelClassName="font-semibold text-neutral-black"
+      className="w-full"
+    />
   );
 }
 
@@ -530,4 +591,29 @@ function parseSelectedValue(
   }
 
   return value;
+}
+
+/**
+ * Currency symbol for the input prefix, derived through Intl (never a
+ * hand-rolled symbol map) — the same derivation as `CollaborativeBudgetField`.
+ */
+function getCurrencySymbol(currency: string): string {
+  return (0)
+    .toLocaleString(undefined, {
+      style: 'currency',
+      currency,
+      currencyDisplay: 'narrowSymbol',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })
+    .replace(/\d/g, '')
+    .trim();
+}
+
+/** Declared `amount.minimum`, when the money schema is well-formed. */
+function getMoneyFieldMinimum(
+  schema: XFormatPropertySchema,
+): number | undefined {
+  const amount = schema.properties?.amount;
+  return isSchemaObjectDefinition(amount) ? amount.minimum : undefined;
 }

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -3,9 +3,12 @@ import {
   type RubricTemplateSchema,
   type TemplateSectionBlock,
   findSchemaOption,
+  getMoneyAnswerAmount,
   groupFieldsBySection,
   isOverallRecommendationField,
+  resolveMoneyDisplayCurrency,
 } from '@op/common/client';
+import { useFormatter } from 'next-intl';
 import type { ReactNode } from 'react';
 
 import { useTranslations } from '@/lib/i18n';
@@ -167,6 +170,26 @@ function RubricFieldResult({
   rationale?: string;
 }) {
   const t = useTranslations();
+  const format = useFormatter();
+
+  if (inferCriterionType(field.schema) === 'money') {
+    const amount = getMoneyAnswerAmount(value);
+    return (
+      <ResultCard
+        value={
+          amount === null
+            ? '—'
+            : // Currency formatting goes through the i18n stack — never a
+              // hand-rolled symbol map.
+              format.number(amount, {
+                style: 'currency',
+                currency: resolveMoneyDisplayCurrency(value, field.schema),
+              })
+        }
+        description={rationale}
+      />
+    );
+  }
 
   if (field.format === 'dropdown') {
     if (inferCriterionType(field.schema) === 'yes_no') {

--- a/apps/app/src/components/decisions/rubricTemplate.test.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.test.ts
@@ -1,7 +1,8 @@
+import type { XFormatPropertySchema } from '@op/common/client';
 import { describe, expect, it } from 'vitest';
 
 import type {
-  RubricCriterionType,
+  EditableRubricCriterionType,
   RubricTemplateSchema,
 } from './rubricTemplate';
 import {
@@ -11,16 +12,18 @@ import {
   createEmptyRubricTemplate,
   getCriteria,
   getCriterion,
+  getCriterionErrors,
   getCriterionOptions,
   getCriterionType,
   inferCriterionType,
+  reorderCriteria,
   setCriterionRequired,
+  updateCriterionJsonSchema,
   setSelectOptions,
   updateCriterionDescription,
-  updateCriterionJsonSchema,
 } from './rubricTemplate';
 
-const ALL_TYPES: RubricCriterionType[] = [
+const ALL_TYPES: EditableRubricCriterionType[] = [
   'scored',
   'yes_no',
   'single_select',
@@ -28,7 +31,7 @@ const ALL_TYPES: RubricCriterionType[] = [
 ];
 
 function templateWithCriterion(
-  type: RubricCriterionType,
+  type: EditableRubricCriterionType,
   criterionId = 'crit1',
 ): RubricTemplateSchema {
   return addCriterion(createEmptyRubricTemplate(), criterionId, type, 'Label');
@@ -278,8 +281,90 @@ describe('getCriteria', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Money criteria (template-authored, not creatable in the builder)
+// ---------------------------------------------------------------------------
+
+const MONEY_SCHEMA: XFormatPropertySchema = {
+  type: 'object',
+  title: 'Design & Engineering Cost',
+  'x-format': 'money',
+  properties: {
+    amount: { type: 'number', minimum: 0 },
+    currency: { type: 'string', const: 'USD', default: 'USD' },
+  },
+  required: ['amount', 'currency'],
+  additionalProperties: false,
+};
+
+function templateWithMoneyCriterion(): RubricTemplateSchema {
+  let template = createEmptyRubricTemplate();
+  template = addCriterion(template, 'scored1', 'scored', 'Impact');
+  template = {
+    ...template,
+    properties: { ...template.properties, cost1: { ...MONEY_SCHEMA } },
+    'x-field-order': [...(template['x-field-order'] ?? []), 'cost1'],
+  };
+  return setCriterionRequired(template, 'cost1', true);
+}
+
+describe('money criteria', () => {
+  it('infers the money type from the declared x-format', () => {
+    expect(inferCriterionType({ ...MONEY_SCHEMA })).toBe('money');
+  });
+
+  it('does not reclassify an object criterion without the declaration', () => {
+    expect(
+      inferCriterionType({
+        type: 'object',
+        properties: { amount: { type: 'number' } },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('surfaces money criteria in getCriteria with their pinned currency', () => {
+    const criteria = getCriteria(templateWithMoneyCriterion());
+    const money = criteria.find((c) => c.id === 'cost1');
+
+    expect(criteria.map((c) => c.id)).toEqual(['scored1', 'cost1']);
+    expect(money?.criterionType).toBe('money');
+    expect(money?.label).toBe('Design & Engineering Cost');
+    expect(money?.required).toBe(true);
+    expect(money?.currency).toBe('USD');
+    expect(money?.maxPoints).toBeUndefined();
+    expect(money?.options).toEqual([]);
+  });
+
+  it('reports no builder validation errors for a money criterion', () => {
+    const money = getCriteria(templateWithMoneyCriterion()).find(
+      (c) => c.id === 'cost1',
+    );
+
+    expect(money && getCriterionErrors(money)).toEqual([]);
+  });
+
+  it('refuses to change a money criterion into an editable type', () => {
+    const template = templateWithMoneyCriterion();
+
+    expect(changeCriterionType(template, 'cost1', 'scored')).toBe(template);
+    expect(getCriterionType(template, 'cost1')).toBe('money');
+  });
+
+  it('keeps money criteria in x-field-order when other criteria are reordered', () => {
+    const template = templateWithMoneyCriterion();
+    const reordered = reorderCriteria(
+      template,
+      getCriteria(template)
+        .map((c) => c.id)
+        .reverse(),
+    );
+
+    expect(reordered['x-field-order']).toEqual(['cost1', 'scored1']);
+  });
+});
+
 describe('section membership under type changes', () => {
-  it('keeps x-section when a criterion changes type', () => {
+  it('keeps x-section when an editable criterion changes type', () => {
     let template = createEmptyRubricTemplate();
     template = addCriterion(template, 'crit1', 'scored', 'Impact');
     template = updateCriterionJsonSchema(template, 'crit1', {

--- a/apps/app/src/components/decisions/rubricTemplate.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.ts
@@ -16,6 +16,8 @@ import type {
 import {
   OVERALL_RECOMMENDATION_KEY,
   RECOMMENDATION_OPTION,
+  getMoneyFieldCurrency,
+  isMoneyFieldSchema,
   isOverallRecommendationField,
 } from '@op/common/client';
 import type { JSONSchema7 } from 'json-schema';
@@ -44,11 +46,24 @@ export type { RubricTemplateSchema };
 // Criterion types
 // ---------------------------------------------------------------------------
 
-export type RubricCriterionType =
+/**
+ * Criterion types the rubric builder can create and switch between.
+ */
+export type EditableRubricCriterionType =
   | 'scored'
   | 'yes_no'
   | 'single_select'
   | 'long_text';
+
+/**
+ * Every criterion type the renderer understands.
+ *
+ * `money` is template-authored only (seeded / per-phase templates), so it is
+ * deliberately outside {@link EditableRubricCriterionType}: the creation and
+ * type-change APIs cannot produce one, and the builder shows it as an inert
+ * read-only card instead of dropping it.
+ */
+export type RubricCriterionType = EditableRubricCriterionType | 'money';
 
 /** A single admin-defined option on a single-select criterion. */
 export interface SelectOption {
@@ -80,6 +95,8 @@ export interface CriterionView {
   scoreLabels: string[];
   /** Admin-defined options. Single-select criteria only (empty for other types). */
   options: SelectOption[];
+  /** Template-pinned currency. Money criteria only. */
+  currency?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -130,7 +147,7 @@ function getSelectOptionEntries(schema: XFormatPropertySchema): SelectOption[] {
  * Callers with i18n access pass translated labels (e.g. Yes/Maybe/No).
  */
 export function createCriterionJsonSchema(
-  type: RubricCriterionType,
+  type: EditableRubricCriterionType,
   selectOptionLabels?: string[],
 ): XFormatPropertySchema {
   switch (type) {
@@ -187,6 +204,12 @@ export function inferCriterionType(
   schema: XFormatPropertySchema,
 ): RubricCriterionType | undefined {
   const xFormat = schema['x-format'];
+
+  // Money is *declared*, never inferred from shape — the legacy structural
+  // inference below stays untouched.
+  if (isMoneyFieldSchema(schema)) {
+    return 'money';
+  }
 
   if (xFormat === 'long-text') {
     return 'long_text';
@@ -323,6 +346,9 @@ export function getCriterion(
     return undefined;
   }
 
+  const schema = getCriterionSchema(template, criterionId);
+  const currency = schema ? getMoneyFieldCurrency(schema) : undefined;
+
   return {
     id: criterionId,
     criterionType,
@@ -332,6 +358,7 @@ export function getCriterion(
     maxPoints: getCriterionMaxPoints(template, criterionId),
     scoreLabels: getCriterionScoreLabels(template, criterionId),
     options: getCriterionOptions(template, criterionId),
+    ...(currency !== undefined ? { currency } : {}),
   };
 }
 
@@ -382,7 +409,7 @@ export function getCriterionErrors(criterion: CriterionView): TranslationKey[] {
 export function addCriterion(
   template: RubricTemplateSchema,
   criterionId: string,
-  type: RubricCriterionType,
+  type: EditableRubricCriterionType,
   label: string,
   selectOptionLabels?: string[],
 ): RubricTemplateSchema {
@@ -434,13 +461,20 @@ export function setCriterionRequired(
 /**
  * Change a criterion's type while preserving its label, description, and
  * required status. The schema is rebuilt from scratch for the new type.
+ *
+ * Money criteria are template-authored and not editable here: switching one
+ * would drop its `x-format`/currency pin, so the call is a no-op.
  */
 export function changeCriterionType(
   template: RubricTemplateSchema,
   criterionId: string,
-  newType: RubricCriterionType,
+  newType: EditableRubricCriterionType,
   selectOptionLabels?: string[],
 ): RubricTemplateSchema {
+  if (getCriterionType(template, criterionId) === 'money') {
+    return template;
+  }
+
   return updateProperty(template, criterionId, (existing) => {
     const newSchema: XFormatPropertySchema = {
       ...createCriterionJsonSchema(newType, selectOptionLabels),

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1437,5 +1437,10 @@
   "Reviewers can see each other's reviews on a proposal": "يمكن للمراجعين رؤية مراجعات بعضهم البعض على المقترح",
   "Turn on Open Reviews?": "تفعيل المراجعات المفتوحة؟",
   "This can lead reviewers to agree with each other more than they would independently.": "قد يؤدي ذلك إلى اتفاق المراجعين مع بعضهم البعض أكثر مما لو كانوا مستقلين.",
-  "Enable": "تفعيل"
+  "Enable": "تفعيل",
+  "Amount": "المبلغ",
+  "Cost estimate": "تقدير التكلفة",
+  "Reviewers enter an amount": "يُدخل المراجعون مبلغًا",
+  "Set by the process template and cannot be edited here.": "مُحدَّد من قالب العملية ولا يمكن تعديله هنا.",
+  "Currency: {code}": "العملة: {code}"
 }

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1440,5 +1440,10 @@
   "Reviewers can see each other's reviews on a proposal": "পর্যালোচকরা একটি প্রস্তাবে একে অপরের পর্যালোচনা দেখতে পারেন",
   "Turn on Open Reviews?": "উন্মুক্ত পর্যালোচনা চালু করবেন?",
   "This can lead reviewers to agree with each other more than they would independently.": "এটি পর্যালোচকদের স্বাধীনভাবে যতটা একমত হতেন তার চেয়ে বেশি একে অপরের সাথে একমত হতে পরিচালিত করতে পারে।",
-  "Enable": "চালু করুন"
+  "Enable": "চালু করুন",
+  "Amount": "পরিমাণ",
+  "Cost estimate": "ব্যয়ের প্রাক্কলন",
+  "Reviewers enter an amount": "পর্যালোচকরা একটি পরিমাণ লিখবেন",
+  "Set by the process template and cannot be edited here.": "প্রক্রিয়া টেমপ্লেট দ্বারা নির্ধারিত, এখানে সম্পাদনা করা যাবে না।",
+  "Currency: {code}": "মুদ্রা: {code}"
 }

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1503,5 +1503,10 @@
   "Voting (max {count} per member)": "Voting (max {count} per member)",
   "Vote editing": "Vote editing",
   "Advances manually": "Advances manually",
-  "Advances by date": "Advances by date"
+  "Advances by date": "Advances by date",
+  "Amount": "Amount",
+  "Cost estimate": "Cost estimate",
+  "Reviewers enter an amount": "Reviewers enter an amount",
+  "Set by the process template and cannot be edited here.": "Set by the process template and cannot be edited here.",
+  "Currency: {code}": "Currency: {code}"
 }

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1437,5 +1437,10 @@
   "Reviewers can see each other's reviews on a proposal": "Las personas revisoras pueden ver las revisiones de las demás en una propuesta",
   "Turn on Open Reviews?": "¿Activar las revisiones abiertas?",
   "This can lead reviewers to agree with each other more than they would independently.": "Esto puede llevar a que las personas revisoras estén de acuerdo entre sí más de lo que lo harían de forma independiente.",
-  "Enable": "Activar"
+  "Enable": "Activar",
+  "Amount": "Importe",
+  "Cost estimate": "Estimación de costes",
+  "Reviewers enter an amount": "Las personas revisoras introducen un importe",
+  "Set by the process template and cannot be edited here.": "Definido por la plantilla del proceso; no se puede editar aquí.",
+  "Currency: {code}": "Moneda: {code}"
 }

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1437,5 +1437,10 @@
   "Reviewers can see each other's reviews on a proposal": "Les évaluateurs peuvent voir les évaluations des autres sur une proposition",
   "Turn on Open Reviews?": "Activer les évaluations ouvertes ?",
   "This can lead reviewers to agree with each other more than they would independently.": "Cela peut amener les évaluateurs à être davantage d’accord entre eux qu’ils ne le seraient de manière indépendante.",
-  "Enable": "Activer"
+  "Enable": "Activer",
+  "Amount": "Montant",
+  "Cost estimate": "Estimation des coûts",
+  "Reviewers enter an amount": "Les évaluateurs saisissent un montant",
+  "Set by the process template and cannot be edited here.": "Défini par le modèle du processus et non modifiable ici.",
+  "Currency: {code}": "Devise : {code}"
 }

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1437,5 +1437,10 @@
   "Reviewers can see each other's reviews on a proposal": "Os avaliadores podem ver as avaliações uns dos outros em uma proposta",
   "Turn on Open Reviews?": "Ativar avaliações abertas?",
   "This can lead reviewers to agree with each other more than they would independently.": "Isso pode levar os avaliadores a concordarem mais uns com os outros do que fariam de forma independente.",
-  "Enable": "Ativar"
+  "Enable": "Ativar",
+  "Amount": "Valor",
+  "Cost estimate": "Estimativa de custo",
+  "Reviewers enter an amount": "Os avaliadores inserem um valor",
+  "Set by the process template and cannot be edited here.": "Definido pelo modelo do processo e não editável aqui.",
+  "Currency: {code}": "Moeda: {code}"
 }

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1439,5 +1439,10 @@
   "Reviewers can see each other's reviews on a proposal": "Dib-u-eegayaashu waxay ku arki karaan dib-u-eegisyada midba midka kale ee soo jeedin",
   "Turn on Open Reviews?": "Shid dib-u-eegisyada furan?",
   "This can lead reviewers to agree with each other more than they would independently.": "Tani waxay u horseedi kartaa in dib-u-eegayaashu isku raacaan midba midka kale in ka badan intii ay si madax-bannaan u samayn lahaayeen.",
-  "Enable": "Shid"
+  "Enable": "Shid",
+  "Amount": "Qadarka",
+  "Cost estimate": "Qiyaasta qiimaha",
+  "Reviewers enter an amount": "Dib-u-eegayaashu waxay gelinayaan qadar",
+  "Set by the process template and cannot be edited here.": "Waxaa lagu dejiyay qaabka habraaca, halkan lagama beddeli karo.",
+  "Currency: {code}": "Lacagta: {code}"
 }

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -122,8 +122,8 @@ export {
   templateCollectsLocation,
   getLocationFieldMapView,
 } from './services/decision/templateLocation';
-// Presentational field grouping. Template-level concepts (not rubric-specific)
-// so proposal templates can adopt them later.
+// Presentational field grouping + money fields. Template-level concepts (not
+// rubric-specific) so proposal templates can adopt them later.
 export {
   TEMPLATE_SECTIONS_KEY,
   TEMPLATE_SECTION_KEY,
@@ -137,6 +137,19 @@ export {
   type SectionableField,
 } from './services/decision/templateSections';
 export { assertRubricTemplateAuthoring } from './services/decision/templateAuthoring';
+export {
+  DEFAULT_MONEY_CURRENCY,
+  assertMoneyFieldSchemas,
+  isSchemaObjectDefinition,
+  buildMoneyFieldAnswer,
+  getMoneyAnswerAmount,
+  getMoneyAnswerCurrency,
+  getMoneyFieldCurrency,
+  isMoneyFieldSchema,
+  isValidCurrencyCode,
+  resolveMoneyDisplayCurrency,
+  type MoneyFieldAnswer,
+} from './services/decision/templateMoney';
 export { assembleProposalData } from './services/decision/assembleProposalData';
 export { relaxLocationCategoryRequirement } from './services/decision/relaxLocationCategoryRequirement';
 export {

--- a/packages/common/src/services/decision/index.ts
+++ b/packages/common/src/services/decision/index.ts
@@ -116,6 +116,7 @@ export * from './listBoundaryShapes';
 export * from './reverseGeocode';
 export * from './templateLocation';
 export * from './templateSections';
+export * from './templateMoney';
 export * from './templateAuthoring';
 export * from './extractProposalText';
 export * from './resolveProposalTemplate';

--- a/packages/common/src/services/decision/templateAuthoring.ts
+++ b/packages/common/src/services/decision/templateAuthoring.ts
@@ -4,11 +4,13 @@
  * AJV answers "is this a compilable JSON Schema, and does this data satisfy
  * it". It cannot answer "will the form this schema describes actually work".
  * Vendor keys carry no shape schema of their own, so anything a client sends
- * under `x-sections` / `x-section` would otherwise persist unchecked and
- * surface as a broken form.
+ * under `x-format` / `x-sections` / `x-section` would otherwise persist
+ * unchecked and surface as a broken form — or worse, a submittable one that
+ * stores something the model forbids.
  *
  * These run at the persistence boundary, next to `validateJsonSchema`.
  */
+import { assertMoneyFieldSchemas } from './templateMoney';
 import type { SectionableTemplate } from './templateSections';
 import { assertContiguousTemplateSections } from './templateSections';
 import type { XFormatPropertySchema } from './types';
@@ -27,5 +29,6 @@ type AuthorableTemplate = SectionableTemplate & {
 export function assertRubricTemplateAuthoring(
   template: AuthorableTemplate,
 ): void {
+  assertMoneyFieldSchemas(template);
   assertContiguousTemplateSections(template);
 }

--- a/packages/common/src/services/decision/templateMoney.test.ts
+++ b/packages/common/src/services/decision/templateMoney.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+
+import { ValidationError } from '../../utils';
+import { SchemaValidator } from './schemaValidator';
+import {
+  assertMoneyFieldSchemas,
+  buildMoneyFieldAnswer,
+  getMoneyAnswerAmount,
+  getMoneyAnswerCurrency,
+  getMoneyFieldCurrency,
+  isMoneyFieldSchema,
+  isValidCurrencyCode,
+  resolveMoneyDisplayCurrency,
+} from './templateMoney';
+import type { RubricTemplateSchema, XFormatPropertySchema } from './types';
+
+function moneySchema({
+  title = 'Cost',
+  currency = 'USD',
+}: {
+  title?: string;
+  currency?: string | null;
+} = {}): XFormatPropertySchema {
+  return {
+    type: 'object',
+    title,
+    'x-format': 'money',
+    properties: {
+      amount: { type: 'number', minimum: 0 },
+      ...(currency
+        ? { currency: { type: 'string', const: currency, default: currency } }
+        : {}),
+    },
+    required: currency ? ['amount', 'currency'] : ['amount'],
+    additionalProperties: false,
+  };
+}
+
+describe('isMoneyFieldSchema', () => {
+  it('detects a money field only from the declared x-format', () => {
+    expect(isMoneyFieldSchema(moneySchema())).toBe(true);
+    // Same object shape, no declaration — deliberately not a money field.
+    expect(
+      isMoneyFieldSchema({ type: 'object', properties: { amount: {} } }),
+    ).toBe(false);
+    expect(isMoneyFieldSchema({ type: 'integer', maximum: 5 })).toBe(false);
+  });
+});
+
+describe('getMoneyFieldCurrency', () => {
+  it('prefers const, then default', () => {
+    expect(getMoneyFieldCurrency(moneySchema({ currency: 'EUR' }))).toBe('EUR');
+    expect(
+      getMoneyFieldCurrency({
+        'x-format': 'money',
+        properties: { currency: { type: 'string', default: 'GBP' } },
+      }),
+    ).toBe('GBP');
+  });
+
+  it('is undefined when no currency is declared or the code is malformed', () => {
+    expect(
+      getMoneyFieldCurrency(moneySchema({ currency: null })),
+    ).toBeUndefined();
+    expect(
+      getMoneyFieldCurrency({
+        'x-format': 'money',
+        properties: { currency: { type: 'string', const: 'DOLLARS' } },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('answer readers', () => {
+  it('reads a well-formed answer', () => {
+    expect(getMoneyAnswerAmount({ amount: 1200.5, currency: 'USD' })).toBe(
+      1200.5,
+    );
+    expect(getMoneyAnswerCurrency({ amount: 1, currency: 'eur' })).toBe('eur');
+  });
+
+  it('tolerates the partial / malformed shapes unvalidated drafts allow', () => {
+    for (const value of [
+      undefined,
+      null,
+      'nope',
+      42,
+      [],
+      {},
+      { amount: '12' },
+      { amount: Number.NaN },
+      { currency: 'USD' },
+    ]) {
+      expect(getMoneyAnswerAmount(value)).toBeNull();
+    }
+    expect(
+      getMoneyAnswerCurrency({ amount: 1, currency: 'US$' }),
+    ).toBeUndefined();
+    expect(getMoneyAnswerCurrency({ amount: 1 })).toBeUndefined();
+  });
+
+  it('guards Intl against malformed stored currency codes', () => {
+    const schema = moneySchema({ currency: 'EUR' });
+    expect(
+      resolveMoneyDisplayCurrency({ amount: 1, currency: '!!' }, schema),
+    ).toBe('EUR');
+    expect(
+      resolveMoneyDisplayCurrency({ amount: 1, currency: 'GBP' }, schema),
+    ).toBe('GBP');
+    // No template currency either → the documented fallback.
+    expect(resolveMoneyDisplayCurrency({}, { 'x-format': 'money' })).toBe(
+      'USD',
+    );
+  });
+
+  it('isValidCurrencyCode accepts three letters only', () => {
+    expect(isValidCurrencyCode('usd')).toBe(true);
+    expect(isValidCurrencyCode('US')).toBe(false);
+    expect(isValidCurrencyCode('USDD')).toBe(false);
+    expect(isValidCurrencyCode(12)).toBe(false);
+  });
+});
+
+describe('buildMoneyFieldAnswer', () => {
+  it('materializes the template currency at fill time', () => {
+    expect(
+      buildMoneyFieldAnswer(500, moneySchema({ currency: 'CAD' })),
+    ).toEqual({
+      amount: 500,
+      currency: 'CAD',
+    });
+  });
+
+  it('falls back to USD when the template declares no currency', () => {
+    expect(buildMoneyFieldAnswer(1, { 'x-format': 'money' })).toEqual({
+      amount: 1,
+      currency: 'USD',
+    });
+  });
+});
+
+describe('assertMoneyFieldSchemas', () => {
+  function template(schema: XFormatPropertySchema): RubricTemplateSchema {
+    return { type: 'object', properties: { cost: schema } };
+  }
+
+  it('accepts the canonical money shape', () => {
+    expect(() =>
+      assertMoneyFieldSchemas(template(moneySchema())),
+    ).not.toThrow();
+  });
+
+  it('ignores properties that do not declare x-format money', () => {
+    expect(() =>
+      assertMoneyFieldSchemas(
+        template({ type: 'object', properties: { amount: {} } }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('ignores boolean subschemas', () => {
+    expect(() =>
+      assertMoneyFieldSchemas({
+        type: 'object',
+        properties: { blocked: false },
+      }),
+    ).not.toThrow();
+  });
+
+  // Each omission below would persist a template whose money input either
+  // cannot be submitted or can store something the model forbids.
+  const unsafe: Array<[string, XFormatPropertySchema]> = [
+    ['a non-object type', { ...moneySchema(), type: 'number' }],
+    [
+      'a missing additionalProperties:false (a stored total becomes possible)',
+      { ...moneySchema(), additionalProperties: undefined },
+    ],
+    [
+      'additionalProperties:true',
+      { ...moneySchema(), additionalProperties: true },
+    ],
+    ['an unrequired amount', { ...moneySchema(), required: ['currency'] }],
+    ['an unrequired currency', { ...moneySchema(), required: ['amount'] }],
+    [
+      'a missing amount property',
+      {
+        ...moneySchema(),
+        properties: {
+          currency: { type: 'string', const: 'USD', default: 'USD' },
+        },
+      },
+    ],
+    [
+      'an integer amount',
+      {
+        ...moneySchema(),
+        properties: {
+          amount: { type: 'integer', minimum: 0 },
+          currency: { type: 'string', const: 'USD', default: 'USD' },
+        },
+      },
+    ],
+    [
+      'an amount without minimum 0',
+      {
+        ...moneySchema(),
+        properties: {
+          amount: { type: 'number' },
+          currency: { type: 'string', const: 'USD', default: 'USD' },
+        },
+      },
+    ],
+    [
+      'a missing currency property (the renderer would store an extra key)',
+      moneySchema({ currency: null }),
+    ],
+    [
+      'a missing currency const',
+      {
+        ...moneySchema(),
+        properties: {
+          amount: { type: 'number', minimum: 0 },
+          currency: { type: 'string', default: 'USD' },
+        },
+      },
+    ],
+    [
+      'a currency const that is not a valid ISO code',
+      {
+        ...moneySchema(),
+        properties: {
+          amount: { type: 'number', minimum: 0 },
+          currency: { type: 'string', const: 'US$', default: 'US$' },
+        },
+      },
+    ],
+    [
+      'a currency default disagreeing with its const',
+      {
+        ...moneySchema(),
+        properties: {
+          amount: { type: 'number', minimum: 0 },
+          currency: { type: 'string', const: 'USD', default: 'EUR' },
+        },
+      },
+    ],
+  ];
+
+  it.each(unsafe)('rejects %s', (_label, schema) => {
+    expect(() => assertMoneyFieldSchemas(template(schema))).toThrow(
+      ValidationError,
+    );
+  });
+});
+
+describe('AJV validation of a money criterion', () => {
+  const validator = new SchemaValidator();
+  const template: RubricTemplateSchema = {
+    type: 'object',
+    'x-field-order': ['cost'],
+    properties: { cost: moneySchema() },
+    required: ['cost'],
+  };
+
+  it('accepts a valid answer', () => {
+    expect(
+      validator.validate(template, { cost: { amount: 1000, currency: 'USD' } })
+        .valid,
+    ).toBe(true);
+  });
+
+  it('rejects a negative amount, an unknown key and a wrong currency', () => {
+    expect(
+      validator.validate(template, { cost: { amount: -1, currency: 'USD' } })
+        .valid,
+    ).toBe(false);
+    expect(
+      validator.validate(template, {
+        cost: { amount: 1, currency: 'USD', total: 999 },
+      }).valid,
+    ).toBe(false);
+    expect(
+      validator.validate(template, { cost: { amount: 1, currency: 'EUR' } })
+        .valid,
+    ).toBe(false);
+  });
+
+  it('rejects a missing required money criterion', () => {
+    expect(validator.validate(template, {}).valid).toBe(false);
+  });
+});

--- a/packages/common/src/services/decision/templateMoney.ts
+++ b/packages/common/src/services/decision/templateMoney.ts
@@ -1,0 +1,250 @@
+/**
+ * Money fields on JSON Schema templates.
+ *
+ * A money field is a *normal* template property whose value is an object,
+ * mirroring the proposal budget field's shape:
+ *
+ * ```json
+ * {
+ *   "type": "object",
+ *   "title": "Design & Engineering Cost",
+ *   "x-format": "money",
+ *   "properties": {
+ *     "amount": { "type": "number", "minimum": 0 },
+ *     "currency": { "type": "string", "const": "USD", "default": "USD" }
+ *   },
+ *   "required": ["amount", "currency"],
+ *   "additionalProperties": false
+ * }
+ * ```
+ *
+ * Being a normal property is the whole point: one top-level key, one answer,
+ * one rationale, AJV enforcing `minimum` / `required` / `const` for free, and
+ * `additionalProperties: false` making a smuggled `total` key unstorable.
+ *
+ * That shape is not optional. `x-format: 'money'` alone is enough to select the
+ * money renderer, so a template that declares the format without the shape
+ * would render an input whose answers AJV then rejects — a form that can never
+ * be submitted. {@link assertMoneyFieldSchemas} rejects such a template at the
+ * persistence boundary, and every reader below only trusts a schema that would
+ * pass it.
+ *
+ * Totals over a group of money fields are **derived at render time, never
+ * stored** — the same philosophy as review scores.
+ */
+import { ValidationError } from '../../utils';
+import type { SectionableTemplate } from './templateSections';
+import type { XFormatPropertySchema } from './types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Stored answer for a money field. */
+export interface MoneyFieldAnswer {
+  amount: number;
+  currency: string;
+}
+
+/**
+ * Currency used when a *reader* has nothing better to go on (an unvalidated
+ * draft answer under a template that predates the authoring guard). Never used
+ * to paper over invalid authoring — see {@link assertMoneyFieldSchemas}.
+ */
+export const DEFAULT_MONEY_CURRENCY = 'USD';
+
+/** ISO 4217 codes are three letters. Stored drafts are unvalidated. */
+const CURRENCY_CODE_PATTERN = /^[A-Za-z]{3}$/;
+
+// ---------------------------------------------------------------------------
+// Runtime narrowing (unknown JSON in, no assertions)
+// ---------------------------------------------------------------------------
+
+/** Narrows a JSON Schema definition to its object form (not `true`/`false`). */
+export function isSchemaObjectDefinition(
+  definition: XFormatPropertySchema | boolean | undefined,
+): definition is XFormatPropertySchema {
+  return typeof definition === 'object' && definition !== null;
+}
+
+/** Narrows an unknown stored value to a plain (non-array) object. */
+function isPlainObject(value: unknown): value is { [key: string]: unknown } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Whether a code is shaped like an ISO 4217 currency code. */
+export function isValidCurrencyCode(code: unknown): code is string {
+  return typeof code === 'string' && CURRENCY_CODE_PATTERN.test(code);
+}
+
+// ---------------------------------------------------------------------------
+// Schema readers
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a property is a money field. Detection is **declared only** — the
+ * `x-format` key — never structural, so it cannot reclassify an existing
+ * scored / yes-no / single-select criterion.
+ */
+export function isMoneyFieldSchema(schema: XFormatPropertySchema): boolean {
+  return schema['x-format'] === 'money';
+}
+
+/**
+ * The currency a money field is pinned to by its template author: the
+ * `currency` sub-property's `const`, else its `default`. `undefined` when the
+ * template declares neither, or declares something malformed — a template that
+ * passed {@link assertMoneyFieldSchemas} always yields a value here.
+ */
+export function getMoneyFieldCurrency(
+  schema: XFormatPropertySchema,
+): string | undefined {
+  const currencySchema = schema.properties?.currency;
+  if (!isSchemaObjectDefinition(currencySchema)) {
+    return undefined;
+  }
+  const declared = currencySchema.const ?? currencySchema.default;
+  return isValidCurrencyCode(declared) ? declared : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Answer readers (drafts are unvalidated — every read is defensive)
+// ---------------------------------------------------------------------------
+
+/** The amount inside a stored money answer, or `null` when absent/malformed. */
+export function getMoneyAnswerAmount(value: unknown): number | null {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+  const amount = value.amount;
+  return typeof amount === 'number' && Number.isFinite(amount) ? amount : null;
+}
+
+/** The currency inside a stored money answer, when it is well-formed. */
+export function getMoneyAnswerCurrency(value: unknown): string | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+  return isValidCurrencyCode(value.currency) ? value.currency : undefined;
+}
+
+/**
+ * Currency to *display* a stored answer in: the stored code when well-formed,
+ * else the template's declared currency, else {@link DEFAULT_MONEY_CURRENCY}.
+ * Stored wins so a submitted review keeps reading in the currency it was filled
+ * in, even after the template is re-pinned. Also guards `Intl.NumberFormat`
+ * against garbage in unvalidated drafts.
+ */
+export function resolveMoneyDisplayCurrency(
+  value: unknown,
+  schema: XFormatPropertySchema,
+): string {
+  return (
+    getMoneyAnswerCurrency(value) ??
+    getMoneyFieldCurrency(schema) ??
+    DEFAULT_MONEY_CURRENCY
+  );
+}
+
+/**
+ * Build the answer to store for a money field. The currency is materialized
+ * from the template at fill time, so a submitted review stays self-describing
+ * even if the template's currency is edited later. Reviewers never pick one.
+ */
+export function buildMoneyFieldAnswer(
+  amount: number,
+  schema: XFormatPropertySchema,
+): MoneyFieldAnswer {
+  return {
+    amount,
+    currency: getMoneyFieldCurrency(schema) ?? DEFAULT_MONEY_CURRENCY,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Template-authoring guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Every declared money property must carry the exact storage shape documented
+ * at the top of this file. AJV validates *answers* against whatever the
+ * template says; it cannot know that the money renderer will produce
+ * `{ amount, currency }`. Without this guard a template can be persisted whose
+ * money fields render an input nobody can ever submit (missing `currency`
+ * property plus `additionalProperties: false`), or that silently accepts a
+ * stored `total` (missing `additionalProperties: false`).
+ *
+ * @throws ValidationError naming the offending property and requirement.
+ */
+export function assertMoneyFieldSchemas(
+  template: SectionableTemplate & {
+    properties?: Record<string, XFormatPropertySchema | boolean>;
+  },
+): void {
+  for (const [key, definition] of Object.entries(template.properties ?? {})) {
+    if (!isSchemaObjectDefinition(definition)) {
+      continue;
+    }
+    if (!isMoneyFieldSchema(definition)) {
+      continue;
+    }
+
+    const problem = findMoneyFieldSchemaProblem(definition);
+    if (problem) {
+      throw new ValidationError(
+        `Money field "${key}" has an invalid schema: ${problem}`,
+        { [key]: problem },
+      );
+    }
+  }
+}
+
+/**
+ * Returns a human-readable description of the first shape requirement a
+ * declared money field breaks, or `undefined` when it is well-formed.
+ */
+function findMoneyFieldSchemaProblem(
+  schema: XFormatPropertySchema,
+): string | undefined {
+  if (schema.type !== 'object') {
+    return "type must be 'object'";
+  }
+
+  if (schema.additionalProperties !== false) {
+    return 'additionalProperties must be false';
+  }
+
+  const required = schema.required ?? [];
+  for (const key of ['amount', 'currency']) {
+    if (!required.includes(key)) {
+      return `required must include '${key}'`;
+    }
+  }
+
+  const amount = schema.properties?.amount;
+  if (!isSchemaObjectDefinition(amount)) {
+    return "an 'amount' property is required";
+  }
+  if (amount.type !== 'number') {
+    return "amount.type must be 'number'";
+  }
+  if (amount.minimum !== 0) {
+    return 'amount.minimum must be 0';
+  }
+
+  const currency = schema.properties?.currency;
+  if (!isSchemaObjectDefinition(currency)) {
+    return "a 'currency' property is required";
+  }
+  if (currency.type !== 'string') {
+    return "currency.type must be 'string'";
+  }
+  if (!isValidCurrencyCode(currency.const)) {
+    return 'currency.const must be a three-letter ISO 4217 code';
+  }
+  if (currency.default !== currency.const) {
+    return 'currency.default must equal currency.const';
+  }
+
+  return undefined;
+}

--- a/packages/common/src/services/decision/types.ts
+++ b/packages/common/src/services/decision/types.ts
@@ -48,6 +48,13 @@ export interface XFormatPropertySchema extends JSONSchema7 {
    * presentational — see `templateSections.ts`.
    */
   'x-section'?: string;
+  /**
+   * Nested subschemas. Keeps JSON Schema 7's definition union — a boolean
+   * subschema (`{ blocked: false }`) stays legal — while letting nested
+   * properties carry the same vendor extensions. Readers must narrow with
+   * `isSchemaObjectDefinition` before touching keywords.
+   */
+  properties?: Record<string, XFormatPropertySchema | boolean>;
 }
 
 /** JSON Schema 7 extended with proposal template vendor extensions. */

--- a/packages/common/src/services/decision/updateDecisionInstance.ts
+++ b/packages/common/src/services/decision/updateDecisionInstance.ts
@@ -98,8 +98,8 @@ export const updateDecisionInstance = async ({
   }> = [];
 
   // Validate rubricTemplate is a structurally valid JSON Schema before
-  // persisting, plus the semantic checks AJV can't express (contiguous
-  // sections).
+  // persisting, plus the semantic checks AJV can't express (money field shape,
+  // contiguous sections).
   if (rubricTemplate !== undefined) {
     schemaValidator.validateJsonSchema(rubricTemplate);
     assertRubricTemplateAuthoring(rubricTemplate);

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -69,6 +69,36 @@ function splitSectionRubric(): RubricTemplateSchema {
   };
 }
 
+/** The canonical money-criterion schema. */
+function moneyCriterion(
+  title: string,
+  currency = 'USD',
+): XFormatPropertySchema {
+  return {
+    type: 'object',
+    title,
+    'x-format': 'money',
+    properties: {
+      amount: { type: 'number', minimum: 0 },
+      currency: { type: 'string', const: currency, default: currency },
+    },
+    required: ['amount', 'currency'],
+    additionalProperties: false,
+  };
+}
+
+/** A single money criterion, so one shape requirement can be broken at a time. */
+function moneyRubric(
+  overrides: Partial<XFormatPropertySchema>,
+): RubricTemplateSchema {
+  return {
+    type: 'object',
+    'x-field-order': ['design'],
+    properties: { design: { ...moneyCriterion('Design'), ...overrides } },
+    required: ['design'],
+  };
+}
+
 describe.concurrent('updateDecisionInstance', () => {
   it('should update instance name', async ({ task, onTestFinished }) => {
     const testData = new TestDecisionsDataManager(task.id, onTestFinished);
@@ -1024,6 +1054,136 @@ describe.concurrent('updateDecisionInstance', () => {
           {
             phaseId: targetPhaseId!,
             rubricTemplate: splitSectionRubric(),
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
+  });
+
+  const unsafeMoneyOverrides: Array<[string, Partial<XFormatPropertySchema>]> =
+    [
+      [
+        'a money criterion without additionalProperties:false',
+        { additionalProperties: undefined },
+      ],
+      [
+        'a money criterion with additionalProperties:true',
+        {
+          additionalProperties: true,
+        },
+      ],
+      [
+        'a money criterion that does not require amount',
+        { required: ['currency'] },
+      ],
+      [
+        'a money criterion that does not require currency',
+        { required: ['amount'] },
+      ],
+      ['a non-object money criterion', { type: 'number' as const }],
+      [
+        'a money criterion with no currency pin',
+        {
+          properties: {
+            amount: { type: 'number' as const, minimum: 0 },
+          },
+        },
+      ],
+      [
+        'a money criterion whose currency const is not an ISO code',
+        {
+          properties: {
+            amount: { type: 'number' as const, minimum: 0 },
+            currency: { type: 'string' as const, const: 'US$', default: 'US$' },
+          },
+        },
+      ],
+      [
+        'a money criterion whose currency default disagrees with its const',
+        {
+          properties: {
+            amount: { type: 'number' as const, minimum: 0 },
+            currency: { type: 'string' as const, const: 'USD', default: 'EUR' },
+          },
+        },
+      ],
+      [
+        'a money criterion with an integer amount',
+        {
+          properties: {
+            amount: { type: 'integer' as const, minimum: 0 },
+            currency: { type: 'string' as const, const: 'USD', default: 'USD' },
+          },
+        },
+      ],
+      [
+        'a money criterion whose amount has no minimum',
+        {
+          properties: {
+            amount: { type: 'number' as const },
+            currency: { type: 'string' as const, const: 'USD', default: 'USD' },
+          },
+        },
+      ],
+    ];
+
+  // `x-format: 'money'` alone selects the money renderer, so a template that
+  // declares it without the exact storage shape would persist a form that
+  // either cannot be submitted or can store a value the model forbids.
+  for (const [label, overrides] of unsafeMoneyOverrides) {
+    it(`rejects ${label}`, async ({ task, onTestFinished }) => {
+      const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+      const setup = await testData.createDecisionSetup({
+        instanceCount: 1,
+        grantAccess: true,
+      });
+      const caller = await createAuthenticatedCaller(setup.userEmail);
+
+      const before = await db.query.processInstances.findFirst({
+        where: { id: setup.instance.instance.id },
+      });
+
+      await expect(
+        caller.decision.updateDecisionInstance({
+          instanceId: setup.instance.instance.id,
+          rubricTemplate: moneyRubric(overrides),
+        }),
+      ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
+
+      const after = await db.query.processInstances.findFirst({
+        where: { id: setup.instance.instance.id },
+      });
+      expect(
+        (after!.instanceData as DecisionInstanceData).rubricTemplate,
+      ).toEqual((before!.instanceData as DecisionInstanceData).rubricTemplate);
+    });
+  }
+
+  it('applies the same money guard to a per-phase rubric template', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const phases = (
+      (setup.instance.instance.instanceData as DecisionInstanceData).phases ??
+      []
+    ).map((phase) => ({ phaseId: phase.phaseId }));
+    const targetPhaseId = phases[0]?.phaseId;
+    expect(targetPhaseId).toBeDefined();
+
+    await expect(
+      caller.decision.updateDecisionInstance({
+        instanceId: setup.instance.instance.id,
+        phases: [
+          {
+            phaseId: targetPhaseId!,
+            rubricTemplate: moneyRubric({ additionalProperties: undefined }),
           },
         ],
       }),

--- a/services/api/src/routers/decision/reviews/rubricMoneyCriteria.test.ts
+++ b/services/api/src/routers/decision/reviews/rubricMoneyCriteria.test.ts
@@ -1,0 +1,312 @@
+import type { RubricTemplateSchema } from '@op/common';
+import { OVERALL_RECOMMENDATION_KEY } from '@op/common/client';
+import { ProposalReviewState } from '@op/db/schema';
+import { db } from '@op/db/test';
+import { describe, expect, it } from 'vitest';
+
+import { appRouter } from '../..';
+import { TestReviewsDataManager } from '../../../test/helpers/TestReviewsDataManager';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../../test/supabase-utils';
+import { createCallerFactory } from '../../../trpcFactory';
+
+const createCaller = createCallerFactory(appRouter);
+
+/**
+ * Columbus feasibility shape (flat slice): three flat money criteria plus a
+ * scored criterion. Criterion ids are opaque, as the builder generates them.
+ *
+ * Every answer lives at `answers[criterionId]` — one top-level key per money
+ * criterion — which is what these tests assert.
+ */
+const DESIGN = 'a1b2c3d4';
+const CONSTRUCTION = 'e5f6a7b8';
+const CONTINGENCY = 'c9d0e1f2';
+
+function moneyCriterion(title: string, currency = 'USD') {
+  return {
+    type: 'object' as const,
+    title,
+    'x-format': 'money' as const,
+    properties: {
+      amount: { type: 'number' as const, minimum: 0 },
+      currency: { type: 'string' as const, const: currency, default: currency },
+    },
+    required: ['amount', 'currency'],
+    additionalProperties: false,
+  };
+}
+
+const rubricTemplate: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': [
+    DESIGN,
+    CONSTRUCTION,
+    CONTINGENCY,
+    'impact',
+    OVERALL_RECOMMENDATION_KEY,
+  ],
+  properties: {
+    [DESIGN]: moneyCriterion('Design & Engineering Cost'),
+    [CONSTRUCTION]: moneyCriterion('Construction / Materials / Labor'),
+    [CONTINGENCY]: moneyCriterion(
+      'Contingency & Permitting (15–20% recommended)',
+    ),
+    impact: {
+      type: 'integer',
+      title: 'Impact',
+      'x-format': 'dropdown',
+      minimum: 1,
+      maximum: 5,
+      oneOf: [
+        { const: 1, title: 'Low' },
+        { const: 5, title: 'High' },
+      ],
+    },
+    [OVERALL_RECOMMENDATION_KEY]: {
+      type: 'string',
+      title: 'Overall Recommendation',
+      'x-format': 'dropdown',
+      oneOf: [
+        { const: 'yes', title: 'Yes' },
+        { const: 'no', title: 'No' },
+      ],
+    },
+  },
+  required: [DESIGN, CONSTRUCTION, 'impact'],
+};
+
+const validMoneyAnswers = {
+  [DESIGN]: { amount: 120000, currency: 'USD' },
+  [CONSTRUCTION]: { amount: 480000.5, currency: 'USD' },
+  [CONTINGENCY]: { amount: 90000, currency: 'USD' },
+};
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+async function seedAssignment(
+  task: { id: string },
+  onTestFinished: (fn: () => void | Promise<void>) => void,
+) {
+  const testData = new TestReviewsDataManager(task.id, onTestFinished);
+  const created = await testData.createReviewAssignment();
+  await testData.setRubricTemplate(created.context, rubricTemplate);
+  const caller = await createAuthenticatedCaller(created.reviewer.email);
+  return { testData, created, caller };
+}
+
+describe.concurrent('rubric money criteria', () => {
+  it('accepts valid money answers and stores them verbatim', async (ctx) => {
+    const { created, caller } = await seedAssignment(
+      ctx.task,
+      ctx.onTestFinished,
+    );
+
+    const result = await caller.decision.submitReview({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { ...validMoneyAnswers, impact: 5 },
+        rationales: {},
+      },
+    });
+
+    expect(result.state).toBe(ProposalReviewState.SUBMITTED);
+    expect(result.reviewData.answers).toEqual({
+      ...validMoneyAnswers,
+      impact: 5,
+    });
+
+    // Read back from the DB: each money answer is its own top-level key.
+    const stored = await db.query.proposalReviews.findFirst({
+      where: { assignmentId: created.assignment.id },
+    });
+    expect(stored?.reviewData).toMatchObject({ answers: validMoneyAnswers });
+  });
+
+  it('rejects a submission missing a required money criterion', async (ctx) => {
+    const { created, caller } = await seedAssignment(
+      ctx.task,
+      ctx.onTestFinished,
+    );
+
+    await expect(
+      caller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: { [DESIGN]: validMoneyAnswers[DESIGN], impact: 5 },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+  });
+
+  it('rejects a negative amount', async (ctx) => {
+    const { created, caller } = await seedAssignment(
+      ctx.task,
+      ctx.onTestFinished,
+    );
+
+    await expect(
+      caller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: {
+            ...validMoneyAnswers,
+            [DESIGN]: { amount: -1, currency: 'USD' },
+            impact: 5,
+          },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+  });
+
+  it('rejects an unknown extra key inside a money answer', async (ctx) => {
+    const { created, caller } = await seedAssignment(
+      ctx.task,
+      ctx.onTestFinished,
+    );
+
+    // `additionalProperties: false` is what makes the derived total
+    // unstorable — there is nowhere to smuggle it.
+    await expect(
+      caller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: {
+            ...validMoneyAnswers,
+            [DESIGN]: { amount: 100, currency: 'USD', total: 999999 },
+            impact: 5,
+          },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+  });
+
+  it('rejects a mismatched or malformed currency', async (ctx) => {
+    const { created, caller } = await seedAssignment(
+      ctx.task,
+      ctx.onTestFinished,
+    );
+
+    await expect(
+      caller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: {
+            ...validMoneyAnswers,
+            [DESIGN]: { amount: 100, currency: 'EUR' },
+            impact: 5,
+          },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+
+    await expect(
+      caller.decision.submitReview({
+        assignmentId: created.assignment.id,
+        reviewData: {
+          answers: {
+            ...validMoneyAnswers,
+            [DESIGN]: { amount: 100, currency: 42 },
+            impact: 5,
+          },
+          rationales: {},
+        },
+      }),
+    ).rejects.toThrow('Rubric validation failed');
+  });
+
+  it('leaves the aggregated score untouched by money answers', async (ctx) => {
+    const { testData, created, caller } = await seedAssignment(
+      ctx.task,
+      ctx.onTestFinished,
+    );
+    await testData.setCurrentPhase(
+      created.context.instance.instance.id,
+      'review',
+    );
+
+    await caller.decision.submitReview({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: {
+          ...validMoneyAnswers,
+          impact: 5,
+          [OVERALL_RECOMMENDATION_KEY]: 'yes',
+        },
+        rationales: {},
+      },
+    });
+
+    const aggregates = await caller.decision.listWithReviewAggregates({
+      processInstanceId: created.context.instance.instance.id,
+      proposalIds: [created.proposal.id],
+    });
+
+    // Only `impact` scores: 5, not 5 + 690000.5.
+    expect(aggregates.items[0]?.aggregates).toMatchObject({
+      reviewsSubmittedCount: 1,
+      averageScore: 5,
+    });
+  });
+
+  it('saves a draft with partial money answers', async (ctx) => {
+    const { created, caller } = await seedAssignment(
+      ctx.task,
+      ctx.onTestFinished,
+    );
+
+    // Drafts are deliberately unvalidated: a half-filled money answer and a
+    // completely missing required one both persist.
+    const partial = {
+      [DESIGN]: { amount: 120000, currency: 'USD' },
+      [CONSTRUCTION]: { currency: 'USD' },
+    };
+
+    const draft = await caller.decision.saveReviewDraft({
+      assignmentId: created.assignment.id,
+      reviewData: { answers: partial, rationales: {} },
+    });
+
+    expect(draft.state).toBe(ProposalReviewState.DRAFT);
+    expect(draft.reviewData.answers).toEqual(partial);
+  });
+
+  it('stores a rationale per money criterion under its own criterion id', async (ctx) => {
+    const { created, caller } = await seedAssignment(
+      ctx.task,
+      ctx.onTestFinished,
+    );
+
+    const rationales = {
+      [DESIGN]: 'Based on the 2025 city schedule of rates.',
+      [CONSTRUCTION]: 'Assumes union labour.',
+      [CONTINGENCY]: '18% of the two lines above.',
+    };
+
+    const result = await caller.decision.submitReview({
+      assignmentId: created.assignment.id,
+      reviewData: {
+        answers: { ...validMoneyAnswers, impact: 5 },
+        rationales,
+      },
+    });
+
+    // Per-field notes need no new storage: the existing flat rationale map
+    // keys on the same criterion ids as the answers.
+    expect(result.reviewData.rationales).toEqual(rationales);
+
+    const stored = await db.query.proposalReviews.findFirst({
+      where: { assignmentId: created.assignment.id },
+    });
+    expect(stored?.reviewData).toMatchObject({ rationales });
+  });
+});


### PR DESCRIPTION
PR C of the rubric-money-sections stack (B #1777 → C → D). Stacked on #1777.

## What

The `money` criterion type — sections not required:

- `templateMoney.ts` (+27 unit tests): `isMoneyFieldSchema`, currency resolution helpers, `buildMoneyFieldAnswer`, `assertMoneyFieldSchemas`, `DEFAULT_MONEY_CURRENCY` — **without** `sumMoneyFields` / `assertTemplateSectionCurrencies` (PR D)
- `assertMoneyFieldSchemas` added to the `assertRubricTemplateAuthoring` guard chain
- `rubricTemplate.ts`: `money` in `RubricCriterionType`, declared-only inference (`x-format: 'money'`, never structural), `currency` on `CriterionView`, `changeCriterionType` no-op for money
- Reviewer form: `MoneyFieldInput` — `@op/ui` NumberField with an Intl-derived currency-symbol `prefixText` (the `CollaborativeBudgetField` pattern; no new design-system components). The currency is template-locked (`const`-pinned), the reviewer types only a number, and the stored answer is the proposal-budget shape `{amount, currency}`
- `ReviewFormContext`: `undefined` deletes the answer key (clearing a money input drops the answer)
- `ReviewFormShell`: TotalScoreCard `criterionType !== 'scored'` hardening
- `SubmittedReviewView` money result branch (formats via `useFormatter`/Intl)
- Builder: inert `MoneyCriterionCard` ("Cost estimate"), template-authored only — excluded from `EditableRubricCriterionType`
- Money i18n keys in all 7 dictionaries (additions only)

## Invariants

- Money detection is declared, never structural — legacy scored/yes_no/single_select inference untouched
- Answer shape exactly `{amount, currency}`, `additionalProperties: false`, currency `const`-pinned
- Stored currency wins on display; three-letter regex guards `Intl.NumberFormat`
- Money criteria are template-authored only; inert in the builder

## Verification

`pnpm typecheck` + `format:check` green; `templateMoney.test.ts` 27/27, `rubricTemplate.test.ts` 25/25. `rubricMoneyCriteria.test.ts` + `updateDecisionInstance.test.ts` money slices run in CI (supabase harness).