### PR TITLE
fix(decisions): translate user content on proposal and review screens

### DIFF
--- a/apps/app/src/components/decisions/Review/ReviewLayout.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewLayout.tsx
@@ -16,6 +16,7 @@ import { ReviewNavbar } from './ReviewNavbar';
 import { ReviewProposalPane } from './ReviewProposalPane';
 import { ReviewRubricForm } from './ReviewRubricForm';
 import type { PreviousReviewPhase } from './ReviewTabs';
+import { ReviewTranslationProvider } from './ReviewTranslationContext';
 
 interface ReviewLayoutProps {
   decisionSlug: string;
@@ -90,27 +91,34 @@ export async function ReviewLayout({
         decisionSlug={decisionSlug}
         allowRevisions={allowRevisions}
       >
-        <div className="flex h-dvh flex-col overflow-hidden bg-white">
-          <ReviewNavbar decisionSlug={decisionSlug} />
+        {/* Inside ReviewFormProvider: the proposal and the rubric it translates
+            both come from the assignment that provider loads. */}
+        <ReviewTranslationProvider assignmentId={assignmentId}>
+          <div className="flex h-dvh flex-col overflow-hidden bg-white">
+            <ReviewNavbar decisionSlug={decisionSlug} />
 
-          <SplitPane className="mx-auto max-w-6xl" defaultMobileTabId="review">
-            <SplitPane.Pane
-              id="proposal"
-              label={<TranslatedText text="Proposal" />}
+            <SplitPane
+              className="mx-auto max-w-6xl"
+              defaultMobileTabId="review"
             >
-              <ReviewProposalPane />
-            </SplitPane.Pane>
-            <SplitPane.Pane
-              id="review"
-              label={<TranslatedText text="Review" />}
-            >
-              <ReviewRubricForm
-                openReviews={openReviews}
-                previousReviewPhases={previousReviewPhases}
-              />
-            </SplitPane.Pane>
-          </SplitPane>
-        </div>
+              <SplitPane.Pane
+                id="proposal"
+                label={<TranslatedText text="Proposal" />}
+              >
+                <ReviewProposalPane />
+              </SplitPane.Pane>
+              <SplitPane.Pane
+                id="review"
+                label={<TranslatedText text="Review" />}
+              >
+                <ReviewRubricForm
+                  openReviews={openReviews}
+                  previousReviewPhases={previousReviewPhases}
+                />
+              </SplitPane.Pane>
+            </SplitPane>
+          </div>
+        </ReviewTranslationProvider>
       </ReviewFormProvider>
     </HydrationBoundary>
   );

--- a/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewProposalPane.tsx
@@ -6,9 +6,11 @@ import { ProposalComments } from '../ProposalComments';
 import { ProposalPreview } from '../ProposalPreview';
 import { AuthorRevisionNote, RevisedOnBadge } from './AuthorRevisionNote';
 import { useReviewForm } from './ReviewFormContext';
+import { useReviewTranslation } from './ReviewTranslationContext';
 
 export function ReviewProposalPane() {
   const { assignment, revisionRequest } = useReviewForm();
+  const { proposal: translation } = useReviewTranslation();
 
   const respondedAt =
     revisionRequest?.state === ProposalReviewRequestState.RESUBMITTED
@@ -20,6 +22,7 @@ export function ReviewProposalPane() {
     <div className="flex flex-col gap-8">
       <ProposalPreview
         proposal={assignment.proposal}
+        translation={translation}
         // The banner needs a comment to show; the date doesn't. A resubmission
         // without one would otherwise leave the reviewer no sign it happened
         // (`responseComment` is null when the author left it empty).

--- a/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewRubricForm.tsx
@@ -32,17 +32,22 @@ import {
 } from '@op/sense/Select';
 import { Switch } from '@op/sense/Switch';
 import { Textarea } from '@op/sense/Textarea';
-import { useId, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 import { LuCircleAlert, LuPlus } from 'react-icons/lu';
 
 import { useTranslations } from '@/lib/i18n';
 
 import { compileRubricSchema } from '../forms/rubric';
 import type { FieldDescriptor } from '../forms/types';
-import { getCriterionMaxPoints, inferCriterionType } from '../rubricTemplate';
+import {
+  getCriterionMaxPoints,
+  inferCriterionType,
+  translateRubricTemplate,
+} from '../rubricTemplate';
 import { useReviewForm } from './ReviewFormContext';
 import { FormShell, TotalScoreCard } from './ReviewFormShell';
 import { type PreviousReviewPhase, ReviewTabs } from './ReviewTabs';
+import { useReviewTranslation } from './ReviewTranslationContext';
 import { SubmittedReviewView } from './SubmittedReviewView';
 import { ViewRevisionRequestModal } from './ViewRevisionRequestModal';
 
@@ -89,7 +94,7 @@ export function ReviewRubricForm({
 function MyReviewForm() {
   const t = useTranslations();
   const {
-    rubricTemplate: template,
+    rubricTemplate: authoredTemplate,
     values,
     rationales,
     overallComment,
@@ -100,6 +105,14 @@ function MyReviewForm() {
     isEditing,
     review,
   } = useReviewForm();
+  const { rubricMeta } = useReviewTranslation();
+
+  // Display copy only — option values, bounds and the required list are
+  // untouched, so the answers this form collects are identical either way.
+  const template = useMemo(
+    () => translateRubricTemplate(authoredTemplate, rubricMeta),
+    [authoredTemplate, rubricMeta],
+  );
   const fields = compileRubricSchema(template);
 
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(

--- a/apps/app/src/components/decisions/Review/ReviewTranslationContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewTranslationContext.tsx
@@ -84,7 +84,15 @@ export function ReviewTranslationProvider({
   // can't be undone by an in-flight request (as in useTranslateDecision).
   const translatingRef = useRef(false);
 
+  // One banner drives both requests, so they succeed or fail as one. A failure
+  // discards whatever the other request returned, and clearing the ref makes
+  // its late success a no-op via the guards below. Keeping a partial result
+  // would hide the banner — the only retry control — with one pane still
+  // untranslated, and a rubric-only success renders no "View original" either,
+  // stranding the screen until a reload.
   const onTranslateError = useCallback(() => {
+    translatingRef.current = false;
+    setTranslated(null);
     toast.error(t('Failed to translate content'));
   }, [t]);
 

--- a/apps/app/src/components/decisions/Review/ReviewTranslationContext.tsx
+++ b/apps/app/src/components/decisions/Review/ReviewTranslationContext.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useAnyContentNeedsTranslation } from '@/hooks/useAnyContentNeedsTranslation';
+import { trpc } from '@op/api/client';
+import {
+  SUPPORTED_LOCALES,
+  type SupportedLocale,
+  type TranslatedFields,
+  parseTranslatedMeta,
+} from '@op/common/client';
+import { toast } from '@op/sense/Toast';
+import { useLocale } from 'next-intl';
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { useTranslations } from '@/lib/i18n';
+
+import type { ProposalTranslation } from '../ProposalPreview';
+import { TranslateBanner } from '../TranslateBanner';
+import type { RubricTranslatedMeta } from '../rubricTemplate';
+import {
+  getProposalDetectionText,
+  getRubricDetectionText,
+} from '../translationDetectionText';
+import { useReviewForm } from './ReviewFormContext';
+
+interface ReviewTranslationValue {
+  /** Passed straight to `ProposalPreview`; undefined until translated. */
+  proposal?: ProposalTranslation;
+  /** Applied to the rubric template; null until translated. */
+  rubricMeta: RubricTranslatedMeta | null;
+}
+
+/** Stable identity so consumers outside a provider don't re-render on it. */
+const NO_TRANSLATION: ReviewTranslationValue = { rubricMeta: null };
+
+const ReviewTranslationContext = createContext<ReviewTranslationValue | null>(
+  null,
+);
+
+/**
+ * Machine translation for the review screen — the proposal in the left pane and
+ * the rubric in the right one, translated together by the single banner this
+ * mounts.
+ *
+ * The two panes are siblings under `SplitPane`, so the state lives here rather
+ * than in either of them: one "Translate to X" click has to move both, and
+ * "View original" has to put both back.
+ */
+export function ReviewTranslationProvider({
+  assignmentId,
+  children,
+}: {
+  assignmentId: string;
+  children: ReactNode;
+}) {
+  const t = useTranslations();
+  const locale = useLocale();
+  const { assignment, rubricTemplate } = useReviewForm();
+  const proposal = assignment.proposal;
+
+  const supportedLocale = (SUPPORTED_LOCALES as readonly string[]).includes(
+    locale,
+  )
+    ? (locale as SupportedLocale)
+    : null;
+
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  const [translated, setTranslated] = useState<{
+    proposal?: TranslatedFields;
+    rubric?: TranslatedFields;
+    sourceLocale: string;
+  } | null>(null);
+
+  // Flipped true on Translate, false on View Original. A response that lands
+  // after the reviewer reverts checks this before writing state, so the revert
+  // can't be undone by an in-flight request (as in useTranslateDecision).
+  const translatingRef = useRef(false);
+
+  const onTranslateError = useCallback(() => {
+    toast.error(t('Failed to translate content'));
+  }, [t]);
+
+  const translateProposalMutation =
+    trpc.translation.translateProposal.useMutation({
+      onSuccess: (data) => {
+        if (!translatingRef.current) {
+          return;
+        }
+        setTranslated((prev) => ({
+          ...prev,
+          proposal: data.translated,
+          sourceLocale: prev?.sourceLocale || data.sourceLocale,
+        }));
+      },
+      onError: onTranslateError,
+    });
+
+  const translateRubricMutation = trpc.translation.translateRubric.useMutation({
+    onSuccess: (data) => {
+      if (!translatingRef.current) {
+        return;
+      }
+      setTranslated((prev) => ({
+        ...prev,
+        rubric: data.translated,
+        sourceLocale: prev?.sourceLocale || data.sourceLocale,
+      }));
+    },
+    onError: onTranslateError,
+  });
+
+  // One sample per surface rather than one concatenated blob: a rubric authored
+  // in Spanish must offer translation even when the proposal is in English, and
+  // vice versa.
+  const samples = useMemo(
+    () => [
+      getProposalDetectionText(proposal),
+      getRubricDetectionText(rubricTemplate),
+    ],
+    [proposal, rubricTemplate],
+  );
+  const needsTranslation = useAnyContentNeedsTranslation(samples);
+
+  const handleTranslate = useCallback(() => {
+    if (!supportedLocale) {
+      return;
+    }
+    translatingRef.current = true;
+    translateProposalMutation.mutate({
+      profileId: proposal.profileId,
+      targetLocale: supportedLocale,
+    });
+    translateRubricMutation.mutate({
+      assignmentId,
+      targetLocale: supportedLocale,
+    });
+  }, [
+    assignmentId,
+    proposal.profileId,
+    supportedLocale,
+    translateProposalMutation,
+    translateRubricMutation,
+  ]);
+
+  const handleViewOriginal = useCallback(() => {
+    translatingRef.current = false;
+    setTranslated(null);
+  }, []);
+
+  const languageNames = useMemo(
+    () => new Intl.DisplayNames([locale], { type: 'language' }),
+    [locale],
+  );
+  const sourceLanguageName = translated
+    ? (languageNames.of(
+        translated.sourceLocale.toLowerCase().split('-')[0] ?? '',
+      ) ?? '')
+    : '';
+
+  const value = useMemo<ReviewTranslationValue>(
+    () => ({
+      proposal: translated?.proposal
+        ? {
+            htmlContent: translated.proposal,
+            sourceLanguageName,
+            onViewOriginal: handleViewOriginal,
+          }
+        : undefined,
+      rubricMeta: translated?.rubric
+        ? parseTranslatedMeta(translated.rubric)
+        : null,
+    }),
+    [translated, sourceLanguageName, handleViewOriginal],
+  );
+
+  const showBanner =
+    !!supportedLocale && needsTranslation && !bannerDismissed && !translated;
+
+  return (
+    <ReviewTranslationContext.Provider value={value}>
+      {children}
+
+      {showBanner && (
+        <TranslateBanner
+          onTranslate={handleTranslate}
+          onDismiss={() => setBannerDismissed(true)}
+          isTranslating={
+            translateProposalMutation.isPending ||
+            translateRubricMutation.isPending
+          }
+          languageName={languageNames.of(locale) ?? locale}
+        />
+      )}
+    </ReviewTranslationContext.Provider>
+  );
+}
+
+/**
+ * Translated review copy, or empty values when no provider is mounted (the
+ * review form also renders inside the admin drill-in and the proposal-keyed
+ * review routes) or nothing has been translated yet.
+ */
+export function useReviewTranslation(): ReviewTranslationValue {
+  return useContext(ReviewTranslationContext) ?? NO_TRANSLATION;
+}

--- a/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
+++ b/apps/app/src/components/decisions/ReviewAssignmentsList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useAnyContentNeedsTranslation } from '@/hooks/useAnyContentNeedsTranslation';
 import { useTrackPageView } from '@/hooks/useTrackPageView';
 import { APIErrorBoundary } from '@/utils/APIErrorBoundary';
 import { getDecisionCommonProperties } from '@op/analytics/client-utils';
@@ -21,7 +22,7 @@ import {
 import { Skeleton } from '@op/sense/Skeleton';
 import { cn } from '@op/sense/lib/utils';
 import { parseAsStringLiteral, useQueryState } from 'nuqs';
-import { Suspense } from 'react';
+import { Suspense, useMemo } from 'react';
 import {
   LuCircleAlert,
   LuCircleCheck,
@@ -36,9 +37,14 @@ import { useTranslations } from '@/lib/i18n';
 
 import { ProposalCount } from './ProposalCount';
 import { ProposalMasonry } from './ProposalMasonry';
+import { ProposalTranslationProvider } from './ProposalTranslationContext';
 import { ResponsiveSelect } from './ResponsiveSelect';
 import { ReviewAssignmentCard } from './ReviewAssignmentCard';
 import { StickyFilterBar } from './StickyFilterBar';
+import { TranslateBanner } from './TranslateBanner';
+import { TranslationNotice } from './TranslationNotice';
+import { getProposalDetectionText } from './translationDetectionText';
+import { useTranslateDecision } from './useTranslateDecision';
 
 const ASSIGNMENT_STATUSES = Object.values(ProposalReviewAssignmentStatus) as [
   string,
@@ -48,11 +54,14 @@ const ASSIGNMENT_STATUSES = Object.values(ProposalReviewAssignmentStatus) as [
 export function ReviewAssignmentsList({
   processInstanceId,
   decisionSlug,
+  decisionProfileId,
   access,
   pinOffset,
 }: {
   processInstanceId: string;
   decisionSlug: string;
+  /** Decision profile whose phase copy, updates and resources translate with the queue. */
+  decisionProfileId?: string | null;
   access?: DecisionAccess;
   /** Px offset where the filter bar pins (clears the floating phase toggle). */
   pinOffset?: number;
@@ -90,6 +99,24 @@ export function ReviewAssignmentsList({
 
   const assignments = data?.assignments ?? [];
   const proposalIds = assignments.map((a) => a.assignment.proposal.id);
+
+  // The reviewer's queue renders the same proposal cards as the "Other
+  // proposals" tab, so it gets the same translation wiring — without it the two
+  // tabs disagreed, one offering translation and one not.
+  const assignedProposals = useMemo(
+    () => assignments.map((item) => item.assignment.proposal),
+    [assignments],
+  );
+  const proposalSamples = useMemo(
+    () => assignedProposals.map(getProposalDetectionText),
+    [assignedProposals],
+  );
+  const needsTranslation = useAnyContentNeedsTranslation(proposalSamples);
+  const translation = useTranslateDecision({
+    proposals: assignedProposals,
+    decisionProfileId,
+    needsTranslation,
+  });
 
   const { data: aggregatesData } =
     trpc.decision.listWithReviewAggregates.useQuery(
@@ -230,6 +257,13 @@ export function ReviewAssignmentsList({
         </StickyFilterBar>
       )}
 
+      {translation.translationState && (
+        <TranslationNotice
+          sourceLanguageName={translation.sourceLanguageName}
+          onViewOriginal={translation.handleViewOriginal}
+        />
+      )}
+
       {/* Cards grid */}
       {isLoading ? (
         <ReviewAssignmentListSkeletonGrid />
@@ -254,25 +288,38 @@ export function ReviewAssignmentsList({
           </EmptyHeader>
         </Empty>
       ) : (
-        <ProposalMasonry>
-          {assignments.map((item) => (
-            <ReviewAssignmentCard
-              key={item.assignment.id}
-              assignment={item}
-              // The proposal-keyed URL resolves per viewer (own review screen
-              // for a reviewer, review progress for an admin).
-              viewHref={`/decisions/${decisionSlug}/proposal/${item.assignment.proposal.profileId}/reviews`}
-              reviewers={
-                aggregatesData?.items.find(
-                  (i) => i.proposal.id === item.assignment.proposal.id,
-                )?.aggregates.reviewers
-              }
-              reviewsHref={`/decisions/${decisionSlug}/proposal/${item.assignment.proposal.profileId}/reviews`}
-              access={access}
-              showCategory={showCategory}
-            />
-          ))}
-        </ProposalMasonry>
+        <ProposalTranslationProvider
+          translations={translation.translationState?.translations ?? {}}
+        >
+          <ProposalMasonry>
+            {assignments.map((item) => (
+              <ReviewAssignmentCard
+                key={item.assignment.id}
+                assignment={item}
+                // The proposal-keyed URL resolves per viewer (own review screen
+                // for a reviewer, review progress for an admin).
+                viewHref={`/decisions/${decisionSlug}/proposal/${item.assignment.proposal.profileId}/reviews`}
+                reviewers={
+                  aggregatesData?.items.find(
+                    (i) => i.proposal.id === item.assignment.proposal.id,
+                  )?.aggregates.reviewers
+                }
+                reviewsHref={`/decisions/${decisionSlug}/proposal/${item.assignment.proposal.profileId}/reviews`}
+                access={access}
+                showCategory={showCategory}
+              />
+            ))}
+          </ProposalMasonry>
+        </ProposalTranslationProvider>
+      )}
+
+      {translation.showBanner && (
+        <TranslateBanner
+          onTranslate={translation.handleTranslate}
+          onDismiss={translation.dismissBanner}
+          isTranslating={translation.isTranslating}
+          languageName={translation.targetLanguageName}
+        />
       )}
     </div>
   );

--- a/apps/app/src/components/decisions/pages/ReviewPage.tsx
+++ b/apps/app/src/components/decisions/pages/ReviewPage.tsx
@@ -67,6 +67,11 @@ export function ReviewPage({
   const actionBarLabel = phaseAdditionalInfo
     ? t('About this phase')
     : undefined;
+  // Admins get the static "Review Progress" heading; only the reviewer-facing
+  // phase copy is author-written, so only it goes through translation.
+  const heroHeadline = translation?.headline ?? currentPhase.headline;
+  const heroDescription =
+    translation?.phaseDescription ?? currentPhase.description;
   const heroImagePath = instance.instanceData?.overview?.heroImage;
   const hasHeroImage = Boolean(heroImagePath);
 
@@ -97,15 +102,11 @@ export function ReviewPage({
               isAdmin ? (
                 <TranslatedText text="Review Progress" />
               ) : (
-                (currentPhase.headline ?? (
-                  <TranslatedText text="Review proposals." />
-                ))
+                (heroHeadline ?? <TranslatedText text="Review proposals." />)
               )
             }
             description={
-              !isAdmin && currentPhase.description ? (
-                <p>{currentPhase.description}</p>
-              ) : undefined
+              !isAdmin && heroDescription ? <p>{heroDescription}</p> : undefined
             }
             variant="standard"
             hasImage={hasHeroImage}
@@ -150,6 +151,7 @@ export function ReviewPage({
                     <ReviewAssignmentsList
                       processInstanceId={instance.id}
                       decisionSlug={decisionSlug}
+                      decisionProfileId={decisionProfileId}
                       access={instance.access}
                       pinOffset={pinOffset}
                     />

--- a/apps/app/src/components/decisions/proposalContentUtils.ts
+++ b/apps/app/src/components/decisions/proposalContentUtils.ts
@@ -86,6 +86,12 @@ export function getProposalContentPreview(
   return null;
 }
 
+/** The proposal fields {@link resolveProposalSystemFields} reads. */
+export type ProposalSystemFieldSource = Pick<
+  Proposal,
+  'proposalData' | 'proposalTemplate' | 'documentContent'
+>;
+
 /**
  * Resolves system field values (title, budget, category) from the pinned
  * TipTap version in `documentContent`, falling back to `proposalData`.
@@ -94,7 +100,9 @@ export function getProposalContentPreview(
  * the version that was actually submitted; the document fragments are
  * the source of truth for submitted proposals.
  */
-export function resolveProposalSystemFields(proposal: Proposal) {
+export function resolveProposalSystemFields(
+  proposal: ProposalSystemFieldSource,
+) {
   const fallback = parseProposalData(proposal.proposalData);
 
   const template = proposal.proposalTemplate as ProposalTemplateSchema | null;

--- a/apps/app/src/components/decisions/rubricTemplate.test.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.test.ts
@@ -16,6 +16,7 @@ import {
   inferCriterionType,
   setCriterionRequired,
   setSelectOptions,
+  translateRubricTemplate,
   updateCriterionDescription,
 } from './rubricTemplate';
 
@@ -274,5 +275,77 @@ describe('getCriteria', () => {
     expect(single?.criterionType).toBe('single_select');
     expect(single?.options).toHaveLength(2);
     expect(single?.options[0]?.title).toBe('Parks');
+  });
+});
+
+describe('translateRubricTemplate', () => {
+  const rubric = () => {
+    let template = createEmptyRubricTemplate();
+    template = addCriterion(template, 'impact', 'single_select', 'Impact');
+    template = updateCriterionDescription(template, 'impact', 'How many?');
+    template = setSelectOptions(template, 'impact', [
+      { value: 'high', title: 'High', description: 'Whole city' },
+      { value: 'low', title: 'Low' },
+    ]);
+    template = setCriterionRequired(template, 'impact', true);
+    return template;
+  };
+
+  const meta = {
+    fieldTitles: { impact: 'Impacto' },
+    fieldDescriptions: { impact: '¿A cuántas personas?' },
+    optionLabels: { impact: { high: 'Alto', low: 'Bajo' } },
+    optionDescriptions: { impact: { high: 'Toda la ciudad' } },
+  };
+
+  it('replaces criterion prompts, descriptions, and option copy', () => {
+    const criterion = getCriterion(
+      translateRubricTemplate(rubric(), meta),
+      'impact',
+    );
+
+    expect(criterion?.label).toBe('Impacto');
+    expect(criterion?.description).toBe('¿A cuántas personas?');
+    expect(criterion?.options.map((option) => option.title)).toEqual([
+      'Alto',
+      'Bajo',
+    ]);
+    expect(criterion?.options[0]?.description).toBe('Toda la ciudad');
+  });
+
+  // Answers are stored against the option `const`, and validation runs off the
+  // required list — translating display copy must not disturb either.
+  it('leaves option values and the required list untouched', () => {
+    const translated = translateRubricTemplate(rubric(), meta);
+    const criterion = getCriterion(translated, 'impact');
+
+    expect(criterion?.options.map((option) => option.value)).toEqual([
+      'high',
+      'low',
+    ]);
+    expect(criterion?.required).toBe(true);
+    expect(translated.required).toEqual(['impact']);
+  });
+
+  it('keeps authored copy for criteria and options with no translation', () => {
+    const translated = translateRubricTemplate(rubric(), {
+      fieldTitles: {},
+      fieldDescriptions: {},
+      optionLabels: { impact: { high: 'Alto' } },
+      optionDescriptions: {},
+    });
+    const criterion = getCriterion(translated, 'impact');
+
+    expect(criterion?.label).toBe('Impact');
+    expect(criterion?.description).toBe('How many?');
+    expect(criterion?.options.map((option) => option.title)).toEqual([
+      'Alto',
+      'Low',
+    ]);
+  });
+
+  it('returns the template unchanged with no translation', () => {
+    const template = rubric();
+    expect(translateRubricTemplate(template, null)).toBe(template);
   });
 });

--- a/apps/app/src/components/decisions/rubricTemplate.ts
+++ b/apps/app/src/components/decisions/rubricTemplate.ts
@@ -550,6 +550,94 @@ export function setSelectOptions(
 }
 
 // ---------------------------------------------------------------------------
+// Translation
+// ---------------------------------------------------------------------------
+
+/**
+ * Translated rubric copy keyed by criterion id (and, for options, by option
+ * value) — the shape `parseTranslatedMeta` produces from a `translateRubric`
+ * response.
+ */
+export interface RubricTranslatedMeta {
+  fieldTitles: Record<string, string>;
+  fieldDescriptions: Record<string, string>;
+  optionLabels: Record<string, Record<string, string>>;
+  optionDescriptions: Record<string, Record<string, string>>;
+}
+
+/**
+ * Returns the template with every criterion prompt, description and option
+ * label replaced by its translation, leaving anything untranslated as-authored.
+ *
+ * Applied at the template level rather than per render site so one call covers
+ * the review form, the submitted-review view and the score card — and so only
+ * display copy moves: `const` option values, `x-format`, bounds and the
+ * `required` list are untouched, which keeps stored answers matching and
+ * validation running against the same values either way.
+ */
+export function translateRubricTemplate(
+  template: RubricTemplateSchema,
+  meta: RubricTranslatedMeta | null,
+): RubricTemplateSchema {
+  if (!meta) {
+    return template;
+  }
+
+  let translated = template;
+
+  for (const criterionId of Object.keys(template.properties ?? {})) {
+    const title = meta.fieldTitles[criterionId];
+    const description = meta.fieldDescriptions[criterionId];
+    const optionLabels = meta.optionLabels[criterionId];
+    const optionDescriptions = meta.optionDescriptions[criterionId];
+
+    if (!title && !description && !optionLabels && !optionDescriptions) {
+      continue;
+    }
+
+    translated = updateProperty(translated, criterionId, (schema) => ({
+      ...schema,
+      ...(title ? { title } : {}),
+      ...(description ? { description } : {}),
+      ...(Array.isArray(schema.oneOf) && (optionLabels || optionDescriptions)
+        ? {
+            oneOf: schema.oneOf.map((entry) =>
+              translateOptionEntry(entry, optionLabels, optionDescriptions),
+            ),
+          }
+        : {}),
+    }));
+  }
+
+  return translated;
+}
+
+/** Swaps one `oneOf` option's label and description; other entry shapes pass through. */
+function translateOptionEntry(
+  entry: JSONSchema7 | boolean,
+  labels: Record<string, string> | undefined,
+  descriptions: Record<string, string> | undefined,
+): JSONSchema7 | boolean {
+  if (!isSchemaObject(entry) || entry.const == null) {
+    return entry;
+  }
+
+  const optionValue = String(entry.const);
+  const title = labels?.[optionValue];
+  const description = descriptions?.[optionValue];
+
+  if (!title && !description) {
+    return entry;
+  }
+
+  return {
+    ...entry,
+    ...(title ? { title } : {}),
+    ...(description ? { description } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Overall Recommendation
 // ---------------------------------------------------------------------------
 

--- a/apps/app/src/components/decisions/translationDetectionText.test.ts
+++ b/apps/app/src/components/decisions/translationDetectionText.test.ts
@@ -1,18 +1,42 @@
+import { parseProposalData } from '@op/common/client';
 import { describe, expect, it } from 'vitest';
 
 import {
   getOverviewDetectionText,
   getProposalDetectionText,
+  getRubricDetectionText,
 } from './translationDetectionText';
+
+type ProposalArg = Parameters<typeof getProposalDetectionText>[0];
+
+/**
+ * Builds the detection input, so each case states only the fields it tests.
+ * `title` and `profileName` are lifted out because they live behind
+ * `proposalData` / `profile` on the real payload.
+ */
+const proposal = ({
+  title,
+  profileName = '',
+  ...rest
+}: { title?: string; profileName?: string } & Omit<
+  Partial<ProposalArg>,
+  'proposalData' | 'profile'
+>): ProposalArg => ({
+  proposalData: parseProposalData(title ? { title } : {}),
+  profile: { name: profileName },
+  ...rest,
+});
 
 describe('getProposalDetectionText', () => {
   it('strips HTML from every string field', () => {
-    const text = getProposalDetectionText({
-      htmlContent: {
-        title: '<h1>Community Garden</h1>',
-        body: '<p>We should plant more trees.</p>',
-      },
-    });
+    const text = getProposalDetectionText(
+      proposal({
+        htmlContent: {
+          title: '<h1>Community Garden</h1>',
+          body: '<p>We should plant more trees.</p>',
+        },
+      }),
+    );
 
     expect(text).toContain('Community Garden');
     expect(text).toContain('We should plant more trees.');
@@ -20,19 +44,83 @@ describe('getProposalDetectionText', () => {
   });
 
   it('reads text from documentContent (the list payload has no htmlContent)', () => {
-    const text = getProposalDetectionText({
-      documentContent: {
-        type: 'html',
-        content: '<p>We should plant more trees in the park.</p>',
-      },
-    });
+    const text = getProposalDetectionText(
+      proposal({
+        documentContent: {
+          type: 'html',
+          content: '<p>We should plant more trees in the park.</p>',
+        },
+      }),
+    );
 
     expect(text).toContain('We should plant more trees in the park.');
     expect(text).not.toContain('<');
   });
 
+  // The list bug: list reads ship no fragments, and previewText is empty for a
+  // proposal with no body — leaving the title as the only sample there is.
+  it('samples the title when there is no body text', () => {
+    const text = getProposalDetectionText(
+      proposal({ title: 'Jardín comunitario' }),
+    );
+
+    expect(text).toContain('Jardín comunitario');
+  });
+
+  it('falls back to the proposal profile name for an untitled proposal', () => {
+    const text = getProposalDetectionText(
+      proposal({ profileName: 'Huerto del barrio' }),
+    );
+
+    expect(text).toContain('Huerto del barrio');
+  });
+
+  it('samples the title alongside the body', () => {
+    const text = getProposalDetectionText(
+      proposal({
+        title: 'Jardín comunitario',
+        previewText: 'We should plant more trees.',
+      }),
+    );
+
+    expect(text).toContain('Jardín comunitario');
+    expect(text).toContain('We should plant more trees.');
+  });
+
   it('returns an empty string when there is no content', () => {
-    expect(getProposalDetectionText({ htmlContent: undefined })).toBe('');
+    expect(getProposalDetectionText(proposal({ htmlContent: undefined }))).toBe(
+      '',
+    );
+  });
+});
+
+describe('getRubricDetectionText', () => {
+  it('joins criterion prompts, descriptions, and option labels', () => {
+    const text = getRubricDetectionText({
+      type: 'object',
+      properties: {
+        impact: {
+          type: 'string',
+          title: 'Impacto comunitario',
+          description: '¿A cuántas personas beneficia?',
+          'x-format': 'dropdown',
+          oneOf: [
+            { const: 'high', title: 'Alto' },
+            { const: 'low', title: 'Bajo' },
+          ],
+        },
+      },
+    });
+
+    expect(text).toContain('Impacto comunitario');
+    expect(text).toContain('¿A cuántas personas beneficia?');
+    expect(text).toContain('Alto');
+    expect(text).toContain('Bajo');
+  });
+
+  it('returns an empty string for a rubric with no criteria', () => {
+    expect(getRubricDetectionText({ type: 'object', properties: {} })).toBe('');
+    expect(getRubricDetectionText(null)).toBe('');
   });
 });
 

--- a/apps/app/src/components/decisions/translationDetectionText.ts
+++ b/apps/app/src/components/decisions/translationDetectionText.ts
@@ -1,12 +1,17 @@
 import {
   type Proposal,
   type ProposalTemplateSchema,
+  type RubricTemplateSchema,
+  parseSchemaOptions,
   serverExtensions,
 } from '@op/common/client';
 import { getTextPreview } from '@op/core';
 import { type JSONContent, generateText } from '@tiptap/core';
 
-import { getProposalContentPreview } from './proposalContentUtils';
+import {
+  getProposalContentPreview,
+  resolveProposalSystemFields,
+} from './proposalContentUtils';
 
 /** Cap the sample fed to language detection — a few hundred chars already suffices. */
 const MAX_SAMPLE_LENGTH = 2000;
@@ -14,28 +19,54 @@ const MAX_SAMPLE_LENGTH = 2000;
 /** The proposal fields language detection reads. */
 type ProposalTextSource = Pick<
   Proposal,
-  'previewText' | 'documentContent' | 'proposalTemplate' | 'htmlContent'
+  | 'previewText'
+  | 'documentContent'
+  | 'proposalTemplate'
+  | 'htmlContent'
+  | 'proposalData'
+  | 'profile'
 >;
 
 const htmlToText = (html: string): string =>
   getTextPreview({ content: html, maxLines: 20, maxLength: MAX_SAMPLE_LENGTH });
 
+/** Joins sample parts, dropping empties, and caps the result. */
+const joinSample = (parts: string[]): string =>
+  parts.filter(Boolean).join('\n').slice(0, MAX_SAMPLE_LENGTH);
+
 /**
- * Plain-text sample of a proposal's body, for language detection.
+ * Plain-text sample of a proposal (title + body), for language detection.
  *
- * Prefers the server-computed `previewText` (list payloads), then
- * `documentContent` (single-proposal payloads, what the cards render from),
- * and finally the rendered `htmlContent` when the collaboration document
- * isn't available yet.
+ * The title always leads the sample: list reads ship no document fragments and
+ * `previewText` is empty for a proposal with a short or empty body, so the title
+ * is often the only text there is. Without it those proposals detected as
+ * "nothing to translate" and the list never offered the banner at all.
+ *
+ * For the body, prefers the server-computed `previewText` (list payloads), then
+ * `documentContent` (single-proposal payloads, what the cards render from), and
+ * finally the rendered `htmlContent` when the collaboration document isn't
+ * available yet.
  */
 export const getProposalDetectionText = (
   proposal: ProposalTextSource,
 ): string => {
+  // Same resolution the card and the header use, so detection samples exactly
+  // the title the reader sees.
+  const { title } = resolveProposalSystemFields(proposal);
+  const parts = [title?.trim() || proposal.profile?.name?.trim() || ''];
+
+  parts.push(getProposalBodyText(proposal));
+
+  return joinSample(parts);
+};
+
+/** Body-only sample; the title is prepended by {@link getProposalDetectionText}. */
+const getProposalBodyText = (proposal: ProposalTextSource): string => {
   // List payloads carry the server-computed preview (already capped) —
   // prefer it so no client-side fragment walk is needed.
   const fromPreview = proposal.previewText?.trim() ?? '';
   if (fromPreview) {
-    return fromPreview.slice(0, MAX_SAMPLE_LENGTH);
+    return fromPreview;
   }
 
   const template =
@@ -43,15 +74,42 @@ export const getProposalDetectionText = (
   const fromDocument =
     getProposalContentPreview(proposal.documentContent, template)?.trim() ?? '';
   if (fromDocument) {
-    return fromDocument.slice(0, MAX_SAMPLE_LENGTH);
+    return fromDocument;
   }
 
-  const fromHtml = Object.values(proposal.htmlContent ?? {})
+  return Object.values(proposal.htmlContent ?? {})
     .filter((value): value is string => typeof value === 'string')
     .map(htmlToText)
     .join('\n')
     .trim();
-  return fromHtml.slice(0, MAX_SAMPLE_LENGTH);
+};
+
+/**
+ * Plain-text sample of a rubric — every criterion's prompt and description, and
+ * each option's label. The reviewer reads this alongside the proposal, so a
+ * foreign-language rubric has to offer translation even when the proposal
+ * itself is already in the reader's language.
+ */
+export const getRubricDetectionText = (
+  rubricTemplate: RubricTemplateSchema | null | undefined,
+): string => {
+  const parts: string[] = [];
+
+  for (const property of Object.values(rubricTemplate?.properties ?? {})) {
+    if (property.title) {
+      parts.push(property.title);
+    }
+    if (property.description) {
+      parts.push(property.description);
+    }
+    for (const option of parseSchemaOptions(property)) {
+      if (option.title) {
+        parts.push(option.title);
+      }
+    }
+  }
+
+  return joinSample(parts);
 };
 
 /** Plain-text sample of a decision overview (headline + description + body). */
@@ -80,5 +138,5 @@ export const getOverviewDetectionText = ({
       // A malformed body doc contributes no detection signal — skip it.
     }
   }
-  return parts.join('\n').slice(0, MAX_SAMPLE_LENGTH);
+  return joinSample(parts);
 };

--- a/packages/common/src/services/translation/index.ts
+++ b/packages/common/src/services/translation/index.ts
@@ -5,6 +5,7 @@ export type { PostTranslation } from './translatePosts';
 export { translateProposal } from './translateProposal';
 export { translateProposals } from './translateProposals';
 export type { ProposalTranslation } from './translateProposal';
+export { translateRubric } from './translateRubric';
 export { translateResources } from './translateResources';
 export type { ResourceTranslation } from './translateResources';
 export type {

--- a/packages/common/src/services/translation/parseTranslatedMeta.test.ts
+++ b/packages/common/src/services/translation/parseTranslatedMeta.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseTranslatedMeta } from './parseTranslatedMeta';
+
+describe('parseTranslatedMeta', () => {
+  it('splits field and option keys into their own maps', () => {
+    const meta = parseTranslatedMeta({
+      'field_title:impact': 'Impacto',
+      'field_desc:impact': '¿A cuántas personas?',
+      'option:impact:high': 'Alto',
+      'option:impact:low': 'Bajo',
+      'option_desc:impact:high': 'Toda la ciudad',
+    });
+
+    expect(meta).toEqual({
+      fieldTitles: { impact: 'Impacto' },
+      fieldDescriptions: { impact: '¿A cuántas personas?' },
+      optionLabels: { impact: { high: 'Alto', low: 'Bajo' } },
+      optionDescriptions: { impact: { high: 'Toda la ciudad' } },
+    });
+  });
+
+  it('keeps an option value that contains a colon intact', () => {
+    const meta = parseTranslatedMeta({ 'option:impact:a:b': 'Etiqueta' });
+
+    expect(meta.optionLabels).toEqual({ impact: { 'a:b': 'Etiqueta' } });
+  });
+
+  it('ignores non-metadata keys and array values', () => {
+    const meta = parseTranslatedMeta({
+      title: 'Jardín comunitario',
+      category: ['Vivienda'],
+      // No option value — nothing to key it by.
+      'option:impact': 'Alto',
+    });
+
+    expect(meta).toEqual({
+      fieldTitles: {},
+      fieldDescriptions: {},
+      optionLabels: {},
+      optionDescriptions: {},
+    });
+  });
+});

--- a/packages/common/src/services/translation/parseTranslatedMeta.ts
+++ b/packages/common/src/services/translation/parseTranslatedMeta.ts
@@ -1,9 +1,16 @@
 import type { TranslatedFields } from './translatedFields';
 
+/**
+ * Splits a flat translation result (as produced by `translateProposal` or
+ * `translateRubric`) into the per-field maps a renderer needs: field titles and
+ * descriptions keyed by field key, and option labels and descriptions keyed by
+ * field key then option value.
+ */
 export function parseTranslatedMeta(translated: TranslatedFields) {
   const fieldTitles: Record<string, string> = {};
   const fieldDescriptions: Record<string, string> = {};
   const optionLabels: Record<string, Record<string, string>> = {};
+  const optionDescriptions: Record<string, Record<string, string>> = {};
 
   for (const [key, value] of Object.entries(translated)) {
     if (typeof value !== 'string') {
@@ -15,15 +22,33 @@ export function parseTranslatedMeta(translated: TranslatedFields) {
     } else if (key.startsWith('field_desc:')) {
       fieldDescriptions[key.slice('field_desc:'.length)] = value;
     } else if (key.startsWith('option:')) {
-      const rest = key.slice('option:'.length);
-      const colonIdx = rest.indexOf(':');
-      if (colonIdx !== -1) {
-        const fieldKey = rest.slice(0, colonIdx);
-        const optionValue = rest.slice(colonIdx + 1);
-        (optionLabels[fieldKey] ??= {})[optionValue] = value;
-      }
+      assignOptionEntry(optionLabels, key.slice('option:'.length), value);
+    } else if (key.startsWith('option_desc:')) {
+      assignOptionEntry(
+        optionDescriptions,
+        key.slice('option_desc:'.length),
+        value,
+      );
     }
   }
 
-  return { fieldTitles, fieldDescriptions, optionLabels };
+  return { fieldTitles, fieldDescriptions, optionLabels, optionDescriptions };
+}
+
+/**
+ * Files a `<fieldKey>:<optionValue>` remainder into a per-field option map.
+ * Split on the first colon only — an option value may contain colons itself.
+ */
+function assignOptionEntry(
+  target: Record<string, Record<string, string>>,
+  rest: string,
+  value: string,
+) {
+  const colonIdx = rest.indexOf(':');
+  if (colonIdx === -1) {
+    return;
+  }
+  const fieldKey = rest.slice(0, colonIdx);
+  const optionValue = rest.slice(colonIdx + 1);
+  (target[fieldKey] ??= {})[optionValue] = value;
 }

--- a/packages/common/src/services/translation/translateRubric.ts
+++ b/packages/common/src/services/translation/translateRubric.ts
@@ -1,0 +1,90 @@
+import type { User } from '@op/supabase/lib';
+import type { TranslatableEntry } from '@op/translation';
+
+import { parseSchemaOptions } from '../decision/proposalDataSchema';
+import { assertReviewAssignmentContext } from '../decision/reviewHelpers';
+import type { SupportedLocale } from './locales';
+import { runTranslateBatch } from './runTranslateBatch';
+import type { TranslatedFields } from './translatedFields';
+import { unflattenTranslatedFields } from './translatedFields';
+
+/**
+ * Translates the rubric a review assignment is scored against — every
+ * criterion's prompt and description, plus each dropdown option's label and
+ * description.
+ *
+ * The result is keyed the same way `translateProposal` keys a proposal's
+ * template metadata (`field_title:` / `field_desc:` / `option:` /
+ * `option_desc:`), so callers run it through the shared
+ * {@link parseTranslatedMeta} to get the per-criterion maps back.
+ */
+export async function translateRubric({
+  assignmentId,
+  targetLocale,
+  user,
+}: {
+  assignmentId: string;
+  targetLocale: SupportedLocale;
+  user: User;
+}): Promise<{
+  translated: TranslatedFields;
+  sourceLocale: string;
+  targetLocale: SupportedLocale;
+}> {
+  // Authorizes the caller against the assignment (reviewer or admin) and
+  // resolves the rubric of the phase the assignment belongs to.
+  const { assignment, instance, rubricTemplate } =
+    await assertReviewAssignmentContext({ assignmentId, user });
+
+  if (!rubricTemplate?.properties) {
+    return { translated: {}, sourceLocale: '', targetLocale };
+  }
+
+  // Keyed by phase, not by assignment: every reviewer of a phase scores against
+  // the same rubric, so they share one cache entry rather than one each.
+  const prefix = `rubric:${instance.id}:${assignment.phaseId}:`;
+  const entries: TranslatableEntry[] = [];
+
+  for (const [criterionKey, property] of Object.entries(
+    rubricTemplate.properties,
+  )) {
+    if (property.title) {
+      entries.push({
+        contentKey: `${prefix}field_title:${criterionKey}`,
+        text: property.title,
+      });
+    }
+    if (property.description) {
+      entries.push({
+        contentKey: `${prefix}field_desc:${criterionKey}`,
+        text: property.description,
+      });
+    }
+
+    for (const option of parseSchemaOptions(property)) {
+      if (option.title) {
+        entries.push({
+          contentKey: `${prefix}option:${criterionKey}:${option.value}`,
+          text: option.title,
+        });
+      }
+      if (option.description) {
+        entries.push({
+          contentKey: `${prefix}option_desc:${criterionKey}:${option.value}`,
+          text: option.description,
+        });
+      }
+    }
+  }
+
+  if (entries.length === 0) {
+    return { translated: {}, sourceLocale: '', targetLocale };
+  }
+
+  const results = await runTranslateBatch(entries, targetLocale);
+
+  return {
+    ...unflattenTranslatedFields(prefix, results),
+    targetLocale,
+  };
+}

--- a/services/api/src/routers/translation/index.ts
+++ b/services/api/src/routers/translation/index.ts
@@ -4,6 +4,7 @@ import { translatePostsRouter } from './translatePosts';
 import { translateProposalRouter } from './translateProposal';
 import { translateProposalsRouter } from './translateProposals';
 import { translateResourcesRouter } from './translateResources';
+import { translateRubricRouter } from './translateRubric';
 
 export const translationRouter = mergeRouters(
   translateDecisionRouter,
@@ -11,4 +12,5 @@ export const translationRouter = mergeRouters(
   translateProposalRouter,
   translateProposalsRouter,
   translateResourcesRouter,
+  translateRubricRouter,
 );

--- a/services/api/src/routers/translation/translateRubric.test.ts
+++ b/services/api/src/routers/translation/translateRubric.test.ts
@@ -1,0 +1,311 @@
+import { mockCollab } from '@op/collab/testing';
+import type { RubricTemplateSchema } from '@op/common';
+import { db } from '@op/db/client';
+import { contentTranslations } from '@op/db/schema';
+import { like } from 'drizzle-orm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appRouter } from '..';
+import { TestReviewsDataManager } from '../../test/helpers/TestReviewsDataManager';
+import {
+  accessTierGatingCell,
+  describeDecisionAccessTierGating,
+  expectFailsAccessTierGate,
+} from '../../test/helpers/gating/decision';
+import {
+  createIsolatedSession,
+  createTestContextWithSession,
+} from '../../test/supabase-utils';
+import { createCallerFactory } from '../../trpcFactory';
+
+// Set a fake API key so the endpoint doesn't throw before reaching the mock
+process.env.DEEPL_API_KEY = 'test-fake-key';
+
+const mockTranslateText = vi.fn((texts: string | string[]) => {
+  const arr = Array.isArray(texts) ? texts : [texts];
+  const results = arr.map((t) => ({
+    text: `[ES] ${t}`,
+    detectedSourceLang: 'en',
+  }));
+  // Mirror deepl-node: a single-string input returns a single result object.
+  return Array.isArray(texts) ? results : results[0];
+});
+
+vi.mock('deepl-node', () => ({
+  DeepLClient: class {
+    translateText = mockTranslateText;
+  },
+}));
+
+const createCaller = createCallerFactory(appRouter);
+
+const rubricTemplate: RubricTemplateSchema = {
+  type: 'object',
+  'x-field-order': ['impact', 'feasibility'],
+  properties: {
+    impact: {
+      type: 'integer',
+      title: 'Impact',
+      description: 'How many residents does this reach?',
+      'x-format': 'dropdown',
+      minimum: 1,
+      maximum: 5,
+      oneOf: [
+        { const: 1, title: 'Low' },
+        { const: 5, title: 'High', description: 'The whole city' },
+      ],
+    },
+    feasibility: {
+      type: 'string',
+      title: 'Feasibility notes',
+      'x-format': 'long-text',
+    },
+  },
+  required: ['impact'],
+};
+
+async function createAuthenticatedCaller(email: string) {
+  const { session } = await createIsolatedSession(email);
+  return createCaller(await createTestContextWithSession(session));
+}
+
+function seedMockCollab(collaborationDocId: string) {
+  mockCollab.setDocResponse(collaborationDocId, {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Community garden proposal content' }],
+      },
+    ],
+  });
+}
+
+/** Assignment + rubric + seeded collab doc, with the cache rows cleaned up after. */
+async function createRubricScenario(
+  testData: TestReviewsDataManager,
+  onTestFinished: (fn: () => Promise<void>) => void,
+) {
+  const created = await testData.createReviewAssignment({
+    title: 'Community Garden Expansion',
+  });
+
+  const { collaborationDocId } = created.proposal.proposalData as {
+    collaborationDocId: string;
+  };
+  seedMockCollab(collaborationDocId);
+
+  await testData.setRubricTemplate(created.context, rubricTemplate);
+
+  const instanceId = created.context.instance.instance.id;
+  onTestFinished(async () => {
+    await db
+      .delete(contentTranslations)
+      .where(like(contentTranslations.contentKey, `rubric:${instanceId}:%`));
+  });
+
+  return created;
+}
+
+describe('translation.translateRubric', () => {
+  beforeEach(() => {
+    mockTranslateText.mockClear();
+  });
+
+  it('translates criterion prompts, descriptions, and option labels', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await createRubricScenario(testData, onTestFinished);
+
+    const caller = await createAuthenticatedCaller(created.reviewer.email);
+
+    const result = await caller.translation.translateRubric({
+      assignmentId: created.assignment.id,
+      targetLocale: 'es',
+    });
+
+    expect(result.sourceLocale).toBe('EN');
+    expect(result.targetLocale).toBe('es');
+    expect(result.translated).toEqual({
+      'field_title:impact': '[ES] Impact',
+      'field_desc:impact': '[ES] How many residents does this reach?',
+      'field_title:feasibility': '[ES] Feasibility notes',
+      'option:impact:1': '[ES] Low',
+      'option:impact:5': '[ES] High',
+      'option_desc:impact:5': '[ES] The whole city',
+    });
+  });
+
+  // Reviewers of a phase all score against the same rubric, so the content keys
+  // are phase-scoped: the second reviewer's request must be a pure cache read.
+  it('shares cached rubric translations across reviewers of the same phase', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await createRubricScenario(testData, onTestFinished);
+
+    const firstCaller = await createAuthenticatedCaller(created.reviewer.email);
+    const first = await translateRubricFor(firstCaller, created.assignment.id);
+    expect(mockTranslateText).toHaveBeenCalled();
+
+    // A second reviewer, on the same phase of the same instance.
+    const otherReviewer = await testData.createReviewer(created.context);
+    const otherAssignment = await testData.createReviewAssignment({
+      context: created.context,
+      reviewer: otherReviewer,
+    });
+    const { collaborationDocId } = otherAssignment.proposal.proposalData as {
+      collaborationDocId: string;
+    };
+    seedMockCollab(collaborationDocId);
+
+    mockTranslateText.mockClear();
+
+    const secondCaller = await createAuthenticatedCaller(otherReviewer.email);
+    const second = await translateRubricFor(
+      secondCaller,
+      otherAssignment.assignment.id,
+    );
+
+    expect(second.translated).toEqual(first.translated);
+    expect(mockTranslateText).not.toHaveBeenCalled();
+  });
+
+  it("rejects a caller who isn't the assignment's reviewer", async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await createRubricScenario(testData, onTestFinished);
+
+    // The proposal's author is a decision member but not this assignment's reviewer.
+    const caller = await createAuthenticatedCaller(created.author.email);
+
+    await expect(
+      caller.translation.translateRubric({
+        assignmentId: created.assignment.id,
+        targetLocale: 'es',
+      }),
+    ).rejects.toMatchObject({
+      cause: { name: 'UnauthorizedError' },
+    });
+  });
+
+  it('returns nothing to translate for an assignment with no rubric', async ({
+    task,
+    onTestFinished,
+  }) => {
+    const testData = new TestReviewsDataManager(task.id, onTestFinished);
+    const created = await testData.createReviewAssignment({
+      title: 'No Rubric Review',
+    });
+
+    const { collaborationDocId } = created.proposal.proposalData as {
+      collaborationDocId: string;
+    };
+    seedMockCollab(collaborationDocId);
+
+    const caller = await createAuthenticatedCaller(created.reviewer.email);
+
+    const result = await caller.translation.translateRubric({
+      assignmentId: created.assignment.id,
+      targetLocale: 'es',
+    });
+
+    expect(result).toEqual({
+      translated: {},
+      sourceLocale: '',
+      targetLocale: 'es',
+    });
+    expect(mockTranslateText).not.toHaveBeenCalled();
+  });
+});
+
+/** Narrow helper so the cache test reads as two identical calls. */
+function translateRubricFor(
+  caller: ReturnType<typeof createCaller>,
+  assignmentId: string,
+) {
+  return caller.translation.translateRubric({
+    assignmentId,
+    targetLocale: 'es',
+  });
+}
+
+describeDecisionAccessTierGating('translation.translateRubric', {
+  noJwtNonPublic: accessTierGatingCell(
+    'rejects no-JWT caller on non-public instance',
+    async ({ task, onTestFinished, callers }) => {
+      const testData = new TestReviewsDataManager(task.id, onTestFinished);
+      await testData.createContext();
+
+      const caller = await callers.noJwt();
+
+      await expectFailsAccessTierGate(
+        caller.translation.translateRubric({
+          assignmentId: crypto.randomUUID(),
+          targetLocale: 'es',
+        }),
+        'none',
+      );
+    },
+  ),
+
+  anonJwtNonPublic: accessTierGatingCell(
+    'rejects anon-JWT caller on non-public instance',
+    async ({ task, onTestFinished, callers }) => {
+      const testData = new TestReviewsDataManager(task.id, onTestFinished);
+      await testData.createContext();
+
+      const caller = await callers.anonJwt();
+
+      await expectFailsAccessTierGate(
+        caller.translation.translateRubric({
+          assignmentId: crypto.randomUUID(),
+          targetLocale: 'es',
+        }),
+        'anon',
+      );
+    },
+  ),
+
+  userJwtNonPublic: accessTierGatingCell(
+    'rejects user-JWT caller on non-public instance',
+    async ({ task, onTestFinished, callers }) => {
+      const testData = new TestReviewsDataManager(task.id, onTestFinished);
+      await testData.createContext();
+
+      const caller = await callers.userJwt();
+
+      await expectFailsAccessTierGate(
+        caller.translation.translateRubric({
+          assignmentId: crypto.randomUUID(),
+          targetLocale: 'es',
+        }),
+        'user',
+      );
+    },
+  ),
+
+  networkJwtNonPublic: accessTierGatingCell(
+    'admits network-JWT caller on non-public instance',
+    async ({ task, onTestFinished, callers }) => {
+      const testData = new TestReviewsDataManager(task.id, onTestFinished);
+      const context = await testData.createContext();
+
+      const caller = await callers.networkJwt(context.defaultReviewer.email);
+
+      await expect(
+        caller.translation.translateRubric({
+          assignmentId: crypto.randomUUID(),
+          targetLocale: 'es',
+        }),
+      ).rejects.not.toMatchObject({
+        cause: { name: 'UnauthorizedError' },
+      });
+    },
+  ),
+});

--- a/services/api/src/routers/translation/translateRubric.ts
+++ b/services/api/src/routers/translation/translateRubric.ts
@@ -1,0 +1,26 @@
+import { SUPPORTED_LOCALES, translateRubric } from '@op/common';
+import { z } from 'zod';
+
+import { networkAuthenticatedProcedure, router } from '../../trpcFactory';
+import { translateOutput } from './translateProposal';
+
+export const translateRubricRouter = router({
+  // Not `openProcedure` like its sibling translation endpoints: a rubric is only
+  // ever reachable through a review assignment, so this matches the tier of
+  // `decision.getReviewAssignment`, which serves the same rubric.
+  translateRubric: networkAuthenticatedProcedure()
+    .input(
+      z.object({
+        assignmentId: z.uuid(),
+        targetLocale: z.enum(SUPPORTED_LOCALES),
+      }),
+    )
+    .output(translateOutput)
+    .mutation(async ({ input, ctx }) => {
+      return translateRubric({
+        assignmentId: input.assignmentId,
+        targetLocale: input.targetLocale,
+        user: ctx.user,
+      });
+    }),
+});


### PR DESCRIPTION
Machine translation reached the decision overview but not the proposal list, the proposal page, or the rubric review screen, so a COWOP reviewer who reads Spanish had no way to review. Three independent causes:

- Language detection sampled only body text, so a proposal with a short or empty body produced no sample and the banner never rendered for a foreign-language title.
- The review screen sat outside every translation provider, and no endpoint could translate rubric criteria at all.
- The reviewer's queue tab rendered outside the provider its sibling tab mounts internally, so the two tabs disagreed.

Translation state lives in two React contexts — one at the decision-view layout, one inside `ProposalsList` — so a new proposal-card surface renders untranslated until it is wired in explicitly. That is why three screens drifted. Rubric translation moves display copy only: option `const` values, bounds and the `required` list stay as authored, so stored answers and validation are unchanged.

## Testing the preview build

Needs a decision whose proposal content is in a language other than your UI locale (switch locale with the header language chooser), plus a review phase with a rubric and at least one assignment. `DEEPL_API_KEY` must be set in the preview environment — translation throws without it.

1. **Proposal list** — on `/decisions/<slug>/current`, with a proposal that has a Spanish title and an empty or one-line body. The "Translate to English" banner appears. On `dev` it does not.
2. **Proposal page** — open that proposal and translate. Title, body and field labels switch; "Translated from Spanish · View original" puts them back.
3. **Review screen** — open `/decisions/<slug>/reviews/<assignmentId>`. One banner. Translating switches the proposal pane *and* the rubric criteria, descriptions and option labels. "View original" reverts both panes together.
4. **Answers survive translation** — while translated, pick a rubric option and type a note, then hit "View original". The selection and the note persist, and the form still submits.
5. **Reviewer queue** — in a review phase, "Proposals to review" offers the banner and translates its cards, matching the "Other proposals" tab.
6. **No regressions** — the decision overview still translates, and an English proposal viewed in English shows no banner.

## Follow-ups (out of scope)

- **Snapshot divergence:** the review pane renders the assignment's pinned proposal snapshot, while `translation.translateProposal` fetches the live proposal. Resubmission re-anchors only the requesting reviewer's assignment, so on a multi-reviewer phase a second reviewer can be shown a translation of newer text than the original beside it. Translate the assignment payload rather than the proposal id.
- **Peer reviews:** the "Other reviews" tab renders a separately-fetched rubric template plus reviewer-authored notes, which have no translation path at all.

Other untranslated surfaces (comments, results, ballot, vote review, review summary) are listed on the Asana task.

Asana: https://app.asana.com/1/1108348036672214/project/1211387328265612/task/1217153730617467
