### PR TITLE
fix(decision): name the field a rejected value belongs to

### DIFF
--- a/packages/common/src/services/decision/schemaValidator.test.ts
+++ b/packages/common/src/services/decision/schemaValidator.test.ts
@@ -1,3 +1,4 @@
+import type { JSONSchema7 } from 'json-schema';
 import { describe, expect, it } from 'vitest';
 
 import { schemaValidator } from './schemaValidator';
@@ -26,5 +27,77 @@ describe('SchemaValidator.validateJsonSchema', () => {
     };
 
     expect(() => schemaValidator.validateJsonSchema(template)).not.toThrow();
+  });
+});
+
+describe('SchemaValidator.validate error messages', () => {
+  /**
+   * A multi-select category field, shaped the way `buildCategorySchema` emits
+   * one: an array whose items match a `oneOf` branch per configured option.
+   * `duplicateLabel` reproduces two categories sharing a label, which is
+   * accepted at configuration time and only surfaces here.
+   */
+  const categorySchema = (duplicateLabel: boolean): JSONSchema7 => ({
+    type: 'object',
+    properties: {
+      category: {
+        type: 'array',
+        title: 'Category',
+        items: {
+          type: 'string',
+          oneOf: [
+            { const: 'test', title: 'test' },
+            ...(duplicateLabel ? [{ const: 'test', title: 'test' }] : []),
+            { const: 'not-a-test', title: 'not-a-test' },
+          ],
+        },
+        uniqueItems: true,
+      },
+    },
+  });
+
+  it('names the field rather than the array index of the failing item', () => {
+    const result = schemaValidator.validate(categorySchema(false), {
+      category: ['no-such-category'],
+    });
+
+    // Regression: the message read "0 is invalid" — the index of the failing
+    // element — because the field name was taken from the last path segment.
+    const message = Object.values(result.errors).join(', ');
+    expect(result.valid).toBe(false);
+    expect(message).toContain('Category');
+    expect(message).not.toMatch(/^0\b/);
+  });
+
+  it('reports an unmatched selection as invalid', () => {
+    const result = schemaValidator.validate(categorySchema(false), {
+      category: ['no-such-category'],
+    });
+
+    expect(Object.values(result.errors)).toEqual([
+      'Category has an invalid selection',
+    ]);
+  });
+
+  it('blames the configuration when duplicate options make a value ambiguous', () => {
+    const result = schemaValidator.validate(categorySchema(true), {
+      category: ['test'],
+    });
+
+    // The submitter picked a real option; it matches two `oneOf` branches, so
+    // "exactly one" cannot hold. Re-picking cannot fix it, so the message has
+    // to point at the duplicate rather than at their choice.
+    const message = Object.values(result.errors).join(', ');
+    expect(result.valid).toBe(false);
+    expect(message).toContain('duplicate options');
+    expect(message).not.toContain('invalid selection');
+  });
+
+  it('accepts an unambiguous selection against the same schema', () => {
+    expect(
+      schemaValidator.validate(categorySchema(true), {
+        category: ['not-a-test'],
+      }).valid,
+    ).toBe(true);
   });
 });

--- a/packages/common/src/services/decision/schemaValidator.ts
+++ b/packages/common/src/services/decision/schemaValidator.ts
@@ -217,6 +217,28 @@ export class SchemaValidator {
   }
 
   /**
+   * The property an error belongs to, ignoring array indices.
+   *
+   * AJV reports a failing array element at `/category/0`, so taking the last
+   * path segment yields `0` — an index, not a field. That has no entry in
+   * `properties`, so the display name fell through to the index itself and the
+   * message read "0 is invalid", naming neither the field nor the problem.
+   * Walking back to the last non-numeric segment recovers the owning property.
+   */
+  private getOwningFieldName(instancePath: string): string {
+    const segments = instancePath.split('/').filter(Boolean);
+
+    for (let i = segments.length - 1; i >= 0; i--) {
+      const segment = segments[i];
+      if (segment && !/^\d+$/.test(segment)) {
+        return segment;
+      }
+    }
+
+    return '';
+  }
+
+  /**
    * Get user-friendly display name for a field by looking up the `title`
    * property from the schema definition. Falls back to capitalizing the key.
    */
@@ -240,7 +262,10 @@ export class SchemaValidator {
     schema?: JSONSchema7,
   ): string {
     const fieldPath = this.getFieldPath(error.instancePath, error.keyword);
-    const fieldName = fieldPath.split('.').pop() || '';
+    const fieldName =
+      this.getOwningFieldName(error.instancePath) ||
+      fieldPath.split('.').pop() ||
+      '';
     const friendlyName = this.getFieldDisplayName(fieldName, schema);
 
     switch (error.keyword) {
@@ -269,6 +294,29 @@ export class SchemaValidator {
       }
       case 'format':
         return `${friendlyName} has an invalid ${error.params?.format} format`;
+      case 'oneOf':
+      case 'const': {
+        // A selection is matched against one `oneOf` branch per configured
+        // option. AJV reports which branches matched in `passingSchemas`:
+        // absent means none did (the ordinary invalid-selection case), while
+        // two or more means the value was ambiguous — the options themselves
+        // carry duplicate values, so `oneOf`'s "exactly one" cannot hold.
+        //
+        // That distinction matters because the second case is not the
+        // submitter's mistake and they cannot resolve it by choosing again:
+        // every proposal picking that option fails until the duplicate is
+        // removed. Saying "invalid" there sends them to re-pick a value that
+        // can never validate.
+        const passingSchemas = error.params?.passingSchemas;
+
+        if (Array.isArray(passingSchemas) && passingSchemas.length > 1) {
+          return `${friendlyName} has duplicate options configured, so this selection is ambiguous — an administrator needs to remove the duplicate`;
+        }
+
+        return `${friendlyName} has an invalid selection`;
+      }
+      case 'uniqueItems':
+        return `${friendlyName} cannot contain the same selection twice`;
       default:
         return `${friendlyName} is invalid`;
     }


### PR DESCRIPTION
Split out of #1750 at review request — found while setting up a proposal to export from, unrelated to exports.

Submitting could fail with `0 is invalid`, naming neither the field nor the problem. The `0` is an array index leaking out: AJV reports a failing element at `/category/0`, and the last path segment was being read as the field name, so any array-valued field reported as its index. Separately, a value matching two `oneOf` branches — two options configured with the same label — was reported as an invalid selection, when the submitter picked a real option and the ambiguity is in the configuration. Every submission choosing it fails until an admin removes the duplicate, so "invalid selection" sends the one person who can't fix it back to re-pick a value that can never validate.

**Worth knowing for review: this validator is shared.** Proposals, reviews, votes, custom form submissions and instance updates all report through it, so these wording changes reach all of them — not just the proposal form where the problem surfaced. No validation logic changed; only the text produced for `oneOf` / `const` / `uniqueItems` and the field name resolution.

Diagnosis only. Duplicate labels are still accepted at configuration time, so the underlying bug survives — this just explains it. The uniqueness check that would prevent it wants its own change, since it also has to settle whether these options should key on identifier rather than label.

## Follow-ups (out of scope)

- **Duplicate option labels are accepted at configuration time:** add a uniqueness check where categories/options are saved, and decide whether the generated schema should key on option id rather than label.
- **These messages bypass translation:** assembled in `@op/common` and rendered directly, so a non-English locale gets English. Long-standing, affects every consumer above.

## LLM Usage

- opus

## Risk Justification

- Message text and field-name resolution only; no validation logic, schema, or data changes.
- Shared validator, so user-facing wording changes across proposals, reviews, voting, custom forms and instance updates.
- Covered by tests added here, including the duplicate-option case and a regression assertion that the message no longer leads with an array index.
