### PR TITLE
fix(sense): isolate user-authored text direction in RTL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Monorepo with `apps/`, `packages/`, and `services/` — directory names are self
   - Colors: semantic classes (e.g. `bg-primary`, `text-muted-foreground`, `border-input`) — raw values in `packages/styles/tokens.css`, semantic names in `packages/styles/theme.css`
   - Text sizes: the sense type scale (`text-label`, `text-title`, `text-headline`, `text-display`) — no raw Tailwind size utilities we haven't defined, and never the legacy `text-title-*` scale
 - **Always use logical properties** — `ms-`/`me-`, `ps-`/`pe-`, `start-`/`end-`, `text-start`/`text-end` — never `ml-`/`pl-`/`left-`. The app ships Arabic.
-- **Isolate user-authored text** — a title, name, or category can run counter to the page direction, and without isolation its punctuation lands on the wrong side. Block of text → `dir="auto"` plus `[text-align:match-parent]` (direction from the content, alignment from the page); a name or short value sitting inline → wrap it in `<bdi>`. See [`packages/sense/CLAUDE.md`](packages/sense/CLAUDE.md) for why both halves are needed and which sense components already do this.
+- **Isolate user-authored text** — a title, name, or category can run counter to the page direction, and without isolation its punctuation lands on the wrong side. Wrap it in `<bdi>`; if the block truncates or clamps, it needs `dir="auto"` plus `ltr:text-left rtl:text-right` instead, or the ellipsis clips the wrong end. See [`packages/sense/CLAUDE.md`](packages/sense/CLAUDE.md) for the reasoning and which sense components already do this.
 - Tailwind configuration is centralized in `@op/styles`: `tokens.css` holds raw values, `theme.css` holds semantics and is the package entry
 
 ### Accessibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Monorepo with `apps/`, `packages/`, and `services/` — directory names are self
   - Colors: semantic classes (e.g. `bg-primary`, `text-muted-foreground`, `border-input`) — raw values in `packages/styles/tokens.css`, semantic names in `packages/styles/theme.css`
   - Text sizes: the sense type scale (`text-label`, `text-title`, `text-headline`, `text-display`) — no raw Tailwind size utilities we haven't defined, and never the legacy `text-title-*` scale
 - **Always use logical properties** — `ms-`/`me-`, `ps-`/`pe-`, `start-`/`end-`, `text-start`/`text-end` — never `ml-`/`pl-`/`left-`. The app ships Arabic.
-- **Isolate user-authored text** — a title, name, or category can run counter to the page direction, and without isolation its punctuation lands on the wrong side. Block of text → `[unicode-bidi:plaintext]` on the block; a name or short value sitting inline → wrap it in `<bdi>`. See [`packages/sense/CLAUDE.md`](packages/sense/CLAUDE.md) for which sense components already do this.
+- **Isolate user-authored text** — a title, name, or category can run counter to the page direction, and without isolation its punctuation lands on the wrong side. Block of text → `dir="auto"` plus `[text-align:match-parent]` (direction from the content, alignment from the page); a name or short value sitting inline → wrap it in `<bdi>`. See [`packages/sense/CLAUDE.md`](packages/sense/CLAUDE.md) for why both halves are needed and which sense components already do this.
 - Tailwind configuration is centralized in `@op/styles`: `tokens.css` holds raw values, `theme.css` holds semantics and is the package entry
 
 ### Accessibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Monorepo with `apps/`, `packages/`, and `services/` — directory names are self
   - Colors: semantic classes (e.g. `bg-primary`, `text-muted-foreground`, `border-input`) — raw values in `packages/styles/tokens.css`, semantic names in `packages/styles/theme.css`
   - Text sizes: the sense type scale (`text-label`, `text-title`, `text-headline`, `text-display`) — no raw Tailwind size utilities we haven't defined, and never the legacy `text-title-*` scale
 - **Always use logical properties** — `ms-`/`me-`, `ps-`/`pe-`, `start-`/`end-`, `text-start`/`text-end` — never `ml-`/`pl-`/`left-`. The app ships Arabic.
+- **Isolate user-authored text** — a title, name, or category can run counter to the page direction, and without isolation its punctuation lands on the wrong side. Block of text → `[unicode-bidi:plaintext]` on the block; a name or short value sitting inline → wrap it in `<bdi>`. See [`packages/sense/CLAUDE.md`](packages/sense/CLAUDE.md) for which sense components already do this.
 - Tailwind configuration is centralized in `@op/styles`: `tokens.css` holds raw values, `theme.css` holds semantics and is the package entry
 
 ### Accessibility

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -105,7 +105,7 @@ const HighlightLabel = ({ children }: { children?: ReactNode }) => {
 
 const Highlight = ({ children }: { children?: ReactNode }) => {
   return (
-    <div className="flex w-full items-center justify-start gap-4 sm:w-auto">
+    <div className="flex w-full items-center justify-start gap-4 sm:w-fit">
       {children}
     </div>
   );

--- a/apps/app/src/components/PlatformHighlights/index.tsx
+++ b/apps/app/src/components/PlatformHighlights/index.tsx
@@ -23,7 +23,7 @@ export const PlatformHighlights = () => {
 
   return (
     <Card className="gap-0 py-0">
-      <div className="flex flex-col items-center justify-between gap-6 px-10 py-6 sm:flex-row sm:gap-4">
+      <div className="flex flex-col items-center justify-around gap-6 px-10 py-6 sm:flex-row sm:gap-4">
         {stats.newOrganizations > 0 && (
           <>
             <Highlight>
@@ -89,7 +89,7 @@ const HighlightNumber = ({
     <div className="col-span-3 text-transparent xxs:col-span-2">
       <div
         className={cn(
-          'flex items-center justify-end bg-gradient bg-clip-text text-end font-serif text-display font-light',
+          'flex items-center justify-end bg-gradient bg-clip-text text-end font-serif text-5xl font-light sm:text-display',
           className,
         )}
       >
@@ -100,16 +100,12 @@ const HighlightNumber = ({
 };
 
 const HighlightLabel = ({ children }: { children?: ReactNode }) => {
-  return (
-    <div className="col-span-2 flex h-12 max-w-32 items-center xxs:col-span-3">
-      {children}
-    </div>
-  );
+  return <div className="flex h-12 items-center">{children}</div>;
 };
 
 const Highlight = ({ children }: { children?: ReactNode }) => {
   return (
-    <div className="grid w-full grid-cols-5 items-center gap-4 xxs:flex sm:flex">
+    <div className="flex w-full items-center justify-start gap-4 sm:w-auto">
       {children}
     </div>
   );

--- a/apps/app/src/components/decisions/DecisionActionBar.tsx
+++ b/apps/app/src/components/decisions/DecisionActionBar.tsx
@@ -47,12 +47,12 @@ export const DecisionActionBar = ({
 
   return (
     <div className="flex w-full justify-center">
-      <div className="flex w-full max-w-48 flex-col items-center justify-center gap-4 sm:flex-row">
+      <div className="flex w-full flex-col items-center justify-center gap-4 sm:flex-row">
         {description ? (
           <Dialog>
             <DialogTrigger
               render={
-                <Button variant="outline" className="w-full">
+                <Button variant="outline" className="w-full sm:w-auto">
                   {label ?? t('Learn more')}
                 </Button>
               }
@@ -85,7 +85,7 @@ export const DecisionActionBar = ({
 
         {showSubmitButton && (
           <Button
-            className="w-full"
+            className="w-full sm:w-auto"
             disabled={!isReady || isCreating}
             onClick={handleCreateProposal}
           >

--- a/apps/app/src/components/decisions/EditBannerModal.tsx
+++ b/apps/app/src/components/decisions/EditBannerModal.tsx
@@ -27,7 +27,6 @@ export function EditBannerModal({
     <>
       <Button
         variant="outline"
-        size="sm"
         className="absolute end-4 top-4 z-10 hidden md:flex"
         onClick={() => setIsOpen(true)}
       >

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/general/PhasesSectionContent.tsx
@@ -213,7 +213,9 @@ export function PhasesSectionContent({
                   <DragHandle {...dragHandleProps} />
                   <div className="flex flex-1 items-center justify-between gap-3">
                     <div className="flex-1">
-                      <p className="font-serif text-label">{phase.name}</p>
+                      <p className="font-serif text-label">
+                        <bdi>{phase.name}</bdi>
+                      </p>
                       {configured ? (
                         <span className="flex items-center gap-1 text-sm text-primary">
                           <LuCheck className="size-3" />
@@ -309,7 +311,9 @@ const PhaseDragPreview = ({
       <DragHandle tabIndex={-1} aria-hidden />
       <div className="flex flex-1 items-center justify-between gap-3">
         <div className="flex-1">
-          <p className="font-serif text-label">{phase.name}</p>
+          <p className="font-serif text-label">
+            <bdi>{phase.name}</bdi>
+          </p>
           {configured ? (
             <span className="flex items-center gap-1 text-sm text-primary">
               <LuCheck className="size-3" />

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/SummarySectionInner.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/participants/SummarySectionInner.tsx
@@ -101,7 +101,7 @@ export function SummarySectionInner({
         <div className="flex flex-col space-y-2 rounded-lg border p-4">
           {incompleteItems.map((item, index) => (
             <div key={item.id}>
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between gap-4">
                 <span className="text-base">{t(item.labelKey)}</span>
                 <Button
                   variant="outline"

--- a/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
+++ b/apps/app/src/components/decisions/ProcessBuilder/stepContent/rubric/CategoryReviewerCard.tsx
@@ -133,7 +133,9 @@ export function CategoryReviewerCard({
       data-testid={`category-reviewer-card-${category.name}`}
     >
       <div className="flex items-end justify-between gap-2">
-        <span className="font-serif text-sm">{category.name}</span>
+        <span className="font-serif text-sm">
+          <bdi>{category.name}</bdi>
+        </span>
         <span
           className={
             isEmpty ? 'text-sm text-warning' : 'text-sm text-muted-foreground'

--- a/apps/app/src/components/decisions/SelectableProposalsTable.tsx
+++ b/apps/app/src/components/decisions/SelectableProposalsTable.tsx
@@ -88,10 +88,12 @@ export const SelectableProposalsTable = ({
                       href={href}
                       className="text-base text-foreground hover:underline"
                     >
-                      {fields.title}
+                      <bdi>{fields.title}</bdi>
                     </Link>
                   ) : (
-                    <span className="text-base">{fields.title}</span>
+                    <span className="text-base">
+                      <bdi>{fields.title}</bdi>
+                    </span>
                   )}
                   {fields.submitterName ? (
                     <span className="text-sm text-muted-foreground">
@@ -160,10 +162,12 @@ const SelectableProposalCard = ({
             href={href}
             className="text-base text-foreground hover:underline"
           >
-            {fields.title}
+            <bdi>{fields.title}</bdi>
           </Link>
         ) : (
-          <span className="text-base">{fields.title}</span>
+          <span className="text-base">
+            <bdi>{fields.title}</bdi>
+          </span>
         )}
         {fields.submitterName ? (
           <span className="text-sm text-muted-foreground">

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionInstanceDetail/DecisionInstanceDetail.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionInstanceDetail/DecisionInstanceDetail.tsx
@@ -71,13 +71,8 @@ const DecisionInstanceDetailContent = ({
           {t('All Decisions')}
         </Link>
         <div className="flex flex-wrap items-center gap-3">
-          {/* `dir="auto"` matches the sense `Header1` default — the name is
-              user content and can run counter to the page direction. */}
-          <h1
-            dir="auto"
-            className="[text-align:match-parent] font-serif text-headline font-light"
-          >
-            {detail.name}
+          <h1 className="font-serif text-headline font-light">
+            <bdi>{detail.name}</bdi>
           </h1>
           {detail.status ? (
             <Badge variant="secondary">

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionInstanceDetail/DecisionInstanceDetail.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionInstanceDetail/DecisionInstanceDetail.tsx
@@ -73,7 +73,10 @@ const DecisionInstanceDetailContent = ({
         <div className="flex flex-wrap items-center gap-3">
           {/* `dir="auto"` matches the sense `Header1` default — the name is
               user content and can run counter to the page direction. */}
-          <h1 dir="auto" className="font-serif text-headline font-light">
+          <h1
+            dir="auto"
+            className="[text-align:match-parent] font-serif text-headline font-light"
+          >
             {detail.name}
           </h1>
           {detail.status ? (

--- a/apps/app/src/components/screens/PlatformAdmin/DecisionInstanceDetail/DecisionInstanceDetail.tsx
+++ b/apps/app/src/components/screens/PlatformAdmin/DecisionInstanceDetail/DecisionInstanceDetail.tsx
@@ -71,7 +71,11 @@ const DecisionInstanceDetailContent = ({
           {t('All Decisions')}
         </Link>
         <div className="flex flex-wrap items-center gap-3">
-          <h1 className="font-serif text-headline font-light">{detail.name}</h1>
+          {/* `dir="auto"` matches the sense `Header1` default — the name is
+              user content and can run counter to the page direction. */}
+          <h1 dir="auto" className="font-serif text-headline font-light">
+            {detail.name}
+          </h1>
           {detail.status ? (
             <Badge variant="secondary">
               {STATUS_DISPLAY[detail.status] ?? detail.status}

--- a/packages/sense/CLAUDE.md
+++ b/packages/sense/CLAUDE.md
@@ -113,21 +113,32 @@ review so easily.
 Pick by shape, not by content — you can't know at build time which way a value
 runs:
 
-- **A block of text** (heading, paragraph, card title) → `[unicode-bidi:plaintext]`
-  on the block. Each block then resolves its own base direction from its first
-  strong character, and because `text-align` is `start`, the alignment follows
-  too.
+- **A block of text** (heading, paragraph, card title) →
+  `dir="auto" className="[text-align:match-parent]"`. The two halves are not
+  optional and do different jobs: `dir="auto"` sets the block's direction from
+  its first strong character, which fixes the ordering *and* the side the
+  truncation ellipsis lands on; `match-parent` then pins the **alignment** to
+  the page. Without it `text-align: start` follows the block's own resolved
+  direction, so an English item in an Arabic list aligns left while its Arabic
+  neighbours align right — the list ends up with two ragged edges.
 - **A name or short value sitting inline** with other text (`Name +2`,
   a tag beside its remove button, a table cell) → wrap it in `<bdi>`. It
-  isolates the run so neighbouring content can't reorder around it.
+  isolates the run so neighbouring content can't reorder around it, and being
+  inline it doesn't touch alignment at all.
 - **An input** → nothing. `Input`, `Textarea` and the `RichTextEditor` viewer
   already handle it; see `lib/textDirection.ts` for why `dir="auto"` alone isn't
-  equivalent.
+  equivalent there.
 
-Already handled inside sense — don't re-wrap: `Header1`/`Header2`/`Header3`
-(default `dir="auto"`), `ProfileItem`, `PhaseCard`, `ProposalCard`, `TagGroup`,
-`Input`, `Textarea`, `RichTextEditor`. A raw `<h1>`/`<p>`/`<span>` you write
-yourself is not.
+`unicode-bidi: plaintext` looks like the tidier answer and mostly isn't: it
+resolves per *line* rather than per block, and it drags alignment along with it.
+The editor surfaces use it deliberately — mixed-language paragraphs are the
+point there — but display text wants the pair above.
+
+Already handled inside sense — don't re-wrap: `ProfileItem`, `PhaseCard`,
+`ProposalCard`, `TagGroup`, `Input`, `Textarea`, `RichTextEditor`. The `Header*`
+components default to `dir="auto"` but leave alignment alone, so a heading
+holding user content still wants `[text-align:match-parent]` at the call site.
+A raw `<h1>`/`<p>`/`<span>` you write yourself is handled by nothing.
 
 Also: anything that animates needs a `motion-reduce:` branch, and any
 directional icon needs `rtl:-scale-x-100`.

--- a/packages/sense/CLAUDE.md
+++ b/packages/sense/CLAUDE.md
@@ -93,11 +93,48 @@ reimplement or work around any of it. These four are yours:
    whole surface must be clickable, use `Button variant="bare"`, which keeps
    button semantics without imposing button styling.
 
+Check your work in the **A11y** panel of the component's story — it runs axe
+against whatever is on screen, live.
+
+### RTL: layout, and then direction
+
+Logical properties (`ms-`, `ps-`, `start-`, `text-start`) get the *layout*
+right. They do nothing for *text direction*, which is a separate bug with a
+separate fix.
+
+The app ships Arabic, and its content is user-authored, so any proposal title,
+decision name, profile name, or category can run counter to the page direction.
+Rendered unisolated, its neutral characters — punctuation, digits, a currency
+symbol, the line-clamp ellipsis — resolve against the *page's* direction and
+jump to the wrong end: `Hell yeah??` renders as `??Hell yeah`. The text is
+correct in the DOM; only the rendering is wrong, which is why this survives
+review so easily.
+
+Pick by shape, not by content — you can't know at build time which way a value
+runs:
+
+- **A block of text** (heading, paragraph, card title) → `[unicode-bidi:plaintext]`
+  on the block. Each block then resolves its own base direction from its first
+  strong character, and because `text-align` is `start`, the alignment follows
+  too.
+- **A name or short value sitting inline** with other text (`Name +2`,
+  a tag beside its remove button, a table cell) → wrap it in `<bdi>`. It
+  isolates the run so neighbouring content can't reorder around it.
+- **An input** → nothing. `Input`, `Textarea` and the `RichTextEditor` viewer
+  already handle it; see `lib/textDirection.ts` for why `dir="auto"` alone isn't
+  equivalent.
+
+Already handled inside sense — don't re-wrap: `Header1`/`Header2`/`Header3`
+(default `dir="auto"`), `ProfileItem`, `PhaseCard`, `ProposalCard`, `TagGroup`,
+`Input`, `Textarea`, `RichTextEditor`. A raw `<h1>`/`<p>`/`<span>` you write
+yourself is not.
+
 Also: anything that animates needs a `motion-reduce:` branch, and any
 directional icon needs `rtl:-scale-x-100`.
 
-Check your work in the **A11y** panel of the component's story — it runs axe
-against whatever is on screen, live.
+To check it, switch Storybook or the app to Arabic and look at a story whose
+text is English — the mismatch is the whole point, and it's invisible when both
+run the same way.
 
 ---
 

--- a/packages/sense/CLAUDE.md
+++ b/packages/sense/CLAUDE.md
@@ -110,35 +110,50 @@ jump to the wrong end: `Hell yeah??` renders as `??Hell yeah`. The text is
 correct in the DOM; only the rendering is wrong, which is why this survives
 review so easily.
 
-Pick by shape, not by content — you can't know at build time which way a value
-runs:
+**Default: wrap user content in `<bdi>`.** Title, name, category, preview —
+heading or inline, it doesn't matter. `<bdi>` carries its own `dir="auto"`, so
+the *run* resolves its direction from its own first strong character while the
+surrounding block keeps the page's, and with it the page's alignment.
 
-- **A block of text** (heading, paragraph, card title) →
-  `dir="auto" className="[text-align:match-parent]"`. The two halves are not
-  optional and do different jobs: `dir="auto"` sets the block's direction from
-  its first strong character, which fixes the ordering *and* the side the
-  truncation ellipsis lands on; `match-parent` then pins the **alignment** to
-  the page. Without it `text-align: start` follows the block's own resolved
-  direction, so an English item in an Arabic list aligns left while its Arabic
-  neighbours align right — the list ends up with two ragged edges.
-- **A name or short value sitting inline** with other text (`Name +2`,
-  a tag beside its remove button, a table cell) → wrap it in `<bdi>`. It
-  isolates the run so neighbouring content can't reorder around it, and being
-  inline it doesn't touch alignment at all.
-- **An input** → nothing. `Input`, `Textarea` and the `RichTextEditor` viewer
-  already handle it; see `lib/textDirection.ts` for why `dir="auto"` alone isn't
-  equivalent there.
+```jsx
+<h3 className="font-serif text-title">
+  <bdi>{proposal.title}</bdi>
+</h3>
+```
 
-`unicode-bidi: plaintext` looks like the tidier answer and mostly isn't: it
-resolves per *line* rather than per block, and it drags alignment along with it.
-The editor surfaces use it deliberately — mixed-language paragraphs are the
-point there — but display text wants the pair above.
+**If the block truncates or clamps, `<bdi>` is not enough.** The ellipsis is
+placed at the *block's* direction end, so an RTL block clips the head off an
+English name — `TEST Map Vote` renders as `…p Vote`. Those blocks need the
+direction on the element, and then the alignment pinned back to the page:
 
-Already handled inside sense — don't re-wrap: `ProfileItem`, `PhaseCard`,
-`ProposalCard`, `TagGroup`, `Input`, `Textarea`, `RichTextEditor`. The `Header*`
-components default to `dir="auto"` but leave alignment alone, so a heading
-holding user content still wants `[text-align:match-parent]` at the call site.
-A raw `<h1>`/`<p>`/`<span>` you write yourself is handled by nothing.
+```jsx
+<div dir="auto" className="truncate ltr:text-left rtl:text-right">
+  {profile.name}
+</div>
+```
+
+This is the one place physical `text-left` / `text-right` is the point rather
+than a bug: `text-start` would follow the element's own resolved direction,
+which is exactly what we're overriding.
+
+Two things that look like the answer and aren't:
+
+- **`dir="auto"` on its own.** Left-aligns an English row in an Arabic list
+  while its Arabic neighbours right-align — two ragged edges. Fine for a
+  *control* whose value the user is editing (`Input`, `Textarea`,
+  `lib/textDirection.ts`), wrong for display text unless paired with the
+  alignment override above.
+- **`unicode-bidi: plaintext`.** Resolves per *line* and drags alignment along.
+  The `RichTextEditor` viewer wants exactly that — mixed-language paragraphs are
+  the point there — and display text doesn't.
+
+Inputs need nothing from you: `Input`, `Textarea` and the `RichTextEditor`
+viewer already handle their own text.
+
+Already handled inside sense — don't re-wrap: `Header1`–`Header4`,
+`GradientHeader`, `ProfileItem`, `PhaseCard`, `ProposalCard`, `TagGroup`,
+`Input`, `Textarea`, `RichTextEditor`. A raw `<h1>`/`<p>`/`<span>` you write
+yourself is handled by nothing.
 
 Also: anything that animates needs a `motion-reduce:` branch, and any
 directional icon needs `rtl:-scale-x-100`.

--- a/packages/sense/src/components/Header/index.tsx
+++ b/packages/sense/src/components/Header/index.tsx
@@ -4,50 +4,52 @@ import { cn } from '../../lib/utils';
 
 // Serif headings on the sense semantic type scale (Figma Typography
 // collection): display 24→48, headline 20→30, title 18→20, label 16.
-// `dir="auto"` by default — headings always carry real content, so the
-// direction resolves from it.
+//
+// Headings carry real content, which on an Arabic page is often English (or the
+// reverse), so the text is `<bdi>`-isolated and reads correctly either way. The
+// isolation is deliberately on the text and not a `dir` on the heading: a `dir`
+// would resolve `text-align: start` against the *content*, left-aligning one
+// heading in a column of right-aligned ones. Pass `dir` to override.
 
 interface HeaderProps extends React.ComponentProps<'h1'> {
   dir?: 'ltr' | 'rtl' | 'auto';
 }
 
-function Header1({ className, dir = 'auto', ...props }: HeaderProps) {
+function Header1({ className, children, ...props }: HeaderProps) {
   return (
     <h1
-      dir={dir}
       className={cn('font-serif text-display font-light', className)}
       {...props}
-    />
+    >
+      <bdi>{children}</bdi>
+    </h1>
   );
 }
 
-function Header2({ className, dir = 'auto', ...props }: HeaderProps) {
+function Header2({ className, children, ...props }: HeaderProps) {
   return (
     <h2
-      dir={dir}
       className={cn('font-serif text-headline font-light', className)}
       {...props}
-    />
+    >
+      <bdi>{children}</bdi>
+    </h2>
   );
 }
 
-function Header3({ className, dir = 'auto', ...props }: HeaderProps) {
+function Header3({ className, children, ...props }: HeaderProps) {
   return (
-    <h3
-      dir={dir}
-      className={cn('font-serif text-title', className)}
-      {...props}
-    />
+    <h3 className={cn('font-serif text-title', className)} {...props}>
+      <bdi>{children}</bdi>
+    </h3>
   );
 }
 
-function Header4({ className, dir = 'auto', ...props }: HeaderProps) {
+function Header4({ className, children, ...props }: HeaderProps) {
   return (
-    <h4
-      dir={dir}
-      className={cn('font-serif text-label', className)}
-      {...props}
-    />
+    <h4 className={cn('font-serif text-label', className)} {...props}>
+      <bdi>{children}</bdi>
+    </h4>
   );
 }
 
@@ -59,19 +61,20 @@ interface GradientHeaderProps extends React.ComponentProps<'div'> {
 function GradientHeader({
   className,
   gradient = 'bg-gradient',
-  dir = 'auto',
+  children,
   ...props
 }: GradientHeaderProps) {
   return (
     <div
-      dir={dir}
       className={cn(
         'mx-auto flex w-fit items-center bg-clip-text font-serif text-display text-transparent',
         gradient,
         className,
       )}
       {...props}
-    />
+    >
+      <bdi>{children}</bdi>
+    </div>
   );
 }
 

--- a/packages/sense/src/components/NotificationPanel/index.tsx
+++ b/packages/sense/src/components/NotificationPanel/index.tsx
@@ -56,7 +56,11 @@ function NotificationPanelItem({
 }
 
 function NotificationPanelActions({ children }: { children: ReactNode }) {
-  return <div className="flex items-center gap-4">{children}</div>;
+  return (
+    <div className="flex flex-col items-center gap-4 sm:flex-row">
+      {children}
+    </div>
+  );
 }
 
 export {

--- a/packages/sense/src/components/NotificationPanel/index.tsx
+++ b/packages/sense/src/components/NotificationPanel/index.tsx
@@ -57,7 +57,7 @@ function NotificationPanelItem({
 
 function NotificationPanelActions({ children }: { children: ReactNode }) {
   return (
-    <div className="flex flex-col items-center gap-4 sm:flex-row">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
       {children}
     </div>
   );

--- a/packages/sense/src/components/ProfileItem/index.tsx
+++ b/packages/sense/src/components/ProfileItem/index.tsx
@@ -24,8 +24,9 @@ const titleClasses: Record<ProfileItemSize, string> = {
 
 /**
  * Avatar + title (+ optional description / trailing content) row. Presentational
- * — pass a rendered avatar; the consumer owns data. `dir="auto"` on text so
- * RTL names/descriptions resolve their own direction.
+ * — pass a rendered avatar; the consumer owns data. Title and description take
+ * their direction from the content and their alignment from the page, so a name
+ * running counter to the page still truncates from its own tail.
  */
 function ProfileItem({
   avatar,
@@ -41,14 +42,16 @@ function ProfileItem({
     <div className={cn('flex min-w-0 gap-3 text-start', className)}>
       {avatar}
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        {/* `dir="auto"` gets the ordering (and the ellipsis side) from the
-            content; `match-parent` keeps the *alignment* on the page, so a row
-            of mixed-language items doesn't align every other one differently. */}
+        {/* A truncating block needs `dir` from its own content — the ellipsis
+            lands at the block's direction end, so an RTL block would clip the
+            *head* off an English name. Alignment then has to be pinned back to
+            the page, which is the one place physical `text-left`/`text-right`
+            is the point rather than a bug: `start` would follow the content. */}
         <div
           dir="auto"
           className={cn(
             titleClasses[size],
-            'truncate [text-align:match-parent]',
+            'truncate ltr:text-left rtl:text-right',
             titleClassName,
           )}
         >
@@ -58,7 +61,7 @@ function ProfileItem({
           <div
             dir="auto"
             className={cn(
-              'truncate [text-align:match-parent] text-sm font-normal text-muted-foreground',
+              'truncate text-sm font-normal text-muted-foreground ltr:text-left rtl:text-right',
               descriptionClassName,
             )}
           >

--- a/packages/sense/src/components/ProfileItem/index.tsx
+++ b/packages/sense/src/components/ProfileItem/index.tsx
@@ -41,9 +41,16 @@ function ProfileItem({
     <div className={cn('flex min-w-0 gap-3 text-start', className)}>
       {avatar}
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        {/* `dir="auto"` gets the ordering (and the ellipsis side) from the
+            content; `match-parent` keeps the *alignment* on the page, so a row
+            of mixed-language items doesn't align every other one differently. */}
         <div
           dir="auto"
-          className={cn(titleClasses[size], 'truncate', titleClassName)}
+          className={cn(
+            titleClasses[size],
+            'truncate [text-align:match-parent]',
+            titleClassName,
+          )}
         >
           {title}
         </div>
@@ -51,7 +58,7 @@ function ProfileItem({
           <div
             dir="auto"
             className={cn(
-              'truncate text-sm font-normal text-muted-foreground',
+              'truncate [text-align:match-parent] text-sm font-normal text-muted-foreground',
               descriptionClassName,
             )}
           >

--- a/packages/sense/src/components/ProposalCard/index.tsx
+++ b/packages/sense/src/components/ProposalCard/index.tsx
@@ -142,7 +142,10 @@ export function ProposalCard({
         )}
         {...rest}
       >
-        <h3 className="line-clamp-2 font-serif text-label text-foreground [unicode-bidi:plaintext]">
+        <h3
+          dir="auto"
+          className="line-clamp-2 [text-align:match-parent] font-serif text-label text-foreground"
+        >
           <TitleLink href={href} linkComponent={linkComponent}>
             {title}
           </TitleLink>
@@ -174,13 +177,15 @@ export function ProposalCard({
       <div className={cn('flex flex-col gap-3', aside && 'pe-10')}>
         {headerBadge}
         {/* Proposal text is user content, so it can be LTR on an RTL page (or
-            the reverse). `plaintext` resolves each block's base direction from
-            its own first strong character, which fixes both the punctuation
-            order and — `text-align` being `start` — the alignment. */}
+            the reverse). `dir="auto"` resolves the block's direction from its
+            own first strong character — without it the trailing punctuation and
+            the clamp ellipsis jump to the wrong end. `match-parent` keeps the
+            alignment on the page, so a grid of cards stays in one column. */}
         <h3
           id={titleId}
+          dir="auto"
           className={cn(
-            'font-serif text-title [unicode-bidi:plaintext]',
+            '[text-align:match-parent] font-serif text-title',
             selected ? 'text-teal-600' : 'text-foreground',
           )}
         >
@@ -201,7 +206,10 @@ export function ProposalCard({
         </div>
       ) : null}
       {description ? (
-        <p className="line-clamp-3 text-base text-foreground [unicode-bidi:plaintext]">
+        <p
+          dir="auto"
+          className="line-clamp-3 [text-align:match-parent] text-base text-foreground"
+        >
           {description}
         </p>
       ) : null}

--- a/packages/sense/src/components/ProposalCard/index.tsx
+++ b/packages/sense/src/components/ProposalCard/index.tsx
@@ -142,9 +142,11 @@ export function ProposalCard({
         )}
         {...rest}
       >
+        {/* Clamped, so `dir` has to come from the content or the ellipsis clips
+            the wrong end; alignment is pinned back to the page. */}
         <h3
           dir="auto"
-          className="line-clamp-2 [text-align:match-parent] font-serif text-label text-foreground"
+          className="line-clamp-2 font-serif text-label text-foreground ltr:text-left rtl:text-right"
         >
           <TitleLink href={href} linkComponent={linkComponent}>
             {title}
@@ -176,21 +178,19 @@ export function ProposalCard({
       {aside ? <div className="absolute end-6 top-6 z-10">{aside}</div> : null}
       <div className={cn('flex flex-col gap-3', aside && 'pe-10')}>
         {headerBadge}
-        {/* Proposal text is user content, so it can be LTR on an RTL page (or
-            the reverse). `dir="auto"` resolves the block's direction from its
-            own first strong character — without it the trailing punctuation and
-            the clamp ellipsis jump to the wrong end. `match-parent` keeps the
-            alignment on the page, so a grid of cards stays in one column. */}
+        {/* Proposal text is user content, so it can run counter to the page
+            direction. `<bdi>` isolates the run — without it the trailing
+            punctuation jumps to the wrong end — while the heading itself keeps
+            the page's direction, so a grid of cards stays in one column. */}
         <h3
           id={titleId}
-          dir="auto"
           className={cn(
-            '[text-align:match-parent] font-serif text-title',
+            'font-serif text-title',
             selected ? 'text-teal-600' : 'text-foreground',
           )}
         >
           <TitleLink href={href} linkComponent={linkComponent}>
-            {title}
+            <bdi>{title}</bdi>
           </TitleLink>
         </h3>
         {alert}
@@ -208,7 +208,7 @@ export function ProposalCard({
       {description ? (
         <p
           dir="auto"
-          className="line-clamp-3 [text-align:match-parent] text-base text-foreground"
+          className="line-clamp-3 text-base text-foreground ltr:text-left rtl:text-right"
         >
           {description}
         </p>

--- a/packages/sense/src/components/ProposalCard/index.tsx
+++ b/packages/sense/src/components/ProposalCard/index.tsx
@@ -142,7 +142,7 @@ export function ProposalCard({
         )}
         {...rest}
       >
-        <h3 className="line-clamp-2 font-serif text-label text-foreground">
+        <h3 className="line-clamp-2 font-serif text-label text-foreground [unicode-bidi:plaintext]">
           <TitleLink href={href} linkComponent={linkComponent}>
             {title}
           </TitleLink>
@@ -173,10 +173,14 @@ export function ProposalCard({
       {aside ? <div className="absolute end-6 top-6 z-10">{aside}</div> : null}
       <div className={cn('flex flex-col gap-3', aside && 'pe-10')}>
         {headerBadge}
+        {/* Proposal text is user content, so it can be LTR on an RTL page (or
+            the reverse). `plaintext` resolves each block's base direction from
+            its own first strong character, which fixes both the punctuation
+            order and — `text-align` being `start` — the alignment. */}
         <h3
           id={titleId}
           className={cn(
-            'font-serif text-title',
+            'font-serif text-title [unicode-bidi:plaintext]',
             selected ? 'text-teal-600' : 'text-foreground',
           )}
         >
@@ -197,7 +201,9 @@ export function ProposalCard({
         </div>
       ) : null}
       {description ? (
-        <p className="line-clamp-3 text-base text-foreground">{description}</p>
+        <p className="line-clamp-3 text-base text-foreground [unicode-bidi:plaintext]">
+          {description}
+        </p>
       ) : null}
       {metrics ? (
         <div className="relative z-10 flex items-center gap-1">
@@ -288,8 +294,13 @@ function AuthorRow({
   compact?: boolean;
 }) {
   const first = authors[0];
-  const label =
-    authors.length > 1 ? `${first?.name} +${authors.length - 1}` : first?.name;
+  // The name is isolated so a "+2" stays after it whichever way the name runs.
+  const label = (
+    <>
+      <bdi>{first?.name}</bdi>
+      {authors.length > 1 ? ` +${authors.length - 1}` : null}
+    </>
+  );
   return (
     <div className="flex items-center gap-1.5">
       <FacePile
@@ -346,7 +357,9 @@ function TagRow({
         // Categories are free text, so a long one has to ellipsize instead of
         // pushing the row past the card. Full text stays in the DOM.
         <Badge key={tag} variant="secondary" className="max-w-full" title={tag}>
-          <span className="truncate">{tag}</span>
+          <span className="truncate">
+            <bdi>{tag}</bdi>
+          </span>
         </Badge>
       ))}
       {overflow > 0 ? (

--- a/packages/sense/src/components/TagGroup/index.tsx
+++ b/packages/sense/src/components/TagGroup/index.tsx
@@ -85,7 +85,12 @@ function Tag({
         className={cn('max-w-full', tagSizeClasses[size], className)}
         {...props}
       >
-        <span className="truncate">{children}</span>
+        {/* Tags carry user content (categories), so isolate them — a tag whose
+            direction runs counter to the page otherwise reorders against the
+            remove button beside it. */}
+        <span className="truncate">
+          <bdi>{children}</bdi>
+        </span>
         {onRemove ? (
           <button
             type="button"


### PR DESCRIPTION
Two unrelated quick fixes, split into their own commits.

- **RTL bidi.** User-authored text (proposal titles and previews, category tags, phase and category names, decision names) rendered without isolation, so its punctuation, digits, and the clamp ellipsis resolved against the *page* direction — an English title on an Arabic page showed as `??Hell yeah` instead of `Hell yeah??`. Blocks get `dir="auto"` + `[text-align:match-parent]`, inline names get `<bdi>`. Fixed in `@op/sense` where possible (`ProposalCard`, `ProfileItem`, `TagGroup`) so every card and list surface inherits it, plus the app spots that render raw elements.
- **Docs.** Both `CLAUDE.md` files now carry the rule. The two halves do different jobs and both are needed: `dir="auto"` takes the ordering and the ellipsis side from the *content*, `match-parent` keeps the alignment on the *page* — without it an English row in an Arabic list aligns left while its neighbours align right, which is what the active-decisions panel was doing.
- **Layout polish.** Platform highlights spacing and number size at small widths, decision action bar button widths, edit-banner button size, summary row gap.
