### PR TITLE
fix(app): check the decision template still exists before creating

### DIFF
--- a/apps/app/src/components/SiteHeader/CreateMenu.tsx
+++ b/apps/app/src/components/SiteHeader/CreateMenu.tsx
@@ -37,8 +37,16 @@ export const CreateMenu = () => {
 
   const createDecisionMutation = useMutation({
     mutationFn: async () => {
-      const { processes: templates } =
-        await utils.decision.listProcesses.ensureData({});
+      // `fetch`, not `ensureData`: template ids are regenerated on every seed
+      // (decision_processes.id is an autoId, and seed-access-control dedupes on
+      // name), so a cached list can hand out an id the server no longer has and
+      // createInstanceFromTemplate 404s. `ensureData` returns cached data
+      // without revalidating, and with gcTime 24h + refetchOnWindowFocus off a
+      // stale entry survives all day. `fetch` respects staleTime (0 here), so
+      // the id is always checked against the server.
+      const { processes: templates } = await utils.decision.listProcesses.fetch(
+        {},
+      );
       const firstTemplate = templates[0];
       if (!firstTemplate) {
         throw new Error('No decision process templates available');


### PR DESCRIPTION
Split out of #1750 at review request — hit while setting up a decision to export from, unrelated to exports.

Creating a decision could fail with `Template with ID '<uuid>' not found`, and stay broken for that browser session while the same click worked for a colleague. The template list was read from cache without revalidation, so once stale it stayed stale — entries are held for 24h and nothing on this path refetches them, not even refocusing the tab. The read now respects its own staleness setting, so the id passed to the create call has just been confirmed by the server.

Staleness is routine rather than exceptional here, which is the part worth a second opinion: template rows are keyed by a generated id while the seed matches them on **name**, so every reseed produces the same templates under new ids. Anyone with a reseeded local database, and any environment rebuilt from seed, is holding ids the server has already discarded.

That upstream disagreement between identity and matching is untouched here. Resolving templates by something stable would remove the need for this check rather than paying a revalidation on every creation — noting it since @scazan raised exactly this in review ("or if the problem is further up where we query by name instead of id").

## LLM Usage

- opus

## Risk Justification

- Trades one cached read for one network read per decision creation; no API, schema, or data changes.
- Removes a cache hit on a low-frequency admin action, so the cost is a single request at click time.
