### PR TITLE
feat(decision): summed rubric sections with derived totals

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -34,7 +34,7 @@ import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
 import { useReviewForm } from './ReviewFormContext';
 import { FormShell, TotalScoreCard } from './ReviewFormShell';
 import { type PreviousReviewPhase, ReviewTabs } from './ReviewTabs';
-import { RubricSectionShell } from './RubricSection';
+import { RubricSectionShell, RubricSectionTotal } from './RubricSection';
 import { SubmittedReviewView } from './SubmittedReviewView';
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
@@ -168,6 +168,7 @@ function MyReviewForm() {
             <RubricBlock
               key={blockKey(block)}
               block={block}
+              answers={values}
               renderCriterion={renderCriterion}
             />
           ))}
@@ -211,13 +212,15 @@ function MyReviewForm() {
 
 /**
  * Render one grouping block: either a bare criterion or a section wrapper
- * with its members.
+ * with its members and (when declared) a derived total row.
  */
 function RubricBlock({
   block,
+  answers,
   renderCriterion,
 }: {
   block: TemplateSectionBlock<FieldDescriptor>;
+  answers: Record<string, unknown>;
   renderCriterion: (field: FieldDescriptor) => ReactNode;
 }) {
   if (block.kind === 'field') {
@@ -227,6 +230,9 @@ function RubricBlock({
   return (
     <RubricSectionShell section={block.section}>
       {block.fields.map(renderCriterion)}
+      {block.section.showTotal && (
+        <RubricSectionTotal fields={block.fields} answers={answers} />
+      )}
     </RubricSectionShell>
   );
 }

--- a/apps/app/src/components/decisions/Review/RubricSection.tsx
+++ b/apps/app/src/components/decisions/Review/RubricSection.tsx
@@ -1,9 +1,20 @@
 'use client';
 
 import type { TemplateSection } from '@op/common/client';
+import { sumMoneyFields } from '@op/common/client';
+import { Surface } from '@op/ui/Surface';
+import { useFormatter } from 'next-intl';
 import type { ReactNode } from 'react';
+import { useCallback } from 'react';
+
+import { useTranslations } from '@/lib/i18n';
 
 import { FieldHeader } from '../forms/FieldHeader';
+import type { FieldDescriptor } from '../forms/types';
+
+// ---------------------------------------------------------------------------
+// Section shell
+// ---------------------------------------------------------------------------
 
 /**
  * A presentational criterion group: the section title in the serif heading
@@ -23,5 +34,53 @@ export function RubricSectionShell({
       <FieldHeader title={section.title} description={section.description} />
       {children}
     </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Derived total
+// ---------------------------------------------------------------------------
+
+/**
+ * Total row for a section that declares `showTotal` — the sum of its money
+ * members' amounts, computed here at render time and never stored. Non-money
+ * members are not summed.
+ */
+export function RubricSectionTotal({
+  fields,
+  answers,
+}: {
+  fields: FieldDescriptor[];
+  answers: Record<string, unknown>;
+}) {
+  const t = useTranslations();
+  const formatMoney = useMoneyFormatter();
+  const { total, currency } = sumMoneyFields(fields, answers);
+
+  return (
+    <Surface
+      variant="filled"
+      className="flex items-center justify-between rounded-lg border-neutral-gray1 p-4"
+    >
+      <span className="text-base text-neutral-charcoal">{t('Total')}</span>
+      <span className="font-serif !text-title-base text-neutral-black">
+        {formatMoney(total ?? 0, currency)}
+      </span>
+    </Surface>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Currency formatting (via the i18n stack — no hand-rolled symbol map)
+// ---------------------------------------------------------------------------
+
+/** Formats an amount as currency in the active locale. */
+export function useMoneyFormatter() {
+  const format = useFormatter();
+
+  return useCallback(
+    (amount: number, currency: string) =>
+      format.number(amount, { style: 'currency', currency }),
+    [format],
   );
 }

--- a/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
+++ b/apps/app/src/components/decisions/Review/SubmittedReviewView.tsx
@@ -17,7 +17,7 @@ import { FieldHeader } from '../forms/FieldHeader';
 import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
 import { inferCriterionType } from '../rubricTemplate';
-import { RubricSectionShell } from './RubricSection';
+import { RubricSectionShell, RubricSectionTotal } from './RubricSection';
 
 export function SubmittedReviewView({
   rubricTemplate,
@@ -52,6 +52,7 @@ export function SubmittedReviewView({
         <ResultBlock
           key={blockKey(block)}
           block={block}
+          answers={answers}
           renderField={renderField}
         />
       ))}
@@ -67,13 +68,16 @@ export function SubmittedReviewView({
 
 /**
  * One grouping block of a submitted review: a bare criterion result, or a
- * section wrapper with its members.
+ * section wrapper with its members and (when declared) the derived total —
+ * re-summed here at read time, exactly as the live form does.
  */
 function ResultBlock({
   block,
+  answers,
   renderField,
 }: {
   block: TemplateSectionBlock<FieldDescriptor>;
+  answers: Record<string, unknown>;
   renderField: (field: FieldDescriptor) => ReactNode;
 }) {
   if (block.kind === 'field') {
@@ -83,6 +87,9 @@ function ResultBlock({
   return (
     <RubricSectionShell section={block.section}>
       {block.fields.map(renderField)}
+      {block.section.showTotal && (
+        <RubricSectionTotal fields={block.fields} answers={answers} />
+      )}
     </RubricSectionShell>
   );
 }

--- a/apps/app/src/lib/i18n/dictionaries/ar.json
+++ b/apps/app/src/lib/i18n/dictionaries/ar.json
@@ -1438,6 +1438,7 @@
   "Turn on Open Reviews?": "تفعيل المراجعات المفتوحة؟",
   "This can lead reviewers to agree with each other more than they would independently.": "قد يؤدي ذلك إلى اتفاق المراجعين مع بعضهم البعض أكثر مما لو كانوا مستقلين.",
   "Enable": "تفعيل",
+  "Total": "الإجمالي",
   "Amount": "المبلغ",
   "Cost estimate": "تقدير التكلفة",
   "Reviewers enter an amount": "يُدخل المراجعون مبلغًا",

--- a/apps/app/src/lib/i18n/dictionaries/bn.json
+++ b/apps/app/src/lib/i18n/dictionaries/bn.json
@@ -1441,6 +1441,7 @@
   "Turn on Open Reviews?": "উন্মুক্ত পর্যালোচনা চালু করবেন?",
   "This can lead reviewers to agree with each other more than they would independently.": "এটি পর্যালোচকদের স্বাধীনভাবে যতটা একমত হতেন তার চেয়ে বেশি একে অপরের সাথে একমত হতে পরিচালিত করতে পারে।",
   "Enable": "চালু করুন",
+  "Total": "মোট",
   "Amount": "পরিমাণ",
   "Cost estimate": "ব্যয়ের প্রাক্কলন",
   "Reviewers enter an amount": "পর্যালোচকরা একটি পরিমাণ লিখবেন",

--- a/apps/app/src/lib/i18n/dictionaries/en.json
+++ b/apps/app/src/lib/i18n/dictionaries/en.json
@@ -1504,6 +1504,7 @@
   "Vote editing": "Vote editing",
   "Advances manually": "Advances manually",
   "Advances by date": "Advances by date",
+  "Total": "Total",
   "Amount": "Amount",
   "Cost estimate": "Cost estimate",
   "Reviewers enter an amount": "Reviewers enter an amount",

--- a/apps/app/src/lib/i18n/dictionaries/es.json
+++ b/apps/app/src/lib/i18n/dictionaries/es.json
@@ -1438,6 +1438,7 @@
   "Turn on Open Reviews?": "¿Activar las revisiones abiertas?",
   "This can lead reviewers to agree with each other more than they would independently.": "Esto puede llevar a que las personas revisoras estén de acuerdo entre sí más de lo que lo harían de forma independiente.",
   "Enable": "Activar",
+  "Total": "Total",
   "Amount": "Importe",
   "Cost estimate": "Estimación de costes",
   "Reviewers enter an amount": "Las personas revisoras introducen un importe",

--- a/apps/app/src/lib/i18n/dictionaries/fr.json
+++ b/apps/app/src/lib/i18n/dictionaries/fr.json
@@ -1438,6 +1438,7 @@
   "Turn on Open Reviews?": "Activer les évaluations ouvertes ?",
   "This can lead reviewers to agree with each other more than they would independently.": "Cela peut amener les évaluateurs à être davantage d’accord entre eux qu’ils ne le seraient de manière indépendante.",
   "Enable": "Activer",
+  "Total": "Total",
   "Amount": "Montant",
   "Cost estimate": "Estimation des coûts",
   "Reviewers enter an amount": "Les évaluateurs saisissent un montant",

--- a/apps/app/src/lib/i18n/dictionaries/pt.json
+++ b/apps/app/src/lib/i18n/dictionaries/pt.json
@@ -1438,6 +1438,7 @@
   "Turn on Open Reviews?": "Ativar avaliações abertas?",
   "This can lead reviewers to agree with each other more than they would independently.": "Isso pode levar os avaliadores a concordarem mais uns com os outros do que fariam de forma independente.",
   "Enable": "Ativar",
+  "Total": "Total",
   "Amount": "Valor",
   "Cost estimate": "Estimativa de custo",
   "Reviewers enter an amount": "Os avaliadores inserem um valor",

--- a/apps/app/src/lib/i18n/dictionaries/so.json
+++ b/apps/app/src/lib/i18n/dictionaries/so.json
@@ -1440,6 +1440,7 @@
   "Turn on Open Reviews?": "Shid dib-u-eegisyada furan?",
   "This can lead reviewers to agree with each other more than they would independently.": "Tani waxay u horseedi kartaa in dib-u-eegayaashu isku raacaan midba midka kale in ka badan intii ay si madax-bannaan u samayn lahaayeen.",
   "Enable": "Shid",
+  "Total": "Wadarta",
   "Amount": "Qadarka",
   "Cost estimate": "Qiyaasta qiimaha",
   "Reviewers enter an amount": "Dib-u-eegayaashu waxay gelinayaan qadar",

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -140,6 +140,7 @@ export { assertRubricTemplateAuthoring } from './services/decision/templateAutho
 export {
   DEFAULT_MONEY_CURRENCY,
   assertMoneyFieldSchemas,
+  assertTemplateSectionCurrencies,
   isSchemaObjectDefinition,
   buildMoneyFieldAnswer,
   getMoneyAnswerAmount,
@@ -148,7 +149,9 @@ export {
   isMoneyFieldSchema,
   isValidCurrencyCode,
   resolveMoneyDisplayCurrency,
+  sumMoneyFields,
   type MoneyFieldAnswer,
+  type MoneyFieldSum,
 } from './services/decision/templateMoney';
 export { assembleProposalData } from './services/decision/assembleProposalData';
 export { relaxLocationCategoryRequirement } from './services/decision/relaxLocationCategoryRequirement';

--- a/packages/common/src/services/decision/templateAuthoring.ts
+++ b/packages/common/src/services/decision/templateAuthoring.ts
@@ -10,7 +10,10 @@
  *
  * These run at the persistence boundary, next to `validateJsonSchema`.
  */
-import { assertMoneyFieldSchemas } from './templateMoney';
+import {
+  assertMoneyFieldSchemas,
+  assertTemplateSectionCurrencies,
+} from './templateMoney';
 import type { SectionableTemplate } from './templateSections';
 import { assertContiguousTemplateSections } from './templateSections';
 import type { XFormatPropertySchema } from './types';
@@ -24,6 +27,10 @@ type AuthorableTemplate = SectionableTemplate & {
 /**
  * Assert a rubric template is safely authored.
  *
+ * Order matters: the money-field shape check runs first so the currency
+ * comparison only ever sees validly pinned currencies, and reports the precise
+ * shape problem rather than a confusing downstream one.
+ *
  * @throws ValidationError describing the first problem found.
  */
 export function assertRubricTemplateAuthoring(
@@ -31,4 +38,5 @@ export function assertRubricTemplateAuthoring(
 ): void {
   assertMoneyFieldSchemas(template);
   assertContiguousTemplateSections(template);
+  assertTemplateSectionCurrencies(template);
 }

--- a/packages/common/src/services/decision/templateMoney.test.ts
+++ b/packages/common/src/services/decision/templateMoney.test.ts
@@ -4,6 +4,7 @@ import { ValidationError } from '../../utils';
 import { SchemaValidator } from './schemaValidator';
 import {
   assertMoneyFieldSchemas,
+  assertTemplateSectionCurrencies,
   buildMoneyFieldAnswer,
   getMoneyAnswerAmount,
   getMoneyAnswerCurrency,
@@ -11,20 +12,24 @@ import {
   isMoneyFieldSchema,
   isValidCurrencyCode,
   resolveMoneyDisplayCurrency,
+  sumMoneyFields,
 } from './templateMoney';
 import type { RubricTemplateSchema, XFormatPropertySchema } from './types';
 
 function moneySchema({
   title = 'Cost',
   currency = 'USD',
+  sectionId,
 }: {
   title?: string;
   currency?: string | null;
+  sectionId?: string;
 } = {}): XFormatPropertySchema {
   return {
     type: 'object',
     title,
     'x-format': 'money',
+    ...(sectionId ? { 'x-section': sectionId } : {}),
     properties: {
       amount: { type: 'number', minimum: 0 },
       ...(currency
@@ -139,6 +144,74 @@ describe('buildMoneyFieldAnswer', () => {
   });
 });
 
+describe('sumMoneyFields', () => {
+  const fields = [
+    { key: 'a', schema: moneySchema() },
+    { key: 'b', schema: moneySchema() },
+    {
+      key: 'notes',
+      schema: { type: 'string' as const, 'x-format': 'long-text' as const },
+    },
+  ];
+
+  it('sums the answered money members only', () => {
+    expect(
+      sumMoneyFields(fields, {
+        a: { amount: 1000, currency: 'USD' },
+        b: { amount: 250.5, currency: 'USD' },
+        notes: 'long text is not money',
+      }),
+    ).toEqual({ total: 1250.5, currency: 'USD', answeredCount: 2 });
+  });
+
+  it('returns a null total when nothing is answered yet', () => {
+    expect(sumMoneyFields(fields, {})).toEqual({
+      total: null,
+      currency: 'USD',
+      answeredCount: 0,
+    });
+  });
+
+  it('ignores partially filled members', () => {
+    expect(
+      sumMoneyFields(fields, { a: { amount: 10, currency: 'USD' }, b: {} }),
+    ).toEqual({ total: 10, currency: 'USD', answeredCount: 1 });
+  });
+
+  it('takes the currency from the template pin when nothing is answered', () => {
+    expect(
+      sumMoneyFields([{ key: 'a', schema: moneySchema({ currency: 'EUR' }) }], {
+        a: {},
+      }).currency,
+    ).toBe('EUR');
+  });
+
+  it('labels the total with the stored currency, not a re-pinned template', () => {
+    // A historical review filled in USD, then the template was re-pinned to
+    // EUR. The individual amounts still read USD (resolveMoneyDisplayCurrency),
+    // so the derived total must agree instead of relabelling the same numbers.
+    const repinned = [
+      { key: 'a', schema: moneySchema({ currency: 'EUR' }) },
+      { key: 'b', schema: moneySchema({ currency: 'EUR' }) },
+    ];
+
+    expect(
+      sumMoneyFields(repinned, {
+        a: { amount: 1000, currency: 'USD' },
+        b: { amount: 250, currency: 'USD' },
+      }),
+    ).toEqual({ total: 1250, currency: 'USD', answeredCount: 2 });
+  });
+
+  it('ignores a malformed stored currency and falls back to the pin', () => {
+    expect(
+      sumMoneyFields([{ key: 'a', schema: moneySchema({ currency: 'EUR' }) }], {
+        a: { amount: 5, currency: 'nonsense' },
+      }).currency,
+    ).toBe('EUR');
+  });
+});
+
 describe('assertMoneyFieldSchemas', () => {
   function template(schema: XFormatPropertySchema): RubricTemplateSchema {
     return { type: 'object', properties: { cost: schema } };
@@ -250,6 +323,89 @@ describe('assertMoneyFieldSchemas', () => {
     expect(() => assertMoneyFieldSchemas(template(schema))).toThrow(
       ValidationError,
     );
+  });
+});
+
+describe('assertTemplateSectionCurrencies', () => {
+  function template(
+    properties: Record<string, XFormatPropertySchema>,
+    showTotal = true,
+  ): RubricTemplateSchema {
+    return {
+      type: 'object',
+      'x-sections': [{ id: 'cost', title: 'Total Estimated Cost', showTotal }],
+      properties,
+    };
+  }
+
+  it('accepts a summed section whose money members share a currency', () => {
+    expect(() =>
+      assertTemplateSectionCurrencies(
+        template({
+          a: moneySchema({ currency: 'USD', sectionId: 'cost' }),
+          b: moneySchema({ currency: 'USD', sectionId: 'cost' }),
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects a summed section that mixes currencies', () => {
+    expect(() =>
+      assertTemplateSectionCurrencies(
+        template({
+          a: moneySchema({ currency: 'USD', sectionId: 'cost' }),
+          b: moneySchema({ currency: 'EUR', sectionId: 'cost' }),
+        }),
+      ),
+    ).toThrow(ValidationError);
+  });
+
+  it('allows mixed currencies in a section that shows no total', () => {
+    expect(() =>
+      assertTemplateSectionCurrencies(
+        template(
+          {
+            a: moneySchema({ currency: 'USD', sectionId: 'cost' }),
+            b: moneySchema({ currency: 'EUR', sectionId: 'cost' }),
+          },
+          false,
+        ),
+      ),
+    ).not.toThrow();
+  });
+
+  it('does not invent a default for an unpinned money field', () => {
+    // No currency declared at all: assertMoneyFieldSchemas is the check that
+    // reports it. This assertion must not substitute USD and thereby call a
+    // mixed section "consistent" — nor crash.
+    expect(() =>
+      assertTemplateSectionCurrencies(
+        template({
+          a: moneySchema({ currency: 'EUR', sectionId: 'cost' }),
+          b: moneySchema({ currency: null, sectionId: 'cost' }),
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('ignores money fields outside the summed section', () => {
+    expect(() =>
+      assertTemplateSectionCurrencies(
+        template({
+          a: moneySchema({ currency: 'USD', sectionId: 'cost' }),
+          loose: moneySchema({ currency: 'EUR' }),
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('is a no-op for templates without sections', () => {
+    expect(() =>
+      assertTemplateSectionCurrencies({
+        type: 'object',
+        properties: { a: moneySchema() },
+      }),
+    ).not.toThrow();
   });
 });
 

--- a/packages/common/src/services/decision/templateMoney.ts
+++ b/packages/common/src/services/decision/templateMoney.ts
@@ -33,7 +33,12 @@
  * stored** — the same philosophy as review scores.
  */
 import { ValidationError } from '../../utils';
-import type { SectionableTemplate } from './templateSections';
+import {
+  type SectionableField,
+  type SectionableTemplate,
+  getFieldSectionId,
+  getTemplateSections,
+} from './templateSections';
 import type { XFormatPropertySchema } from './types';
 
 // ---------------------------------------------------------------------------
@@ -44,6 +49,16 @@ import type { XFormatPropertySchema } from './types';
 export interface MoneyFieldAnswer {
   amount: number;
   currency: string;
+}
+
+/** A currency-tagged sum derived from several money answers. */
+export interface MoneyFieldSum {
+  /** Sum of the answered amounts. `null` when nothing is answered yet. */
+  total: number | null;
+  /** Currency to format `total` in. */
+  currency: string;
+  /** How many member fields contributed an amount. */
+  answeredCount: number;
 }
 
 /**
@@ -162,6 +177,56 @@ export function buildMoneyFieldAnswer(
 }
 
 // ---------------------------------------------------------------------------
+// Derived totals
+// ---------------------------------------------------------------------------
+
+/**
+ * Sum the money members of a field list. Non-money members are simply not
+ * summed, so a mixed section with `showTotal` totals only its money fields.
+ *
+ * The total is labelled with the **first answered member's stored currency**,
+ * falling back to the template pin only when no answered member carries one.
+ * Stored-first matters after a template is re-pinned: a historical review's
+ * amounts and its derived total must agree, and they are the amounts that were
+ * actually entered — the same precedence as
+ * {@link resolveMoneyDisplayCurrency}. A summed section is guaranteed
+ * single-currency at authoring time by {@link assertTemplateSectionCurrencies}.
+ */
+export function sumMoneyFields<TField extends SectionableField>(
+  fields: TField[],
+  answers: Record<string, unknown>,
+): MoneyFieldSum {
+  let total: number | null = null;
+  let answeredCount = 0;
+  let answeredCurrency: string | undefined;
+  let templateCurrency: string | undefined;
+
+  for (const field of fields) {
+    if (!isMoneyFieldSchema(field.schema)) {
+      continue;
+    }
+
+    templateCurrency ??= getMoneyFieldCurrency(field.schema);
+
+    const answer = answers[field.key];
+    const amount = getMoneyAnswerAmount(answer);
+    if (amount === null) {
+      continue;
+    }
+
+    answeredCurrency ??= getMoneyAnswerCurrency(answer);
+    total = (total ?? 0) + amount;
+    answeredCount += 1;
+  }
+
+  return {
+    total,
+    currency: answeredCurrency ?? templateCurrency ?? DEFAULT_MONEY_CURRENCY,
+    answeredCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Template-authoring guards
 // ---------------------------------------------------------------------------
 
@@ -194,6 +259,68 @@ export function assertMoneyFieldSchemas(
       throw new ValidationError(
         `Money field "${key}" has an invalid schema: ${problem}`,
         { [key]: problem },
+      );
+    }
+  }
+}
+
+/**
+ * A sum over mixed currencies is meaningless, so a section that declares
+ * `showTotal` must have all of its money members pinned to one currency.
+ * Currencies are template-declared (`const`), so this is a static check.
+ *
+ * Run {@link assertMoneyFieldSchemas} first: this check only compares
+ * currencies that are validly declared, and never substitutes a default for a
+ * missing one — inventing USD here would let invalid authoring pass as
+ * "consistent".
+ *
+ * @throws ValidationError when a summed section mixes currencies.
+ */
+export function assertTemplateSectionCurrencies(
+  template: SectionableTemplate & {
+    properties?: Record<string, XFormatPropertySchema | boolean>;
+  },
+): void {
+  const summedSectionIds = new Set(
+    getTemplateSections(template)
+      .filter((section) => section.showTotal)
+      .map((section) => section.id),
+  );
+
+  if (summedSectionIds.size === 0) {
+    return;
+  }
+
+  const currenciesBySection = new Map<string, Set<string>>();
+
+  for (const definition of Object.values(template.properties ?? {})) {
+    if (!isSchemaObjectDefinition(definition)) {
+      continue;
+    }
+    if (!isMoneyFieldSchema(definition)) {
+      continue;
+    }
+    const sectionId = getFieldSectionId(definition);
+    if (!sectionId || !summedSectionIds.has(sectionId)) {
+      continue;
+    }
+    const currency = getMoneyFieldCurrency(definition);
+    if (currency === undefined) {
+      // Invalid authoring; assertMoneyFieldSchemas is the check that reports
+      // it. Skipping keeps this assertion from either crashing or blessing it.
+      continue;
+    }
+    const seen = currenciesBySection.get(sectionId) ?? new Set<string>();
+    seen.add(currency);
+    currenciesBySection.set(sectionId, seen);
+  }
+
+  for (const [sectionId, currencies] of currenciesBySection) {
+    if (currencies.size > 1) {
+      const listed = [...currencies].sort().join(', ');
+      throw new ValidationError(
+        `Section "${sectionId}" shows a total but mixes currencies (${listed}); a summed section must use one currency`,
+        { [`x-sections.${sectionId}`]: 'Mixed currencies in a summed section' },
       );
     }
   }

--- a/packages/common/src/services/decision/templateSections.test.ts
+++ b/packages/common/src/services/decision/templateSections.test.ts
@@ -18,14 +18,14 @@ function field(key: string, schema: XFormatPropertySchema = {}) {
 
 const sections = [
   { id: 's1', title: 'Total Estimated Cost', description: 'All-in cost' },
-  { id: 's2', title: 'Community Impact' },
+  { id: 's2', title: 'Community Impact', showTotal: true },
 ];
 
 describe('getTemplateSections', () => {
   it('returns declared sections in declaration order', () => {
     expect(getTemplateSections({ 'x-sections': sections })).toEqual([
       { id: 's1', title: 'Total Estimated Cost', description: 'All-in cost' },
-      { id: 's2', title: 'Community Impact' },
+      { id: 's2', title: 'Community Impact', showTotal: true },
     ]);
   });
 
@@ -60,6 +60,14 @@ describe('getTemplateSections', () => {
     expect(
       groupFieldsBySection({ 'x-sections': [{ id: 'untitled' }] }, [orphan]),
     ).toEqual([{ kind: 'field', field: orphan }]);
+  });
+
+  it('only honours showTotal when it is literally true', () => {
+    expect(
+      getTemplateSections({
+        'x-sections': [{ id: 'a', title: 'A', showTotal: 'yes' }],
+      })[0]?.showTotal,
+    ).toBeUndefined();
   });
 });
 

--- a/packages/common/src/services/decision/templateSections.ts
+++ b/packages/common/src/services/decision/templateSections.ts
@@ -5,7 +5,7 @@
  * with one property per field, ordered by `x-field-order`. Sections add
  * *layout only* on top of that, via two vendor keys:
  *
- * - top-level `x-sections: [{ id, title, description? }]`
+ * - top-level `x-sections: [{ id, title, description?, showTotal? }]`
  * - per-property `x-section: <sectionId>`
  *
  * Nothing else changes: answers stay keyed by the property id, `required`
@@ -34,6 +34,12 @@ export interface TemplateSection {
   id: string;
   title: string;
   description?: string;
+  /**
+   * Render a derived total row after the section's members. The total is
+   * computed at render time from the members' money answers and is never
+   * stored (see `templateMoney.ts`).
+   */
+  showTotal?: boolean;
 }
 
 /**
@@ -105,6 +111,7 @@ export function getTemplateSections(
       ...(typeof entry.description === 'string'
         ? { description: entry.description }
         : {}),
+      ...(entry.showTotal === true ? { showTotal: true } : {}),
     });
   }
 

--- a/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
+++ b/services/api/src/routers/decision/instances/updateDecisionInstance.test.ts
@@ -69,15 +69,17 @@ function splitSectionRubric(): RubricTemplateSchema {
   };
 }
 
-/** The canonical money-criterion schema. */
+/** The canonical money-criterion schema, optionally in a section. */
 function moneyCriterion(
   title: string,
   currency = 'USD',
+  sectionId?: string,
 ): XFormatPropertySchema {
   return {
     type: 'object',
     title,
     'x-format': 'money',
+    ...(sectionId ? { 'x-section': sectionId } : {}),
     properties: {
       amount: { type: 'number', minimum: 0 },
       currency: { type: 'string', const: currency, default: currency },
@@ -96,6 +98,33 @@ function moneyRubric(
     'x-field-order': ['design'],
     properties: { design: { ...moneyCriterion('Design'), ...overrides } },
     required: ['design'],
+  };
+}
+
+/**
+ * Rubric with one presentational section that shows a derived total, and two
+ * money criteria in it — one currency per criterion, so the pair can be made
+ * to agree or disagree.
+ */
+function sectionedMoneyRubric(
+  firstCurrency: string,
+  secondCurrency: string,
+): RubricTemplateSchema {
+  return {
+    type: 'object',
+    'x-sections': [
+      { id: 'cost', title: 'Total Estimated Cost', showTotal: true },
+    ],
+    'x-field-order': ['design', 'construction'],
+    properties: {
+      design: moneyCriterion(
+        'Design & Engineering Cost',
+        firstCurrency,
+        'cost',
+      ),
+      construction: moneyCriterion('Construction', secondCurrency, 'cost'),
+    },
+    required: ['design', 'construction'],
   };
 }
 
@@ -1058,6 +1087,63 @@ describe.concurrent('updateDecisionInstance', () => {
         ],
       }),
     ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
+  });
+
+  it('accepts a summed section whose money criteria share a currency', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    await expect(
+      caller.decision.updateDecisionInstance({
+        instanceId: setup.instance.instance.id,
+        rubricTemplate: sectionedMoneyRubric('USD', 'USD'),
+      }),
+    ).resolves.toBeDefined();
+
+    const dbInstance = await db.query.processInstances.findFirst({
+      where: { id: setup.instance.instance.id },
+    });
+    const instanceData = dbInstance!.instanceData as DecisionInstanceData;
+    expect(instanceData.rubricTemplate?.['x-sections']).toEqual([
+      { id: 'cost', title: 'Total Estimated Cost', showTotal: true },
+    ]);
+  });
+
+  it('rejects a summed section whose money criteria mix currencies', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestDecisionsDataManager(task.id, onTestFinished);
+    const setup = await testData.createDecisionSetup({
+      instanceCount: 1,
+      grantAccess: true,
+    });
+    const caller = await createAuthenticatedCaller(setup.userEmail);
+
+    const before = await db.query.processInstances.findFirst({
+      where: { id: setup.instance.instance.id },
+    });
+
+    await expect(
+      caller.decision.updateDecisionInstance({
+        instanceId: setup.instance.instance.id,
+        rubricTemplate: sectionedMoneyRubric('USD', 'EUR'),
+      }),
+    ).rejects.toMatchObject({ cause: { name: 'ValidationError' } });
+
+    const after = await db.query.processInstances.findFirst({
+      where: { id: setup.instance.instance.id },
+    });
+    expect(
+      (after!.instanceData as DecisionInstanceData).rubricTemplate,
+    ).toEqual((before!.instanceData as DecisionInstanceData).rubricTemplate);
   });
 
   const unsafeMoneyOverrides: Array<[string, Partial<XFormatPropertySchema>]> =

--- a/services/api/src/routers/decision/reviews/rubricMoneyCriteria.test.ts
+++ b/services/api/src/routers/decision/reviews/rubricMoneyCriteria.test.ts
@@ -15,12 +15,15 @@ import { createCallerFactory } from '../../../trpcFactory';
 const createCaller = createCallerFactory(appRouter);
 
 /**
- * Columbus feasibility shape (flat slice): three flat money criteria plus a
- * scored criterion. Criterion ids are opaque, as the builder generates them.
+ * Columbus feasibility shape: one presentational section ("Total Estimated
+ * Cost", `showTotal`) whose three members are flat money criteria, plus a
+ * scored criterion outside the section. Section ids and criterion ids are
+ * opaque, as the builder generates them.
  *
- * Every answer lives at `answers[criterionId]` — one top-level key per money
- * criterion — which is what these tests assert.
+ * The section is layout only — every answer still lives at
+ * `answers[criterionId]`, which is what these tests assert.
  */
+const COST_SECTION_ID = 'sec-9f1c';
 const DESIGN = 'a1b2c3d4';
 const CONSTRUCTION = 'e5f6a7b8';
 const CONTINGENCY = 'c9d0e1f2';
@@ -30,6 +33,7 @@ function moneyCriterion(title: string, currency = 'USD') {
     type: 'object' as const,
     title,
     'x-format': 'money' as const,
+    'x-section': COST_SECTION_ID,
     properties: {
       amount: { type: 'number' as const, minimum: 0 },
       currency: { type: 'string' as const, const: currency, default: currency },
@@ -41,6 +45,13 @@ function moneyCriterion(title: string, currency = 'USD') {
 
 const rubricTemplate: RubricTemplateSchema = {
   type: 'object',
+  'x-sections': [
+    {
+      id: COST_SECTION_ID,
+      title: 'Total Estimated Cost',
+      showTotal: true,
+    },
+  ],
   'x-field-order': [
     DESIGN,
     CONSTRUCTION,


### PR DESCRIPTION
PR D — top of the rubric-money-sections stack (B #1777 → C #1779 → D). Stacked on #1779. The only slice where sections and money touch — deliberately last and small so the coupling is reviewable on its own.

## What

- `TemplateSection.showTotal?: boolean` (passed through only when literally `true`)
- `sumMoneyFields`: non-money members skipped; total labelled with the first answered member's stored currency, falling back to the template pin — same precedence as `resolveMoneyDisplayCurrency`
- `assertTemplateSectionCurrencies` in the authoring guard chain after `assertMoneyFieldSchemas` (skips invalidly-declared currencies rather than inventing USD)
- `RubricSectionTotal` + `useMoneyFormatter`; total row rendered in `ReviewRubricForm` and `SubmittedReviewView` when `block.section.showTotal`
- "Total" i18n key in all 7 dictionaries (add-only)
- Tests: `sumMoneyFields` + currency-assert units (+156 lines), the full Columbus shape in `rubricMoneyCriteria.test.ts` (section + three money criteria + `showTotal`), mixed-currency rejection with rollback assertion in `updateDecisionInstance.test.ts`

## Invariants

- The total is derived at render/read time, **never stored** (ADR 0004, carrying ADR 0003's surviving principle)
- One currency per summed section, enforced statically at the persistence boundary
- Currency formatting through `useFormatter`/`Intl.NumberFormat`, never a hand-rolled symbol map

## Notes

`useAmountPlaceholder` from the original #1768 was dropped — its only consumer was the cancelled CurrencyField. With this PR the stack fully supersedes #1768.

## Verification

`pnpm typecheck` + `format:check` green; packages/common unit tests 59/59. services/api integration files run in CI (supabase harness).