### PR TITLE
fix(app): pin the workspace root both dev servers build from

### DIFF
--- a/apps/api/next.config.mjs
+++ b/apps/api/next.config.mjs
@@ -1,4 +1,8 @@
 import dotenv from 'dotenv';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 try {
   if (process.env.NODE_ENV === 'development') {
@@ -28,6 +32,12 @@ dotenv.config({
 const config = {
   serverExternalPackages: ['sharp', 'onnxruntime-node'],
   turbopack: {
+    // Pin the workspace root. Turbopack otherwise infers it by walking up for
+    // lockfiles, so a stray package-lock.json above the monorepo (e.g. an `npm
+    // install` run in $HOME) silently moves the root and emits externals
+    // symlinks under .next/dev/node_modules with the wrong relative depth —
+    // producing "Cannot find module '@swc/helpers-<hash>/...'" at runtime.
+    root: path.resolve(__dirname, '../..'),
     resolveAlias: {
       // In e2e mode, swap external services for in-process mocks so the API
       // server never makes network calls to TipTap Cloud or PostHog.

--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -66,6 +66,12 @@ const config = {
     authInterrupts: true,
   },
   turbopack: {
+    // Pin the workspace root. Turbopack otherwise infers it by walking up for
+    // lockfiles, so a stray package-lock.json above the monorepo (e.g. an `npm
+    // install` run in $HOME) silently moves the root and emits externals
+    // symlinks under .next/dev/node_modules with the wrong relative depth —
+    // producing "Cannot find module '@swc/helpers-<hash>/...'" at runtime.
+    root: path.resolve(__dirname, '../..'),
     resolveAlias: {
       // Disable the 'tls' module on the client side
       tls: { browser: '' },


### PR DESCRIPTION
Split out of #1750 at review request — picked up while getting local dev working, unrelated to exports.

Turbopack infers the workspace root by walking up from the app until it finds a lockfile. If one exists *above* the repository — an `npm install` run once in `$HOME` leaves one — the inferred root moves up with it. The build still succeeds; the externals symlinks under `.next/dev/node_modules` are just written for a root further away than the real one, and the app then fails at runtime with `Cannot find module '@swc/helpers-<hash>/...'`. Nothing in that message points at the workspace root, so the debugging goes into reinstalling dependencies and clearing caches instead. Naming the root removes the inference. Both dev servers are pinned rather than only the one where it surfaced, since the same walk happens in each.

**This is the part worth arguing about, and why it's on its own branch.** @scazan and @iwillig both questioned whether it's needed, and the honest answer is that it can't be settled from the repo: `pnpm-lock.yaml` *is* at the repo root, so in an ordinary checkout the inference already resolves correctly and this changes nothing. It's insurance against a condition that lives on a machine, not in the repository.

The deciding evidence is whoever hit the original `@swc/helpers` failure saying whether they had a stray lockfile above the monorepo:

```bash
ls ~/package-lock.json ~/pnpm-lock.yaml ~/../package-lock.json 2>/dev/null
```

If nothing turns up, the reasoning here is wrong and this should be closed rather than merged.

## LLM Usage

- opus

## Risk Justification

- Dev-server configuration only; no application code, and no effect on production builds (`next build --webpack`).
- Pins a value that is already inferred correctly in a clean checkout, so the expected behaviour change is none.
- If the inferred root were ever *intended* to differ from the repo root, this would override it — no current setup relies on that.
