### PR TITLE
fix(app): stop the process builder saving from inside a state updater

### DIFF
--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhaseDetailPage.tsx
@@ -150,15 +150,17 @@ function PhaseDetailForm({
   const allPhasesRef = useRef(allPhases);
   allPhasesRef.current = allPhases;
 
+  // The next phase is computed here rather than inside a `setPhase` updater:
+  // updaters must be pure, and React runs them during render, so saving from
+  // one wrote to the autosave store mid-render and scheduled an update on
+  // ProcessBuilderHeaderContent while this component was still rendering.
+  // Safe to read `phase` from the closure because every caller updates once
+  // per event — if that ever changes, this needs a ref, not an updater.
   const updatePhase = (updates: Partial<PhaseDefinition>) => {
     if (!phase) {
       return;
     }
     const updated = { ...phase, ...updates };
-    // Side effects (saveChanges → store update) must run in the event handler,
-    // never inside the setState updater — the updater executes during render,
-    // and writing the store there updates subscribers (e.g. MobileSidebar)
-    // mid-render.
     setPhase(updated);
     saveChanges({
       phases: toPayload(

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/ReviewSettingsContent.tsx
@@ -94,21 +94,24 @@ export function ReviewSettingsContent({
           : phase.rules,
     }));
 
+  // Computed outside a `setSettings` updater: updaters must be pure, and React
+  // runs them during render, so saving from one wrote to the autosave store
+  // mid-render and scheduled an update on other store subscribers while this
+  // component was still rendering. Safe to read `settings` from the closure
+  // because every caller updates one field per event.
   const updateSettings = (updates: Partial<ReviewSettings>) => {
-    setSettings((prev) => {
-      const updated = { ...prev, ...updates };
-      // scope and revisions write to different places: scope to the review
-      // phase's rules, revisions to legacy config. Route each independently.
-      if (updates.scope !== undefined && reviewPhase) {
-        saveChanges({ phases: phasesWithScope(updated.scope) });
-      }
-      if (updates.reviewsAllowRevisions !== undefined) {
-        saveChanges({
-          config: { reviewsAllowRevisions: updated.reviewsAllowRevisions },
-        });
-      }
-      return updated;
-    });
+    const updated = { ...settings, ...updates };
+    setSettings(updated);
+    // scope and revisions write to different places: scope to the review
+    // phase's rules, revisions to legacy config. Route each independently.
+    if (updates.scope !== undefined && reviewPhase) {
+      saveChanges({ phases: phasesWithScope(updated.scope) });
+    }
+    if (updates.reviewsAllowRevisions !== undefined) {
+      saveChanges({
+        config: { reviewsAllowRevisions: updated.reviewsAllowRevisions },
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
Split out of #1750 at review request — these were found while setting up a decision to export from, and were carried along rather than separated.

Both the phase editor and the review settings saved by calling into the autosave store from inside a state updater. Updaters must be pure and React runs them during render (twice in dev), so each edit wrote to that store mid-render and scheduled an update on other subscribers while the editing component was still rendering — the "cannot update a component while rendering a different component" warning, with the write itself able to run more than once per edit. Both now compute, set, then save.

Worth a reviewer's attention: each screen now reads its current value from the closure rather than the updater's argument, so two edits arriving in the same tick would lose one. That holds today because every caller changes a single field per user event, and both places say so — but it is the assumption this change rests on, and it is why these are better reviewed here than inside an export PR.

## LLM Usage

- opus

## Risk Justification

- Behaviour-preserving for single-field edits, which is every current caller; no API, schema, or data changes.
- The closure read replaces an updater's `prev`, so a future caller batching two field changes into one event would drop one. Called out in the code comments at both sites.
